### PR TITLE
Stepper: Allowing unequal spatial dimensions grid

### DIFF
--- a/plasmapy/classes/species.py
+++ b/plasmapy/classes/species.py
@@ -85,9 +85,9 @@ class Species:
                                          dtype=float) * (u.m / u.s)
         # create intermediate array of dimension (nx,ny,nz,3) in order to allow
         # interpolation on non-equal spatial domain dimensions
-        _B = np.moveaxis(self.plasma.magnetic_field.si.value,0,-1)
-        _E = np.moveaxis(self.plasma.electric_field.si.value,0,-1)
-        
+        _B = np.moveaxis(self.plasma.magnetic_field.si.value, 0, -1)
+        _E = np.moveaxis(self.plasma.electric_field.si.value, 0, -1)
+
         self._B_interpolator = RegularGridInterpolator(
             (self.plasma.x.si.value,
              self.plasma.y.si.value,
@@ -200,7 +200,7 @@ class Species:
         return f"Species(q={self.q:.4e},m={self.m:.4e},N={self.N}," \
                f"name=\"{self.name}\",NT={self.NT})"
 
-    def __str__(self): # coveralls: ignore
+    def __str__(self):  # coveralls: ignore
         return f"{self.N} {self.scaling:.2e}-{self.name} with " \
                f"q = {self.q:.2e}, m = {self.m:.2e}, " \
                f"{self.saved_iterations} saved history " \
@@ -210,7 +210,6 @@ class Species:
         """ Draws trajectory history."""
         from astropy.visualization import quantity_support
         import matplotlib.pyplot as plt
-        from mpl_toolkits.mplot3d import Axes3D
 
         quantity_support()
         fig = plt.figure()
@@ -237,7 +236,6 @@ class Species:
         """
         from astropy.visualization import quantity_support
         import matplotlib.pyplot as plt
-        from mpl_toolkits.mplot3d import Axes3D
 
         quantity_support()
         fig, ax = plt.subplots()

--- a/plasmapy/classes/species.py
+++ b/plasmapy/classes/species.py
@@ -105,7 +105,6 @@ class Species:
             bounds_error=True)
 
     def _interpolate_fields(self):
-        print(self.x.si.value)
         interpolated_b = self._B_interpolator(self.x.si.value) * u.T
         interpolated_e = self._E_interpolator(self.x.si.value) * u.V / u.m
         return interpolated_b, interpolated_e
@@ -210,6 +209,7 @@ class Species:
         """ Draws trajectory history."""
         from astropy.visualization import quantity_support
         import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d import Axes3D
 
         quantity_support()
         fig = plt.figure()
@@ -236,6 +236,7 @@ class Species:
         """
         from astropy.visualization import quantity_support
         import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d import Axes3D
 
         quantity_support()
         fig, ax = plt.subplots()

--- a/plasmapy/classes/species.py
+++ b/plasmapy/classes/species.py
@@ -83,11 +83,16 @@ class Species:
                                          dtype=float) * u.m
         self.velocity_history = np.zeros((self.NT, *self.v.shape),
                                          dtype=float) * (u.m / u.s)
+        # create intermediate array of dimension (nx,ny,nz,3) in order to allow
+        # interpolation on non-equal spatial domain dimensions
+        _B = np.moveaxis(self.plasma.magnetic_field.si.value,0,-1)
+        _E = np.moveaxis(self.plasma.electric_field.si.value,0,-1)
+        
         self._B_interpolator = RegularGridInterpolator(
             (self.plasma.x.si.value,
              self.plasma.y.si.value,
              self.plasma.z.si.value),
-            self.plasma.magnetic_field.T.si.value,
+            _B,
             method="linear",
             bounds_error=True)
 
@@ -95,11 +100,12 @@ class Species:
             (self.plasma.x.si.value,
              self.plasma.y.si.value,
              self.plasma.z.si.value),
-            self.plasma.electric_field.T.si.value,
+            _E,
             method="linear",
             bounds_error=True)
 
     def _interpolate_fields(self):
+        print(self.x.si.value)
         interpolated_b = self._B_interpolator(self.x.si.value) * u.T
         interpolated_e = self._E_interpolator(self.x.si.value) * u.V / u.m
         return interpolated_b, interpolated_e

--- a/plasmapy/classes/tests/test_Species.py
+++ b/plasmapy/classes/tests/test_Species.py
@@ -189,3 +189,15 @@ def test_particle_exb_nonuniform_drift():
     #
     # s.test_kinetic_energy()
 """
+
+def test_particle_nonuniform_grid():
+    '''
+        Test the particle stepper when the spatial domain dimensions are not equal
+    '''   
+    x = np.linspace(0,1,10)*u.m
+    y = np.linspace(0,1,20)*u.m
+    z = np.linspace(0,1,30)*u.m
+    
+    plasma = Plasma(x,y,z)
+    
+    Species(plasma, 'e', dt=1e-14*u.s, nt=1e3)

--- a/plasmapy/classes/tests/test_Species.py
+++ b/plasmapy/classes/tests/test_Species.py
@@ -190,14 +190,16 @@ def test_particle_exb_nonuniform_drift():
     # s.test_kinetic_energy()
 """
 
+
 def test_particle_nonuniform_grid():
     '''
-        Test the particle stepper when the spatial domain dimensions are not equal
-    '''   
-    x = np.linspace(0,1,10)*u.m
-    y = np.linspace(0,1,20)*u.m
-    z = np.linspace(0,1,30)*u.m
-    
-    plasma = Plasma(x,y,z)
-    
+        Test the particle stepper when the spatial domain dimensions
+        are unequal
+    '''
+    x = np.linspace(0, 1, 10)*u.m
+    y = np.linspace(0, 1, 20)*u.m
+    z = np.linspace(0, 1, 30)*u.m
+
+    plasma = Plasma(x, y, z)
+
     Species(plasma, 'e', dt=1e-14*u.s, nt=1e3)

--- a/plasmapy/classes/tests/test_Species.py
+++ b/plasmapy/classes/tests/test_Species.py
@@ -202,4 +202,4 @@ def test_particle_nonuniform_grid():
 
     plasma = Plasma(x, y, z)
 
-    Species(plasma, 'e', dt=1e-14*u.s, nt=1e3)
+    Species(plasma, 'e', dt=1e-14*u.s, nt=5).run()


### PR DESCRIPTION
Modified the interpolation routine to allow unequal spatial dimension grid (nx,ny,nz) with nx!=ny!=nz. 
Also added a test case. 