### PR TITLE
Omitting __init__.py in coverage tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,8 @@
 [report]
-omit = 
-	ci-helpers/*
-	*/tests/*
+omit =
+ 	ci-helpers/*
+ 	*/tests/*
+	*__init__.py
+exclude_lines =
+    def __repr__
+    def __str__


### PR DESCRIPTION
Given that `__init__.py` files don't really do much except exposing, and with Astropy graduating to 2.0 there's a bunch of trouble with their imports, it seems to make little sense to test them. This is a small commit that removes them from Coveralls testing.

I'm not sure whether removing those is good or bad for our testing (probably "neutral without annoyances"), but it's something to consider. Feel free to close this if it's unhelpful!