### PR TITLE
Check consistency of argument ordering in physics

### DIFF
--- a/plasmapy/physics/tests/test_transport.py
+++ b/plasmapy/physics/tests/test_transport.py
@@ -18,37 +18,37 @@ def test_Coulomb_logarithm():
     particles = ('e', 'p')
 
     for i in range(3):
-        assert np.isclose(Coulomb_logarithm(n_e[i], T[i], particles),
+        assert np.isclose(Coulomb_logarithm(T[i], n_e[i], particles),
                           Lambda[i], atol=0.01)
 
-    assert np.isclose(Coulomb_logarithm(5*u.m**-3, 1*u.eV, ('e', 'e')),
-                      Coulomb_logarithm(5*u.m**-3, 11604.5220*u.K, ('e', 'e')))
+    assert np.isclose(Coulomb_logarithm(1*u.eV, 5*u.m**-3, ('e', 'e')),
+                      Coulomb_logarithm(11604.5220*u.K, 5*u.m**-3, ('e', 'e')))
 
-    assert np.isclose(Coulomb_logarithm(1e9*u.cm**-3, 1e2*u.K, ('e', 'p')),
+    assert np.isclose(Coulomb_logarithm(1e2*u.K, 1e9*u.cm**-3, ('e', 'p')),
                       5.97, atol=0.01)
 
-    assert np.isclose(Coulomb_logarithm(1e9*u.cm**-3, 1e7*u.K, ('e', 'p')),
+    assert np.isclose(Coulomb_logarithm(1e7*u.K, 1e9*u.cm**-3, ('e', 'p')),
                       21.6, atol=0.1)
 
-    assert np.isclose(Coulomb_logarithm(1e24*u.cm**-3, 1e8*u.K, ('e', 'p')),
+    assert np.isclose(Coulomb_logarithm(1e8*u.K, 1e24*u.cm**-3, ('e', 'p')),
                       6.69, atol=0.01)
 
-    assert np.allclose(Coulomb_logarithm(n_e, T, particles), Lambda, atol=0.01)
+    assert np.allclose(Coulomb_logarithm(T, n_e, particles), Lambda, atol=0.01)
 
-    assert np.isclose(Coulomb_logarithm(5*u.m**-3, 1e5*u.K, ('e', 'e'),
+    assert np.isclose(Coulomb_logarithm(1e5*u.K, 5*u.m**-3, ('e', 'e'),
                                         V=1e4*u.m/u.s), 21.379082011)
 
     with pytest.raises(UserWarning):
-        Coulomb_logarithm(1*u.m**-3, 1e5*u.K, ('e', 'p'), 299792458*u.m/u.s)
+        Coulomb_logarithm(1e5*u.K, 1*u.m**-3, ('e', 'p'), 299792458*u.m/u.s)
 
     with pytest.raises(u.UnitConversionError):
-        Coulomb_logarithm(1*u.m**-3, 1e5*u.g, ('e', 'p'), 29979245*u.m/u.s)
+        Coulomb_logarithm(1e5*u.g, 1*u.m**-3, ('e', 'p'), 29979245*u.m/u.s)
 
     with pytest.raises(ValueError):
-        Coulomb_logarithm(5*u.m**-3, 1*u.K, ('e'))
+        Coulomb_logarithm(1*u.K, 5*u.m**-3, ('e'))
 
     with pytest.raises(ValueError):
-        Coulomb_logarithm(5*u.m**-3, 1*u.K, ('e', 'g'))
+        Coulomb_logarithm(1*u.K, 5*u.m**-3, ('e', 'g'))
 
     with pytest.raises(ValueError):
-        Coulomb_logarithm(5*u.m**-3, 1*u.K, ('e', 'D'))
+        Coulomb_logarithm(1*u.K, 5*u.m**-3, ('e', 'D'))

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -8,8 +8,8 @@ from ..atomic import (ion_mass, charge_state)
 from .parameters import Debye_length
 
 
-@check_quantity({"n_e": {"units": units.m**-3},
-                 "T": {"units": units.K, "can_be_negative": False}
+@check_quantity({"T": {"units": units.K, "can_be_negative": False},
+                 "n_e": {"units": units.m**-3}
                  })
 def Coulomb_logarithm(T, n_e, particles, V=None):
     r"""Estimates the Coulomb logarithm.

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -91,9 +91,9 @@ def Coulomb_logarithm(T, n_e, particles, V=None):
     Examples
     --------
     >>> from astropy import units as u
-    >>> Coulomb_logarithm(T=1e6*units.K, n_e=1e19*units.m**-3, ('e', 'p'))
+    >>> Coulomb_logarithm(T=1e6*u.K, n_e=1e19*u.m**-3, ('e', 'p'))
     14.748259780491056
-    >>> Coulomb_logarithm(1e6*units.K, 1e19*units.m**-3, ('e', 'p'),
+    >>> Coulomb_logarithm(1e6*u.K, 1e19*u.m**-3, ('e', 'p'),
                           V=1e6*u.m/u.s)
 
     References

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -11,18 +11,19 @@ from .parameters import Debye_length
 @check_quantity({"n_e": {"units": units.m**-3},
                  "T": {"units": units.K, "can_be_negative": False}
                  })
-def Coulomb_logarithm(n_e, T, particles, V=None):
+def Coulomb_logarithm(T, n_e, particles, V=None):
     r"""Estimates the Coulomb logarithm.
 
     Parameters
     ----------
-    n_e : Quantity
-        The electron density in units convertible to per cubic meter.
 
     T : Quantity
-        Temperature in units of temperature or energy per particle,
-        which is assumed to be equal for both the test particle and
-        the target particle
+    Temperature in units of temperature or energy per particle,
+    which is assumed to be equal for both the test particle and
+    the target particle
+
+    n_e : Quantity
+        The electron density in units convertible to per cubic meter.
 
     particles : tuple
         A tuple containing string representations of the test particle


### PR DESCRIPTION
Closes #133

All the definitions in physics:

```
def Lorentz_factor(V):

def deBroglie_wavelength(V, particle):

def Alfven_speed(B, density, ion="p"):

def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
                    gamma_e=1, gamma_i=3, ion='p'):

def electron_thermal_speed(T_e):

def ion_thermal_speed(T_i, ion='p'):

def electron_gyrofrequency(B):

def ion_gyrofrequency(B, ion='p'):

def electron_gyroradius(B, *args, Vperp=None, T_e=None):

def ion_gyroradius(B, *args, Vperp=None, T_i=None, ion='p'):

def electron_plasma_frequency(n_e):

def ion_plasma_frequency(n_i, ion='p'):

def Debye_length(T_e, n_e):

def Debye_number(T_e, n_e):

def ion_inertial_length(n_i, ion='p'):

def electron_inertial_length(n_e):

def magnetic_pressure(B):

def magnetic_energy_density(B: units.T):

def upper_hybrid_frequency(B, n_e):

def lower_hybrid_frequency(B, n_i, ion='p'):

def Coulomb_logarithm(n_e, T, particles, V=None):
```

All the definitions, except the one for Coulomb_logarithm follow this order: 

> B V particle density T gamma N ion

So, I altered the definition of Coulomb_logarithm to:
`def Coulomb_logarithm(T, n_e, particles, V=None):`
And updated the docstring and tests to reflect this change.

Funnily enough, the example in the  docstring already used the new order AND imported:
`from astropy import units as u ` but referred to it as `unit.` which I also fixed.