### PR TITLE
remove coveralls requirement as unnecessary dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
         - source ci-helpers/travis/setup_conda.sh
         - "pip install -r requirements/base.txt"
         - pip install flake8
+        - pip install coveralls
 
 # Run flake8 tests
 before_script:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,3 @@
 numpy (>= 1.13)
 scipy (>= 0.19)
 astropy (>= 2.0)
-coveralls


### PR DESCRIPTION
 Closes #120.

It appears that `coveralls` is only required in a development environment, and has therefore been removed. 

Removing the coveralls dependency also removes the following dependencies:
* certifi-2017.7.27.1 
* chardet-3.0.4
* coverage-4.4.1 
* docopt-0.6.2 
* idna-2.6 
* requests-2.18.4 
* urllib3-1.22           

Only the following dependencies are installed:
* astropy-2.0.2 
* numpy-1.13.1 
* py-1.4.34 
* pytest-3.2.2 
* scipy-0.19.1 