### PR TITLE
Set up travis notifications for the matrix room

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,13 @@ script: coverage run -m pytest
 # Assess test coverage
 after_success:
         - coveralls
+
+# Hook travis into matrix channel for notifications
+notifications:
+    webhooks:
+        urls:
+            - "https://scalar.vector.im/api/neb/services/hooks/dHJhdmlzLWNpLyU0MFNvbGFyRHJldyUzQW1hdHJpeC5vcmcvJTIxaGtXQ2l5aFF5eGlZSmxVdEtGJTNBbWF0cml4Lm9yZw"
+        on_success: change  # always|never|change
+        on_failure: always
+        on_start: never
+


### PR DESCRIPTION
Just a small addition to the travis config file that lets it send notifications about the current test status to the matrix room. Clearly this assumes we continue using the matrix room - it can be removed again if we don't.