### PR TITLE
Revise vision statement and create roadmap document

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,19 +9,27 @@ requests](https://github.com/PlasmaPy/plasmapy/pulls), and
 
 ## Features to be included in Version 0.1 release
 
-- Base plasma class for 
-- MHD simulation capability
-- PIC simulation capability
-- Simulation analysis tools
 - Plasma parameter calculations
-- Magnetic topology analysis tools (tentative)
+- Base plasma class
+- MHD simulation capability (finite difference & spectral)
+- PIC simulation capability (only 1D for v0.1?)
+- Simulation visualization/analysis tools
+  - Basic turbulence analysis functionality from
+    [TurbPlasma](https://github.com/tulasinandan/TurbPlasma) (to be
+    speeded up via Numba/Cython)
+- Magnetic topology analysis tools (data cube)
 
 ## Features to be included in Version 0.2 release
 
 - Grad-Shafranov solver
 - Dispersion solver
+- Magnetic topology analysis tools (cylindrical geometry)
+- MHD simulation capability (finite element)
+- PIC simulation capability (2D)
+- Spacecraft data analysis
+- Experimental analysis tools
 
 ## Features to be included at indefinite time in future
 
-- Experimental analysis tools
 - Analytical plasma physics tools (with SymPy)
+- Capability to read in CDF files (separate package?)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,3 +33,9 @@ requests](https://github.com/PlasmaPy/plasmapy/pulls), and
 
 - Analytical plasma physics tools (with SymPy)
 - Capability to read in CDF files (separate package?)
+
+## Future events
+
+- Code development meeting
+- Software Carpentry workshops at plasma physics conferences
+- Python in Plasma Physics conference?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,27 @@
+# PlasmaPy Development Roadmap
+
+This document summarizes the overall development plans for PlasmaPy.
+This roadmap is very fluid and is subject to change due to community
+priorities.  For the most up-to-date information, see PlasmaPy's
+[issues](https://github.com/PlasmaPy/plasmapy/issues), [pull
+requests](https://github.com/PlasmaPy/plasmapy/pulls), and
+[projects](https://github.com/PlasmaPy/PlasmaPy/projects).
+
+## Features to be included in Version 0.1 release
+
+- Base plasma class for 
+- MHD simulation capability
+- PIC simulation capability
+- Simulation analysis tools
+- Plasma parameter calculations
+- Magnetic topology analysis tools (tentative)
+
+## Features to be included in Version 0.2 release
+
+- Grad-Shafranov solver
+- Dispersion solver
+
+## Features to be included at indefinite time in future
+
+- Experimental analysis tools
+- Analytical plasma physics tools (with SymPy)

--- a/vision_statement.md
+++ b/vision_statement.md
@@ -114,8 +114,8 @@ conduct](https://www.python.org/psf/codeofconduct/).
 
 The Coordinating Committee (CC) will oversee the PlasmaPy project and
 code development.  The CC will ensure that roles are being filled,
-facilitate intergroup communication, coordinate and delegate tasks,
-manage the project repository, oversee the code review process,
+facilitate community-wide communication, coordinate and delegate
+tasks, manage the project repository, oversee the code review process,
 regulate intercompatibility between different subpackages, seek
 funding mechanisms, facilitate compromises and cooperation, enforce
 the code of conduct, and foster a culture of appreciation.

--- a/vision_statement.md
+++ b/vision_statement.md
@@ -112,22 +112,13 @@ conduct](https://www.python.org/psf/codeofconduct/).
 
 ## Organizational structure
 
-The Coordinating Committee (CC) will oversee the PlasmaPy project.
-This committee will take a big picture approach defining the goals and
-future directions of PlasmaPy.  The CC will make sure that roles are
-being filled, necessary tasks are being completed, facilitating
-intergroup communication (including the email list and HipChat group),
-coordinating and delegating tasks, seeking funding mechanisms,
-facilitating compromises and cooperation, and fostering a culture of
-appreciation.
- 
-The Code Development Committee (CDC) will directly oversee the
-development of the codebase.  This committee will be responsible for
-managing the project repository, reviewing and accepting pull requests,
-ensuring intercompatibility between different subpackages, and
-coordinating automated testing.  The CDC will be responsible for
-ensuring that the PlasmaPy codebase adheres to the standards defined
-in this document.
+The Coordinating Committee (CC) will oversee the PlasmaPy project and
+code development.  The CC will ensure that roles are being filled,
+facilitate intergroup communication, coordinate and delegate tasks,
+manage the project repository, oversee the code review process,
+regulate intercompatibility between different subpackages, seek
+funding mechanisms, facilitate compromises and cooperation, enforce
+the code of conduct, and foster a culture of appreciation.
 
 The Community Engagement Committee (CEC) will be responsible for
 organizing conferences, trainings, and workshops; maintaining and
@@ -171,11 +162,11 @@ the project that are director towards the initial developers.
 New code and edits should be submitted as a pull request to the
 development branch of the PlasmaPy repository on GitHub.  The pull
 request will undergo a code review by the subpackage maintainers
-and/or the CDC, who will provide suggestions on how the contributor
-may update the pull request.  Subpackage maintainers will generally be
+and/or the CC, who will provide suggestions on how the contributor may
+update the pull request.  Subpackage maintainers will generally be
 responsible for deciding on pull requests with minor changes, while
 pull requests with major changes should be decided jointly by the
-subpackage maintainers and the CDC.  The CDC and CEC will develop a
+subpackage maintainers and the CC.  The CC and CEC will develop a
 friendly guide on how users may contribute new code to PlasmaPy.
 
 New code should conform to the [PEP 8 style guide for Python
@@ -206,10 +197,10 @@ not require community discussion.  The CC shall maintain a GitHub
 repository of PLEPs.  PLEPs will be made openly available for
 community discussion and transparency for a period of at least four
 weeks, during which time the proposal may be updated and revised by
-the proposers.  The CC and CDC shall approve or decline these
-proposals after seeking community input.  The rationale behind the
-decision and a summary of the community discussion shall be recorded
-along with the PLEP.
+the proposers.  The CC shall approve or decline these proposals after
+seeking community input.  The rationale behind the decision and a
+summary of the community discussion shall be recorded along with the
+PLEP.
 
 ## Programming guidelines
 


### PR DESCRIPTION
This pull request contains updates to the vision statement after a few months into the project.  

The main change is to absorb the Code Development Committee into the Coordinating Committee.    The responsibilities for both of these committees are blurred, and this pull request combines the two committees into a single committee.  For the first few months of active code development, the organization has been very informal.  This pull request is in advance of solidifying committee membership.

Are there any other changes that we should make while we're revisiting the vision statement?  I'll read through this page again in case there are any other places we'd like to update this.