### PR TITLE
Calculate the Coulomb logarithm, Lorentz factor, and de Broglie wavelength

### DIFF
--- a/plasmapy/constants/atomic.py
+++ b/plasmapy/constants/atomic.py
@@ -800,7 +800,7 @@ def ion_mass(argument, Z=None, mass_numb=None):
                               "range of known isotopes or electrons/ions.")
 
     if isinstance(argument, str) and \
-            str(argument).lower() in ['e+', 'positron', 'e', 'electron']:
+            str(argument).lower() in ['e+', 'positron', 'e', 'e-', 'electron']:
         return const.m_e
 
     if atomic_number(argument) == 0:

--- a/plasmapy/constants/atomic.py
+++ b/plasmapy/constants/atomic.py
@@ -800,7 +800,7 @@ def ion_mass(argument, Z=None, mass_numb=None):
                               "range of known isotopes or electrons/ions.")
 
     if isinstance(argument, str) and \
-            str(argument).lower() in ['e+', 'positron']:
+            str(argument).lower() in ['e+', 'positron', 'e', 'electron']:
         return const.m_e
 
     if atomic_number(argument) == 0:

--- a/plasmapy/physics/__init__.py
+++ b/plasmapy/physics/__init__.py
@@ -20,3 +20,5 @@ from .parameters import (Alfven_speed,
                          upper_hybrid_frequency,
                          lower_hybrid_frequency,
                          )
+
+from .transport import Coulomb_logarithm

--- a/plasmapy/physics/__init__.py
+++ b/plasmapy/physics/__init__.py
@@ -21,4 +21,10 @@ from .parameters import (Alfven_speed,
                          lower_hybrid_frequency,
                          )
 
+from .quantum import deBroglie_wavelength
+
+from .relativity import Lorentz_factor
+
 from .transport import Coulomb_logarithm
+
+

--- a/plasmapy/physics/__init__.py
+++ b/plasmapy/physics/__init__.py
@@ -26,5 +26,3 @@ from .quantum import deBroglie_wavelength
 from .relativity import Lorentz_factor
 
 from .transport import Coulomb_logarithm
-
-

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -98,7 +98,8 @@ def Alfven_speed(B, density, ion="p"):
     Raises
     ------
     TypeError
-        The magnetic field and density arguments are not Quantities.
+        The magnetic field and density arguments are not Quantities and
+        cannot be converted into Quantities.
 
     UnitConversionError
         If the magnetic field or density is not in appropriate units.

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -82,7 +82,8 @@ def deBroglie_wavelength(V, particle):
 
         lambda_dB = np.zeros_like(V.value)
         lambda_dB[is_zero] = np.inf*units.m
-        lambda_dB[nonzero] = h / (m * V[nonzero] * Lorentz_factor(V[nonzero]))
+        lambda_dB[is_nonzero] = \
+            h / (m * V[is_nonzero] * Lorentz_factor(V[is_nonzero]))
 
     else:
 

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -86,13 +86,9 @@ def deBroglie_wavelength(V, particle):
 
     if V.size > 1:
 
-        lambda_dBr = np.zeros_like(V.value)*units.m
-
-        for i in range(V.size):
-            if V.flat[i].value == 0:
-                lambda_dBr.flat[i] = np.inf*units.m
-            else:
-                lambda_dBr.flat[i] = h/(m*V.flat[i]*Lorentz_factor(V.flat[i]))
+        lambda_dBr = np.ones(V.shape) * np.inf * units.m
+        indices = V.value != 0
+        lambda_dBr[indices] = h / (m*V[indices]*Lorentz_factor(V[indices]))
 
     else:
 

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -1,0 +1,94 @@
+import numpy as np
+from astropy import units
+from ..constants import c, h, ion_mass
+from ..utils import _check_quantity, _check_relativistic
+from .relativity import Lorentz_factor
+
+
+def deBroglie_wavelength(V, particle):
+    """Calculates the de Broglie wavelength.
+
+    Parameters
+    ----------
+    V : Quantity
+        Particle velocity in units convertible to meters per second.
+
+    particle : string or Quantity
+        Representation of the particle species (e.g., 'e', 'p', 'D+',
+        or 'He-4 1+', or the particle mass in units convertible to
+        kilograms.
+
+    Returns
+    -------
+    lambda_dB : Quantity
+        The de Broglie wavelength in units of meters.
+
+    Raises
+    ------
+    TypeError
+        The velocity is not a Quantity and cannot be converted into a
+        Quantity.
+
+    UnitConversionError
+        If the velocity is not in appropriate units.
+
+    ValueError
+        If the magnitude of V is faster than the speed of light.
+
+    UserWarning
+        If V is not a Quantity, then a UserWarning will be raised and
+        units of meters per second will be assumed.
+
+    Notes
+    -----
+    The de Broglie wavelength is given by
+
+    .. math::
+    \lambda_{dB} = \frac{h}{p} = \frac{h}{\gamma m V}.
+
+    where :math:`h` is the Planck constant, :math:`p` is the
+    relativistic momentum of the particle, :math:`gamma` is the
+    Lorentz factor, `m` is the particle's mass, and :math:`V` is the
+    particle's velocity.
+
+    Examples
+    --------
+    >>> from astropy import units as u
+    >>> velocity = 1.4e7*u.m/u.s
+    >>> deBroglie_wavelength(velocity, 'e')
+    <Quantity 5.1899709519786425e-11 m>
+    >>> deBroglie_wavelength(V = 0*u.m/u.s, particle = 'D+')
+    <Quantity inf m>
+
+    """
+
+    _check_quantity(V, 'V', 'deBroglie_wavelength', units.m/units.s)
+
+    V = np.abs(V)
+
+    if np.any(V >= c):
+        raise ValueError("Velocity input in deBroglie_wavelength cannot be "
+                         "greater than or equal to the speed of light.")
+
+    try:
+        m = ion_mass(particle)  # Replace with more general routine!
+    except Exception:
+        raise ValueError("Unable to find particle mass.")
+
+    if V.size > 1:
+
+        is_zero = np.where(V == 0*units.m/units.s)
+        is_nonzero = np.invert(is_zero)
+
+        lambda_dB = np.zeros_like(V.value)
+        lambda_dB[is_zero] = np.inf*units.m
+        lambda_dB[nonzero] = h / (m * V[nonzero] * Lorentz_factor(V[nonzero]))
+
+    else:
+
+        if V == 0*units.m/units.s:
+            lambda_dB = np.inf*units.m
+        else:
+            lambda_dB = h / (Lorentz_factor(V) * m * V)
+
+    return lambda_dB.to(units.m)

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -6,7 +6,7 @@ from .relativity import Lorentz_factor
 
 
 def deBroglie_wavelength(V, particle):
-    """Calculates the de Broglie wavelength.
+    r"""Calculates the de Broglie wavelength.
 
     Parameters
     ----------

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -86,13 +86,13 @@ def deBroglie_wavelength(V, particle):
 
     if V.size > 1:
 
-        is_zero = np.where(V == 0*units.m/units.s)
-        is_nonzero = ~is_zero
+        lambda_dBr = np.zeros_like(V.value)*units.m
 
-        lambda_dBr = np.zeros_like(V.value)
-        lambda_dBr[is_zero] = np.inf*units.m
-        lambda_dBr[is_nonzero] = \
-            h / (m * V[is_nonzero] * Lorentz_factor(V[is_nonzero]))
+        for i in range(V.size):
+            if V.flat[i].value == 0:
+                lambda_dBr.flat[i] = np.inf*units.m
+            else:
+                lambda_dBr.flat[i] = h/(m*V.flat[i]*Lorentz_factor(V.flat[i]))
 
     else:
 

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -70,26 +70,35 @@ def deBroglie_wavelength(V, particle):
         raise ValueError("Velocity input in deBroglie_wavelength cannot be "
                          "greater than or equal to the speed of light.")
 
-    try:
-        m = ion_mass(particle)  # TODO: Replace with more general routine!
-    except Exception:
-        raise ValueError("Unable to find particle mass.")
+    if not isinstance(particle, units.Quantity):
+        try:
+            m = ion_mass(particle)  # TODO: Replace with more general routine!
+        except Exception:
+            raise ValueError("Unable to find particle mass.")
+    else:
+        try:
+            m = particle.to(units.kg)
+        except Exception:
+            raise units.UnitConversionError("The second argument for deBroglie"
+                                            " wavelength must be either a "
+                                            "representation of a particle or a"
+                                            " Quantity with units of mass.")
 
     if V.size > 1:
 
         is_zero = np.where(V == 0*units.m/units.s)
         is_nonzero = ~is_zero
 
-        lambda_dB = np.zeros_like(V.value)
-        lambda_dB[is_zero] = np.inf*units.m
-        lambda_dB[is_nonzero] = \
+        lambda_dBr = np.zeros_like(V.value)
+        lambda_dBr[is_zero] = np.inf*units.m
+        lambda_dBr[is_nonzero] = \
             h / (m * V[is_nonzero] * Lorentz_factor(V[is_nonzero]))
 
     else:
 
         if V == 0*units.m/units.s:
-            lambda_dB = np.inf*units.m
+            lambda_dBr = np.inf*units.m
         else:
-            lambda_dB = h / (Lorentz_factor(V) * m * V)
+            lambda_dBr = h / (Lorentz_factor(V) * m * V)
 
-    return lambda_dB.to(units.m)
+    return lambda_dBr.to(units.m)

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -71,14 +71,14 @@ def deBroglie_wavelength(V, particle):
                          "greater than or equal to the speed of light.")
 
     try:
-        m = ion_mass(particle)  # Replace with more general routine!
+        m = ion_mass(particle)  # TODO: Replace with more general routine!
     except Exception:
         raise ValueError("Unable to find particle mass.")
 
     if V.size > 1:
 
         is_zero = np.where(V == 0*units.m/units.s)
-        is_nonzero = np.invert(is_zero)
+        is_nonzero = ~is_zero
 
         lambda_dB = np.zeros_like(V.value)
         lambda_dB[is_zero] = np.inf*units.m

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -65,8 +65,8 @@ def Lorentz_factor(V):
 
         gamma = np.zeros_like(V.value)
 
-        equals_c = np.where(np.abs(V) == c)
-        is_slow = np.invert(equals_c)
+        equals_c = np.abs(V) == c
+        is_slow = ~equals_c
 
         gamma[is_slow] = ((1 - (V[is_slow]/c)**2)**-0.5).value
         gamma[equals_c] = np.inf

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -1,0 +1,80 @@
+import numpy as np
+from astropy import units
+
+from ..constants import c, ion_mass, charge_state
+from ..utils import _check_quantity
+
+
+def Lorentz_factor(V):
+    r"""Returns the Lorentz factor.
+
+    Parameters
+    ----------
+    V : Quantity
+        The velocity in units convertible to meters per second.
+
+    Returns
+    -------
+    gamma : float or ndarray
+        The Lorentz factor associated with the inputted velocities
+
+    Raises
+    ------
+    TypeError
+        The velocity is not a Quantity and cannot be converted into a
+        Quantity.
+
+    UnitConversionError
+        If the velocity is not in appropriate units.
+
+    ValueError
+        If the magnitude of V is faster than the speed of light.
+
+    UserWarning
+        If V is not a Quantity, then a UserWarning will be raised and
+        units of meters per second will be assumed.
+
+    Notes
+    -----
+    The Lorentz factor is a dimensionless number given by
+
+    .. math::
+    \gamma = \frac{1}{\sqrt{1-\frac{V^2}{c^2}}}
+
+    The Lorentz factor is approximately one for sub-relativistic
+    velocities, and goes to infinity as the velocity approaches the
+    speed of light.
+
+    Examples
+    --------
+    >>> from astropy import units as u
+    >>> velocity = 1.4e8*u.m/u.s
+    >>> Lorentz_factor(velocity)
+    1.130885603948959
+    >>> Lorentz_factor(299792458*u.m/u.s)
+
+    """
+
+    _check_quantity(V, 'V', 'Lorentz_factor', units.m/units.s)
+
+    if not np.all(np.abs(V) <= c):
+        raise ValueError("The Lorentz factor cannot be calculated for speeds "
+                         "faster than the speed of light.")
+
+    if V.size > 1:
+
+        gamma = np.zeros_like(V.value)
+
+        equals_c = np.where(np.abs(V) == c)
+        is_slow = np.invert(equals_c)
+
+        gamma[is_slow] = ((1 - (V[is_slow]/c)**2)**-0.5).value
+        gamma[equals_c] = np.inf
+
+    else:
+        if np.abs(V) == c:
+            gamma = np.inf
+        else:
+            gamma = ((1 - (V/c)**2)**-0.5).value
+
+    return gamma

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -17,9 +17,20 @@ def test_deBroglie_wavelength():
     assert deBroglie_wavelength(-5e5*u.m/u.s, 'p') == \
         deBroglie_wavelength(5e5*u.m/u.s, 'p')
 
+    assert deBroglie_wavelength(-5e5*u.m/u.s, 'e+') == \
+        deBroglie_wavelength(5e5*u.m/u.s, 'e')
+
+    assert deBroglie_wavelength(1*u.m/u.s, 5*u.kg) == \
+        deBroglie_wavelength(100*u.cm/u.s, 5000*u.g)
+    
     with pytest.raises(ValueError):
         deBroglie_wavelength(c*1.000000001, 'e')
 
     with pytest.raises(UserWarning):
-        # Use the Kolakowski constant for no reason besides that it's cool
-        deBroglie_wavelength(0.794507192779479276240362415636045646, 'Be-7 1+')
+        deBroglie_wavelength(0.79450719277, 'Be-7 1+')
+
+    with pytest.raises(u.UnitConversionError):
+        deBroglie_wavelength(8*u.m/u.s, 5*u.m)
+
+    with pytest.raises(ValueError):
+        deBroglie_wavelength(8*u.m/u.s, 'sddsf')

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+import astropy.units as u
+from ...constants import c, h
+from ..quantum import deBroglie_wavelength
+
+
+def test_deBroglie_wavelength():
+
+    dbwavelength1 = deBroglie_wavelength(2e7*u.cm/u.s, 'e')
+    assert np.isclose(dbwavelength1.value, 3.628845222852886e-11)
+    assert dbwavelength1.unit == u.m
+
+    dbwavelength2 = deBroglie_wavelength(0*u.m/u.s, 'e')
+    assert dbwavelength2 == np.inf*u.m
+
+    assert deBroglie_wavelength(-5e5*u.m/u.s, 'p') == \
+        deBroglie_wavelength(5e5*u.m/u.s, 'p')
+
+    with pytest.raises(ValueError):
+        deBroglie_wavelength(c*1.000000001, 'e')
+
+    with pytest.raises(UserWarning):
+        # Use the Kolakowski constant for no reason besides that it's cool
+        deBroglie_wavelength(0.794507192779479276240362415636045646, 'Be-7 1+')

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -15,9 +15,24 @@ def test_deBroglie_wavelength():
     assert dbwavelength2 == np.inf*u.m
 
 
-    V_array = np.array([3e6,6e6])*u.m/u.s
+    V_array = np.array([2e5,0])*u.m/u.s
+    dbwavelength_arr = deBroglie_wavelength(V_array, 'e')
 
-    deBroglie_wavelength(V_array, 'e')
+    assert np.isclose(dbwavelength_arr.value[0], 3.628845222852886e-11)
+    assert dbwavelength_arr.value[1] == np.inf
+    assert dbwavelength_arr.unit == u.m
+
+
+    V_array = np.array([2e5,2e5])*u.m/u.s
+    dbwavelength_arr = deBroglie_wavelength(V_array, 'e')
+
+    assert np.isclose(dbwavelength_arr.value[0], 3.628845222852886e-11)
+    assert np.isclose(dbwavelength_arr.value[1], 3.628845222852886e-11)
+    assert dbwavelength_arr.unit == u.m
+
+
+#    assert dbwavelength_arr[0]
+#    assert dbwavelength2 == 
 
     assert deBroglie_wavelength(-5e5*u.m/u.s, 'p') == \
         deBroglie_wavelength(5e5*u.m/u.s, 'p')

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -14,6 +14,11 @@ def test_deBroglie_wavelength():
     dbwavelength2 = deBroglie_wavelength(0*u.m/u.s, 'e')
     assert dbwavelength2 == np.inf*u.m
 
+
+    V_array = np.array([3e6,6e6])*u.m/u.s
+
+    deBroglie_wavelength(V_array, 'e')
+
     assert deBroglie_wavelength(-5e5*u.m/u.s, 'p') == \
         deBroglie_wavelength(5e5*u.m/u.s, 'p')
 

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -22,7 +22,7 @@ def test_deBroglie_wavelength():
 
     assert deBroglie_wavelength(1*u.m/u.s, 5*u.kg) == \
         deBroglie_wavelength(100*u.cm/u.s, 5000*u.g)
-    
+
     with pytest.raises(ValueError):
         deBroglie_wavelength(c*1.000000001, 'e')
 

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -14,25 +14,19 @@ def test_deBroglie_wavelength():
     dbwavelength2 = deBroglie_wavelength(0*u.m/u.s, 'e')
     assert dbwavelength2 == np.inf*u.m
 
-
-    V_array = np.array([2e5,0])*u.m/u.s
+    V_array = np.array([2e5, 0])*u.m/u.s
     dbwavelength_arr = deBroglie_wavelength(V_array, 'e')
 
     assert np.isclose(dbwavelength_arr.value[0], 3.628845222852886e-11)
     assert dbwavelength_arr.value[1] == np.inf
     assert dbwavelength_arr.unit == u.m
 
-
-    V_array = np.array([2e5,2e5])*u.m/u.s
+    V_array = np.array([2e5, 2e5])*u.m/u.s
     dbwavelength_arr = deBroglie_wavelength(V_array, 'e')
 
     assert np.isclose(dbwavelength_arr.value[0], 3.628845222852886e-11)
     assert np.isclose(dbwavelength_arr.value[1], 3.628845222852886e-11)
     assert dbwavelength_arr.unit == u.m
-
-
-#    assert dbwavelength_arr[0]
-#    assert dbwavelength2 == 
 
     assert deBroglie_wavelength(-5e5*u.m/u.s, 'p') == \
         deBroglie_wavelength(5e5*u.m/u.s, 'p')

--- a/plasmapy/physics/tests/test_relativity.py
+++ b/plasmapy/physics/tests/test_relativity.py
@@ -33,3 +33,6 @@ def test_Lorentz_factor():
 
     with pytest.raises(UserWarning):
         Lorentz_factor(2.2)
+
+    with pytest.raises(u.UnitConversionError):
+        Lorentz_factor(4*u.kg)

--- a/plasmapy/physics/tests/test_relativity.py
+++ b/plasmapy/physics/tests/test_relativity.py
@@ -1,0 +1,32 @@
+"""Tests for functions in relativity.py."""
+
+import pytest
+import numpy as np
+from astropy import units as u
+from ...constants import c
+from ..relativity import Lorentz_factor
+
+
+def test_Lorentz_factor():
+    """Test Lorentz_factor in relativity.py"""
+    
+    V = 123456789*u.m/u.s
+    assert np.isclose(Lorentz_factor(V), (1/np.sqrt(1-V**2/c**2)).value)
+    assert Lorentz_factor(-V) == Lorentz_factor(V)
+
+    assert np.isclose(Lorentz_factor(0*u.m/u.s), 1.0)
+    assert Lorentz_factor(c) == np.inf
+
+    V_arr = np.array([987532.0, 299792458])*u.m/u.s
+    gamma_arr = Lorentz_factor(V_arr)
+    assert np.isclose(gamma_arr[0], (1/np.sqrt(1-V_arr[0]**2/c**2)).value)
+    assert gamma_arr[1] == np.inf
+
+    with pytest.raises(ValueError):
+        Lorentz_factor(1.0000000001*c)
+
+    with pytest.raises((ValueError, UserWarning)):
+        Lorentz_factor(299792459)
+
+    with pytest.raises(UserWarning):
+        Lorentz_factor(2.2)

--- a/plasmapy/physics/tests/test_relativity.py
+++ b/plasmapy/physics/tests/test_relativity.py
@@ -22,6 +22,9 @@ def test_Lorentz_factor():
     assert np.isclose(gamma_arr[0], (1/np.sqrt(1-V_arr[0]**2/c**2)).value)
     assert gamma_arr[1] == np.inf
 
+    assert (Lorentz_factor(3*u.m/u.s)*u.dimensionless_unscaled).unit == \
+        u.dimensionless_unscaled
+
     with pytest.raises(ValueError):
         Lorentz_factor(1.0000000001*c)
 

--- a/plasmapy/physics/tests/test_relativity.py
+++ b/plasmapy/physics/tests/test_relativity.py
@@ -9,7 +9,7 @@ from ..relativity import Lorentz_factor
 
 def test_Lorentz_factor():
     """Test Lorentz_factor in relativity.py"""
-    
+
     V = 123456789*u.m/u.s
     assert np.isclose(Lorentz_factor(V), (1/np.sqrt(1-V**2/c**2)).value)
     assert Lorentz_factor(-V) == Lorentz_factor(V)

--- a/plasmapy/physics/tests/test_transport.py
+++ b/plasmapy/physics/tests/test_transport.py
@@ -38,4 +38,4 @@ def test_Coulomb_logarithm():
         Coulomb_logarithm(1*u.m**-3, 1e5*u.K, ('e', 'p'), 299792458*u.m/u.s)
 
     with pytest.raises(u.UnitConversionError):
-        Coulomb_logarithm(1*u.m**-3, 1e5*u.K, ('e', 'p'), 29979245*u.m/u.s)
+        Coulomb_logarithm(1*u.m**-3, 1e5*u.g, ('e', 'p'), 29979245*u.m/u.s)

--- a/plasmapy/physics/tests/test_transport.py
+++ b/plasmapy/physics/tests/test_transport.py
@@ -10,4 +10,23 @@ from ..transport import (Coulomb_logarithm)
 
 
 def test_Coulomb_logarithm():
-    Coulomb_logarithm()
+
+    n_e = np.array([1e9, 1e9, 1e24])*u.cm**-3
+    T = np.array([1e2, 1e7, 1e8])*u.K
+    Lambda = np.array([5.97, 21.66, 6.69])
+    particles = ('e', 'p')
+
+    for i in range(3):
+        assert np.isclose(Coulomb_logarithm(n_e[i], T[i], particles),
+                          Lambda[i], atol=0.01)
+
+    assert np.isclose(Coulomb_logarithm(1e9*u.cm**-3, 1e2*u.K, ('e', 'p')),
+                      5.97, atol=0.01)
+
+    assert np.isclose(Coulomb_logarithm(1e9*u.cm**-3, 1e7*u.K, ('e', 'p')),
+                      21.6, atol=0.1)
+
+    assert np.isclose(Coulomb_logarithm(1e24*u.cm**-3, 1e8*u.K, ('e', 'p')),
+                      6.69, atol=0.01)
+
+    

--- a/plasmapy/physics/tests/test_transport.py
+++ b/plasmapy/physics/tests/test_transport.py
@@ -1,5 +1,6 @@
 """Tests for functions that calculate transport coefficients."""
 
+
 import numpy as np
 import pytest
 from astropy import units as u
@@ -16,6 +17,8 @@ def test_Coulomb_logarithm():
     Lambda = np.array([5.97, 21.66, 6.69])
     particles = ('e', 'p')
 
+    Coulomb_logarithm(5*u.m**-3, 1*u.eV, ('e', 'e'))
+
     for i in range(3):
         assert np.isclose(Coulomb_logarithm(n_e[i], T[i], particles),
                           Lambda[i], atol=0.01)
@@ -29,4 +32,10 @@ def test_Coulomb_logarithm():
     assert np.isclose(Coulomb_logarithm(1e24*u.cm**-3, 1e8*u.K, ('e', 'p')),
                       6.69, atol=0.01)
 
-    
+    assert np.allclose(Coulomb_logarithm(n_e, T, particles), Lambda, atol=0.01)
+
+    with pytest.raises(UserWarning):
+        Coulomb_logarithm(1*u.m**-3, 1e5*u.K, ('e', 'p'), 299792458*u.m/u.s)
+
+    with pytest.raises(u.UnitConversionError):
+        Coulomb_logarithm(1*u.m**-3, 1e5*u.K, ('e', 'p'), 29979245*u.m/u.s)

--- a/plasmapy/physics/tests/test_transport.py
+++ b/plasmapy/physics/tests/test_transport.py
@@ -17,11 +17,12 @@ def test_Coulomb_logarithm():
     Lambda = np.array([5.97, 21.66, 6.69])
     particles = ('e', 'p')
 
-    Coulomb_logarithm(5*u.m**-3, 1*u.eV, ('e', 'e'))
-
     for i in range(3):
         assert np.isclose(Coulomb_logarithm(n_e[i], T[i], particles),
                           Lambda[i], atol=0.01)
+
+    assert np.isclose(Coulomb_logarithm(5*u.m**-3, 1*u.eV, ('e', 'e')),
+                      Coulomb_logarithm(5*u.m**-3, 11604.5220*u.K, ('e', 'e')))
 
     assert np.isclose(Coulomb_logarithm(1e9*u.cm**-3, 1e2*u.K, ('e', 'p')),
                       5.97, atol=0.01)
@@ -33,6 +34,9 @@ def test_Coulomb_logarithm():
                       6.69, atol=0.01)
 
     assert np.allclose(Coulomb_logarithm(n_e, T, particles), Lambda, atol=0.01)
+
+    assert np.isclose(Coulomb_logarithm(5*u.m**-3, 1e5*u.K, ('e', 'e'),
+                                        V=1e4*u.m/u.s), 21.379082011)
 
     with pytest.raises(UserWarning):
         Coulomb_logarithm(1*u.m**-3, 1e5*u.K, ('e', 'p'), 299792458*u.m/u.s)

--- a/plasmapy/physics/tests/test_transport.py
+++ b/plasmapy/physics/tests/test_transport.py
@@ -1,0 +1,13 @@
+"""Tests for functions that calculate transport coefficients."""
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+from ...constants import c, m_p, m_e, e, mu0
+
+from ..transport import (Coulomb_logarithm)
+
+
+def test_Coulomb_logarithm():
+    Coulomb_logarithm()

--- a/plasmapy/physics/tests/test_transport.py
+++ b/plasmapy/physics/tests/test_transport.py
@@ -39,3 +39,12 @@ def test_Coulomb_logarithm():
 
     with pytest.raises(u.UnitConversionError):
         Coulomb_logarithm(1*u.m**-3, 1e5*u.g, ('e', 'p'), 29979245*u.m/u.s)
+
+    with pytest.raises(ValueError):
+        Coulomb_logarithm(5*u.m**-3, 1*u.K, ('e'))
+
+    with pytest.raises(ValueError):
+        Coulomb_logarithm(5*u.m**-3, 1*u.K, ('e', 'g'))
+
+    with pytest.raises(ValueError):
+        Coulomb_logarithm(5*u.m**-3, 1*u.K, ('e', 'D'))

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -9,8 +9,8 @@ from .parameters import Debye_length
 from .quantum import deBroglie_wavelength
 
 
-def Coulomb_logarithm(T = 1e6*units.K, n_e = 1e19*units.m**-3,
-                      particles = ('e', 'p') ):
+def Coulomb_logarithm(T=1e6*units.K, n_e=1e19*units.m**-3,
+                      particles=('e', 'p')):
     r"""Estimates the Coulomb logarithm.
 
     Parameters
@@ -78,8 +78,8 @@ def Coulomb_logarithm(T = 1e6*units.K, n_e = 1e19*units.m**-3,
     # involve electrons, it would probably make more sense to choose
     # the electron temperature.
 
-    _check_quantity(T, 'T', 'Coulomb_logarithm', u.K)
-    _check_quantity(n_e, 'n_e', 'Coulomb_logarithm', u.m**-3)
+    _check_quantity(T, 'T', 'Coulomb_logarithm', units.K)
+    _check_quantity(n_e, 'n_e', 'Coulomb_logarithm', units.m**-3)
 
     if len(particles) != 2:
         raise ValueError("Incorrect number of particles in Coulomb_logarithm")
@@ -106,7 +106,11 @@ def Coulomb_logarithm(T = 1e6*units.K, n_e = 1e19*units.m**-3,
 
     bperp = q1*q2/(12*pi*eps0*k_B*T) # Bittencourt eq
 
-    # The second possibility is the de Broglie wavelength
+
+
+    # The second possibility is the electron de Broglie wavelength.
+    # The wave nature of ions can usually be neglected (Spitzer 1962).
+    # 
 
     m1 = ion_mass(particles[0])
     m2 = ion_mass(particles[1])

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -64,7 +64,7 @@ def Coulomb_logarithm(n_e, T, particles, V=None):
     \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
 
     where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
-    impact parameters for Coulomb collisions.
+    impact parameters for Coulomb collisions _[1].
 
     The outer impact parameter is given by the Debye length:
     :math:`b_{min} = \lambda_D` which is a function of electron
@@ -80,11 +80,13 @@ def Coulomb_logarithm(n_e, T, particles, V=None):
     corresponding to the reduced mass of the two particles and the
     relative velocity between collisions.  This function uses the
     standard practice of choosing the inner impact parameter to be the
-    maximum of these two possibilities.
+    maximum of these two possibilities.  Some inconsistencies exist in
+    the literature on how to define the inner impact parameter _[2].
 
-    Errors associated with the Coulomb logarithm are of order its inverse
-    If the Coulomb logarithm is of order unity, then the assumptions
-    made in the standard analysis of Coulomb collisions are invalid.
+    Errors associated with the Coulomb logarithm are of order its
+    inverse If the Coulomb logarithm is of order unity, then the
+    assumptions made in the standard analysis of Coulomb collisions
+    are invalid.
 
     Examples
     --------
@@ -93,6 +95,15 @@ def Coulomb_logarithm(n_e, T, particles, V=None):
     14.748259780491056
     >>> Coulomb_logarithm(1e6*units.K, 1e19*units.m**-3, ('e', 'p'),
                           V=1e6*u.m/u.s)
+
+    References
+    ----------
+    .. [1] Physics of Fully Ionized Gases, L. Spitzer (1962)
+
+    .. [2] Comparison of Coulomb Collision Rates in the Plasma Physics
+    and Magnetically Confined Fusion Literature, W. Fundamenski and
+    O.E. Garcia, EFDA–JET–R(07)01
+    (http://www.euro-fusionscipub.org/wp-content/uploads/2014/11/EFDR07001.pdf)
 
     """
 

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -1,38 +1,128 @@
 """Functions to calculate transport coefficients."""
 
 from astropy import units
-
-from ..constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi, ion_mass,
-                         charge_state)
-
 import numpy as np
-
 from ..utils import _check_quantity
+from ..constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi, h, hbar,
+                         ion_mass, charge_state)
+from .parameters import Debye_length
+from .quantum import deBroglie_wavelength
 
 
-def Coulomb_logarithm():
-    r"""Returns the Coulomb logarithm.
+def Coulomb_logarithm(T = 1e6*units.K, n_e = 1e19*units.m**-3,
+                      particles = ('e', 'p') ):
+    r"""Estimates the Coulomb logarithm.
 
     Parameters
     ----------
+    T : Quantity
+        Temperature in units of temperature or energy per particle.
+
+    n_e : Quantity
+        The electron density in units convertible to per cubic meter,
+        defaulting to
+
+    particles : tuple containing two objects
+        A tuple containing
 
     Returns
     -------
-    The number 15.
+    lnLambda : float or numpy.ndarray
+        An estimate of the Coulomb logarithm
 
     Raises
     ------
 
+
+
     Notes
     -----
+    The Coulomb logarithm is given by
+
+    .. math::
+    \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+
+    where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
+    impact parameters.
+
+    The outer impact parameter is generally accepted to be the Debye
+    length: `b_{min} = \lambda_D`.  At distances greater than the
+    Debye length,
+
+    At this distance, charges from particles are screened out by other
+    particles.
+
+    There is some disagreement on what the inner impact parameter
+    should be.
 
     Examples
     --------
+    >>> from astropy import units as u
+    >>> Coulomb_logarithm(T=1e6*units.K, n_e=1e19*units.m**-3)
 
     See also
     --------
-    Debye_number
+
+    References
+    ----------
+
+    [1] Bittencourt
+
+    [2] Mulser, Alber, and Murakami (2014)
 
     """
 
-    return 15.0
+    # The temperatures of the two species are assumed to be the same.
+    # The temperature comes up in the calculation of the Debye length
+    # and the relative velocity between particles.  If the collisions
+    # involve electrons, it would probably make more sense to choose
+    # the electron temperature.
+
+    _check_quantity(T, 'T', 'Coulomb_logarithm', u.K)
+    _check_quantity(n_e, 'n_e', 'Coulomb_logarithm', u.m**-3)
+
+    if len(particles) != 2:
+        raise ValueError("Incorrect number of particles in Coulomb_logarithm")
+
+    # The outer impact parameter is the Debye length.  At distances
+    # greater than the Debye length, the electrostatic potential of a
+    # single particle is screened out by the electrostatic potentials
+    # of other particles.  Past this distance, the electric fields of
+    # individual particles do not affect each other.
+
+    bmax = Debye_length(T, n_e)
+
+    # The choice of inner impact parameter is somewhat more
+    # controversial.
+
+
+    # Heuristic arguments suggest that the minimum impact paramter is
+    # the maximum of either the de Broglie wavelength (below which
+    # quantum effects dominate) or the angle of perpendicular
+    # deflection.
+
+    q1 = np.abs(e*charge_state(particles[0]))
+    q2 = np.abs(e*charge_state(particles[1]))
+
+    bperp = q1*q2/(12*pi*eps0*k_B*T) # Bittencourt eq
+
+    # The second possibility is the de Broglie wavelength
+
+    m1 = ion_mass(particles[0])
+    m2 = ion_mass(particles[1])
+
+    reduced_mass = m1*m2/(m1+m2)
+
+    # What thermal velocity?  How to define this between arbitrary particles?
+
+#    b_deBroglie = hbar/
+
+    bmin = bperp  # temporary
+
+    # The minimum
+
+    lnLambda = np.log(bmax/bmin)
+
+    return lnLambda
+
+

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -1,0 +1,38 @@
+"""Functions to calculate transport coefficients."""
+
+from astropy import units
+
+from ..constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi, ion_mass,
+                         charge_state)
+
+import numpy as np
+
+from ..utils import _check_quantity
+
+
+def Coulomb_logarithm():
+    r"""Returns the Coulomb logarithm.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    The number 15.
+
+    Raises
+    ------
+
+    Notes
+    -----
+
+    Examples
+    --------
+
+    See also
+    --------
+    Debye_number
+
+    """
+
+    return 15.0

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -46,6 +46,11 @@ def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
         If the argument contains NaNs or other invalid values as
         determined by the keywords.
 
+    UserWarning
+        If a Quantity is not provided and unique units are provided, a
+        UserWarning will be raised and the inputted units will be
+        assumed.
+
     Examples
     --------
     >>> from astropy import units as u
@@ -167,7 +172,7 @@ def _check_relativistic(V, funcname, betafrac=0.1):
         raise u.UnitConversionError(errmsg)
 
     if np.any(np.isnan(V.value)):
-        raise ValueError("V includes NaNs in _check_relativistic")
+        raise ValueError("V includes NaNs in " + funcname)
 
     beta = np.max(np.abs((V/c).value))
 


### PR DESCRIPTION
This pull request will create a function called `Coulomb_logarithm` that is needed for a bunch of transport coefficients that involve Coulomb collisions.  This function will need to specify what the particles are that are colliding (e.g., electron-electron or electron-proton collisions).  

There are approximations in the NRL Plasma Formulary, for example, but the expressions there do not contain the physics.  It will be better for people to be able to read the function and understand the physics of what is going on.  The documentation also should have a good, concise discussion of the physics.

The inner length scale is sometimes the de Broglie wavelength, which will require a new function...perhaps in `quantum.py`?  

I would like to get this to be as accurate as we can, so it is rather annoying that the uncertainty in the Coulomb logarithm is of order its reciprocal (e.g., 10-20%).

I haven't really written anything yet so there's no need to review, but it helps to have access to Travis and Coveralls.  If you have a favorite reference that discusses Coulomb logarithms, please let me know!