### PR TITLE
Include astropy-helpers as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "astropy-helpers"]
+	path = astropy-helpers
+	url = git@github.com:astropy/astropy-helpers.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "astropy-helpers"]
 	path = astropy-helpers
-	url = git@github.com:astropy/astropy-helpers.git
+	url = https://github.com/astropy/astropy-helpers

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "astropy-helpers"]
 	path = astropy-helpers
-	url = https://github.com/astropy/astropy-helpers
+	url = https://github.com/astropy/astropy-helpers.git

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -3,3 +3,4 @@ pycodestyle:
     - ez_setup.py
     - ah_bootstrap.py
     - astropy_helpers/
+    - vision_statement.md

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,5 @@
+pycodestyle:
+  exclude:
+    - ez_setup.py
+    - ah_bootstrap.py
+    - astropy_helpers/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
         - "3.6"
 
+git:
+    submodules: false
+
 # Install dependencies
 install:
         - git clone git://github.com/astropy/ci-helpers.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+package_name = plasmapy
+description = PlasmaPy: A Python Package for Plasma Physics
+author = PlasmaPy Developers
+license = BSD
+url = http://www.plasmapy.org/
+github_project = PlasmaPy/plasmapy
+
+[tool:pytest]
+norecursedirs = "astropy_helpers"


### PR DESCRIPTION
As described by [APE 4](https://github.com/astropy/astropy-APEs/blob/master/APE4.rst), [astropy-helpers](https://github.com/astropy/astropy-helpers) includes a bunch of setup tools and other functionality to be used in Astropy and affiliated packages.  

I used the following command to initialize the submodule:
```ShellSession
git submodule add git@github.com:astropy/astropy-helpers.git
```

The command to update astropy-helpers to the most recent version should be:
```ShellSession
git submodule update --remote --merge astropy-helpers
```