### PR TITLE
WIP: Decorators

### DIFF
--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -13,7 +13,7 @@ import numpy as np
 # For future: change these into decorators.  _check_quantity does a
 # bit more than @quantity_input as it can allow
 
-from ..utils import _check_quantity, _check_relativistic
+from ..utils import _check_quantity, check_quantity, check_relativistic
 
 
 r"""Values should be returned as an Astropy Quantity in SI units.
@@ -72,6 +72,7 @@ by an angular frequency to get a length scale:
 """
 
 
+@check_relativistic()
 def Alfven_speed(B, density, ion="p"):
     r"""Returns the Alfven speed.
 
@@ -178,11 +179,15 @@ def Alfven_speed(B, density, ion="p"):
     except Exception:
         raise ValueError("Unable to find Alfven speed")
 
-    _check_relativistic(V_A, 'Alfven_speed')
-
     return V_A
 
 
+@check_quantity({
+    'T_i': {'units': units.K, 'can_be_negative': False},
+    'T_e': {'units': units.K, 'can_be_negative': False},
+    'ignore': {'ignore': True}
+})
+@check_relativistic()
 def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
                     gamma_e=1, gamma_i=3, ion='p'):
     r"""Returns the ion sound speed for an electron-ion plasma.
@@ -302,11 +307,6 @@ def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
         raise ValueError("The adiabatic index for ions must be between "
                          "one and infinity")
 
-    _check_quantity(T_i, 'T_i', 'ion_sound_speed', units.K,
-                    can_be_negative=False)
-    _check_quantity(T_e, 'T_e', 'ion_sound_speed', units.K,
-                    can_be_negative=False)
-
     T_i = T_i.to(units.K, equivalencies=units.temperature_energy())
     T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
 
@@ -316,11 +316,13 @@ def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
     except Exception:
         raise ValueError("Unable to find ion sound speed.")
 
-    _check_relativistic(V_S, 'ion_sound_speed')
-
     return V_S
 
 
+@check_quantity({
+    'T_e': {'units': units.K, 'can_be_negative': False}
+})
+@check_relativistic()
 def electron_thermal_speed(T_e):
     r"""Returns the most probable speed for an electron within a
     Maxwellian distribution.
@@ -376,17 +378,16 @@ def electron_thermal_speed(T_e):
 
     """
 
-    _check_quantity(T_e, 'T_e', 'electron_thermal_speed', units.K,
-                    can_be_negative=False)
-
     T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
     V_Te = (np.sqrt(2*k_B*T_e/m_e)).to(units.m/units.s)
-
-    _check_relativistic(V_Te, 'electron_thermal_speed')
 
     return V_Te
 
 
+@check_quantity({
+    'T_i': {'units': units.K, 'can_be_negative': False}
+})
+@check_relativistic()
 def ion_thermal_speed(T_i, ion='p'):
     r"""Returns the most probable speed for an ion within a Maxwellian
     distribution.
@@ -449,9 +450,6 @@ def ion_thermal_speed(T_i, ion='p'):
 
     """
 
-    _check_quantity(T_i, 'T_i', 'ion_thermal_speed', units.K,
-                    can_be_negative=False)
-
     T_i = T_i.to(units.K, equivalencies=units.temperature_energy())
 
     try:
@@ -461,11 +459,12 @@ def ion_thermal_speed(T_i, ion='p'):
 
     V_Ti = (np.sqrt(2*k_B*T_i/m_i)).to(units.m/units.s)
 
-    _check_relativistic(V_Ti, 'ion_thermal_speed')
-
     return V_Ti
 
 
+@check_quantity({
+    'B': {'units': units.T}
+})
 def electron_gyrofrequency(B):
     r"""Calculate the electron gyrofrequency in units of radians per second.
 
@@ -524,13 +523,13 @@ def electron_gyrofrequency(B):
 
     """
 
-    _check_quantity(B, 'B', 'electron_gyrofrequency', units.T)
-
     omega_ce = units.rad*(e*np.abs(B)/m_e).to(1/units.s)
 
     return omega_ce
 
-
+@check_quantity({
+    'B': {'units': units.T}
+})
 def ion_gyrofrequency(B, ion='p'):
     r"""Calculate the ion gyrofrequency in units of radians per second.
 
@@ -591,8 +590,6 @@ def ion_gyrofrequency(B, ion='p'):
     >>> ion_gyrofrequency(0.01*u.T, ion='T')
 
     """
-
-    _check_quantity(B, 'B', 'ion_gyrofrequency', units.T)
 
     try:
         m_i = ion_mass(ion)
@@ -842,6 +839,9 @@ def ion_gyroradius(B, *args, Vperp=None, T_i=None, ion='p'):
     return r_Li.to(units.m, equivalencies=units.dimensionless_angles())
 
 
+@check_quantity({
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
 def electron_plasma_frequency(n_e):
     r"""Calculates the electron plasma frequency.
 
@@ -892,14 +892,14 @@ def electron_plasma_frequency(n_e):
 
     """
 
-    _check_quantity(n_e, 'n_e', 'electron_plasma_frequency', units.m**-3,
-                    can_be_negative=False)
-
     omega_pe = (units.rad*e*np.sqrt(n_e/(eps0*m_e))).to(units.rad/units.s)
 
     return omega_pe
 
 
+@check_quantity({
+    'n_i': {'units': units.m**-3, 'can_be_negative': False}
+})
 def ion_plasma_frequency(n_i, ion='p'):
     r"""Calculates the ion plasma frequency.
 
@@ -958,9 +958,6 @@ def ion_plasma_frequency(n_i, ion='p'):
 
     """
 
-    _check_quantity(n_i, 'n_i', 'ion_plasma_frequency', units.m**-3,
-                    can_be_negative=False)
-
     try:
         m_i = ion_mass(ion)
         Z = charge_state(ion)
@@ -974,6 +971,10 @@ def ion_plasma_frequency(n_i, ion='p'):
     return omega_pi.si
 
 
+@check_quantity({
+    'T_e': {'units': units.K, 'can_be_negative': False},
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
 def Debye_length(T_e, n_e):
     r"""Calculate the Debye length.
 
@@ -1033,11 +1034,6 @@ def Debye_length(T_e, n_e):
 
     """
 
-    _check_quantity(T_e, 'T_e', 'Debye_length', units.K,
-                    can_be_negative=False)
-    _check_quantity(n_e, 'n_e', 'Debye_length', units.m**-3,
-                    can_be_negative=False)
-
     T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
 
     try:
@@ -1048,6 +1044,10 @@ def Debye_length(T_e, n_e):
     return lambda_D
 
 
+@check_quantity({
+    'T_e': {'units': units.K, 'can_be_negative': False},
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
 def Debye_number(T_e, n_e):
     r"""Returns the Debye number.
 
@@ -1102,11 +1102,6 @@ def Debye_number(T_e, n_e):
 
     """
 
-    _check_quantity(T_e, 'T_e', 'Debye_number', units.K,
-                    can_be_negative=False)
-    _check_quantity(n_e, 'n_e', 'Debye_number', units.m**-3,
-                    can_be_negative=False)
-
     try:
         lambda_D = Debye_length(T_e, n_e)
         N_D = (4/3)*np.pi*n_e*lambda_D**3
@@ -1116,6 +1111,9 @@ def Debye_number(T_e, n_e):
     return N_D.to(units.dimensionless_unscaled)
 
 
+@check_quantity({
+    'n_i': {'units': units.m**-3, 'can_be_negative': False}
+})
 def ion_inertial_length(n_i, ion='p'):
     r"""Calculate the ion inertial length,
 
@@ -1170,15 +1168,15 @@ def ion_inertial_length(n_i, ion='p'):
     except Exception:
         raise ValueError("Invalid ion in ion_inertial_length.")
 
-    _check_quantity(n_i, 'n_i', 'ion_inertial_length', units.m**-3,
-                    can_be_negative=False)
-
     omega_pi = ion_plasma_frequency(n_i, ion=ion)
     d_i = (c/omega_pi).to(units.m, equivalencies=units.dimensionless_angles())
 
     return d_i
 
 
+@check_quantity({
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
 def electron_inertial_length(n_e):
     r"""Returns the electron inertial length.
 
@@ -1222,15 +1220,15 @@ def electron_inertial_length(n_e):
 
     """
 
-    _check_quantity(n_e, 'n_e', 'electron_inertial_length', units.m**-3,
-                    can_be_negative=False)
-
     omega_pe = electron_plasma_frequency(n_e)
     d_e = (c/omega_pe).to(units.m, equivalencies=units.dimensionless_angles())
 
     return d_e
 
 
+@check_quantity({
+    'B': {'units': units.T}
+})
 def magnetic_pressure(B):
     r"""Calculate the magnetic pressure.
 
@@ -1284,13 +1282,14 @@ def magnetic_pressure(B):
 
     """
 
-    _check_quantity(B, 'B', 'magnetic_pressure', units.T)
-
     p_B = (B**2/(2*mu0)).to(units.Pa)
 
     return p_B
 
 
+@check_quantity({
+    'B': {'units': units.T}
+})
 def magnetic_energy_density(B):
     r"""Calculate the magnetic energy density.
 
@@ -1344,13 +1343,15 @@ def magnetic_energy_density(B):
 
     """
 
-    _check_quantity(B, 'B', 'magnetic_energy_density', units.T)
-
     E_B = (B**2/(2*mu0)).to(units.J/units.m**3)
 
     return E_B
 
 
+@check_quantity({
+    'B': {'units': units.T},
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
 def upper_hybrid_frequency(B, n_e):
     r"""Returns the upper hybrid frequency.
 
@@ -1400,10 +1401,6 @@ def upper_hybrid_frequency(B, n_e):
 
     """
 
-    _check_quantity(B, 'B', 'upper_hybrid_frequency', units.T)
-    _check_quantity(n_e, 'n_e', 'upper_hybrid_frequency', units.m**-3,
-                    can_be_negative=False)
-
     try:
         omega_pe = electron_plasma_frequency(n_e=n_e)
         omega_ce = electron_gyrofrequency(B)
@@ -1414,6 +1411,10 @@ def upper_hybrid_frequency(B, n_e):
     return omega_uh
 
 
+@check_quantity({
+    'B': {'units': units.T},
+    'n_i': {'units': units.m**-3, 'can_be_negative': False}
+})
 def lower_hybrid_frequency(B, n_i, ion='p'):
     r"""Returns the lower hybrid frequency.
 
@@ -1472,10 +1473,6 @@ def lower_hybrid_frequency(B, n_i, ion='p'):
     <Quantity 578372732.8478782 rad / s>
 
     """
-
-    _check_quantity(B, 'B', 'lower_hybrid_frequency', units.T)
-    _check_quantity(n_i, 'n_i', 'lower_hybrid_frequency', units.m**-3,
-                    can_be_negative=False)
 
     # We do not need a charge state here, so the sole intent is to
     # catch invalid ions.

--- a/plasmapy/utils/__init__.py
+++ b/plasmapy/utils/__init__.py
@@ -1,2 +1,3 @@
 from .checks import (_check_quantity,
-                     _check_relativistic)
+                     check_quantity,
+                     check_relativistic)

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -5,108 +5,124 @@ from astropy import units as u
 import pytest
 
 from ...constants import c
-from ..checks import (_check_quantity, _check_relativistic)
+from ..checks import (check_quantity, check_relativistic)
 
 
 def test__check_quantity():
+    def run_test(arg_value, units, can_be_negative=True, can_be_complex=False, can_be_inf=True):
+        """ Tests the check_quantity decorator
+        Tests that the given value is an astropy Quantity with correct units
+        and valid numerical values
+        Builds a method, decorates it, and immediately calls it
+        """
+        @check_quantity({
+            'arg': {'units': units, 'can_be_negative': can_be_negative, 'can_be_complex': can_be_complex, 'can_be_inf': can_be_inf}
+        })
+        def test_method(arg): pass
+        test_method(arg_value)
 
     # exceptions associated with the units keyword
+    with pytest.raises(TypeError):
+        run_test(5*u.T, 5*u.T)
 
     with pytest.raises(TypeError):
-        _check_quantity(5*u.T, 'arg', 'funcname', 5*u.T)
+        run_test(5*u.T, 5)
 
     with pytest.raises(TypeError):
-        _check_quantity(5*u.T, 'arg', 'funcname', 5)
+        run_test(5*u.T, [u.T, 1])
 
     with pytest.raises(TypeError):
-        _check_quantity(5*u.T, 'arg', 'funcname', [u.T, 1])
+        run_test(5*u.T, [1, u.m])
 
     with pytest.raises(TypeError):
-        _check_quantity(5*u.T, 'arg', 'funcname', [1, u.m])
-
-    with pytest.raises(TypeError):
-        _check_quantity(u.T, 'arg', 'funcname', u.J)
+        run_test(u.T, u.J)
 
     with pytest.raises(UserWarning):
-        _check_quantity(5.0, 'arg', 'funcname', u.m)
+        run_test(5.0, u.m)
 
     with pytest.raises(u.UnitConversionError):
-        _check_quantity(3*u.m/u.s, 'V', 'f', u.m)
+        run_test(3*u.m/u.s, u.m)
 
     # check basic functionality
 
-    _check_quantity(5*u.T, 'B', 'f', u.T)
-    _check_quantity(3*u.m/u.s, 'V', 'f', u.m/u.s)
-    _check_quantity(3*u.m/u.s, 'V', 'f', [u.m/u.s])
-    _check_quantity(3*u.m/u.s**2, 'a', 'f', [u.m/u.s, u.m/(u.s**2)])
-    _check_quantity(3*u.km/u.yr, 'V', 'f', u.m/u.s)
+    run_test(5*u.T, u.T)
+    run_test(3*u.m/u.s, u.m/u.s)
+    run_test(3*u.m/u.s, [u.m/u.s])
+    run_test(3*u.m/u.s**2, [u.m/u.s, u.m/(u.s**2)])
+    run_test(3*u.km/u.yr, u.m/u.s)
 
     # check temperature in units of energy per particle (e.g., eV)
 
-    _check_quantity(5*u.eV, 'T', 'f', u.K)
-    _check_quantity(5*u.K, 'T', 'f', u.eV)
-    _check_quantity(5*u.keV, 'T', 'f', [u.m, u.K])
+    run_test(5*u.eV, u.K)
+    run_test(5*u.K, u.eV)
+    run_test(5*u.keV, [u.m, u.K])
 
     # check keywords relating to numerical values
 
-    _check_quantity(5j*u.m, 'L', 'f', u.m, can_be_complex=True)
-    _check_quantity(np.inf*u.T, 'B', 'f', u.T)
+    run_test(5j*u.m, u.m, can_be_complex=True)
+    run_test(np.inf*u.T, u.T)
 
     with pytest.raises(ValueError):
-        _check_quantity(-5*u.K, 'T', 'f', u.K, can_be_negative=False)
+        run_test(-5*u.K, u.K, can_be_negative=False)
 
     with pytest.raises(ValueError):
-        _check_quantity(5j*u.K, 'T', 'f', u.K)
+        run_test(5j*u.K, u.K)
 
     with pytest.raises(ValueError):
-        _check_quantity(np.inf*u.K, 'T', 'f', u.K, can_be_inf=False)
+        run_test(np.inf*u.K, u.K, can_be_inf=False)
 
 
 def test__check_relativistic():
 
-    _check_relativistic(0*u.m/u.s, 'f')
-    _check_relativistic(0.099999*c, 'f')
-    _check_relativistic(-0.09*c, 'f')
-    _check_relativistic(5*u.AA/u.Gyr, 'f')
+    def run_test(value, betafrac=0.1):
+        @check_relativistic(betafrac=betafrac)
+        def test_method():
+            return value
+        test_method()
+
+    run_test(0*u.m/u.s)
+    run_test(0.099999*c)
+    run_test(-0.09*c)
+    run_test(5*u.AA/u.Gyr)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(0.11*c, 'f')
+        run_test(0.11*c)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(1.0*c, 'f')
+        run_test(1.0*c)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(1.1*c, 'f')
+        run_test(1.1*c)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(np.inf*u.cm/u.s, 'f')
+        run_test(np.inf*u.cm/u.s)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(-0.11*c, 'f')
+        run_test(-0.11*c)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(-1.0*c, 'f')
+        run_test(-1.0*c)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(-1.1*c, 'f')
+        run_test(-1.1*c)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(-np.inf*u.cm/u.s, 'f')
+        run_test(-np.inf*u.cm/u.s)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(2997924581*u.cm/u.s, 'f')
+        run_test(2997924581*u.cm/u.s)
 
     with pytest.raises(UserWarning):
-        _check_relativistic(0.02*c, 'f', betafrac=0.01)
+        run_test(0.02*c, betafrac=0.01)
 
     with pytest.raises(TypeError):
-        _check_relativistic(u.m/u.s, 'f')
+        run_test(u.m/u.s)
 
     with pytest.raises(TypeError):
-        _check_relativistic(51513.35, 'f')
+        run_test(51513.35)
 
     with pytest.raises(u.UnitConversionError):
-        _check_relativistic(5*u.m, 'f')
+        run_test(5*u.m)
 
     with pytest.raises(ValueError):
-        _check_relativistic(np.nan*u.m/u.s, 'f')
+        run_test(np.nan*u.m/u.s)


### PR DESCRIPTION
Closes #55 

This is a work-in-progress. Still to do:
* figure out how to handle the cases in `parameters.py` where computation happens before the original calls to `_check_quantity`
* once that is done, clean up the remaining export of `_check_quantity` in `utils/__init__.py` and nest that method inside of the `check_quantity` decorator to keep the namespace clean
* clean up documentation, including providing a documentation of the options provided in the validation dicts: `units`, `can_be_negative`, `can_be_complex`, `can_be_inf`, and `ignore`

Some features of the decorators:
* eliminates the need to repeat the function name- it's pulled from the Python function metadata
* `@check_quantity` works fine with default parameters, and also verifies that the given default is correct (if forced to fall back to the default)
* if a function is marked `@check_quantity`, its params must match the given validation dict exactly. If it does not, a `TypeError` is thrown. This includes if a parameter gets renamed in the method definition, but not in the validation dict, and vice versa. This will stop parameters from getting silently skipped from validation if someone carelessly renames a param.
* if a function is marked `@check_quantity`, then all of its parameters that are of type `units.Quantity` must be validated or explicitly ignored by providing a `{ 'ignore': True }` dict for that param

This also cleans up the tests nicely, since we don't have to provide a fake function name and arg name anymore.