### PR TITLE
Add patent clause to license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # PlasmaPy License
 
-Copyright (c) 2015-2017, PlasmaPy Community.
+Copyright (c) 2015-2017, PlasmaPy Developers.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017, PlasmaPy Community. All rights reserved.
+Copyright (c) 2015-2017, PlasmaPy Community.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# PlasmaPy License
+
 Copyright (c) 2015-2017, PlasmaPy Community.
 
 Redistribution and use in source and binary forms, with or without
@@ -38,6 +40,8 @@ Contribution.
 Except as expressly stated above, no rights or licenses from any
 copyright holder or contributor is granted under this license, whether
 expressly, by implication, estoppel or otherwise.
+
+## Disclaimer
 
 This software is provided by the copyright holders and contributors "as is"
 and any express or implied warranties, including, but not limited to, the 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -14,6 +14,31 @@ modification, are permitted provided that the following conditions are met:
   to endorse or promote products derived from this software without specific 
   prior written permission.
 
+Subject to the terms and conditions of this license, each copyright
+holder and contributor hereby grants to those receiving rights under
+this license a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except for failure to satisfy the
+conditions of this license) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer this software,
+where such license applies only to those patent claims, already
+acquired or hereafter acquired, licensable by such copyright holder or
+contributor that are necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright
+holders and non-copyrightable additions of contributors, in source or
+binary form) alone; or
+
+(b) combination of their Contribution(s) with the work of authorship
+to which such Contribution(s) was added by such copyright holder or
+contributor, if, at the time the Contribution is added, such addition
+causes such combination to be necessarily infringed. The patent
+license shall not apply to any other combinations which include the
+Contribution.
+
+Except as expressly stated above, no rights or licenses from any
+copyright holder or contributor is granted under this license, whether
+expressly, by implication, estoppel or otherwise.
+
 This software is provided by the copyright holders and contributors "as is"
 and any express or implied warranties, including, but not limited to, the 
 implied warranties of merchantability and fitness for a particular purpose are 

--- a/README.md
+++ b/README.md
@@ -32,5 +32,6 @@ PlasmaPy requires Python 3.6 and is
 
 ## License
 
-PlasmaPy is licensed under a 3-clause BSD style license - see
-``LICENSE.md`` file in the top-level directory.
+PlasmaPy is licensed under a 3-clause BSD license with an express
+patent grant - see the [``LICENSE.md``](LICENSE.md) file in the
+top-level directory.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ PlasmaPy requires Python 3.6 and is
 
 ## License
 
-PlasmaPy is licensed under a 3-clause BSD license with an express
-patent grant - see the [``LICENSE.md``](LICENSE.md) file in the
-top-level directory.
+PlasmaPy is licensed under a 3-clause BSD license with added protections
+against software patents - see the [``LICENSE.md``](LICENSE.md) file in
+the top-level directory.

--- a/licenses/PlasmaPy_LICENSE_preOct2017.md
+++ b/licenses/PlasmaPy_LICENSE_preOct2017.md
@@ -1,4 +1,4 @@
-# [PlasmaPy License prior to 2017 October 19](#old-license)
+# PlasmaPy License prior to 2017 October 19
 
 Copyright (c) 2015-2017, PlasmaPy Community. All rights reserved.
 
@@ -38,7 +38,8 @@ was [updated on 2017 October
 protections against software patents from the [BSD+Patent
 license](https://opensource.org/licenses/BSDplusPatent).  Updates
 prior to 2017 October 19 remain available under [PlasmaPy's old
-license](old-license).  Most contributors to PlasmaPy [have
+license](plasmapy-license-prior-to-2017-october-19).  Most
+contributors to PlasmaPy [have
 agreed](https://github.com/PlasmaPy/PlasmaPy/pull/114) to have
 their contributions covered by the [new
 license](https://github.com/PlasmaPy/PlasmaPy/blob/master/LICENSE.md).
@@ -47,4 +48,5 @@ Pull requests
 [#77](https://github.com/PlasmaPy/PlasmaPy/pull/77),
 [#107](https://github.com/PlasmaPy/PlasmaPy/pull/107), and
 [#108](https://github.com/PlasmaPy/PlasmaPy/pull/108) are covered
-solely by [PlasmaPy's old license](old-license).
+solely by [PlasmaPy's old
+license](plasmapy-license-prior-to-2017-october-19).

--- a/licenses/PlasmaPy_LICENSE_preOct2017.md
+++ b/licenses/PlasmaPy_LICENSE_preOct2017.md
@@ -1,0 +1,70 @@
+# PlasmaPy License for contributions prior to October 10, 2017
+
+Copyright (c) 2015-2017, PlasmaPy Community. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of PlasmaPy nor the names of its contributors may
+  be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+This software is provided by the copyright holders and contributors
+"as is" and any express or implied warranties, including, but not
+limited to, the implied warranties of merchantability and fitness for
+a particular purpose are disclaimed. In no event shall the copyright
+holder or contributors be liable for any direct, indirect, incidental,
+special, exemplary, or consequential damages (including, but not
+limited to, procurement of substitute goods or services; loss of use,
+data, or profits; or business interruption) however caused and on any
+theory of liability, whether in contract, strict liability, or tort
+(including negligence or otherwise) arising in any way out of the use
+of this software, even if advised of the possibility of such damage.
+
+# Notice
+
+On October 10, 2017, the following patent grant (originally from the
+[BSD+Patent license](https://opensource.org/licenses/BSDplusPatent))
+was added to PlasmaPy's license:
+
+> Subject to the terms and conditions of this license, each copyright
+> holder and contributor hereby grants to those receiving rights under
+> this license a perpetual, worldwide, non-exclusive, no-charge,
+> royalty-free, irrevocable (except for failure to satisfy the
+> conditions of this license) patent license to make, have made, use,
+> offer to sell, sell, import, and otherwise transfer this software,
+> where such license applies only to those patent claims, already
+> acquired or hereafter acquired, licensable by such copyright holder or
+> contributor that are necessarily infringed by:
+> 
+> (a) their Contribution(s) (the licensed copyrights of copyright
+> holders and non-copyrightable additions of contributors, in source or
+> binary form) alone; or
+> 
+> (b) combination of their Contribution(s) with the work of authorship
+> to which such Contribution(s) was added by such copyright holder or
+> contributor, if, at the time the Contribution is added, such addition
+> causes such combination to be necessarily infringed. The patent
+> license shall not apply to any other combinations which include the
+> Contribution.
+> 
+> Except as expressly stated above, no rights or licenses from any
+> copyright holder or contributor is granted under this license, whether
+> expressly, by implication, estoppel or otherwise.
+
+This patent grant applies to all contributions made after being
+adopted on October 10, 2017.  This patent grant does not apply to
+contributions made prior to its adoption, except as follows.  The
+following contributors and copyright holders have agreed for this
+patent grant to cover their contributions to PlasmaPy prior to October
+10, 2017:
+
+* Nick Murphy (namurphy)

--- a/licenses/PlasmaPy_LICENSE_preOct2017.md
+++ b/licenses/PlasmaPy_LICENSE_preOct2017.md
@@ -1,4 +1,4 @@
-# PlasmaPy License for contributions prior to October 10, 2017
+# [PlasmaPy License prior to 2017 October 19](#old-license)
 
 Copyright (c) 2015-2017, PlasmaPy Community. All rights reserved.
 
@@ -31,40 +31,20 @@ of this software, even if advised of the possibility of such damage.
 
 # Notice
 
-On October 10, 2017, the following patent grant (originally from the
-[BSD+Patent license](https://opensource.org/licenses/BSDplusPatent))
-was added to PlasmaPy's license:
-
-> Subject to the terms and conditions of this license, each copyright
-> holder and contributor hereby grants to those receiving rights under
-> this license a perpetual, worldwide, non-exclusive, no-charge,
-> royalty-free, irrevocable (except for failure to satisfy the
-> conditions of this license) patent license to make, have made, use,
-> offer to sell, sell, import, and otherwise transfer this software,
-> where such license applies only to those patent claims, already
-> acquired or hereafter acquired, licensable by such copyright holder or
-> contributor that are necessarily infringed by:
-> 
-> (a) their Contribution(s) (the licensed copyrights of copyright
-> holders and non-copyrightable additions of contributors, in source or
-> binary form) alone; or
-> 
-> (b) combination of their Contribution(s) with the work of authorship
-> to which such Contribution(s) was added by such copyright holder or
-> contributor, if, at the time the Contribution is added, such addition
-> causes such combination to be necessarily infringed. The patent
-> license shall not apply to any other combinations which include the
-> Contribution.
-> 
-> Except as expressly stated above, no rights or licenses from any
-> copyright holder or contributor is granted under this license, whether
-> expressly, by implication, estoppel or otherwise.
-
-This patent grant applies to all contributions made after being
-adopted on October 10, 2017.  This patent grant does not apply to
-contributions made prior to its adoption, except as follows.  The
-following contributors and copyright holders have agreed for this
-patent grant to cover their contributions to PlasmaPy prior to October
-10, 2017:
-
-* Nick Murphy (namurphy)
+[PlasmaPy's
+license](https://github.com/PlasmaPy/PlasmaPy/blob/master/LICENSE.md)
+was [updated on 2017 October
+19](https://github.com/PlasmaPy/PlasmaPy/pull/114) to include
+protections against software patents from the [BSD+Patent
+license](https://opensource.org/licenses/BSDplusPatent).  Updates
+prior to 2017 October 19 remain available under [PlasmaPy's old
+license](old-license).  Most contributors to PlasmaPy [have
+agreed](https://github.com/PlasmaPy/PlasmaPy/pull/114) to have
+their contributions covered by the [new
+license](https://github.com/PlasmaPy/PlasmaPy/blob/master/LICENSE.md).
+Pull requests
+[#63](https://github.com/PlasmaPy/PlasmaPy/pull/63),
+[#77](https://github.com/PlasmaPy/PlasmaPy/pull/77),
+[#107](https://github.com/PlasmaPy/PlasmaPy/pull/107), and
+[#108](https://github.com/PlasmaPy/PlasmaPy/pull/108) are covered
+solely by [PlasmaPy's old license](old-license).


### PR DESCRIPTION
The Open Source Initiative (OSI) recently approved a new license that consists of the [BSD 2-clause license with an added patent clause](https://opensource.org/licenses/BSDplusPatent).  The purpose of the patent clause is to give users the right to continue to use a package even if a contributor patents their contribution.  This new license resolves an issue that has been raised about the BSD license (and many others) that it does not explicitly protect against software patents.

This commit adds the patent clause to our BSD 3-clause license to ensure that future users have the right to continue to use the package even if part of it gets patented.

> Subject to the terms and conditions of this license, each copyright holder and contributor hereby grants to those receiving rights under this license a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except for failure to satisfy the conditions of this license) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer this software, where such license applies only to those patent claims, already acquired or hereafter acquired, licensable by such copyright holder or contributor that are necessarily infringed by:
> 
> (a) their Contribution(s) (the licensed copyrights of copyright holders and non-copyrightable additions of contributors, in source or binary form) alone;
> 
> or
> 
> (b) combination of their Contribution(s) with the work of authorship to which such Contribution(s) was added by such copyright holder or contributor, if, at the time the Contribution is added, such addition causes such combination to be necessarily infringed. The patent license shall not apply to any other combinations which include the Contribution.
> 
> Except as expressly stated above, no rights or licenses from any copyright holder or contributor is granted under this license, whether expressly, by implication, estoppel or otherwise.

This pull request also removes "All rights reserved" in the copyright notice because this clause [no longer has any legal significance](https://en.wikipedia.org/w/index.php?title=All_rights_reserved&oldid=799152223).  I also modified headings and improved markdown formatting.

This license and patent clause will take effect for all future contributions to and versions of PlasmaPy after it is accepted.  Earlier versions of PlasmaPy can continue to be distributed under the previous license.  I consent to granting this patent clause for my prior contributions.

Please comment below if you approve of this license change.

Thank you!
-Nick