### PR TITLE
Added functions to quantum.py

### DIFF
--- a/plasmapy/physics/__init__.py
+++ b/plasmapy/physics/__init__.py
@@ -16,7 +16,10 @@ from .parameters import (Alfven_speed,
                          lower_hybrid_frequency,
                          )
 
-from .quantum import deBroglie_wavelength
+from .quantum import (deBroglie_wavelength,
+                      Fermi_energy,
+                      Thomas_Fermi_length,
+                      )
 
 from .relativity import Lorentz_factor
 

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -2,20 +2,12 @@
 Functions for quantum parameters, including electron degenerate
 gases and warm dense matter.
 """
-if __name__ == "__main__":    
-    import numpy as np
-    from astropy import units
-    from plasmapy.constants import c, h, hbar, m_e, eps0, e, k_B
-    from plasmapy.atomic import ion_mass
-    from plasmapy.utils import _check_quantity, _check_relativistic, check_quantity
-    from plasmapy.physics.relativity import Lorentz_factor
-else:
-    import numpy as np
-    from astropy import units
-    from ..constants import c, h, hbar, m_e, eps0, e, k_B
-    from ..atomic import ion_mass
-    from ..utils import _check_quantity, _check_relativistic, check_quantity
-    from .relativity import Lorentz_factor
+import numpy as np
+from astropy import units
+from ..constants import c, h, hbar, m_e, eps0, e, k_B
+from ..atomic import ion_mass
+from ..utils import _check_quantity, _check_relativistic, check_quantity
+from .relativity import Lorentz_factor
 
 
 def deBroglie_wavelength(V, particle):

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -1,9 +1,21 @@
-import numpy as np
-from astropy import units
-from ..constants import c, h
-from ..atomic import ion_mass
-from ..utils import _check_quantity, _check_relativistic
-from .relativity import Lorentz_factor
+"""
+Functions for quantum parameters, including electron degenerate
+gases and warm dense matter.
+"""
+if __name__ == "__main__":    
+    import numpy as np
+    from astropy import units
+    from plasmapy.constants import c, h, hbar, m_e, eps0, e, k_B
+    from plasmapy.atomic import ion_mass
+    from plasmapy.utils import _check_quantity, _check_relativistic, check_quantity
+    from plasmapy.physics.relativity import Lorentz_factor
+else:
+    import numpy as np
+    from astropy import units
+    from ..constants import c, h, hbar, m_e, eps0, e, k_B
+    from ..atomic import ion_mass
+    from ..utils import _check_quantity, _check_relativistic, check_quantity
+    from .relativity import Lorentz_factor
 
 
 def deBroglie_wavelength(V, particle):
@@ -99,3 +111,187 @@ def deBroglie_wavelength(V, particle):
             lambda_dBr = h / (Lorentz_factor(V) * m * V)
 
     return lambda_dBr.to(units.m)
+
+
+@check_quantity({
+    'T_e': {'units': units.K, 'can_be_negative': False}
+})
+def thermal_deBroglie_wavelength(T_e):
+    r"""Calculate the thermal deBroglie wavelength for electrons.
+
+    Parameters
+    ----------
+    T_e: Quantity
+        Electron temperature
+
+    Returns
+    -------
+    lambda_dbTh: Quantity
+        The thermal deBroglie wavelength for electrons in meters
+
+    Raises
+    ------
+    TypeError
+        If argument is not a Quantity
+
+    UnitConversionError
+        If argument is in incorrect units
+
+    ValueError
+        If argument contains invalid values
+
+    UserWarning
+        If units are not provided and SI units are assumed
+
+    Notes
+    -----
+    The thermal deBroglie wavelength is approximately the average deBroglie
+    wavelength for electrons in an ideal gas and is given by
+
+    .. math::
+    \lambda_dbTh = \frac{h}{\sqrt{2 \pi m_e k_B T_e}}
+
+    See also
+    --------
+    
+
+    Example
+    -------
+    >>> from astropy import units as u
+    >>> thermal_deBroglie_wavelength(1 * u.eV)
+    <Quantity 6.919367518364532e-10 m>
+
+    """
+    T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
+    try:
+        lambda_dbTh = h / np.sqrt(2 * np.pi * m_e * k_B * T_e)
+    except Exception:
+        raise ValueError("Unable to find thermal deBroglie wavelength.")
+    return lambda_dbTh.to(units.m)
+
+@check_quantity({
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
+def Fermi_energy(n_e):
+    r"""Calculate the Thomas-Fermi screening length.
+
+    Parameters
+    ----------
+    n_e: Quantity
+        Electron number density
+
+    Returns
+    -------
+    energy_F: Quantity
+        The Fermi energy in Joules
+
+    Raises
+    ------
+    TypeError
+        If argument is not a Quantity
+
+    UnitConversionError
+        If argument is in incorrect units
+
+    ValueError
+        If argument contains invalid values
+
+    UserWarning
+        If units are not provided and SI units are assumed
+
+    Notes
+    -----
+    The Fermi energy is the kinetic energy in a degenerate electron gas
+    and is given by
+
+    .. math::
+    E_F = \frac{\pi^2 \hbar^2}{2 m_e}\left(\frac{3 n_e}{\pi}\right)^{2/3}
+
+    This quantity is often used in place of thermal energy for analysis
+    of cold, dense plasmas (e.g. warm dense matter, condensed matter).
+
+    See also
+    --------
+    Thomas_Fermi_length
+
+    Example
+    -------
+    >>> from astropy import units as u
+    >>> Fermi_energy(1e23 * u.cm**-3)
+    <Quantity 1.2586761116196002e-18 J>
+
+    """
+    try:
+        coeff = (np.pi * hbar) ** 2 / (2 * m_e)
+        energy_F = coeff * (3 * n_e / np.pi) ** (2/3)
+    except Exception:
+        raise ValueError("Unable to find Fermi energy.")
+    return energy_F.to(units.Joule)
+
+@check_quantity({
+    'n_e': {'units': units.m**-3, 'can_be_negative': False}
+})
+def Thomas_Fermi_length(n_e):
+    r"""Calculate the Thomas-Fermi screening length.
+
+    Parameters
+    ----------
+    n_e: Quantity
+        Electron number density
+
+    Returns
+    -------
+    lambda_TF: Quantity
+        The Thomas-Fermi screening length in meters
+
+    Raises
+    ------
+    TypeError
+        If argument is not a Quantity
+
+    UnitConversionError
+        If argument is in incorrect units
+
+    ValueError
+        If argument contains invalid values
+
+    UserWarning
+        If units are not provided and SI units are assumed
+
+    Notes
+    -----
+    The Thomas-Fermi screening length is the exponential scale length for 
+    charge screening and is given by
+
+    .. math::
+    \lambda_TF = \sqrt{\frac{2 \epsilon_0 E_F}{3 n_e e^2}}
+
+    for an electron degenerate gas.
+    
+    This quantity is often used in place of the Debye length for analysis
+    of cold, dense plasmas (e.g. warm dense matter, condensed matter).
+
+    The electrical potential will drop by a factor of 1/e every Thomas-Fermi
+    screening length.
+
+    Plasmas will generally be quasineutral on length scales significantly
+    larger than the Thomas-Fermi screening length.
+
+    See also
+    --------
+    Fermi_energy
+
+    Example
+    -------
+    >>> from astropy import units as u
+    >>> Thomas_Fermi_length(1e23 * u.cm**-3)
+    <Quantity 5.379914085596706e-11 m>
+
+    """
+    try:
+        energy_F = Fermi_energy(n_e)
+        lambda_TF = np.sqrt(2 * eps0 * energy_F / (3 * n_e * e ** 2))
+    except Exception:
+        raise ValueError("Unable to find Thomas Fermi screening length.")
+    
+    return lambda_TF.to(units.m)

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -165,7 +165,7 @@ def thermal_deBroglie_wavelength(T_e):
     'n_e': {'units': units.m**-3, 'can_be_negative': False}
 })
 def Fermi_energy(n_e):
-    r"""Calculate the Thomas-Fermi screening length.
+    r"""Calculate the Fermi energy.
 
     Parameters
     ----------

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -155,10 +155,7 @@ def thermal_deBroglie_wavelength(T_e):
 
     """
     T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
-    try:
-        lambda_dbTh = h / np.sqrt(2 * np.pi * m_e * k_B * T_e)
-    except Exception:
-        raise ValueError("Unable to find thermal deBroglie wavelength.")
+    lambda_dbTh = h / np.sqrt(2 * np.pi * m_e * k_B * T_e)
     return lambda_dbTh.to(units.m)
 
 @check_quantity({
@@ -213,11 +210,8 @@ def Fermi_energy(n_e):
     <Quantity 1.2586761116196002e-18 J>
 
     """
-    try:
-        coeff = (np.pi * hbar) ** 2 / (2 * m_e)
-        energy_F = coeff * (3 * n_e / np.pi) ** (2/3)
-    except Exception:
-        raise ValueError("Unable to find Fermi energy.")
+    coeff = (np.pi * hbar) ** 2 / (2 * m_e)
+    energy_F = coeff * (3 * n_e / np.pi) ** (2/3)
     return energy_F.to(units.Joule)
 
 @check_quantity({
@@ -280,10 +274,6 @@ def Thomas_Fermi_length(n_e):
     <Quantity 5.379914085596706e-11 m>
 
     """
-    try:
-        energy_F = Fermi_energy(n_e)
-        lambda_TF = np.sqrt(2 * eps0 * energy_F / (3 * n_e * e ** 2))
-    except Exception:
-        raise ValueError("Unable to find Thomas Fermi screening length.")
-    
+    energy_F = Fermi_energy(n_e)
+    lambda_TF = np.sqrt(2 * eps0 * energy_F / (3 * n_e * e ** 2))
     return lambda_TF.to(units.m)

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -1,9 +1,21 @@
-import numpy as np
-import pytest
-import astropy.units as u
-from ...constants import c, h
-from ..quantum import deBroglie_wavelength
-
+if __name__ == "__main__":    
+    import numpy as np
+    import pytest
+    import astropy.units as u
+    from plasmapy.constants import c, h
+    from plasmapy.physics.quantum import(deBroglie_wavelength, 
+                                         thermal_deBroglie_wavelength, 
+                                         Fermi_energy, 
+                                         Thomas_Fermi_length)
+else:
+    import numpy as np
+    import pytest
+    import astropy.units as u
+    from ...constants import c, h
+    from ..quantum import (deBroglie_wavelength, 
+                           thermal_deBroglie_wavelength, 
+                           Fermi_energy, 
+                           Thomas_Fermi_length)
 
 def test_deBroglie_wavelength():
 
@@ -48,3 +60,37 @@ def test_deBroglie_wavelength():
 
     with pytest.raises(ValueError):
         deBroglie_wavelength(8*u.m/u.s, 'sddsf')
+
+# defining some plasma parameters for tests
+T_e = 1 * u.eV
+n_e = 1e23 * u.cm**-3
+# should probably change this to use unittest module
+# add tests for numpy arrays as inputs
+# add tests for different astropy units (random fuzzing method?)
+def test_thermal_deBroglie_wavelength():
+    r"""Test the thermal_deBroglie_wavelength function in quantum.py."""
+    lambda_dbTh = thermal_deBroglie_wavelength(T_e)
+    # test a simple case for expected value
+    assert np.isclose(lambda_dbTh.value,
+                      6.919367518364532e-10)
+    # testing returned units
+    assert lambda_dbTh.unit == u.m
+
+def test_Fermi_energy():
+    r"""Test the Fermi_energy function in quantum.py."""
+    energy_F = Fermi_energy(n_e)
+    # test a simple case for expected value
+    assert np.isclose(energy_F.value,
+                      1.2586761116196002e-18)
+    # testing returned units
+    assert energy_F.unit == u.J
+
+def test_Thomas_Fermi_length():
+    r"""Test the Thomas_Fermi_length function in quantum.py."""
+    lambda_TF = Thomas_Fermi_length(n_e)
+    # test a simple case for expected value
+    assert np.isclose(lambda_TF.value,
+                      5.379914085596706e-11)
+    # testing returned units
+    assert lambda_TF.unit == u.m
+    

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -71,6 +71,11 @@ def test_thermal_deBroglie_wavelength():
                       atol=0.0), expectStr
     # testing returned units
     assert lambda_dbTh.unit == u.m
+    # testing exceptions
+    with pytest.raises(TypeError):
+        thermal_deBroglie_wavelength("Bad Input")
+    with pytest.raises(ValueError):
+        thermal_deBroglie_wavelength(T_e=-1*u.eV)
 
 def test_Fermi_energy():
     r"""Test the Fermi_energy function in quantum.py."""
@@ -86,6 +91,11 @@ def test_Fermi_energy():
                       atol=0.0), expectStr
     # testing returned units
     assert energy_F.unit == u.J
+    # testing exceptions
+    with pytest.raises(TypeError):
+        Fermi_energy("Bad Input")
+    with pytest.raises(ValueError):
+        Fermi_energy(n_e=-1*u.m**-3)
 
 def test_Thomas_Fermi_length():
     r"""Test the Thomas_Fermi_length function in quantum.py."""
@@ -101,4 +111,9 @@ def test_Thomas_Fermi_length():
                       atol=0.0), expectStr
     # testing returned units
     assert lambda_TF.unit == u.m
+    # testing exceptions
+    with pytest.raises(TypeError):
+        Thomas_Fermi_length("Bad Input")
+    with pytest.raises(ValueError):
+        Thomas_Fermi_length(n_e=-1*u.m**-3)
     

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -60,30 +60,45 @@ n_e = 1e23 * u.cm**-3
 def test_thermal_deBroglie_wavelength():
     r"""Test the thermal_deBroglie_wavelength function in quantum.py."""
     lambda_dbTh = thermal_deBroglie_wavelength(T_e)
+    # true value at 1 eV
+    lambda_dbTh_true = 6.919367518364532e-10
     # test a simple case for expected value
-    expectStr = "Thermal deBroglie wavelength is off expected result for 1eV"
+    expectStr = ("Thermal deBroglie wavelength at 1 eV should be "
+                 f"{lambda_dbTh_true} and not {lambda_dbTh}")
     assert np.isclose(lambda_dbTh.value,
-                      6.919367518364532e-10), expectStr
+                      lambda_dbTh_true,
+                      rtol=1e-15,
+                      atol=0.0), expectStr
     # testing returned units
     assert lambda_dbTh.unit == u.m
 
 def test_Fermi_energy():
     r"""Test the Fermi_energy function in quantum.py."""
     energy_F = Fermi_energy(n_e)
+    # true value at 1e23 cm-3
+    energy_F_true = 1.2586761116196002e-18
     # test a simple case for expected value
-    expectStr = "Fermi energy is off expected result for 1e23 cm^-3"
+    expectStr = ("Fermi energy at 1e23 cm^-3 should be "
+                 f"{energy_F_true} and not {energy_F}.")
     assert np.isclose(energy_F.value,
-                      1.2586761116196002e-18), expectStr
+                      energy_F_true,
+                      rtol=1e-15,
+                      atol=0.0), expectStr
     # testing returned units
     assert energy_F.unit == u.J
 
 def test_Thomas_Fermi_length():
     r"""Test the Thomas_Fermi_length function in quantum.py."""
     lambda_TF = Thomas_Fermi_length(n_e)
+    # true value at 1e23 cm-3
+    lambda_TF_true = 5.379914085596706e-11
     # test a simple case for expected value
-    expectStr = "Thomas-Fermi length is off expected result for 1e23 cm^-3"
+    expectStr = ("Thomas-Fermi length at 1e23 cm^-3 should be "
+                 f"{lambda_TF_true} and not {lambda_TF}.")
     assert np.isclose(lambda_TF.value,
-                      5.379914085596706e-11), expectStr
+                      lambda_TF_true,
+                      rtol=1e-15,
+                      atol=0.0), expectStr
     # testing returned units
     assert lambda_TF.unit == u.m
     

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -1,21 +1,11 @@
-if __name__ == "__main__":    
-    import numpy as np
-    import pytest
-    import astropy.units as u
-    from plasmapy.constants import c, h
-    from plasmapy.physics.quantum import(deBroglie_wavelength, 
-                                         thermal_deBroglie_wavelength, 
-                                         Fermi_energy, 
-                                         Thomas_Fermi_length)
-else:
-    import numpy as np
-    import pytest
-    import astropy.units as u
-    from ...constants import c, h
-    from ..quantum import (deBroglie_wavelength, 
-                           thermal_deBroglie_wavelength, 
-                           Fermi_energy, 
-                           Thomas_Fermi_length)
+import numpy as np
+import pytest
+import astropy.units as u
+from ...constants import c, h
+from ..quantum import (deBroglie_wavelength, 
+                       thermal_deBroglie_wavelength, 
+                       Fermi_energy, 
+                       Thomas_Fermi_length)
 
 def test_deBroglie_wavelength():
 
@@ -71,8 +61,9 @@ def test_thermal_deBroglie_wavelength():
     r"""Test the thermal_deBroglie_wavelength function in quantum.py."""
     lambda_dbTh = thermal_deBroglie_wavelength(T_e)
     # test a simple case for expected value
+    expectStr = "Thermal deBroglie wavelength is off expected result for 1eV"
     assert np.isclose(lambda_dbTh.value,
-                      6.919367518364532e-10)
+                      6.919367518364532e-10), expectStr
     # testing returned units
     assert lambda_dbTh.unit == u.m
 
@@ -80,8 +71,9 @@ def test_Fermi_energy():
     r"""Test the Fermi_energy function in quantum.py."""
     energy_F = Fermi_energy(n_e)
     # test a simple case for expected value
+    expectStr = "Fermi energy is off expected result for 1e23 cm^-3"
     assert np.isclose(energy_F.value,
-                      1.2586761116196002e-18)
+                      1.2586761116196002e-18), expectStr
     # testing returned units
     assert energy_F.unit == u.J
 
@@ -89,8 +81,9 @@ def test_Thomas_Fermi_length():
     r"""Test the Thomas_Fermi_length function in quantum.py."""
     lambda_TF = Thomas_Fermi_length(n_e)
     # test a simple case for expected value
+    expectStr = "Thomas-Fermi length is off expected result for 1e23 cm^-3"
     assert np.isclose(lambda_TF.value,
-                      5.379914085596706e-11)
+                      5.379914085596706e-11), expectStr
     # testing returned units
     assert lambda_TF.unit == u.m
     


### PR DESCRIPTION
Added functions for thermal deBroglie length, Thomas-Fermi screening length, and Fermi energy. Also added corresponding tests and imports in __init__.py. Added check to quantum.py and test_quantum.py for if module is called __main__, which then swaps from relative to absolute path imports. This allows for individual execution/testing of these modules.