### PR TITLE
Check decorators

### DIFF
--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -1321,6 +1321,7 @@ def magnetic_energy_density(B: units.T):
 
     return E_B
 
+
 @check_quantity("B")
 @check_quantity("n_e", can_be_negative=False)
 def upper_hybrid_frequency(B: units.T, n_e: units.m**-3):
@@ -1384,7 +1385,7 @@ def upper_hybrid_frequency(B: units.T, n_e: units.m**-3):
 
 @check_quantity("B")
 @check_quantity("n_i", can_be_negative=False)
-def lower_hybrid_frequency(B: units.T, n_i:units.m**-3, ion='p'):
+def lower_hybrid_frequency(B: units.T, n_i: units.m**-3, ion='p'):
     r"""Returns the lower hybrid frequency.
 
     Parameters

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -13,7 +13,7 @@ import numpy as np
 # For future: change these into decorators.  _check_quantity does a
 # bit more than @quantity_input as it can allow
 
-from ..utils import _check_quantity, _check_relativistic
+from ..utils import _check_quantity, check_relativistic, check_quantity
 
 
 r"""Values should be returned as an Astropy Quantity in SI units.
@@ -72,6 +72,7 @@ by an angular frequency to get a length scale:
 """
 
 
+@check_relativistic
 def Alfven_speed(B, density, ion="p"):
     r"""Returns the Alfven speed.
 
@@ -178,12 +179,13 @@ def Alfven_speed(B, density, ion="p"):
     except Exception:
         raise ValueError("Unable to find Alfven speed")
 
-    _check_relativistic(V_A, 'Alfven_speed')
-
     return V_A
 
 
-def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
+@check_relativistic
+@check_quantity("T_e", can_be_negative=False)
+@check_quantity("T_i", can_be_negative=False)
+def ion_sound_speed(*ignore, T_e: units.K=0*units.K, T_i: units.K=0*units.K,
                     gamma_e=1, gamma_i=3, ion='p'):
     r"""Returns the ion sound speed for an electron-ion plasma.
 
@@ -302,11 +304,6 @@ def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
         raise ValueError("The adiabatic index for ions must be between "
                          "one and infinity")
 
-    _check_quantity(T_i, 'T_i', 'ion_sound_speed', units.K,
-                    can_be_negative=False)
-    _check_quantity(T_e, 'T_e', 'ion_sound_speed', units.K,
-                    can_be_negative=False)
-
     T_i = T_i.to(units.K, equivalencies=units.temperature_energy())
     T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
 
@@ -316,12 +313,12 @@ def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
     except Exception:
         raise ValueError("Unable to find ion sound speed.")
 
-    _check_relativistic(V_S, 'ion_sound_speed')
-
     return V_S
 
 
-def electron_thermal_speed(T_e):
+@check_relativistic
+@check_quantity("T_e", can_be_negative=False)
+def electron_thermal_speed(T_e: units.K):
     r"""Returns the most probable speed for an electron within a
     Maxwellian distribution.
 
@@ -376,18 +373,15 @@ def electron_thermal_speed(T_e):
 
     """
 
-    _check_quantity(T_e, 'T_e', 'electron_thermal_speed', units.K,
-                    can_be_negative=False)
-
     T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
     V_Te = (np.sqrt(2*k_B*T_e/m_e)).to(units.m/units.s)
-
-    _check_relativistic(V_Te, 'electron_thermal_speed')
 
     return V_Te
 
 
-def ion_thermal_speed(T_i, ion='p'):
+@check_relativistic
+@check_quantity("T_i", can_be_negative=False)
+def ion_thermal_speed(T_i: units.K, ion='p'):
     r"""Returns the most probable speed for an ion within a Maxwellian
     distribution.
 
@@ -449,9 +443,6 @@ def ion_thermal_speed(T_i, ion='p'):
 
     """
 
-    _check_quantity(T_i, 'T_i', 'ion_thermal_speed', units.K,
-                    can_be_negative=False)
-
     T_i = T_i.to(units.K, equivalencies=units.temperature_energy())
 
     try:
@@ -461,12 +452,11 @@ def ion_thermal_speed(T_i, ion='p'):
 
     V_Ti = (np.sqrt(2*k_B*T_i/m_i)).to(units.m/units.s)
 
-    _check_relativistic(V_Ti, 'ion_thermal_speed')
-
     return V_Ti
 
 
-def electron_gyrofrequency(B):
+@check_quantity("B")
+def electron_gyrofrequency(B: units.T):
     r"""Calculate the electron gyrofrequency in units of radians per second.
 
     Parameters
@@ -524,14 +514,13 @@ def electron_gyrofrequency(B):
 
     """
 
-    _check_quantity(B, 'B', 'electron_gyrofrequency', units.T)
-
     omega_ce = units.rad*(e*np.abs(B)/m_e).to(1/units.s)
 
     return omega_ce
 
 
-def ion_gyrofrequency(B, ion='p'):
+@check_quantity("B")
+def ion_gyrofrequency(B: units.T, ion='p'):
     r"""Calculate the ion gyrofrequency in units of radians per second.
 
     Parameters
@@ -591,8 +580,6 @@ def ion_gyrofrequency(B, ion='p'):
     >>> ion_gyrofrequency(0.01*u.T, ion='T')
 
     """
-
-    _check_quantity(B, 'B', 'ion_gyrofrequency', units.T)
 
     try:
         m_i = ion_mass(ion)
@@ -842,7 +829,8 @@ def ion_gyroradius(B, *args, Vperp=None, T_i=None, ion='p'):
     return r_Li.to(units.m, equivalencies=units.dimensionless_angles())
 
 
-def electron_plasma_frequency(n_e):
+@check_quantity("n_e", can_be_negative=False)
+def electron_plasma_frequency(n_e: units.m**-3):
     r"""Calculates the electron plasma frequency.
 
     Parameters
@@ -892,15 +880,13 @@ def electron_plasma_frequency(n_e):
 
     """
 
-    _check_quantity(n_e, 'n_e', 'electron_plasma_frequency', units.m**-3,
-                    can_be_negative=False)
-
     omega_pe = (units.rad*e*np.sqrt(n_e/(eps0*m_e))).to(units.rad/units.s)
 
     return omega_pe
 
 
-def ion_plasma_frequency(n_i, ion='p'):
+@check_quantity("n_i", can_be_negative=False)
+def ion_plasma_frequency(n_i: units.m**-3, ion='p'):
     r"""Calculates the ion plasma frequency.
 
     Parameters
@@ -958,9 +944,6 @@ def ion_plasma_frequency(n_i, ion='p'):
 
     """
 
-    _check_quantity(n_i, 'n_i', 'ion_plasma_frequency', units.m**-3,
-                    can_be_negative=False)
-
     try:
         m_i = ion_mass(ion)
         Z = charge_state(ion)
@@ -974,7 +957,9 @@ def ion_plasma_frequency(n_i, ion='p'):
     return omega_pi.si
 
 
-def Debye_length(T_e, n_e):
+@check_quantity("T_e", can_be_negative=False)
+@check_quantity("n_e", can_be_negative=False)
+def Debye_length(T_e: units.K, n_e: units.m**-3):
     r"""Calculate the Debye length.
 
     Parameters
@@ -1033,11 +1018,6 @@ def Debye_length(T_e, n_e):
 
     """
 
-    _check_quantity(T_e, 'T_e', 'Debye_length', units.K,
-                    can_be_negative=False)
-    _check_quantity(n_e, 'n_e', 'Debye_length', units.m**-3,
-                    can_be_negative=False)
-
     T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
 
     try:
@@ -1048,7 +1028,9 @@ def Debye_length(T_e, n_e):
     return lambda_D
 
 
-def Debye_number(T_e, n_e):
+@check_quantity("T_e", can_be_negative=False)
+@check_quantity("n_e", can_be_negative=False)
+def Debye_number(T_e: units.K, n_e: units.m**-3):
     r"""Returns the Debye number.
 
     Parameters
@@ -1102,11 +1084,6 @@ def Debye_number(T_e, n_e):
 
     """
 
-    _check_quantity(T_e, 'T_e', 'Debye_number', units.K,
-                    can_be_negative=False)
-    _check_quantity(n_e, 'n_e', 'Debye_number', units.m**-3,
-                    can_be_negative=False)
-
     try:
         lambda_D = Debye_length(T_e, n_e)
         N_D = (4/3)*np.pi*n_e*lambda_D**3
@@ -1116,7 +1093,8 @@ def Debye_number(T_e, n_e):
     return N_D.to(units.dimensionless_unscaled)
 
 
-def ion_inertial_length(n_i, ion='p'):
+@check_quantity("n_i", can_be_negative=False)
+def ion_inertial_length(n_i: units.m**-3, ion='p'):
     r"""Calculate the ion inertial length,
 
     Parameters
@@ -1170,16 +1148,14 @@ def ion_inertial_length(n_i, ion='p'):
     except Exception:
         raise ValueError("Invalid ion in ion_inertial_length.")
 
-    _check_quantity(n_i, 'n_i', 'ion_inertial_length', units.m**-3,
-                    can_be_negative=False)
-
     omega_pi = ion_plasma_frequency(n_i, ion=ion)
     d_i = (c/omega_pi).to(units.m, equivalencies=units.dimensionless_angles())
 
     return d_i
 
 
-def electron_inertial_length(n_e):
+@check_quantity("n_e", can_be_negative=False)
+def electron_inertial_length(n_e: units.m**-3):
     r"""Returns the electron inertial length.
 
     Parameters
@@ -1222,16 +1198,14 @@ def electron_inertial_length(n_e):
 
     """
 
-    _check_quantity(n_e, 'n_e', 'electron_inertial_length', units.m**-3,
-                    can_be_negative=False)
-
     omega_pe = electron_plasma_frequency(n_e)
     d_e = (c/omega_pe).to(units.m, equivalencies=units.dimensionless_angles())
 
     return d_e
 
 
-def magnetic_pressure(B):
+@check_quantity("B")
+def magnetic_pressure(B: units.T):
     r"""Calculate the magnetic pressure.
 
     Parameters
@@ -1284,14 +1258,13 @@ def magnetic_pressure(B):
 
     """
 
-    _check_quantity(B, 'B', 'magnetic_pressure', units.T)
-
     p_B = (B**2/(2*mu0)).to(units.Pa)
 
     return p_B
 
 
-def magnetic_energy_density(B):
+@check_quantity("B")
+def magnetic_energy_density(B: units.T):
     r"""Calculate the magnetic energy density.
 
     Parameters
@@ -1344,14 +1317,13 @@ def magnetic_energy_density(B):
 
     """
 
-    _check_quantity(B, 'B', 'magnetic_energy_density', units.T)
-
     E_B = (B**2/(2*mu0)).to(units.J/units.m**3)
 
     return E_B
 
-
-def upper_hybrid_frequency(B, n_e):
+@check_quantity("B")
+@check_quantity("n_e", can_be_negative=False)
+def upper_hybrid_frequency(B: units.T, n_e: units.m**-3):
     r"""Returns the upper hybrid frequency.
 
     Parameters
@@ -1400,10 +1372,6 @@ def upper_hybrid_frequency(B, n_e):
 
     """
 
-    _check_quantity(B, 'B', 'upper_hybrid_frequency', units.T)
-    _check_quantity(n_e, 'n_e', 'upper_hybrid_frequency', units.m**-3,
-                    can_be_negative=False)
-
     try:
         omega_pe = electron_plasma_frequency(n_e=n_e)
         omega_ce = electron_gyrofrequency(B)
@@ -1414,7 +1382,9 @@ def upper_hybrid_frequency(B, n_e):
     return omega_uh
 
 
-def lower_hybrid_frequency(B, n_i, ion='p'):
+@check_quantity("B")
+@check_quantity("n_i", can_be_negative=False)
+def lower_hybrid_frequency(B: units.T, n_i:units.m**-3, ion='p'):
     r"""Returns the lower hybrid frequency.
 
     Parameters
@@ -1472,10 +1442,6 @@ def lower_hybrid_frequency(B, n_i, ion='p'):
     <Quantity 578372732.8478782 rad / s>
 
     """
-
-    _check_quantity(B, 'B', 'lower_hybrid_frequency', units.T)
-    _check_quantity(n_i, 'n_i', 'lower_hybrid_frequency', units.m**-3,
-                    can_be_negative=False)
 
     # We do not need a charge state here, so the sole intent is to
     # catch invalid ions.

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -183,9 +183,11 @@ def Alfven_speed(B, density, ion="p"):
 
 
 @check_relativistic
-@check_quantity("T_e", can_be_negative=False)
-@check_quantity("T_i", can_be_negative=False)
-def ion_sound_speed(*ignore, T_e: units.K=0*units.K, T_i: units.K=0*units.K,
+@check_quantity({
+    'T_i': {'units': units.K, 'can_be_negative': False},
+    'T_e': {'units': units.K, 'can_be_negative': False}
+})
+def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
                     gamma_e=1, gamma_i=3, ion='p'):
     r"""Returns the ion sound speed for an electron-ion plasma.
 
@@ -317,8 +319,10 @@ def ion_sound_speed(*ignore, T_e: units.K=0*units.K, T_i: units.K=0*units.K,
 
 
 @check_relativistic
-@check_quantity("T_e", can_be_negative=False)
-def electron_thermal_speed(T_e: units.K):
+@check_quantity({
+    'T_e': {'units': units.K, 'can_be_negative': False}
+})
+def electron_thermal_speed(T_e):
     r"""Returns the most probable speed for an electron within a
     Maxwellian distribution.
 
@@ -380,8 +384,10 @@ def electron_thermal_speed(T_e: units.K):
 
 
 @check_relativistic
-@check_quantity("T_i", can_be_negative=False)
-def ion_thermal_speed(T_i: units.K, ion='p'):
+@check_quantity({
+    'T_i': {'units': units.K, 'can_be_negative': False}
+})
+def ion_thermal_speed(T_i, ion='p'):
     r"""Returns the most probable speed for an ion within a Maxwellian
     distribution.
 
@@ -455,8 +461,10 @@ def ion_thermal_speed(T_i: units.K, ion='p'):
     return V_Ti
 
 
-@check_quantity("B")
-def electron_gyrofrequency(B: units.T):
+@check_quantity({
+    'B': {'units': units.T}
+})
+def electron_gyrofrequency(B):
     r"""Calculate the electron gyrofrequency in units of radians per second.
 
     Parameters
@@ -519,8 +527,10 @@ def electron_gyrofrequency(B: units.T):
     return omega_ce
 
 
-@check_quantity("B")
-def ion_gyrofrequency(B: units.T, ion='p'):
+@check_quantity({
+    'B': {'units': units.T}
+})
+def ion_gyrofrequency(B, ion='p'):
     r"""Calculate the ion gyrofrequency in units of radians per second.
 
     Parameters
@@ -829,8 +839,10 @@ def ion_gyroradius(B, *args, Vperp=None, T_i=None, ion='p'):
     return r_Li.to(units.m, equivalencies=units.dimensionless_angles())
 
 
-@check_quantity("n_e", can_be_negative=False)
-def electron_plasma_frequency(n_e: units.m**-3):
+@check_quantity({
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
+def electron_plasma_frequency(n_e):
     r"""Calculates the electron plasma frequency.
 
     Parameters
@@ -885,8 +897,10 @@ def electron_plasma_frequency(n_e: units.m**-3):
     return omega_pe
 
 
-@check_quantity("n_i", can_be_negative=False)
-def ion_plasma_frequency(n_i: units.m**-3, ion='p'):
+@check_quantity({
+    'n_i': {'units': units.m**-3, 'can_be_negative': False}
+})
+def ion_plasma_frequency(n_i, ion='p'):
     r"""Calculates the ion plasma frequency.
 
     Parameters
@@ -957,9 +971,11 @@ def ion_plasma_frequency(n_i: units.m**-3, ion='p'):
     return omega_pi.si
 
 
-@check_quantity("T_e", can_be_negative=False)
-@check_quantity("n_e", can_be_negative=False)
-def Debye_length(T_e: units.K, n_e: units.m**-3):
+@check_quantity({
+    'T_e': {'units': units.K, 'can_be_negative': False},
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
+def Debye_length(T_e, n_e):
     r"""Calculate the Debye length.
 
     Parameters
@@ -1028,9 +1044,11 @@ def Debye_length(T_e: units.K, n_e: units.m**-3):
     return lambda_D
 
 
-@check_quantity("T_e", can_be_negative=False)
-@check_quantity("n_e", can_be_negative=False)
-def Debye_number(T_e: units.K, n_e: units.m**-3):
+@check_quantity({
+    'T_e': {'units': units.K, 'can_be_negative': False},
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
+def Debye_number(T_e, n_e):
     r"""Returns the Debye number.
 
     Parameters
@@ -1093,8 +1111,10 @@ def Debye_number(T_e: units.K, n_e: units.m**-3):
     return N_D.to(units.dimensionless_unscaled)
 
 
-@check_quantity("n_i", can_be_negative=False)
-def ion_inertial_length(n_i: units.m**-3, ion='p'):
+@check_quantity({
+    'n_i': {'units': units.m**-3, 'can_be_negative': False}
+})
+def ion_inertial_length(n_i, ion='p'):
     r"""Calculate the ion inertial length,
 
     Parameters
@@ -1154,8 +1174,10 @@ def ion_inertial_length(n_i: units.m**-3, ion='p'):
     return d_i
 
 
-@check_quantity("n_e", can_be_negative=False)
-def electron_inertial_length(n_e: units.m**-3):
+@check_quantity({
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
+def electron_inertial_length(n_e):
     r"""Returns the electron inertial length.
 
     Parameters
@@ -1204,8 +1226,10 @@ def electron_inertial_length(n_e: units.m**-3):
     return d_e
 
 
-@check_quantity("B")
-def magnetic_pressure(B: units.T):
+@check_quantity({
+    'B': {'units': units.T}
+})
+def magnetic_pressure(B):
     r"""Calculate the magnetic pressure.
 
     Parameters
@@ -1263,7 +1287,9 @@ def magnetic_pressure(B: units.T):
     return p_B
 
 
-@check_quantity("B")
+@check_quantity({
+    'B': {'units': units.T}
+})
 def magnetic_energy_density(B: units.T):
     r"""Calculate the magnetic energy density.
 
@@ -1322,9 +1348,11 @@ def magnetic_energy_density(B: units.T):
     return E_B
 
 
-@check_quantity("B")
-@check_quantity("n_e", can_be_negative=False)
-def upper_hybrid_frequency(B: units.T, n_e: units.m**-3):
+@check_quantity({
+    'B': {'units': units.T},
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
+def upper_hybrid_frequency(B, n_e):
     r"""Returns the upper hybrid frequency.
 
     Parameters
@@ -1383,9 +1411,11 @@ def upper_hybrid_frequency(B: units.T, n_e: units.m**-3):
     return omega_uh
 
 
-@check_quantity("B")
-@check_quantity("n_i", can_be_negative=False)
-def lower_hybrid_frequency(B: units.T, n_i: units.m**-3, ion='p'):
+@check_quantity({
+    'B': {'units': units.T},
+    'n_i': {'units': units.m**-3, 'can_be_negative': False}
+})
+def lower_hybrid_frequency(B, n_i, ion='p'):
     r"""Returns the lower hybrid frequency.
 
     Parameters

--- a/plasmapy/utils/__init__.py
+++ b/plasmapy/utils/__init__.py
@@ -1,2 +1,4 @@
 from .checks import (_check_quantity,
-                     _check_relativistic)
+                     _check_relativistic,
+                     check_quantity,
+                     check_relativistic)

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -51,6 +51,7 @@ def check_quantity(argname, can_be_negative=True,
     >>> def func(x: u.m, y: u.s=1*u.s):
     >>>     return x
     >>> func(1*u.m, 2*u.s)
+
     """
     def decorator(f):
         wrapped_sign = inspect.signature(f)

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -6,8 +6,7 @@ from astropy import units as u
 from ..constants import c
 
 
-def check_quantity(validations, can_be_negative=True,
-                   can_be_complex=False, can_be_inf=True):
+def check_quantity(validations):
     """Raises exceptions if `argname` in decorated function is not an
     astropy Quantity with correct units and valid numerical values.
 
@@ -64,19 +63,25 @@ def check_quantity(validations, can_be_negative=True,
             # names of params to check
             validated_params = set(validations.keys())
 
-            missing_params = [param for param in (validated_params - given_params)]
+            missing_params = [
+                param for param in (validated_params - given_params)
+            ]
 
             if len(missing_params) > 0:
                 params_str = ", ".join(missing_params)
                 raise TypeError(
-                    f"Call to {fname} is missing validated params {params_str}")
+                    f"Call to {fname} is missing "
+                    f"validated params {params_str}")
 
             for param_to_check, validation_settings in validations.items():
                 value_to_check = given_params_values[param_to_check]
 
-                can_be_negative = validation_settings.get('can_be_negative', True)
-                can_be_complex = validation_settings.get('can_be_complex', False)
-                can_be_inf = validation_settings.get('can_be_inf', True)
+                can_be_negative = validation_settings.get(
+                    'can_be_negative', True)
+                can_be_complex = validation_settings.get(
+                    'can_be_complex', False)
+                can_be_inf = validation_settings.get(
+                    'can_be_inf', True)
 
                 _check_quantity(value_to_check,
                                 param_to_check,
@@ -85,7 +90,6 @@ def check_quantity(validations, can_be_negative=True,
                                 can_be_negative=can_be_negative,
                                 can_be_complex=can_be_complex,
                                 can_be_inf=can_be_inf)
-
 
             return f(*args, **kwargs)
         return wrapper

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -47,9 +47,10 @@ def check_quantity(argname, can_be_negative=True,
     --------
     >>> from astropy import units as u
     >>> @check_quantity("x")
-    >>> def func(x: u.m):
+    >>> @check_quantity("y", can_be_negative=False)
+    >>> def func(x: u.m, y: u.s=1*u.s):
     >>>     return x
-    >>> func(1*u.m)
+    >>> func(1*u.m, 2*u.s)
     """
     def decorator(f):
         wrapped_sign = inspect.signature(f)

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -1,7 +1,50 @@
+from functools import wraps
 import numpy as np
 from astropy import units as u
 from ..constants import c
 
+
+def check_relativistic(func=None, betafrac=0.1):
+    """Raises an error when the output of the decorated
+    function is greater than betafrac times the speed of light
+
+    Parameters
+    ----------
+    func : function, optional
+        The function to decorate
+    betafrac : float, optional
+        The minimum fraction of the speed of light that will raise a
+        UserWarning
+
+    Returns
+    -------
+    function
+        Decorated function
+
+    Examples
+    --------
+    >>> from astropy import units as u
+    >>> @check_relativistic
+    >>> def speed():
+    >>>     return 1*u.m/u.s
+
+    Passing in a custom `betafrac`
+    >>> @check_relativistic(betafrac=0.01)
+    >>> def speed():
+    >>>     return 1*u.m/u.s
+
+    """
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return_ = f(*args, **kwargs)
+            _check_relativistic(return_, f.__name__,
+                                betafrac=betafrac)
+            return return_
+        return wrapper
+    if func:
+        return decorator(func)
+    return decorator
 
 def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
                     can_be_complex=False, can_be_inf=True):

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -61,7 +61,7 @@ def check_quantity(argname, can_be_negative=True,
             bind_args = wrapped_sign.bind(*args, **kwargs)
             try:
                 param = wrapped_sign.parameters[argname]
-            except:
+            except KeyError:
                 raise ValueError(f"{argname} is not an argument name")
 
             # Handle keyword arguments that uses default values

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -65,7 +65,8 @@ def test__check_quantity_errors_non_default(
                         can_be_inf=can_be_inf)
 
 
-@pytest.mark.parametrize("value, units, error", quantity_error_examples_default)
+@pytest.mark.parametrize(
+    "value, units, error", quantity_error_examples_default)
 def test__check_quantity_errors_default(value, units, error):
     with pytest.raises(error):
         _check_quantity(value, 'arg', 'funcname', units)
@@ -88,7 +89,8 @@ def test__check_quantity_default(value, units):
 
 
 # Tests for check_quantity decorator
-@pytest.mark.parametrize("value, units, error", quantity_error_examples_default)
+@pytest.mark.parametrize(
+    "value, units, error", quantity_error_examples_default)
 def test_check_quantity_decorator_errors_default(value, units, error):
 
     @check_quantity("x")

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -64,12 +64,15 @@ def test__check_quantity():
         _check_quantity(np.inf*u.K, 'T', 'f', u.K, can_be_inf=False)
 
 
+# (speed, betafrac)
 non_relativistic_speeds = [
     (0*u.m/u.s, 0.1),
     (0.099999*c, 0.1),
     (-0.09*c, 0.1),
     (5*u.AA/u.Gyr, 0.1)
 ]
+
+# (speed, betafrac, error)
 relativisitc_error_inputs = [
     (0.11*c, 0.1, UserWarning),
     (1.0*c, 0.1, UserWarning),

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -193,8 +193,10 @@ def test_check_quantity_decorator_invalid_name():
     def func(x: u.m):
         return x
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         func(1*u.m)
+
+    assert "bad is not an argument name" == str(e.value)
 
 
 def test_check_quantity_decorator_no_annotation():
@@ -203,8 +205,10 @@ def test_check_quantity_decorator_no_annotation():
     def func(x):
         return x
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as e:
         func(1*u.m)
+
+    assert "x has no type annotation" == str(e.value)
 
 
 # (speed, betafrac)

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -62,51 +62,33 @@ def test__check_quantity():
         _check_quantity(np.inf*u.K, 'T', 'f', u.K, can_be_inf=False)
 
 
-def test__check_relativistic():
+non_relativistic_speeds = [
+    0*u.m/u.s, 0.099999*c, -0.09*c, 5*u.AA/u.Gyr
+]
+relativisitc_error_inputs = [
+    (0.11*c, 0.1, UserWarning),
+    (1.0*c, 0.1, UserWarning),
+    (1.1*c, 0.1, UserWarning),
+    (np.inf*u.cm/u.s, 0.1, UserWarning),
+    (-0.11*c, 0.1, UserWarning),
+    (-1.0*c, 0.1, UserWarning),
+    (-1.1*c, 0.1, UserWarning),
+    (-np.inf*u.cm/u.s, 0.1, UserWarning),
+    (2997924581*u.cm/u.s, 0.1, UserWarning),
+    (0.02*c, 0.01, UserWarning),
+    (u.m/u.s, 0.1, TypeError),
+    (51513.35, 0.1, TypeError),
+    (5*u.m, 0.1, u.UnitConversionError),
+    (np.nan*u.m/u.s, 0.1, ValueError)
+]
 
-    _check_relativistic(0*u.m/u.s, 'f')
-    _check_relativistic(0.099999*c, 'f')
-    _check_relativistic(-0.09*c, 'f')
-    _check_relativistic(5*u.AA/u.Gyr, 'f')
 
-    with pytest.raises(UserWarning):
-        _check_relativistic(0.11*c, 'f')
+@pytest.mark.parametrize("speed", non_relativistic_speeds)
+def test__check_relativisitc_valid(speed):
+    _check_relativistic(speed, 'f')
 
-    with pytest.raises(UserWarning):
-        _check_relativistic(1.0*c, 'f')
 
-    with pytest.raises(UserWarning):
-        _check_relativistic(1.1*c, 'f')
-
-    with pytest.raises(UserWarning):
-        _check_relativistic(np.inf*u.cm/u.s, 'f')
-
-    with pytest.raises(UserWarning):
-        _check_relativistic(-0.11*c, 'f')
-
-    with pytest.raises(UserWarning):
-        _check_relativistic(-1.0*c, 'f')
-
-    with pytest.raises(UserWarning):
-        _check_relativistic(-1.1*c, 'f')
-
-    with pytest.raises(UserWarning):
-        _check_relativistic(-np.inf*u.cm/u.s, 'f')
-
-    with pytest.raises(UserWarning):
-        _check_relativistic(2997924581*u.cm/u.s, 'f')
-
-    with pytest.raises(UserWarning):
-        _check_relativistic(0.02*c, 'f', betafrac=0.01)
-
-    with pytest.raises(TypeError):
-        _check_relativistic(u.m/u.s, 'f')
-
-    with pytest.raises(TypeError):
-        _check_relativistic(51513.35, 'f')
-
-    with pytest.raises(u.UnitConversionError):
-        _check_relativistic(5*u.m, 'f')
-
-    with pytest.raises(ValueError):
-        _check_relativistic(np.nan*u.m/u.s, 'f')
+@pytest.mark.parametrize("speed, betafrac, error", relativisitc_error_inputs)
+def test__check_relativistic_errors(speed, betafrac, error):
+    with pytest.raises(error):
+        _check_relativistic(speed, 'f', betafrac=betafrac)

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -198,7 +198,7 @@ def test_check_quantity_decorator_two_args_one_kwargs_default():
     def func(x, y, another, z=10*u.eV):
         return x*y*z
 
-    func(1*u.m, 1*u.s, 10)
+    func(1*u.m, 1*u.s, 10*u.T)
 
 
 def test_check_quantity_decorator_two_args_one_kwargs_not_default():
@@ -208,7 +208,7 @@ def test_check_quantity_decorator_two_args_one_kwargs_not_default():
         "y": {"units": u.s, "can_be_negative": False},
         "z": {"units": u.eV, "can_be_inf": False}
     })
-    def func(x: u.m, y: u.s, z: u.eV=10*u.eV):
+    def func(x, y, z=10*u.eV):
         return x*y*z
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
Attempt to resolve issue: https://github.com/PlasmaPy/PlasmaPy/issues/55

Refactors `test_checks` to use `pytest.mark.parametrize` so the new decorators can use the same examples as `_check_quantity` and `_check_relativistic`.

Using `check_relativistic`:
```python
from astropy import units as u
@check_relativistic
def speed():
    return 1*u.m/u.s
```
or with keywords:
```python
@check_relativistic(betafrac=0.01)
def speed():
    return 1*u.m/u.s
```

Using `check_quantity`:
```python
@check_quantity("x")
@check_quantity("y", can_be_negative=False)
def func(x: u.m, y: u.s=1*u.s):
    return x
func(1*u.m, 2*u.s)
```

I was able to convert most parameter functions. Parameter functions `electron_gyroradius`, `ion_gyroradius`, and `Alfven_speed` could not be converted because it does some preprocessing before checking the units.