### PR TITLE
Creating code_of_conduct.md

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of  
+fostering an open and welcoming community, we pledge to respect all people who  
+contribute through reporting issues, posting feature requests, updating  
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free  
+experience for everyone, regardless of level of experience, gender, gender  
+identity and expression, sexual orientation, disability, personal appearance,  
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery  
+* Personal attacks  
+* Trolling or insulting/derogatory comments  
+* Public or private harassment  
+* Publishing other's private information, such as physical or electronic  
+  addresses, without explicit permission  
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or  
+reject comments, commits, code, wiki edits, issues, and other contributions  
+that are not aligned to this Code of Conduct, or to ban temporarily or  
+permanently any contributor for other behaviors that they deem inappropriate,  
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to  
+fairly and consistently applying these principles to every aspect of managing  
+this project. Project maintainers who do not follow or enforce the Code of  
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces  
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be  
+reported by contacting a project maintainer at namurphy@cfa.harvard.edu. All  
+complaints will be reviewed and investigated and will result in a response that  
+is deemed necessary and appropriate to the circumstances. Maintainers are  
+obligated to maintain confidentiality with regard to the reporter of an  
+incident.  
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/


### PR DESCRIPTION
Beginning with version 1.3 of the Contributor Covenant code of conduct