### PR TITLE
Implement astropy.units.quantity_input to physics

### DIFF
--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -13,7 +13,7 @@ import numpy as np
 # For future: change these into decorators.  _check_quantity does a
 # bit more than @quantity_input as it can allow
 
-from ..utils import _check_quantity, check_relativistic, check_quantity
+from ..utils import check_relativistic, check_positive, check_finite
 
 
 r"""Values should be returned as an Astropy Quantity in SI units.
@@ -73,7 +73,9 @@ by an angular frequency to get a length scale:
 
 
 @check_relativistic
-def Alfven_speed(B, density, ion="p"):
+@check_positive("density")
+@quantity_input
+def Alfven_speed(B: units.T, density, ion="p"): # TODO density
     r"""Returns the Alfven speed.
 
     Parameters
@@ -147,10 +149,6 @@ def Alfven_speed(B, density, ion="p"):
     <Quantity 4.317387029559353 cm / us>
     """
 
-    _check_quantity(B, 'B', 'Alfven_speed', units.T)
-    _check_quantity(density, 'density', 'Alfven_speed',
-                    [units.m**-3, units.kg/units.m**3], can_be_negative=False)
-
     B = B.to(units.T)
     density = density.si
 
@@ -176,11 +174,9 @@ def Alfven_speed(B, density, ion="p"):
 
 
 @check_relativistic
-@check_quantity({
-    'T_i': {'units': units.K, 'can_be_negative': False},
-    'T_e': {'units': units.K, 'can_be_negative': False}
-})
-def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
+@check_positive('T_e', 'T_i')
+@quantity_input
+def ion_sound_speed(*ignore, T_e = 0*units.K, T_i=0*units.K,
                     gamma_e=1, gamma_i=3, ion='p'):
     r"""Returns the ion sound speed for an electron-ion plasma.
 
@@ -312,9 +308,8 @@ def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
 
 
 @check_relativistic
-@check_quantity({
-    'T': {'units': units.K, 'can_be_negative': False}
-})
+@check_positive('T')
+@quantity_input
 def thermal_speed(T, particle="e", method="most_probable"):
     r"""Returns the most probable speed for an particle within a Maxwellian
     distribution.
@@ -406,11 +401,7 @@ def thermal_speed(T, particle="e", method="most_probable"):
 
     return V
 
-
-@check_quantity({
-    'B': {'units': units.T}
-})
-def gyrofrequency(B, particle='e'):
+def gyrofrequency(B: units.T, particle='e'):
     r"""Calculate the particle gyrofrequency in units of radians per second.
 
     Parameters
@@ -622,9 +613,8 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
     return r_Li.to(units.m, equivalencies=units.dimensionless_angles())
 
 
-@check_quantity({
-    'n': {'units': units.m**-3, 'can_be_negative': False}
-})
+@check_positive('n')
+@quantity_input
 def plasma_frequency(n, particle='e'):
     r"""Calculates the particle plasma frequency.
     Defaults to the fastest, electron plasma frequency.
@@ -700,11 +690,9 @@ def plasma_frequency(n, particle='e'):
     return omega_p.si
 
 
-@check_quantity({
-    'T_e': {'units': units.K, 'can_be_negative': False},
-    'n_e': {'units': units.m**-3, 'can_be_negative': False}
-})
-def Debye_length(T_e, n_e):
+@check_positive("T_e", "n_e")
+@quantity_input
+def Debye_length(T_e, n_e: units.m**-3):
     r"""Calculate the Debye length.
 
     Parameters
@@ -773,11 +761,9 @@ def Debye_length(T_e, n_e):
     return lambda_D
 
 
-@check_quantity({
-    'T_e': {'units': units.K, 'can_be_negative': False},
-    'n_e': {'units': units.m**-3, 'can_be_negative': False}
-})
-def Debye_number(T_e, n_e):
+@check_positive("T_e", "n_e")
+@quantity_input
+def Debye_number(T_e, n_e: units.m**-3):
     r"""Returns the Debye number.
 
     Parameters
@@ -839,11 +825,9 @@ def Debye_number(T_e, n_e):
 
     return N_D.to(units.dimensionless_unscaled)
 
-
-@check_quantity({
-    'n': {'units': units.m**-3, 'can_be_negative': False}
-})
-def inertial_length(n, particle='e'):
+@check_positive('n')
+@quantity_input
+def inertial_length(n: units.m**-3, particle='e'):
     r"""Calculate the particle inertial length,
 
     Parameters
@@ -908,10 +892,8 @@ def inertial_length(n, particle='e'):
     return d
 
 
-@check_quantity({
-    'B': {'units': units.T}
-})
-def magnetic_pressure(B):
+@quantity_input
+def magnetic_pressure(B: units.T):
     r"""Calculate the magnetic pressure.
 
     Parameters
@@ -968,10 +950,7 @@ def magnetic_pressure(B):
 
     return p_B
 
-
-@check_quantity({
-    'B': {'units': units.T}
-})
+@quantity_input
 def magnetic_energy_density(B: units.T):
     r"""Calculate the magnetic energy density.
 
@@ -1029,12 +1008,9 @@ def magnetic_energy_density(B: units.T):
 
     return E_B
 
-
-@check_quantity({
-    'B': {'units': units.T},
-    'n_e': {'units': units.m**-3, 'can_be_negative': False}
-})
-def upper_hybrid_frequency(B, n_e):
+@check_positive('n_e')
+@quantity_input
+def upper_hybrid_frequency(B: units.T, n_e: units.m**-3):
     r"""Returns the upper hybrid frequency.
 
     Parameters
@@ -1093,11 +1069,9 @@ def upper_hybrid_frequency(B, n_e):
     return omega_uh
 
 
-@check_quantity({
-    'B': {'units': units.T},
-    'n_i': {'units': units.m**-3, 'can_be_negative': False}
-})
-def lower_hybrid_frequency(B, n_i, ion='p'):
+@check_positive('n_e')
+@quantity_input
+def lower_hybrid_frequency(B: units.T, n_i: units.m**-3, ion='p'):
     r"""Returns the lower hybrid frequency.
 
     Parameters

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -1066,7 +1066,7 @@ def upper_hybrid_frequency(B: units.T, n_e: units.m**-3):
     return omega_uh
 
 
-@check_positive('n_e')
+@check_positive('n_i')
 @quantity_input
 def lower_hybrid_frequency(B: units.T, n_i: units.m**-3, ion='p'):
     r"""Returns the lower hybrid frequency.

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -485,7 +485,9 @@ def gyrofrequency(B: units.T, particle='e'):
     return omega_ci
 
 
-def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
+@quantity_input(equivalencies = units.temperature_energy())
+def gyroradius(B: units.T, *args, Vperp: units.m/units.s=None,
+               T: units.K = None, particle='e'):
     r"""Returns the particle gyroradius.
 
     Parameters
@@ -497,7 +499,7 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
         The component of particle velocity that is perpendicular to the
         magnetic field in units convertible to meters per second.
 
-    T_i: Quantity, optional
+    T: Quantity, optional
         The particle temperature in units convertible to kelvin.
 
     particle : string, optional
@@ -565,7 +567,7 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
     <Quantity 288002.38837768475 m>
     >>> gyroradius(400*u.G, 1e7*u.m/u.s, particle='Fe+++')
     <Quantity 48.23129811339086 m>
-    >>> gyroradius(B = 0.01*u.T, T_i = 1e6*u.K)
+    >>> gyroradius(B = 0.01*u.T, T = 1e6*u.K)
     <Quantity 0.0031303339253265536 m>
     >>> gyroradius(B = 0.01*u.T, Vperp = 1e6*u.m/u.s)
     <Quantity 0.0005685630062091092 m>
@@ -578,7 +580,7 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
 
     """
 
-    if Vperp is not None and T_i is not None:
+    if Vperp is not None and T is not None:
         raise ValueError("Cannot have both Vperp and T_i as arguments to "
                          "gyroradius")
 
@@ -591,20 +593,15 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
         if arg.unit == units.m/units.s:
             Vperp = arg
         elif arg.unit in (units.J, units.K):
-            T_i = arg.to(units.K, equivalencies=units.temperature_energy())
+            T = arg.to(units.K, equivalencies=units.temperature_energy())
         else:
             raise units.UnitConversionError("Incorrect units for positional "
                                             "argument in gyroradius")
     elif len(args) > 0:
         raise ValueError("Incorrect inputs to gyroradius")
 
-    _check_quantity(B, 'B', 'gyroradius', units.T)
-
-    if Vperp is not None:
-        _check_quantity(Vperp, 'Vperp', 'gyroradius', units.m/units.s)
-    elif T_i is not None:
-        _check_quantity(T_i, 'T_i', 'gyroradius', units.K)
-        Vperp = thermal_speed(T_i, particle=particle)
+    if T is not None:
+        Vperp = thermal_speed(T, particle=particle)
 
     omega_ci = gyrofrequency(B, particle)
 

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -1,12 +1,14 @@
 import numpy as np
 from astropy import units
+from astropy.units import quantity_input
 from ..constants import c, h
 from ..atomic import ion_mass
-from ..utils import _check_quantity, _check_relativistic
+from ..utils import check_relativistic, check_positive, check_finite
 from .relativity import Lorentz_factor
 
 
-def deBroglie_wavelength(V, particle):
+@quantity_input
+def deBroglie_wavelength(V: units.m/units.s, particle):
     r"""Calculates the de Broglie wavelength.
 
     Parameters
@@ -62,8 +64,6 @@ def deBroglie_wavelength(V, particle):
     <Quantity inf m>
 
     """
-
-    _check_quantity(V, 'V', 'deBroglie_wavelength', units.m/units.s)
 
     V = np.abs(V)
 

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -3,10 +3,12 @@ from astropy import units
 
 from ..constants import c
 from ..atomic import (ion_mass, charge_state)
-from ..utils import _check_quantity
+from ..utils import check_relativistic, check_positive, check_finite
+from astropy.units import quantity_input
 
 
-def Lorentz_factor(V):
+@quantity_input
+def Lorentz_factor(V: units.m/units.s):
     r"""Returns the Lorentz factor.
 
     Parameters
@@ -55,8 +57,6 @@ def Lorentz_factor(V):
     >>> Lorentz_factor(299792458*u.m/u.s)
     inf
     """
-
-    _check_quantity(V, 'V', 'Lorentz_factor', units.m/units.s)
 
     if not np.all(np.abs(V) <= c):
         raise ValueError("The Lorentz factor cannot be calculated for speeds "

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -94,7 +94,7 @@ def test_Alfven_speed():
     with pytest.raises(ValueError):
         Alfven_speed(B_arr, rho_negarr)
 
-    with pytest.raises(u.UnitConversionError):
+    with pytest.raises(u.UnitsError):
         Alfven_speed(5*u.A, n_i, ion='p')
 
     with pytest.raises(TypeError):

--- a/plasmapy/physics/tests/test_relativity.py
+++ b/plasmapy/physics/tests/test_relativity.py
@@ -31,7 +31,7 @@ def test_Lorentz_factor():
     with pytest.raises((ValueError, UserWarning)):
         Lorentz_factor(299792459)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         Lorentz_factor(2.2)
 
     with pytest.raises(u.UnitConversionError):

--- a/plasmapy/physics/tests/test_transport.py
+++ b/plasmapy/physics/tests/test_transport.py
@@ -38,7 +38,7 @@ def test_Coulomb_logarithm():
     assert np.isclose(Coulomb_logarithm(1e5*u.K, 5*u.m**-3, ('e', 'e'),
                                         V=1e4*u.m/u.s), 21.379082011)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         Coulomb_logarithm(1e5*u.K, 1*u.m**-3, ('e', 'p'), 299792458*u.m/u.s)
 
     with pytest.raises(u.UnitConversionError):

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -2,16 +2,15 @@
 
 from astropy import units
 import numpy as np
-from ..utils import check_quantity, _check_relativistic
+from ..utils import check_relativistic, check_positive, check_finite
 from ..constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi, h, hbar)
 from ..atomic import (ion_mass, charge_state)
 from .parameters import Debye_length
 
 
-@check_quantity({"T": {"units": units.K, "can_be_negative": False},
-                 "n_e": {"units": units.m**-3}
-                 })
-def Coulomb_logarithm(T, n_e, particles, V=None):
+@check_positive('T', 'n_e')
+@units.quantity_input
+def Coulomb_logarithm(T, n_e: units.m**-3, particles, V=None):
     r"""Estimates the Coulomb logarithm.
 
     Parameters

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -10,7 +10,7 @@ from .parameters import Debye_length
 
 @check_positive('T', 'n_e')
 @units.quantity_input
-def Coulomb_logarithm(T, n_e: units.m**-3, particles, V=None):
+def Coulomb_logarithm(T, n_e: units.m**-3, particles, V: units.m/units.s =None):
     r"""Estimates the Coulomb logarithm.
 
     Parameters
@@ -162,8 +162,6 @@ def Coulomb_logarithm(T, n_e: units.m**-3, particles, V=None):
 
     if V is None:
         V = np.sqrt(3 * k_B * T / reduced_mass)
-    else:
-        _check_relativistic(V, 'Coulomb_logarithm', betafrac=0.8)
 
     # The first possibility is that the inner impact parameter
     # corresponds to a deflection of 90 degrees, which is valid when

--- a/plasmapy/utils/__init__.py
+++ b/plasmapy/utils/__init__.py
@@ -1,4 +1,1 @@
-from .checks import (_check_quantity,
-                     _check_relativistic,
-                     check_quantity,
-                     check_relativistic)
+from .checks import check_relativistic, check_positive, check_finite

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -5,10 +5,7 @@ from astropy import units as u
 import pytest
 
 from ...constants import c
-from ..checks import (
-    _check_quantity, _check_relativistic, check_relativistic,
-    check_quantity
-)
+from ..checks import (_check_relativistic, check_relativistic, )
 
 
 # (value, units, error)
@@ -50,170 +47,6 @@ quantity_valid_examples_default = [
 quantity_valid_examples_non_default = [
     (5j*u.m, u.m, True, True, True)
 ]
-
-
-# Tests for _check_quantity
-@pytest.mark.parametrize(
-    "value, units, can_be_negative, can_be_complex, can_be_inf, error",
-    quantity_error_examples_non_default)
-def test__check_quantity_errors_non_default(
-        value, units, can_be_negative, can_be_complex, can_be_inf, error):
-    with pytest.raises(error):
-        _check_quantity(value, 'arg', 'funcname', units,
-                        can_be_negative=can_be_negative,
-                        can_be_complex=can_be_complex,
-                        can_be_inf=can_be_inf)
-
-
-@pytest.mark.parametrize(
-    "value, units, error", quantity_error_examples_default)
-def test__check_quantity_errors_default(value, units, error):
-    with pytest.raises(error):
-        _check_quantity(value, 'arg', 'funcname', units)
-
-
-@pytest.mark.parametrize(
-    "value, units, can_be_negative, can_be_complex, can_be_inf",
-    quantity_valid_examples_non_default)
-def test__check_quantity_non_default(
-        value, units, can_be_negative, can_be_complex, can_be_inf):
-    _check_quantity(value, 'arg', 'funcname', units,
-                    can_be_negative=can_be_negative,
-                    can_be_complex=can_be_complex,
-                    can_be_inf=can_be_inf)
-
-
-@pytest.mark.parametrize("value, units", quantity_valid_examples_default)
-def test__check_quantity_default(value, units):
-    _check_quantity(value, 'arg', 'funcname', units)
-
-
-# Tests for check_quantity decorator
-@pytest.mark.parametrize(
-    "value, units, error", quantity_error_examples_default)
-def test_check_quantity_decorator_errors_default(value, units, error):
-
-    @check_quantity({
-        "x": {"units": units}
-    })
-    def func(x):
-        return x
-
-    with pytest.raises(error):
-        func(value)
-
-
-@pytest.mark.parametrize(
-    "value, units, can_be_negative, can_be_complex, can_be_inf, error",
-    quantity_error_examples_non_default)
-def test_check_quantity_decorator_errors_non_default(
-        value, units, can_be_negative, can_be_complex, can_be_inf, error):
-
-    @check_quantity({
-        "x": {"units": units, "can_be_negative": can_be_negative,
-              "can_be_complex": can_be_complex, "can_be_inf": can_be_inf}
-    })
-    def func(x):
-        return x
-
-    with pytest.raises(error):
-        func(value)
-
-
-@pytest.mark.parametrize("value, units", quantity_valid_examples_default)
-def test_check_quantity_decorator_default(value, units):
-
-    @check_quantity({
-        "x": {"units": units}
-    })
-    def func(x):
-        return x
-
-    func(value)
-
-
-@pytest.mark.parametrize(
-    "value, units, can_be_negative, can_be_complex, can_be_inf",
-    quantity_valid_examples_non_default)
-def test_check_quantity_decorator_non_default(
-        value, units, can_be_negative, can_be_complex, can_be_inf):
-
-    @check_quantity({
-        "x": {"units": units, "can_be_negative": can_be_negative,
-              "can_be_complex": can_be_complex, "can_be_inf": can_be_inf}
-    })
-    def func(x):
-        return x
-
-    func(value)
-
-
-def test_check_quantity_decorator_missing_validated_params():
-
-    @check_quantity({
-        "x": {"units": u.m},
-        "y": {"units": u.s}
-    })
-    def func(x):
-        return x
-
-    with pytest.raises(TypeError) as e:
-        func(1*u.m)
-
-    assert "Call to func is missing validated params y" == str(e.value)
-
-
-def test_check_quantity_decorator_two_args_default():
-
-    @check_quantity({
-        "x": {"units": u.m},
-        "y": {"units": u.s}
-    })
-    def func(x, y):
-        return x/y
-
-    func(1*u.m, 1*u.s)
-
-
-def test_check_quantity_decorator_two_args_not_default():
-
-    @check_quantity({
-        "x": {"units": u.m, "can_be_negative": False},
-        "y": {"units": u.s}
-    })
-    def func(x, y):
-        return x/y
-
-    with pytest.raises(ValueError):
-        func(-1*u.m, 2*u.s)
-
-
-def test_check_quantity_decorator_two_args_one_kwargs_default():
-
-    @check_quantity({
-        "x": {"units": u.m},
-        "y": {"units": u.s},
-        "z": {"units": u.eV}
-    })
-    def func(x, y, another, z=10*u.eV):
-        return x*y*z
-
-    func(1*u.m, 1*u.s, 10*u.T)
-
-
-def test_check_quantity_decorator_two_args_one_kwargs_not_default():
-
-    @check_quantity({
-        "x": {"units": u.m},
-        "y": {"units": u.s, "can_be_negative": False},
-        "z": {"units": u.eV, "can_be_inf": False}
-    })
-    def func(x, y, z=10*u.eV):
-        return x*y*z
-
-    with pytest.raises(ValueError):
-        func(1*u.m, 1*u.s, z=np.inf*u.eV)
-
 
 # (speed, betafrac)
 non_relativistic_speed_examples = [
@@ -277,8 +110,7 @@ def test_check_relativistic_decorator_no_args(speed):
     speed_func()
 
 
-@pytest.mark.parametrize(
-    "speed",
+@pytest.mark.parametrize("speed",
     [item[0] for item in non_relativistic_speed_examples])
 def test_check_relativistic_decorator_no_args_parentheses(speed):
 

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -57,7 +57,7 @@ non_relativistic_speed_examples = [
 ]
 
 # (speed, betafrac, error)
-relativisitc_error_examples = [
+relativisitc_warning_examples = [
     (0.11*c, 0.1, UserWarning),
     (1.0*c, 0.1, UserWarning),
     (1.1*c, 0.1, UserWarning),
@@ -67,7 +67,9 @@ relativisitc_error_examples = [
     (-1.1*c, 0.1, UserWarning),
     (-np.inf*u.cm/u.s, 0.1, UserWarning),
     (2997924581*u.cm/u.s, 0.1, UserWarning),
-    (0.02*c, 0.01, UserWarning),
+    (0.02*c, 0.01, UserWarning)]
+
+relativisitc_error_examples = [
     (u.m/u.s, 0.1, TypeError),
     (51513.35, 0.1, TypeError),
     (5*u.m, 0.1, u.UnitConversionError),
@@ -129,4 +131,14 @@ def test_check_relativistic_decorator_errors(speed, betafrac, error):
         return speed
 
     with pytest.raises(error):
+        speed_func()
+
+@pytest.mark.parametrize("speed, betafrac, warning", relativisitc_warning_examples)
+def test_check_relativistic_decorator_warnings(speed, betafrac, warning):
+
+    @check_relativistic(betafrac=betafrac)
+    def speed_func():
+        return speed
+
+    with pytest.warns(warning):
         speed_func()


### PR DESCRIPTION
This is heavily work in progress, tests will fail, coverage will decrease and the PEP8 bot shall grit teeth. But we shall endure, and we shall get there, and this code shall work without exception.

Eventually.

Some of the stuff I've done alongside introducing quantity_input:
* Separate number density and mass density as keywords in Alfven speed to bypass issues with the previous approach not playing well with 
* Add check_positive decorator (work in progress as I figure out how to do this)
* Switch UserWarning from exception to warning