### PR TITLE
Added/modified 1D and 3D Maxwellian speed/velocity distributions

### DIFF
--- a/plasmapy/physics/__init__.py
+++ b/plasmapy/physics/__init__.py
@@ -25,4 +25,7 @@ from .relativity import Lorentz_factor
 
 from .transport import Coulomb_logarithm
 
-from .distribution import (Maxwellian_1D)
+from .distribution import (Maxwellian_1D,
+                           Maxwellian_speed_1D,
+                           Maxwellian_velocity_3D,
+                           Maxwellian_speed_3D)

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -1,6 +1,6 @@
 """Functions to deal with distribution : generate, fit, calculate"""
 
-from astropy import units
+from astropy import units as u
 
 from astropy.units import (UnitConversionError, UnitsError, quantity_input,
                            Quantity)
@@ -14,14 +14,14 @@ import numpy as np
 from ..utils import _check_quantity, check_relativistic, check_quantity
 
 
-@units.quantity_input
-def Maxwellian_1D(v: units.m/units.s,
+@u.quantity_input
+def Maxwellian_1D(v: u.m/u.s,
                   T, 
                   particle="e",
-                  V_drift=0*units.m/units.s):
+                  V_drift=0*u.m/u.s):
     r"""Returns the probability at the velocity `v` in m/s
-    to find a particle `particle` in a plasma of temperature `T`
-    following the Maxwellian distribution function.
+     to find a particle `particle` in a plasma of temperature `T`
+     following the Maxwellian distribution function.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def Maxwellian_1D(v: units.m/units.s,
     <Quantity 5.916329687405703e-07 s / m>
     """
     # convert temperature to Kelvins
-    T = T.to(units.K, equivalencies=units.temperature_energy())
+    T = T.to(u.K, equivalencies=u.temperature_energy())
     # get thermal velocity and thermal velocity squared
     vTh = thermal_speed(T, particle=particle, method="most_probable")
     vThSq = vTh ** 2
@@ -89,17 +89,17 @@ def Maxwellian_1D(v: units.m/units.s,
         distFunc = coeff * expTerm
     except Exception:
         raise ValueError("Unable to get distribution function.")
-    return distFunc.to(units.s/units.m)
+    return distFunc.to(u.s/u.m)
 
-@units.quantity_input
-def Maxwellian_velocity_3D(vx: units.m/units.s,
-                           vy: units.m/units.s,
-                           vz: units.m/units.s,
+@u.quantity_input
+def Maxwellian_velocity_3D(vx: u.m/u.s,
+                           vy: u.m/u.s,
+                           vz: u.m/u.s,
                            T, 
                            particle="e",
-                           Vx_drift=0*units.m/units.s,
-                           Vy_drift=0*units.m/units.s,
-                           Vz_drift=0*units.m/units.s):
+                           Vx_drift=0*u.m/u.s,
+                           Vy_drift=0*u.m/u.s,
+                           Vz_drift=0*u.m/u.s):
     r"""Return the probability of finding a particle with velocity components
     `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
     `T` which follows the 3D Maxwellian distribution function. This 
@@ -184,7 +184,7 @@ def Maxwellian_velocity_3D(vx: units.m/units.s,
     
     """
     # convert temperature to Kelvins
-    T = T.to(units.K, equivalencies=units.temperature_energy())
+    T = T.to(u.K, equivalencies=u.temperature_energy())
     # get thermal velocity and thermal velocity squared
     vTh = thermal_speed(T, particle=particle, method="most_probable")
     # accounting for thermal velocity in 3D
@@ -199,13 +199,13 @@ def Maxwellian_velocity_3D(vx: units.m/units.s,
         distFunc = coeff * expTerm
     except Exception:
         raise ValueError("Unable to get distribution function.")
-    return distFunc.to((units.s/units.m) ** 3)
+    return distFunc.to((u.s/u.m) ** 3)
 
-@units.quantity_input
-def Maxwellian_speed_1D(v: units.m/units.s,
+@u.quantity_input
+def Maxwellian_speed_1D(v: u.m/u.s,
                         T, 
                         particle="e",
-                        V_drift=0*units.m/units.s):
+                        V_drift=0*u.m/u.s):
     r"""Return the probability of finding a particle with speed `v` in m/s
      in an equilibrium plasma of temperature `T` which follows the 
      Maxwellian distribution function.
@@ -266,7 +266,7 @@ def Maxwellian_speed_1D(v: units.m/units.s,
     
     """
     # convert temperature to Kelvins
-    T = T.to(units.K, equivalencies=units.temperature_energy())
+    T = T.to(u.K, equivalencies=u.temperature_energy())
     # get thermal velocity and thermal velocity squared
     vTh = thermal_speed(T, particle=particle, method="most_probable")
     vThSq = vTh ** 2
@@ -280,17 +280,17 @@ def Maxwellian_speed_1D(v: units.m/units.s,
         distFunc = coeff1 * coeff2 * expTerm
     except Exception:
         raise ValueError("Unable to get distribution function.")
-    return distFunc.to(units.s/units.m)
+    return distFunc.to(u.s/u.m)
 
-@units.quantity_input
-def Maxwellian_speed_3D(vx: units.m/units.s,
-                        vy: units.m/units.s,
-                        vz: units.m/units.s,
+@u.quantity_input
+def Maxwellian_speed_3D(vx: u.m/u.s,
+                        vy: u.m/u.s,
+                        vz: u.m/u.s,
                         T, 
                         particle="e",
-                        Vx_drift=0*units.m/units.s,
-                        Vy_drift=0*units.m/units.s,
-                        Vz_drift=0*units.m/units.s):
+                        Vx_drift=0*u.m/u.s,
+                        Vy_drift=0*u.m/u.s,
+                        Vz_drift=0*u.m/u.s):
     r"""Return the probability of finding a particle with speed components
     `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
     `T` which follows the 3D Maxwellian distribution function. This 
@@ -374,7 +374,7 @@ def Maxwellian_speed_3D(vx: units.m/units.s,
     
     """
     # convert temperature to Kelvins
-    T = T.to(units.K, equivalencies=units.temperature_energy())
+    T = T.to(u.K, equivalencies=u.temperature_energy())
     # Get particle speed and drift speed
     v = np.sqrt(vx ** 2 + vy ** 2 + vz ** 2)
     V_drift = np.sqrt(Vx_drift ** 2 + Vy_drift ** 2 + Vz_drift ** 2)
@@ -386,4 +386,4 @@ def Maxwellian_speed_3D(vx: units.m/units.s,
                                        V_drift=V_drift)
     except Exception:
         raise ValueError("Unable to get distribution function.")
-    return distFunc.to(units.s/units.m)
+    return distFunc.to(u.s/u.m)

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -73,14 +73,14 @@ def Maxwellian_1D(v: units.m/units.s,
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
     >>> Maxwellian_1D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
-    <Quantity 5.916329687405701e-07 s / m>
+    <Quantity 5.916329687405703e-07 s / m>
     """
     # convert temperature to Kelvins
     T = T.to(units.K, equivalencies=units.temperature_energy())
     # get thermal velocity and thermal velocity squared
     vTh = thermal_speed(T, particle=particle, method="most_probable")
     vThSq = vTh ** 2
-    # Get particle velocity squared
+    # Get square of relative particle velocity
     vSq = (v - V_drift) ** 2
     # calculating distribution function
     try:
@@ -97,9 +97,9 @@ def Maxwellian_velocity_3D(vx: units.m/units.s,
                            vz: units.m/units.s,
                            T, 
                            particle="e",
-                           vx_drift=0*units.m/units.s,
-                           vy_drift=0*units.m/units.s,
-                           vz_drift=0*units.m/units.s):
+                           Vx_drift=0*units.m/units.s,
+                           Vy_drift=0*units.m/units.s,
+                           Vz_drift=0*units.m/units.s):
     r"""Return the probability of finding a particle with velocity components
     `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
     `T` which follows the 3D Maxwellian distribution function. This 
@@ -124,13 +124,13 @@ def Maxwellian_velocity_3D(vx: units.m/units.s,
         for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
         which defaults to electrons.
         
-    vx_drift: Quantity
+    Vx_drift: Quantity
         The drift velocity in x-direction units convertible to m/s
         
-    vy_drift: Quantity
+    Vy_drift: Quantity
         The drift velocity in y-direction units convertible to m/s
         
-    vz_drift: Quantity
+    Vz_drift: Quantity
         The drift velocity in z-direction units convertible to m/s
 
     Returns
@@ -159,7 +159,7 @@ def Maxwellian_velocity_3D(vx: units.m/units.s,
     is given by:
 
     .. math::
-    f = (\pi * v_Th^2)^{-3/2} \exp(-(\vec{v} - \vec{v_{drift}})^2 / v_Th^2)
+    f = (\pi * v_Th^2)^{-3/2} \exp(-(\vec{v} - \vec{V_{drift}})^2 / v_Th^2)
     where v_Th = \sqrt(2 k_B T / m) is the thermal speed
 
     See also
@@ -168,6 +168,18 @@ def Maxwellian_velocity_3D(vx: units.m/units.s,
 
     Example
     -------
+    >>> from plasmapy.physics import Maxwellian_velocity_3D
+    >>> from astropy import units as u
+    >>> v=1*u.m/u.s
+    >>> Maxwellian_velocity_3D(vx=v,
+    ... vy=v,
+    ... vz=v,
+    ... T=30000*u.K,
+    ... particle='e',
+    ... Vx_drift=0*u.m/u.s,
+    ... Vy_drift=0*u.m/u.s,
+    ... Vz_drift=0*u.m/u.s)
+    <Quantity 3.985430307328086e-20 s3 / m3>
     
     
     """
@@ -178,8 +190,8 @@ def Maxwellian_velocity_3D(vx: units.m/units.s,
     # accounting for thermal velocity in 3D
     vTh3D = np.sqrt(3) * vTh
     vThSq = vTh3D ** 2
-    # Get particle velocity squared
-    vSq = ((vx-vx_drift) ** 2 + (vy-vy_drift) ** 2 + (vz-vz_drift) ** 2)
+    # Get square of relative particle velocity
+    vSq = ((vx-Vx_drift) ** 2 + (vy-Vy_drift) ** 2 + (vz-Vz_drift) ** 2)
     # calculating distribution function
     try:
         coeff = (vThSq * np.pi) ** (-3 / 2)
@@ -193,7 +205,7 @@ def Maxwellian_velocity_3D(vx: units.m/units.s,
 def Maxwellian_speed_1D(v: units.m/units.s,
                         T, 
                         particle="e",
-                        v_drift=0*units.m/units.s):
+                        V_drift=0*units.m/units.s):
     r"""Return the probability of finding a particle with speed `v` in m/s
      in an equilibrium plasma of temperature `T` which follows the 
      Maxwellian distribution function.
@@ -211,7 +223,7 @@ def Maxwellian_speed_1D(v: units.m/units.s,
         for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
         which defaults to electrons.
     
-    v_drift: Quantity
+    V_drift: Quantity
         The drift speed in units convertible to m/s
 
     Returns
@@ -240,12 +252,17 @@ def Maxwellian_speed_1D(v: units.m/units.s,
     is given by:
 
     .. math::
-    f(v) = 4 \pi v^2 (\pi * v_Th^2)^{-3/2} \exp(-(v - v_{drift})^2 / v_Th^2)
+    f(v) = 4 \pi v^2 (\pi * v_Th^2)^{-3/2} \exp(-(v - V_{drift})^2 / v_Th^2)
     where v_Th = \sqrt(2 k_B T / m) is the thermal speed
 
 
     Example
     -------
+    >>> from plasmapy.physics import Maxwellian_speed_1D
+    >>> from astropy import units as u
+    >>> v=1*u.m/u.s
+    >>> Maxwellian_speed_1D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
+    <Quantity 2.602357544747327e-18 s / m>
     
     """
     # convert temperature to Kelvins
@@ -253,8 +270,8 @@ def Maxwellian_speed_1D(v: units.m/units.s,
     # get thermal velocity and thermal velocity squared
     vTh = thermal_speed(T, particle=particle, method="most_probable")
     vThSq = vTh ** 2
-    # square of particle velocity [m^2/s^2]
-    vSq = (v - v_drift) ** 2
+    # get square of relative particle velocity
+    vSq = (v - V_drift) ** 2
     # calculating distribution function
     try:
         coeff1 = (np.pi * vThSq) ** (-3 / 2)
@@ -271,9 +288,9 @@ def Maxwellian_speed_3D(vx: units.m/units.s,
                         vz: units.m/units.s,
                         T, 
                         particle="e",
-                        vx_drift=0*units.m/units.s,
-                        vy_drift=0*units.m/units.s,
-                        vz_drift=0*units.m/units.s):
+                        Vx_drift=0*units.m/units.s,
+                        Vy_drift=0*units.m/units.s,
+                        Vz_drift=0*units.m/units.s):
     r"""Return the probability of finding a particle with speed components
     `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
     `T` which follows the 3D Maxwellian distribution function. This 
@@ -298,13 +315,13 @@ def Maxwellian_speed_3D(vx: units.m/units.s,
         for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
         which defaults to electrons.
         
-    vx_drift: Quantity
+    Vx_drift: Quantity
         The drift speed in x-direction units convertible to m/s
         
-    vy_drift: Quantity
+    Vy_drift: Quantity
         The drift speed in y-direction units convertible to m/s
         
-    vz_drift: Quantity
+    Vz_drift: Quantity
         The drift speed in z-direction units convertible to m/s
         
     Returns
@@ -333,7 +350,7 @@ def Maxwellian_speed_3D(vx: units.m/units.s,
     is given by:
 
     .. math::
-    f = 4 \pi \vec{v}^2 (\pi * v_Th^2)^{-3/2} \exp(-(\vec{v} - \vec{v_{drift}})^2 / v_Th^2)
+    f = 4 \pi \vec{v}^2 (\pi * v_Th^2)^{-3/2} \exp(-(\vec{v} - \vec{V_{drift}})^2 / v_Th^2)
     where v_Th = \sqrt(2 k_B T / m) is the thermal speed
 
     See also
@@ -342,19 +359,31 @@ def Maxwellian_speed_3D(vx: units.m/units.s,
 
     Example
     -------
+    >>> from plasmapy.physics import Maxwellian_speed_3D
+    >>> from astropy import units as u
+    >>> v=1*u.m/u.s
+    >>> Maxwellian_speed_3D(vx=v,
+    ... vy=v,
+    ... vz=v,
+    ... T=30000*u.K,
+    ... particle='e',
+    ... Vx_drift=0*u.m/u.s,
+    ... Vy_drift=0*u.m/u.s,
+    ... Vz_drift=0*u.m/u.s)
+    <Quantity 7.80707263422481e-18 s / m>
     
     """
     # convert temperature to Kelvins
     T = T.to(units.K, equivalencies=units.temperature_energy())
     # Get particle speed and drift speed
     v = np.sqrt(vx ** 2 + vy ** 2 + vz ** 2)
-    v_drift = np.sqrt(vx_drift ** 2 + vy_drift ** 2 + vz_drift ** 2)
+    V_drift = np.sqrt(Vx_drift ** 2 + Vy_drift ** 2 + Vz_drift ** 2)
     # calculating distribution function
     try:
         distFunc = Maxwellian_speed_1D(v=v,
                                        T=T, 
                                        particle=particle,
-                                       v_drift=v_drift)
+                                       V_drift=V_drift)
     except Exception:
         raise ValueError("Unable to get distribution function.")
     return distFunc.to(units.s/units.m)

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -1,17 +1,8 @@
 """Functions to deal with distribution : generate, fit, calculate"""
 import astropy as astropy
 from astropy import units as u
-
-from astropy.units import (UnitConversionError, UnitsError, quantity_input,
-                           Quantity)
-
-from ..constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi, e)
-from ..atomic import (ion_mass, charge_state)
-from ..atomic.atomic import _is_electron as is_electron
 from .parameters import thermal_speed
 import numpy as np
-
-from ..utils import _check_quantity, check_relativistic, check_quantity
 
 
 def Maxwellian_1D(v,

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -91,15 +91,124 @@ def Maxwellian_1D(v: u.m/u.s,
         raise ValueError("Unable to get distribution function.")
     return distFunc.to(u.s/u.m)
 
-@u.quantity_input
-def Maxwellian_velocity_3D(vx: u.m/u.s,
-                           vy: u.m/u.s,
-                           vz: u.m/u.s,
+#@u.quantity_input
+#def Maxwellian_velocity_3D(vx: u.m/u.s,
+#                           vy: u.m/u.s,
+#                           vz: u.m/u.s,
+#                           T, 
+#                           particle="e",
+#                           Vx_drift=0*u.m/u.s,
+#                           Vy_drift=0*u.m/u.s,
+#                           Vz_drift=0*u.m/u.s):
+#    r"""Return the probability of finding a particle with velocity components
+#    `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
+#    `T` which follows the 3D Maxwellian distribution function. This 
+#    function assumes Cartesian coordinates.
+#
+#    Parameters
+#    ----------
+#    vx: Quantity
+#        The velocity in x-direction units convertible to m/s
+#        
+#    vy: Quantity
+#        The velocity in y-direction units convertible to m/s
+#        
+#    vz: Quantity
+#        The velocity in z-direction units convertible to m/s
+#
+#    T: Quantity
+#        The temperature, preferably in Kelvin
+#
+#    particle: string, optional
+#        Representation of the particle species(e.g., 'p' for protons, 'D+'
+#        for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
+#        which defaults to electrons.
+#        
+#    Vx_drift: Quantity
+#        The drift velocity in x-direction units convertible to m/s
+#        
+#    Vy_drift: Quantity
+#        The drift velocity in y-direction units convertible to m/s
+#        
+#    Vz_drift: Quantity
+#        The drift velocity in z-direction units convertible to m/s
+#
+#    Returns
+#    -------
+#    f : Quantity
+#        probability in Velocity^-1, normalized so that:
+#        $\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1}
+#
+#    Raises
+#    ------
+#    TypeError
+#        The parameter arguments are not Quantities and
+#        cannot be converted into Quantities.
+#
+#    UnitConversionError
+#        If the parameters is not in appropriate units.
+#
+#    ValueError
+#        If the temperature is negative, or the particle mass or charge state
+#        cannot be found.
+#
+#    Notes
+#    -----
+#    In one dimension, the Maxwellian speed distribution function describing
+#    the distribution of particles with speed v in a plasma with temperature T
+#    is given by:
+#
+#    .. math::
+#    f = (\pi * v_Th^2)^{-3/2} \exp(-(\vec{v} - \vec{V_{drift}})^2 / v_Th^2)
+#    where v_Th = \sqrt(2 k_B T / m) is the thermal speed
+#
+#    See also
+#    --------
+#    Maxwellian_1D
+#
+#    Example
+#    -------
+#    >>> from plasmapy.physics import Maxwellian_velocity_3D
+#    >>> from astropy import units as u
+#    >>> v=1*u.m/u.s
+#    >>> Maxwellian_velocity_3D(vx=v,
+#    ... vy=v,
+#    ... vz=v,
+#    ... T=30000*u.K,
+#    ... particle='e',
+#    ... Vx_drift=0*u.m/u.s,
+#    ... Vy_drift=0*u.m/u.s,
+#    ... Vz_drift=0*u.m/u.s)
+#    <Quantity 3.985430307328086e-20 s3 / m3>
+#    
+#    
+#    """
+#    # convert temperature to Kelvins
+#    T = T.to(u.K, equivalencies=u.temperature_energy())
+#    # get thermal velocity and thermal velocity squared
+#    vTh = thermal_speed(T, particle=particle, method="most_probable")
+#    # accounting for thermal velocity in 3D
+#    vTh3D = np.sqrt(3) * vTh
+#    vThSq = vTh3D ** 2
+#    # Get square of relative particle velocity
+#    vSq = ((vx-Vx_drift) ** 2 + (vy-Vy_drift) ** 2 + (vz-Vz_drift) ** 2)
+#    # calculating distribution function
+#    try:
+#        coeff = (vThSq * np.pi) ** (-3 / 2)
+#        expTerm = np.exp(-vSq / vThSq)
+#        distFunc = coeff * expTerm
+#    except Exception:
+#        raise ValueError("Unable to get distribution function.")
+#    return distFunc.to((u.s/u.m) ** 3)
+
+def Maxwellian_velocity_3D(vx,
+                           vy,
+                           vz,
                            T, 
                            particle="e",
-                           Vx_drift=0*u.m/u.s,
-                           Vy_drift=0*u.m/u.s,
-                           Vz_drift=0*u.m/u.s):
+                           Vx_drift=0,
+                           Vy_drift=0,
+                           Vz_drift=0):
     r"""Return the probability of finding a particle with velocity components
     `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
     `T` which follows the 3D Maxwellian distribution function. This 
@@ -183,23 +292,22 @@ def Maxwellian_velocity_3D(vx: u.m/u.s,
     
     
     """
-    # convert temperature to Kelvins
-    T = T.to(u.K, equivalencies=u.temperature_energy())
-    # get thermal velocity and thermal velocity squared
-    vTh = thermal_speed(T, particle=particle, method="most_probable")
+#    # convert temperature to Kelvins
+#    T = T.to(u.K, equivalencies=u.temperature_energy())
+#    # get thermal velocity and thermal velocity squared
+#    vTh = (thermal_speed(T, particle=particle, method="most_probable")).value
+    vTh = np.sqrt(1.6e-19 * T / (2 * 9.11e-31))
     # accounting for thermal velocity in 3D
-    vTh3D = np.sqrt(3) * vTh
-    vThSq = vTh3D ** 2
+    vThSq = 3 * vTh ** 2
+#    vTh3D = np.sqrt(3) * vTh
+#    vThSq = vTh3D ** 2
     # Get square of relative particle velocity
     vSq = ((vx-Vx_drift) ** 2 + (vy-Vy_drift) ** 2 + (vz-Vz_drift) ** 2)
     # calculating distribution function
-    try:
-        coeff = (vThSq * np.pi) ** (-3 / 2)
-        expTerm = np.exp(-vSq / vThSq)
-        distFunc = coeff * expTerm
-    except Exception:
-        raise ValueError("Unable to get distribution function.")
-    return distFunc.to((u.s/u.m) ** 3)
+    coeff = (vThSq * np.pi) ** (-3 / 2)
+    expTerm = np.exp(-vSq / vThSq)
+    distFunc = coeff * expTerm
+    return distFunc
 
 @u.quantity_input
 def Maxwellian_speed_1D(v: u.m/u.s,

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -8,6 +8,7 @@ from astropy.units import (UnitConversionError, UnitsError, quantity_input,
 from ..constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi, e)
 from ..atomic import (ion_mass, charge_state)
 from ..atomic.atomic import _is_electron as is_electron
+from .parameters import thermal_speed
 import numpy as np
 
 from ..utils import _check_quantity, check_relativistic, check_quantity
@@ -15,7 +16,8 @@ from ..utils import _check_quantity, check_relativistic, check_quantity
 
 @units.quantity_input
 def Maxwellian_1D(v: units.m/units.s,
-                  T: units.K, particle="e",
+                  T, 
+                  particle="e",
                   V_drift=0*units.m/units.s):
     r"""Returns the probability at the velocity `v` in m/s
     to find a particle `particle` in a plasma of temperature `T`
@@ -33,11 +35,14 @@ def Maxwellian_1D(v: units.m/units.s,
         Representation of the particle species(e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
         which defaults to electrons.
+        
+    V_drift: Quantity, optional
+        The drift velocity in units convertible to m/s
 
     Returns
     -------
     f : Quantity
-        probability in Velocity^-1, normized so that: :math:`\int_{-\infty}^{+\infty} f(v) dv = 1`
+        probability in Velocity^-1, normalized so that: :math:`\int_{-\infty}^{+\infty} f(v) dv = 1`
 
     Raises
     ------
@@ -58,7 +63,9 @@ def Maxwellian_1D(v: units.m/units.s,
     mass m, velocity v, a drift velocity V and with temperature T is:
 
     .. math::
-        f = \sqrt{\frac{m}{2 \pi k_B T}} e^{-\frac{m}{2 k_B T} (v-V)^2}
+    	f = \sqrt{\frac{m}{2 \pi k_B T}} e^{-\frac{m}{2 k_B T} (v-V)^2}
+    	f = (\pi * v_Th^2)^{-1/2} e^{-(v - v_{drift})^2 / v_Th^2}
+    	where v_Th = \sqrt(2 k_B T / m) is the thermal speed
 
     Examples
     --------
@@ -68,25 +75,286 @@ def Maxwellian_1D(v: units.m/units.s,
     >>> Maxwellian_1D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
     <Quantity 5.916329687405701e-07 s / m>
     """
+    # convert temperature to Kelvins
+    T = T.to(units.K, equivalencies=units.temperature_energy())
+    # get thermal velocity and thermal velocity squared
+    vTh = thermal_speed(T, particle=particle, method="most_probable")
+    vThSq = vTh ** 2
+    # Get particle velocity squared
+    vSq = (v - V_drift) ** 2
+    # calculating distribution function
+    try:
+        coeff = (vThSq * np.pi) ** (-1 / 2)
+        expTerm = np.exp(-vSq / vThSq)
+        distFunc = coeff * expTerm
+    except Exception:
+        raise ValueError("Unable to get distribution function.")
+    return distFunc.to(units.s/units.m)
 
-    # pass to Kelvin
+@units.quantity_input
+def Maxwellian_velocity_3D(vx: units.m/units.s,
+                           vy: units.m/units.s,
+                           vz: units.m/units.s,
+                           T, 
+                           particle="e",
+                           vx_drift=0*units.m/units.s,
+                           vy_drift=0*units.m/units.s,
+                           vz_drift=0*units.m/units.s):
+    r"""Return the probability of finding a particle with velocity components
+    `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
+    `T` which follows the 3D Maxwellian distribution function. This 
+    function assumes Cartesian coordinates.
 
-    if T.unit.is_equivalent(units.K):
-        T = T.to(units.K, equivalencies=units.temperature_energy())
+    Parameters
+    ----------
+    vx: Quantity
+        The velocity in x-direction units convertible to m/s
+        
+    vy: Quantity
+        The velocity in y-direction units convertible to m/s
+        
+    vz: Quantity
+        The velocity in z-direction units convertible to m/s
 
-    # Get mass
+    T: Quantity
+        The temperature, preferably in Kelvin
 
-    if is_electron(particle):
-        m_s = m_e
+    particle: string, optional
+        Representation of the particle species(e.g., 'p' for protons, 'D+'
+        for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
+        which defaults to electrons.
+        
+    vx_drift: Quantity
+        The drift velocity in x-direction units convertible to m/s
+        
+    vy_drift: Quantity
+        The drift velocity in y-direction units convertible to m/s
+        
+    vz_drift: Quantity
+        The drift velocity in z-direction units convertible to m/s
 
-    else:
-        try:
-            m_s = ion_mass(particle)
-        except Exception:
-            raise ValueError("Unable to find ion mass in Maxwellian_1D")
+    Returns
+    -------
+    f : Quantity
+        probability in Velocity^-1, normalized so that:
+        $\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1}
 
-    T = k_B*T
+    Raises
+    ------
+    TypeError
+        The parameter arguments are not Quantities and
+        cannot be converted into Quantities.
 
-    f = np.sqrt((m_s/(2*pi*T)))*np.exp(-m_s/(2*T)*(v-V_drift)**2)
+    UnitConversionError
+        If the parameters is not in appropriate units.
 
-    return f.to(units.s/units.m)
+    ValueError
+        If the temperature is negative, or the particle mass or charge state
+        cannot be found.
+
+    Notes
+    -----
+    In one dimension, the Maxwellian speed distribution function describing
+    the distribution of particles with speed v in a plasma with temperature T
+    is given by:
+
+    .. math::
+    f = (\pi * v_Th^2)^{-3/2} \exp(-(\vec{v} - \vec{v_{drift}})^2 / v_Th^2)
+    where v_Th = \sqrt(2 k_B T / m) is the thermal speed
+
+    See also
+    --------
+    Maxwellian_1D
+
+    Example
+    -------
+    
+    
+    """
+    # convert temperature to Kelvins
+    T = T.to(units.K, equivalencies=units.temperature_energy())
+    # get thermal velocity and thermal velocity squared
+    vTh = thermal_speed(T, particle=particle, method="most_probable")
+    # accounting for thermal velocity in 3D
+    vTh3D = np.sqrt(3) * vTh
+    vThSq = vTh3D ** 2
+    # Get particle velocity squared
+    vSq = ((vx-vx_drift) ** 2 + (vy-vy_drift) ** 2 + (vz-vz_drift) ** 2)
+    # calculating distribution function
+    try:
+        coeff = (vThSq * np.pi) ** (-3 / 2)
+        expTerm = np.exp(-vSq / vThSq)
+        distFunc = coeff * expTerm
+    except Exception:
+        raise ValueError("Unable to get distribution function.")
+    return distFunc.to((units.s/units.m) ** 3)
+
+@units.quantity_input
+def Maxwellian_speed_1D(v: units.m/units.s,
+                        T, 
+                        particle="e",
+                        v_drift=0*units.m/units.s):
+    r"""Return the probability of finding a particle with speed `v` in m/s
+     in an equilibrium plasma of temperature `T` which follows the 
+     Maxwellian distribution function.
+
+    Parameters
+    ----------
+    v: Quantity
+        The speed in units convertible to m/s
+
+    T: Quantity
+        The temperature, preferably in Kelvin
+
+    particle: string, optional
+        Representation of the particle species(e.g., 'p' for protons, 'D+'
+        for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
+        which defaults to electrons.
+    
+    v_drift: Quantity
+        The drift speed in units convertible to m/s
+
+    Returns
+    -------
+    f : Quantity
+        probability in speed^-1, normalized so that:
+        $\int_{0}^{\infty} f(v) dv = 1}
+
+    Raises
+    ------
+    TypeError
+        The parameter arguments are not Quantities and
+        cannot be converted into Quantities.
+
+    UnitConversionError
+        If the parameters is not in appropriate units.
+
+    ValueError
+        If the temperature is negative, or the particle mass or charge state
+        cannot be found.
+
+    Notes
+    -----
+    In one dimension, the Maxwellian speed distribution function describing
+    the distribution of particles with speed v in a plasma with temperature T
+    is given by:
+
+    .. math::
+    f(v) = 4 \pi v^2 (\pi * v_Th^2)^{-3/2} \exp(-(v - v_{drift})^2 / v_Th^2)
+    where v_Th = \sqrt(2 k_B T / m) is the thermal speed
+
+
+    Example
+    -------
+    
+    """
+    # convert temperature to Kelvins
+    T = T.to(units.K, equivalencies=units.temperature_energy())
+    # get thermal velocity and thermal velocity squared
+    vTh = thermal_speed(T, particle=particle, method="most_probable")
+    vThSq = vTh ** 2
+    # square of particle velocity [m^2/s^2]
+    vSq = (v - v_drift) ** 2
+    # calculating distribution function
+    try:
+        coeff1 = (np.pi * vThSq) ** (-3 / 2)
+        coeff2 = 4 * np.pi * vSq
+        expTerm = np.exp(-vSq / vThSq)
+        distFunc = coeff1 * coeff2 * expTerm
+    except Exception:
+        raise ValueError("Unable to get distribution function.")
+    return distFunc.to(units.s/units.m)
+
+@units.quantity_input
+def Maxwellian_speed_3D(vx: units.m/units.s,
+                        vy: units.m/units.s,
+                        vz: units.m/units.s,
+                        T, 
+                        particle="e",
+                        vx_drift=0*units.m/units.s,
+                        vy_drift=0*units.m/units.s,
+                        vz_drift=0*units.m/units.s):
+    r"""Return the probability of finding a particle with speed components
+    `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
+    `T` which follows the 3D Maxwellian distribution function. This 
+    function assumes Cartesian coordinates.
+
+    Parameters
+    ----------
+    vx: Quantity
+        The speed in x-direction units convertible to m/s
+        
+    vy: Quantity
+        The speed in y-direction units convertible to m/s
+        
+    vz: Quantity
+        The speed in z-direction units convertible to m/s
+
+    T: Quantity
+        The temperature, preferably in Kelvin
+
+    particle: string, optional
+        Representation of the particle species(e.g., 'p' for protons, 'D+'
+        for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
+        which defaults to electrons.
+        
+    vx_drift: Quantity
+        The drift speed in x-direction units convertible to m/s
+        
+    vy_drift: Quantity
+        The drift speed in y-direction units convertible to m/s
+        
+    vz_drift: Quantity
+        The drift speed in z-direction units convertible to m/s
+        
+    Returns
+    -------
+    f : Quantity
+        probability in speed^-1, normalized so that:
+        $\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1}
+
+    Raises
+    ------
+    TypeError
+        The parameter arguments are not Quantities and
+        cannot be converted into Quantities.
+
+    UnitConversionError
+        If the parameters is not in appropriate units.
+
+    ValueError
+        If the temperature is negative, or the particle mass or charge state
+        cannot be found.
+
+    Notes
+    -----
+    In one dimension, the Maxwellian speed distribution function describing
+    the distribution of particles with speed v in a plasma with temperature T
+    is given by:
+
+    .. math::
+    f = 4 \pi \vec{v}^2 (\pi * v_Th^2)^{-3/2} \exp(-(\vec{v} - \vec{v_{drift}})^2 / v_Th^2)
+    where v_Th = \sqrt(2 k_B T / m) is the thermal speed
+
+    See also
+    --------
+    Maxwellian_speed_1D
+
+    Example
+    -------
+    
+    """
+    # convert temperature to Kelvins
+    T = T.to(units.K, equivalencies=units.temperature_energy())
+    # Get particle speed and drift speed
+    v = np.sqrt(vx ** 2 + vy ** 2 + vz ** 2)
+    v_drift = np.sqrt(vx_drift ** 2 + vy_drift ** 2 + vz_drift ** 2)
+    # calculating distribution function
+    try:
+        distFunc = Maxwellian_speed_1D(v=v,
+                                       T=T, 
+                                       particle=particle,
+                                       v_drift=v_drift)
+    except Exception:
+        raise ValueError("Unable to get distribution function.")
+    return distFunc.to(units.s/units.m)

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -1,5 +1,5 @@
 """Functions to deal with distribution : generate, fit, calculate"""
-
+import astropy as astropy
 from astropy import units as u
 
 from astropy.units import (UnitConversionError, UnitsError, quantity_input,
@@ -90,116 +90,6 @@ def Maxwellian_1D(v: u.m/u.s,
     except Exception:
         raise ValueError("Unable to get distribution function.")
     return distFunc.to(u.s/u.m)
-
-#@u.quantity_input
-#def Maxwellian_velocity_3D(vx: u.m/u.s,
-#                           vy: u.m/u.s,
-#                           vz: u.m/u.s,
-#                           T, 
-#                           particle="e",
-#                           Vx_drift=0*u.m/u.s,
-#                           Vy_drift=0*u.m/u.s,
-#                           Vz_drift=0*u.m/u.s):
-#    r"""Return the probability of finding a particle with velocity components
-#    `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
-#    `T` which follows the 3D Maxwellian distribution function. This 
-#    function assumes Cartesian coordinates.
-#
-#    Parameters
-#    ----------
-#    vx: Quantity
-#        The velocity in x-direction units convertible to m/s
-#        
-#    vy: Quantity
-#        The velocity in y-direction units convertible to m/s
-#        
-#    vz: Quantity
-#        The velocity in z-direction units convertible to m/s
-#
-#    T: Quantity
-#        The temperature, preferably in Kelvin
-#
-#    particle: string, optional
-#        Representation of the particle species(e.g., 'p' for protons, 'D+'
-#        for deuterium, or 'He-4 +1' for $He_4^{+1}$ : singly ionized helium-4),
-#        which defaults to electrons.
-#        
-#    Vx_drift: Quantity
-#        The drift velocity in x-direction units convertible to m/s
-#        
-#    Vy_drift: Quantity
-#        The drift velocity in y-direction units convertible to m/s
-#        
-#    Vz_drift: Quantity
-#        The drift velocity in z-direction units convertible to m/s
-#
-#    Returns
-#    -------
-#    f : Quantity
-#        probability in Velocity^-1, normalized so that:
-#        $\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1}
-#
-#    Raises
-#    ------
-#    TypeError
-#        The parameter arguments are not Quantities and
-#        cannot be converted into Quantities.
-#
-#    UnitConversionError
-#        If the parameters is not in appropriate units.
-#
-#    ValueError
-#        If the temperature is negative, or the particle mass or charge state
-#        cannot be found.
-#
-#    Notes
-#    -----
-#    In one dimension, the Maxwellian speed distribution function describing
-#    the distribution of particles with speed v in a plasma with temperature T
-#    is given by:
-#
-#    .. math::
-#    f = (\pi * v_Th^2)^{-3/2} \exp(-(\vec{v} - \vec{V_{drift}})^2 / v_Th^2)
-#    where v_Th = \sqrt(2 k_B T / m) is the thermal speed
-#
-#    See also
-#    --------
-#    Maxwellian_1D
-#
-#    Example
-#    -------
-#    >>> from plasmapy.physics import Maxwellian_velocity_3D
-#    >>> from astropy import units as u
-#    >>> v=1*u.m/u.s
-#    >>> Maxwellian_velocity_3D(vx=v,
-#    ... vy=v,
-#    ... vz=v,
-#    ... T=30000*u.K,
-#    ... particle='e',
-#    ... Vx_drift=0*u.m/u.s,
-#    ... Vy_drift=0*u.m/u.s,
-#    ... Vz_drift=0*u.m/u.s)
-#    <Quantity 3.985430307328086e-20 s3 / m3>
-#    
-#    
-#    """
-#    # convert temperature to Kelvins
-#    T = T.to(u.K, equivalencies=u.temperature_energy())
-#    # get thermal velocity and thermal velocity squared
-#    vTh = thermal_speed(T, particle=particle, method="most_probable")
-#    # accounting for thermal velocity in 3D
-#    vTh3D = np.sqrt(3) * vTh
-#    vThSq = vTh3D ** 2
-#    # Get square of relative particle velocity
-#    vSq = ((vx-Vx_drift) ** 2 + (vy-Vy_drift) ** 2 + (vz-Vz_drift) ** 2)
-#    # calculating distribution function
-#    try:
-#        coeff = (vThSq * np.pi) ** (-3 / 2)
-#        expTerm = np.exp(-vSq / vThSq)
-#        distFunc = coeff * expTerm
-#    except Exception:
-#        raise ValueError("Unable to get distribution function.")
-#    return distFunc.to((u.s/u.m) ** 3)
 
 def Maxwellian_velocity_3D(vx,
                            vy,
@@ -301,7 +191,7 @@ def Maxwellian_velocity_3D(vx,
     ... Vx_drift=0*u.m/u.s,
     ... Vy_drift=0*u.m/u.s,
     ... Vz_drift=0*u.m/u.s)
-    <Quantity 3.985430307328086e-20 s3 / m3>
+    <Quantity 3.985430307328085e-20 s3 / m3>
     
     
     """
@@ -314,11 +204,14 @@ def Maxwellian_velocity_3D(vx,
         # catching case where drift velocities have default values, they
         # need to be assigned units
         if Vx_drift == 0:
-            Vx_drift = Vx_drift * u.m/u.s
+            if not isinstance(Vx_drift, astropy.units.quantity.Quantity):
+                Vx_drift = Vx_drift * u.m/u.s
         if Vy_drift == 0:
-            Vy_drift = Vy_drift * u.m/u.s
+            if not isinstance(Vy_drift, astropy.units.quantity.Quantity):
+                Vy_drift = Vy_drift * u.m/u.s
         if Vz_drift == 0:
-            Vz_drift = Vz_drift * u.m/u.s
+            if not isinstance(Vz_drift, astropy.units.quantity.Quantity):
+                Vz_drift = Vz_drift * u.m/u.s
         # checking units of drift velocities
         Vx_drift = Vx_drift.to(u.m/u.s)
         Vy_drift = Vy_drift.to(u.m/u.s)
@@ -433,7 +326,8 @@ def Maxwellian_speed_1D(v,
         # catching case where drift velocity has default value, and
         # needs to be assigned units
         if V_drift == 0:
-            V_drift = V_drift * u.m/u.s
+            if not isinstance(V_drift, astropy.units.quantity.Quantity):
+                V_drift = V_drift * u.m/u.s
         # checking drift velocity units
         V_drift = V_drift.to(u.m/u.s)
         # convert temperature to Kelvins
@@ -565,7 +459,7 @@ def Maxwellian_speed_3D(vx,
     ... Vx_drift=0*u.m/u.s,
     ... Vy_drift=0*u.m/u.s,
     ... Vz_drift=0*u.m/u.s)
-    <Quantity 7.80707263422481e-18 s / m>
+    <Quantity 1.7623854373113508e-53 s3 / m3>
     
     """
     if units == "units":
@@ -577,11 +471,14 @@ def Maxwellian_speed_3D(vx,
         # catching case where drift velocities have default values, they
         # need to be assigned units
         if Vx_drift == 0:
-            Vx_drift = Vx_drift * u.m/u.s
+            if not isinstance(Vx_drift, astropy.units.quantity.Quantity):
+                Vx_drift = Vx_drift * u.m/u.s
         if Vy_drift == 0:
-            Vy_drift = Vy_drift * u.m/u.s
+            if not isinstance(Vy_drift, astropy.units.quantity.Quantity):
+                Vy_drift = Vy_drift * u.m/u.s
         if Vz_drift == 0:
-            Vz_drift = Vz_drift * u.m/u.s
+            if not isinstance(Vz_drift, astropy.units.quantity.Quantity):
+                Vz_drift = Vz_drift * u.m/u.s
         Vx_drift = Vx_drift.to(u.m/u.s)
         Vy_drift = Vy_drift.to(u.m/u.s)
         Vz_drift = Vz_drift.to(u.m/u.s)

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -83,12 +83,9 @@ def Maxwellian_1D(v: u.m/u.s,
     # Get square of relative particle velocity
     vSq = (v - V_drift) ** 2
     # calculating distribution function
-    try:
-        coeff = (vThSq * np.pi) ** (-1 / 2)
-        expTerm = np.exp(-vSq / vThSq)
-        distFunc = coeff * expTerm
-    except Exception:
-        raise ValueError("Unable to get distribution function.")
+    coeff = (vThSq * np.pi) ** (-1 / 2)
+    expTerm = np.exp(-vSq / vThSq)
+    distFunc = coeff * expTerm
     return distFunc.to(u.s/u.m)
 
 def Maxwellian_velocity_3D(vx,
@@ -346,13 +343,10 @@ def Maxwellian_speed_1D(v,
     # get square of relative particle speed
     vSq = (v - V_drift) ** 2
     # calculating distribution function
-    try:
-        coeff1 = (np.pi * vThSq) ** (-3 / 2)
-        coeff2 = 4 * np.pi * vSq
-        expTerm = np.exp(-vSq / vThSq)
-        distFunc = coeff1 * coeff2 * expTerm
-    except Exception:
-        raise ValueError("Unable to get distribution function.")
+    coeff1 = (np.pi * vThSq) ** (-3 / 2)
+    coeff2 = 4 * np.pi * vSq
+    expTerm = np.exp(-vSq / vThSq)
+    distFunc = coeff1 * coeff2 * expTerm
     if units == "units":
         return distFunc.to(u.s/u.m)
     elif units == "unitless":
@@ -493,29 +487,27 @@ def Maxwellian_speed_3D(vx,
     elif np.isnan(vTh) and units == "unitless":
         # assuming unitless temperature is in Kelvins
         vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable")).si.value
-    try:
-        fx = Maxwellian_speed_1D(vx,
-                                 T, 
-                                 particle=particle,
-                                 V_drift=Vx_drift,
-                                 vTh=vTh,
-                                 units=units)
-        fy = Maxwellian_speed_1D(vy,
-                                 T, 
-                                 particle=particle,
-                                 V_drift=Vy_drift,
-                                 vTh=vTh,
-                                 units=units)
-        fz = Maxwellian_speed_1D(vz,
-                                 T, 
-                                 particle=particle,
-                                 V_drift=Vz_drift,
-                                 vTh=vTh,
-                                 units=units)
-        # multiplying probabilities in each axis to get 3D probability
-        distFunc = fx * fy * fz
-    except Exception:
-        raise ValueError("Unable to get distribution function.")
+    # getting distribution functions along each axis
+    fx = Maxwellian_speed_1D(vx,
+                             T, 
+                             particle=particle,
+                             V_drift=Vx_drift,
+                             vTh=vTh,
+                             units=units)
+    fy = Maxwellian_speed_1D(vy,
+                             T, 
+                             particle=particle,
+                             V_drift=Vy_drift,
+                             vTh=vTh,
+                             units=units)
+    fz = Maxwellian_speed_1D(vz,
+                             T, 
+                             particle=particle,
+                             V_drift=Vz_drift,
+                             vTh=vTh,
+                             units=units)
+    # multiplying probabilities in each axis to get 3D probability
+    distFunc = fx * fy * fz
     if units == "units":
         return distFunc.to((u.s/u.m)**3)
     elif units == "unitless":

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -99,7 +99,7 @@ def Maxwellian_velocity_3D(vx,
                            Vx_drift=0,
                            Vy_drift=0,
                            Vz_drift=0,
-                           vTh=-1,
+                           vTh=np.nan,
                            units="units"):
     r"""Return the probability of finding a particle with velocity components
     `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
@@ -218,15 +218,15 @@ def Maxwellian_velocity_3D(vx,
         Vz_drift = Vz_drift.to(u.m/u.s)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
-        if vTh == -1:
+        if np.isnan(vTh):
             # get thermal velocity and thermal velocity squared
             vTh = (thermal_speed(T, particle=particle, method="most_probable"))
-        elif vTh != -1:
+        elif not np.isnan(vTh):
             # check units of thermal velocity
             vTh = vTh.to(u.m/u.s)
-    elif vTh == -1 and units == "unitless":
+    elif np.isnan(vTh) and units == "unitless":
         # assuming unitless temperature is in Kelvins
-        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable"))
+        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable")).si.value
     # accounting for thermal velocity in 3D
     vThSq = 3 * vTh ** 2
 #    vTh3D = np.sqrt(3) * vTh
@@ -247,7 +247,7 @@ def Maxwellian_speed_1D(v,
                         T, 
                         particle="e",
                         V_drift=0,
-                        vTh=-1,
+                        vTh=np.nan,
                         units="units"):
     r"""Return the probability of finding a particle with speed `v` in m/s
      in an equilibrium plasma of temperature `T` which follows the 
@@ -332,15 +332,15 @@ def Maxwellian_speed_1D(v,
         V_drift = V_drift.to(u.m/u.s)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
-        if vTh == -1:
+        if np.isnan(vTh):
             # get thermal velocity and thermal velocity squared
             vTh = (thermal_speed(T, particle=particle, method="most_probable"))
-        elif vTh != -1:
+        elif not np.isnan(vTh):
             # check units of thermal velocity
             vTh = vTh.to(u.m/u.s)
-    elif vTh == -1 and units == "unitless":
+    elif np.isnan(vTh) and units == "unitless":
         # assuming unitless temperature is in Kelvins
-        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable"))
+        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable")).si.value
     # getting square of thermal speed
     vThSq = vTh ** 2
     # get square of relative particle speed
@@ -367,7 +367,7 @@ def Maxwellian_speed_3D(vx,
                         Vx_drift=0,
                         Vy_drift=0,
                         Vz_drift=0,
-                        vTh=-1,
+                        vTh=np.nan,
                         units="units"):
     r"""Return the probability of finding a particle with speed components
     `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature 
@@ -484,15 +484,15 @@ def Maxwellian_speed_3D(vx,
         Vz_drift = Vz_drift.to(u.m/u.s)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
-        if vTh == -1:
+        if np.isnan(vTh):
             # get thermal velocity and thermal velocity squared
             vTh = (thermal_speed(T, particle=particle, method="most_probable"))
-        elif vTh != -1:
+        elif not np.isnan(vTh):
             # check units of thermal velocity
             vTh = vTh.to(u.m/u.s)
-    elif vTh == -1 and units == "unitless":
+    elif np.isnan(vTh) and units == "unitless":
         # assuming unitless temperature is in Kelvins
-        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable"))
+        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable")).si.value
     try:
         fx = Maxwellian_speed_1D(vx,
                                  T, 

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -93,13 +93,17 @@ def Maxwellian_1D(v,
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
             # get thermal velocity and thermal velocity squared
-            vTh = (thermal_speed(T, particle=particle, method="most_probable"))
+            vTh = (thermal_speed(T, 
+                                 particle=particle, 
+                                 method="most_probable"))
         elif not np.isnan(vTh):
             # check units of thermal velocity
             vTh = vTh.to(u.m/u.s)
     elif np.isnan(vTh) and units == "unitless":
         # assuming unitless temperature is in Kelvins
-        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable")).si.value
+        vTh = (thermal_speed(T*u.K, 
+                             particle=particle, 
+                             method="most_probable")).si.value
     # Get thermal velocity squared
     vThSq = vTh ** 2
     # Get square of relative particle velocity
@@ -242,13 +246,17 @@ def Maxwellian_velocity_3D(vx,
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
             # get thermal velocity and thermal velocity squared
-            vTh = (thermal_speed(T, particle=particle, method="most_probable"))
+            vTh = (thermal_speed(T, 
+                                 particle=particle, 
+                                 method="most_probable"))
         elif not np.isnan(vTh):
             # check units of thermal velocity
             vTh = vTh.to(u.m/u.s)
     elif np.isnan(vTh) and units == "unitless":
         # assuming unitless temperature is in Kelvins
-        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable")).si.value
+        vTh = (thermal_speed(T*u.K, 
+                             particle=particle, 
+                             method="most_probable")).si.value
     # accounting for thermal velocity in 3D
     vThSq = 3 * vTh ** 2
     # Get square of relative particle velocity
@@ -354,13 +362,17 @@ def Maxwellian_speed_1D(v,
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
             # get thermal velocity and thermal velocity squared
-            vTh = (thermal_speed(T, particle=particle, method="most_probable"))
+            vTh = (thermal_speed(T, 
+                                 particle=particle, 
+                                 method="most_probable"))
         elif not np.isnan(vTh):
             # check units of thermal velocity
             vTh = vTh.to(u.m/u.s)
     elif np.isnan(vTh) and units == "unitless":
         # assuming unitless temperature is in Kelvins
-        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable")).si.value
+        vTh = (thermal_speed(T*u.K, 
+                             particle=particle, 
+                             method="most_probable")).si.value
     # getting square of thermal speed
     vThSq = vTh ** 2
     # get square of relative particle speed
@@ -503,13 +515,17 @@ def Maxwellian_speed_3D(vx,
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
             # get thermal velocity and thermal velocity squared
-            vTh = (thermal_speed(T, particle=particle, method="most_probable"))
+            vTh = (thermal_speed(T, 
+                                 particle=particle, 
+                                 method="most_probable"))
         elif not np.isnan(vTh):
             # check units of thermal velocity
             vTh = vTh.to(u.m/u.s)
     elif np.isnan(vTh) and units == "unitless":
         # assuming unitless temperature is in Kelvins
-        vTh = (thermal_speed(T*u.K, particle=particle, method="most_probable")).si.value
+        vTh = (thermal_speed(T*u.K, 
+                             particle=particle, 
+                             method="most_probable")).si.value
     # getting distribution functions along each axis
     fx = Maxwellian_speed_1D(vx,
                              T, 

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -5,17 +5,12 @@ import pytest
 from astropy import units as u
 import scipy.integrate as spint
 
-
-from ...constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi, e)
-from ...atomic import (ion_mass, charge_state)
+from ...constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi)
 from ..distribution import (Maxwellian_1D,
                             Maxwellian_speed_1D,
                             Maxwellian_velocity_3D,
                             Maxwellian_speed_3D)
 from ..parameters import thermal_speed
-
-
-
 
 # test class for Maxwellian_1D (velocity) function:
 class Test_Maxwellian_1D(object):
@@ -26,7 +21,9 @@ class Test_Maxwellian_1D(object):
         self.start = -5000
         self.stop = - self.start
         self.dv = 10000 * u.m/u.s
-        self.v_vect = np.arange(self.start, self.stop, dtype='float64') * self.dv
+        self.v_vect = np.arange(self.start, 
+                                self.stop, 
+                                dtype='float64') * self.dv
     def test_max_noDrift(self):
         """
         Checks maximum value of distribution function is in expected place,
@@ -77,6 +74,7 @@ class Test_Maxwellian_1D(object):
             Maxwellian_1D(1*u.m/u.s,
                           T=1*u.K,
                           particle='XXX')
+
 
 # test class for Maxwellian_speed_1D function
 class Test_Maxwellian_speed_1D(object):
@@ -139,7 +137,8 @@ class Test_Maxwellian_velocity_3D(object):
                               epsabs=1e0,
                               epsrel=1e0,
                               )
-        # value returned from tplquad is (integral, error), we just need the 1st
+        # value returned from tplquad is (integral, error), we just need 
+        # the 1st
         integVal = integ[0]
         exceptStr = ("Integral of distribution function should be 1 "
                      f"and not {integVal}.")
@@ -147,6 +146,7 @@ class Test_Maxwellian_velocity_3D(object):
                           1,
                           rtol=1e-3,
                           atol=0.0), exceptStr
+
 
 # test class for Maxwellian_speed_3D function
 class Test_Maxwellian_speed_3D(object):
@@ -158,6 +158,12 @@ class Test_Maxwellian_speed_3D(object):
         self.vTh = thermal_speed(self.T,
                                  particle=self.particle,
                                  method="most_probable")
+        self.vx = 1 * u.m/u.s
+        self.vy = 1 * u.m/u.s
+        self.vz = 1 * u.m/u.s
+        self.Vx_drift = 0 * u.m/u.s
+        self.Vy_drift = 0 * u.m/u.s
+        self.Vz_drift = 0 * u.m/u.s
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
@@ -184,7 +190,8 @@ class Test_Maxwellian_speed_3D(object):
                               epsabs=1e0,
                               epsrel=1e0,
                               )
-        # value returned from tplquad is (integral, error), we just need the 1st
+        # value returned from tplquad is (integral, error), we just need 
+        # the 1st
         integVal = integ[0]
         exceptStr = ("Integral of distribution function should be 1 "
                      f"and not {integVal}")
@@ -196,15 +203,81 @@ class Test_Maxwellian_speed_3D(object):
         """
         Tests distribution function with units, but not passing vTh.
         """
+        distFuncTrue = 1.2656798868233342e-51
+        distFunc = Maxwellian_speed_3D(vx=self.vx,
+                                       vy=self.vy,
+                                       vz=self.vz,
+                                       T=self.T, 
+                                       particle="e",
+                                       units="units")
+        errStr = (f"Distribution function should be {distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, distFuncTrue), errStr
     def test_units_vTh(self):
         """
         Tests distribution function with units and passing vTh.
         """
+        distFuncTrue = 1.2656798868233342e-51
+        distFunc = Maxwellian_speed_3D(vx=self.vx,
+                                       vy=self.vy,
+                                       vz=self.vz,
+                                       T=self.T,
+                                       vTh=self.vTh,
+                                       particle="e",
+                                       units="units")
+        errStr = (f"Distribution function should be {distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, distFuncTrue), errStr
     def test_unitless_no_vTh(self):
         """
         Tests distribution function without units, and not passing vTh.
         """
+        # converting T to SI then stripping units
+        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+        T = T.si.value
+        distFuncTrue = 1.2656798868233342e-51
+        distFunc = Maxwellian_speed_3D(vx=self.vx.si.value,
+                                       vy=self.vy.si.value,
+                                       vz=self.vz.si.value,
+                                       T=T, 
+                                       particle="e",
+                                       units="unitless")
+        errStr = (f"Distribution function should be {distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc, distFuncTrue), errStr
     def test_unitless_vTh(self):
         """
         Tests distribution function without units, and with passing vTh.
         """
+        # converting T to SI then stripping units
+        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+        T = T.si.value
+        distFuncTrue = 1.2656798868233342e-51
+        distFunc = Maxwellian_speed_3D(vx=self.vx.si.value,
+                                       vy=self.vy.si.value,
+                                       vz=self.vz.si.value,
+                                       T=T,
+                                       vTh=self.vTh.si.value,
+                                       particle="e",
+                                       units="unitless")
+        errStr = (f"Distribution function should be {distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc, distFuncTrue), errStr
+    def test_zero_drift_units(self):
+        """
+        Testing inputting drift equal to 0 with units. These should just
+        get passed and not have extra units applied to them.
+        """
+        distFuncTrue = 1.2656798868233342e-51
+        distFunc = Maxwellian_speed_3D(vx=self.vx,
+                                       vy=self.vy,
+                                       vz=self.vz,
+                                       T=self.T,
+                                       particle="e",
+                                       Vx_drift=self.Vx_drift,
+                                       Vy_drift=self.Vy_drift,
+                                       Vz_drift=self.Vz_drift,
+                                       units="units")
+        errStr = (f"Distribution function should be {distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, distFuncTrue), errStr

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -3,11 +3,16 @@
 import numpy as np
 import pytest
 from astropy import units as u
+import scipy.integrate as spint
 
 
 from ...constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi, e)
 from ...atomic import (ion_mass, charge_state)
-from ..distribution import (Maxwellian_1D)
+from ..distribution import (Maxwellian_1D,
+                            Maxwellian_speed_1D,
+                            Maxwellian_velocity_3D,
+                            Maxwellian_speed_3D)
+from ..parameters import thermal_speed
 
 T_e = 30000*u.K
 V_drift = 1000000*u.m/u.s
@@ -42,3 +47,84 @@ def test_Maxwellian_1D():
 
     with pytest.raises(ValueError):
         Maxwellian_1D(1*u.m/u.s, T=1*u.K, particle='XXX')
+
+def test_Maxwellian_speed_1D():
+    r"""test the 1D Maxwellian speed distribution function"""
+    T = 1.0 * u.eV
+    particle = 'H'
+    # get thermal velocity and thermal velocity squared
+    vTh = thermal_speed(T, particle=particle, method="most_probable")
+    # setting up integration from 0 to 10*vTh
+    xData1D = np.arange(0, 10.01, 0.01) * vTh
+    yData1D = Maxwellian_speed_1D(v=xData1D,T=T,particle=particle)
+    # integrating, this should be close to 1
+    integ = spint.trapz(y=yData1D, x=xData1D)
+    print("1D integral {0}".format(integ))
+    exceptStr = "Integral of distribution function should be 1."
+    assert np.isclose(integ.value, 1), exceptStr
+    
+    
+def test_Maxwellian_velocity_3D():
+    r"""test the 3D Maxwellian velocity distribution function"""
+    T = 1.0 * u.eV
+    particle = 'H'
+    # get thermal velocity and thermal velocity squared
+    vTh = thermal_speed(T, particle=particle, method="most_probable")
+    # defining a closure with partially applied arguments
+    def velDist3D(vx, vy, vz):
+        velDist = Maxwellian_velocity_3D(vx=vx,
+                                         vy=vy,
+                                         vz=vz,
+                                         T=T, 
+                                         particle=particle)
+        return velDist
+    # setting up integration from -10*vTh to 10*vTh, which is close to Inf
+    infApprox = 10 * vTh
+    # if I recall correctly, astropy.units may have trouble with
+    # accounting for units in integrals, so this step currently fails when
+    # tplquad tries to convert a quantity with units to a scalar.
+    # integrating, this should be close to 1
+    integ = spint.tplquad(velDist3D,
+                          -infApprox,
+                          infApprox,
+                          lambda z: -infApprox,
+                          lambda z: infApprox,
+                          lambda z, y: -infApprox,
+                          lambda z, y: infApprox,
+                          epsabs=1.49e-08*u.m/u.m, 
+                          epsrel=1.49e-08*u.m/u.m)
+    exceptStr = "Integral of distribution function should be 1."
+    assert np.isclose(integ.value, 1), exceptStr
+    
+def test_Maxwellian_speed_3D():
+    r"""test the 3D Maxwellian speed distribution function"""
+    T = 1.0 * u.eV
+    particle = 'H'
+    # get thermal velocity and thermal velocity squared
+    vTh = thermal_speed(T, particle=particle, method="most_probable")
+    # defining a closure with partially applied arguments so that we
+    # can do a triple integral over vx, vy, vz
+    def speedDist3D(vx, vy, vz):
+        speedDist = Maxwellian_speed_3D(vx=vx,
+                                        vy=vy,
+                                        vz=vz,
+                                        T=T, 
+                                        particle=particle)
+        return speedDist
+    # setting up integration from 0 to 10*vTh, which is close to Inf
+    infApprox = 10 * vTh
+    # if I recall correctly, astropy.units may have trouble with
+    # accounting for units in integrals, so this step currently fails when
+    # tplquad tries to convert a quantity with units to a scalar.
+    # integrating, this should be close to 1
+    integ = spint.tplquad(speedDist3D,
+                          0*u.m/u.s,
+                          infApprox,
+                          lambda z: 0*u.m/u.s,
+                          lambda z: infApprox,
+                          lambda z, y: 0*u.m/u.s,
+                          lambda z, y: infApprox,
+                          epsabs=1.49e-08*u.m/u.m, 
+                          epsrel=1.49e-08*u.m/u.m)
+    exceptStr = "Integral of distribution function should be 1."
+    assert np.isclose(integ.value, 1), exceptStr

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -59,7 +59,6 @@ def test_Maxwellian_speed_1D():
     yData1D = Maxwellian_speed_1D(v=xData1D,T=T,particle=particle)
     # integrating, this should be close to 1
     integ = spint.trapz(y=yData1D, x=xData1D)
-    print("1D integral {0}".format(integ))
     exceptStr = "Integral of distribution function should be 1."
     assert np.isclose(integ.value, 1), exceptStr
     

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -69,32 +69,21 @@ def test_Maxwellian_velocity_3D():
     particle = 'H'
     # get thermal velocity and thermal velocity squared
     vTh = thermal_speed(T, particle=particle, method="most_probable")
-    # defining a closure with partially applied arguments
-    def velDist3D(vx, vy, vz):
-        # tplquad passes values without units, so we add units so that
-        # Maxwellian_velocity_3D can handle them
-        velDist = Maxwellian_velocity_3D(vx=vx*u.m/u.s,
-                                         vy=vy*u.m/u.s,
-                                         vz=vz*u.m/u.s,
-                                         T=T, 
-                                         particle=particle)
-        # return value stripped of units so tplquad can handle it
-        return velDist.value
+    vTh = vTh.si.value
     # setting up integration from -10*vTh to 10*vTh, which is close to Inf
-    infApprox = (10 * vTh).value
-    # if I recall correctly, astropy.units may have trouble with
-    # accounting for units in integrals, so this step currently fails when
-    # tplquad tries to convert a quantity with units to a scalar.
+    infApprox = (10 * vTh)
     # integrating, this should be close to 1
-    integ = spint.tplquad(velDist3D,
+    integ = spint.tplquad(Maxwellian_velocity_3D,
                           -infApprox,
                           infApprox,
                           lambda z: -infApprox,
                           lambda z: infApprox,
                           lambda z, y: -infApprox,
                           lambda z, y: infApprox,
-                          epsabs=5.0e-1, 
-                          epsrel=5.0e-1)
+                          args=(T,particle,0,0,0, vTh, "unitless"),
+                          epsabs=1e0,
+                          epsrel=1e0,
+                          )
     # value returned from tplquad is (integral, error), we just need the 1st
     integVal = integ[0]
     exceptStr = ("Integral of distribution function should be 1 "
@@ -104,41 +93,32 @@ def test_Maxwellian_velocity_3D():
                       rtol=1e-3,
                       atol=0.0), exceptStr
     
-#def test_Maxwellian_speed_3D():
-#    r"""test the 3D Maxwellian speed distribution function"""
-#    T = 1.0 * u.eV
-#    particle = 'H'
-#    # get thermal velocity and thermal velocity squared
-#    vTh = thermal_speed(T, particle=particle, method="most_probable")
-#    # defining a closure with partially applied arguments so that we
-#    # can do a triple integral over vx, vy, vz
-#    def speedDist3D(vx, vy, vz):
-#        # tplquad passes values without units, so we add units so that
-#        # Maxwellian_speed_3D can handle them
-#        speedDist = Maxwellian_speed_3D(vx=vx*u.m/u.s,
-#                                        vy=vy*u.m/u.s,
-#                                        vz=vz*u.m/u.s,
-#                                        T=T, 
-#                                        particle=particle)
-#        # return value stripped of units so tplquad can handle it
-#        return speedDist.si.value
-#    # setting up integration from 0 to 10*vTh, which is close to Inf
-#    infApprox = (10 * vTh).si.value
-#    # integral should be close to 1
-#    integ = spint.tplquad(speedDist3D,
-#                          0,
-#                          infApprox,
-#                          lambda z: 0,
-#                          lambda z: infApprox,
-#                          lambda z, y: 0,
-#                          lambda z, y: infApprox,
-#                          epsabs=5.0e-1, 
-#                          epsrel=5.0e-1)
-#    # value returned from tplquad is (integral, error), we just need the 1st
-#    integVal = integ[0]
-#    exceptStr = ("Integral of distribution function should be 1 "
-#                 f"and not {integVal}")
-#    assert np.isclose(integVal,
-#                      1,
-#                      rtol=-3,
-#                      atol=0.0), exceptStr
+def test_Maxwellian_speed_3D():
+    r"""test the 3D Maxwellian speed distribution function"""
+    T = 1.0 * u.eV
+    particle = 'H'
+    # get thermal velocity and thermal velocity squared
+    vTh = thermal_speed(T, particle=particle, method="most_probable")
+    vTh = vTh.si.value
+    # setting up integration from 0 to 10*vTh, which is close to Inf
+    infApprox = (10 * vTh)
+    # integral should be close to 1
+    integ = spint.tplquad(Maxwellian_speed_3D,
+                          0,
+                          infApprox,
+                          lambda z: 0,
+                          lambda z: infApprox,
+                          lambda z, y: 0,
+                          lambda z, y: infApprox,
+                          args=(T,particle,0,0,0, vTh, "unitless"),
+                          epsabs=1e0,
+                          epsrel=1e0,
+                          )
+    # value returned from tplquad is (integral, error), we just need the 1st
+    integVal = integ[0]
+    exceptStr = ("Integral of distribution function should be 1 "
+                 f"and not {integVal}")
+    assert np.isclose(integVal,
+                      1,
+                      rtol=1e-3,
+                      atol=0.0), exceptStr

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -79,9 +79,9 @@ def test_Maxwellian_velocity_3D():
                                          T=T, 
                                          particle=particle)
         # return value stripped of units so tplquad can handle it
-        return velDist.si.value
+        return velDist.value
     # setting up integration from -10*vTh to 10*vTh, which is close to Inf
-    infApprox = (10 * vTh).si.value
+    infApprox = (10 * vTh).value
     # if I recall correctly, astropy.units may have trouble with
     # accounting for units in integrals, so this step currently fails when
     # tplquad tries to convert a quantity with units to a scalar.
@@ -93,7 +93,7 @@ def test_Maxwellian_velocity_3D():
                           lambda z: infApprox,
                           lambda z, y: -infApprox,
                           lambda z, y: infApprox,
-                          epsabs=0.0, 
+                          epsabs=5.0e-1, 
                           epsrel=5.0e-1)
     # value returned from tplquad is (integral, error), we just need the 1st
     integVal = integ[0]
@@ -104,41 +104,41 @@ def test_Maxwellian_velocity_3D():
                       rtol=1e-3,
                       atol=0.0), exceptStr
     
-def test_Maxwellian_speed_3D():
-    r"""test the 3D Maxwellian speed distribution function"""
-    T = 1.0 * u.eV
-    particle = 'H'
-    # get thermal velocity and thermal velocity squared
-    vTh = thermal_speed(T, particle=particle, method="most_probable")
-    # defining a closure with partially applied arguments so that we
-    # can do a triple integral over vx, vy, vz
-    def speedDist3D(vx, vy, vz):
-        # tplquad passes values without units, so we add units so that
-        # Maxwellian_speed_3D can handle them
-        speedDist = Maxwellian_speed_3D(vx=vx*u.m/u.s,
-                                        vy=vy*u.m/u.s,
-                                        vz=vz*u.m/u.s,
-                                        T=T, 
-                                        particle=particle)
-        # return value stripped of units so tplquad can handle it
-        return speedDist.si.value
-    # setting up integration from 0 to 10*vTh, which is close to Inf
-    infApprox = (10 * vTh).si.value
-    # integral should be close to 1
-    integ = spint.tplquad(speedDist3D,
-                          0,
-                          infApprox,
-                          lambda z: 0,
-                          lambda z: infApprox,
-                          lambda z, y: 0,
-                          lambda z, y: infApprox,
-                          epsabs=5.0e-1, 
-                          epsrel=5.0e-1)
-    # value returned from tplquad is (integral, error), we just need the 1st
-    integVal = integ[0]
-    exceptStr = ("Integral of distribution function should be 1 "
-                 f"and not {integVal}")
-    assert np.isclose(integVal,
-                      1,
-                      rtol=-3,
-                      atol=0.0), exceptStr
+#def test_Maxwellian_speed_3D():
+#    r"""test the 3D Maxwellian speed distribution function"""
+#    T = 1.0 * u.eV
+#    particle = 'H'
+#    # get thermal velocity and thermal velocity squared
+#    vTh = thermal_speed(T, particle=particle, method="most_probable")
+#    # defining a closure with partially applied arguments so that we
+#    # can do a triple integral over vx, vy, vz
+#    def speedDist3D(vx, vy, vz):
+#        # tplquad passes values without units, so we add units so that
+#        # Maxwellian_speed_3D can handle them
+#        speedDist = Maxwellian_speed_3D(vx=vx*u.m/u.s,
+#                                        vy=vy*u.m/u.s,
+#                                        vz=vz*u.m/u.s,
+#                                        T=T, 
+#                                        particle=particle)
+#        # return value stripped of units so tplquad can handle it
+#        return speedDist.si.value
+#    # setting up integration from 0 to 10*vTh, which is close to Inf
+#    infApprox = (10 * vTh).si.value
+#    # integral should be close to 1
+#    integ = spint.tplquad(speedDist3D,
+#                          0,
+#                          infApprox,
+#                          lambda z: 0,
+#                          lambda z: infApprox,
+#                          lambda z, y: 0,
+#                          lambda z, y: infApprox,
+#                          epsabs=5.0e-1, 
+#                          epsrel=5.0e-1)
+#    # value returned from tplquad is (integral, error), we just need the 1st
+#    integVal = integ[0]
+#    exceptStr = ("Integral of distribution function should be 1 "
+#                 f"and not {integVal}")
+#    assert np.isclose(integVal,
+#                      1,
+#                      rtol=-3,
+#                      atol=0.0), exceptStr

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -17,13 +17,21 @@ class Test_Maxwellian_1D(object):
     def setup_method(self):
         """initializing parameters for tests """
         self.T_e = 30000*u.K
+        self.v = 1e5 * u.m/u.s
         self.V_drift = 1000000*u.m/u.s
+        self.V_drift2 = 0 * u.m/u.s
+        self.V_drift3 = 1e5 * u.m/u.s
         self.start = -5000
         self.stop = - self.start
         self.dv = 10000 * u.m/u.s
         self.v_vect = np.arange(self.start, 
                                 self.stop, 
                                 dtype='float64') * self.dv
+        self.particle = "e"
+        self.vTh = thermal_speed(self.T_e,
+                                 particle=self.particle,
+                                 method="most_probable")
+        self.distFuncTrue = 5.851627151617136e-07
     def test_max_noDrift(self):
         """
         Checks maximum value of distribution function is in expected place,
@@ -31,7 +39,7 @@ class Test_Maxwellian_1D(object):
         """
         max_index = Maxwellian_1D(self.v_vect, 
                                   T=self.T_e, 
-                                  particle='e', 
+                                  particle=self.particle, 
                                   V_drift=0*u.m/u.s
                                   ).argmax()
         assert np.isclose(self.v_vect[max_index].value, 0.0)
@@ -42,7 +50,7 @@ class Test_Maxwellian_1D(object):
         """
         max_index = Maxwellian_1D(self.v_vect,
                                   T=self.T_e,
-                                  particle='e',
+                                  particle=self.particle,
                                   V_drift=self.V_drift
                                   ).argmax()
         assert np.isclose(self.v_vect[max_index].value, self.V_drift.value)
@@ -53,7 +61,7 @@ class Test_Maxwellian_1D(object):
         # integral of the distribution over v_vect
         integral = (Maxwellian_1D(self.v_vect,
                                   T=30000*u.K,
-                                  particle='e')).sum()*self.dv
+                                  particle=self.particle)).sum()*self.dv
         assert np.isclose(integral, 1.0)
     def test_std(self):
         """
@@ -61,7 +69,7 @@ class Test_Maxwellian_1D(object):
         """
         std = (Maxwellian_1D(self.v_vect,
                              T=self.T_e,
-                             particle='e')*self.v_vect**2*self.dv).sum()
+                             particle=self.particle)*self.v_vect**2*self.dv).sum()
         std = np.sqrt(std)
         T_distri = (std**2/k_B*m_e).to(u.K)
         assert np.isclose(T_distri.value, self.T_e.value)
@@ -74,6 +82,102 @@ class Test_Maxwellian_1D(object):
             Maxwellian_1D(1*u.m/u.s,
                           T=1*u.K,
                           particle='XXX')
+    def test_units_no_vTh(self):
+        """
+        Tests distribution function with units, but not passing vTh.
+        """
+        distFunc = Maxwellian_1D(v=self.v,
+                                 T=self.T_e, 
+                                 particle=self.particle,
+                                 units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_units_vTh(self):
+        """
+        Tests distribution function with units and passing vTh.
+        """
+        distFunc = Maxwellian_1D(v=self.v,
+                                 T=self.T_e, 
+                                 vTh=self.vTh,
+                                 particle=self.particle,
+                                 units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_unitless_no_vTh(self):
+        """
+        Tests distribution function without units, and not passing vTh.
+        """
+        # converting T to SI then stripping units
+        T_e = self.T_e.to(u.K, equivalencies=u.temperature_energy())
+        T_e = T_e.si.value
+        distFunc = Maxwellian_1D(v=self.v.si.value,
+                                 T=T_e,
+                                 particle=self.particle,
+                                 units="unitless")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_unitless_vTh(self):
+        """
+        Tests distribution function without units, and with passing vTh.
+        """
+        # converting T to SI then stripping units
+        T_e = self.T_e.to(u.K, equivalencies=u.temperature_energy())
+        T_e = T_e.si.value
+        distFunc = Maxwellian_1D(v=self.v.si.value,
+                                 T=T_e, 
+                                 vTh=self.vTh.si.value,
+                                 particle=self.particle,
+                                 units="unitless")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_zero_drift_units(self):
+        """
+        Testing inputting drift equal to 0 with units. These should just
+        get passed and not have extra units applied to them.
+        """
+        distFunc = Maxwellian_1D(v=self.v,
+                                 T=self.T_e,
+                                 particle=self.particle,
+                                 V_drift=self.V_drift2,
+                                 units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_value_drift_units(self):
+        """
+        Testing vdrifts with values
+        """
+        testVal = ((self.vTh**2 * np.pi) ** (-1 / 2)).si.value
+        distFunc = Maxwellian_1D(v=self.v,
+                                 T=self.T_e,
+                                 particle=self.particle,
+                                 V_drift=self.V_drift3,
+                                 units="units")
+        errStr = (f"Distribution function should be {testVal} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          testVal,
+                          rtol=1e-8,
+                          atol=0.0), errStr
 
 
 # test class for Maxwellian_speed_1D function
@@ -86,6 +190,10 @@ class Test_Maxwellian_speed_1D(object):
         self.vTh = thermal_speed(self.T,
                                  particle=self.particle,
                                  method="most_probable")
+        self.v = 1e5 * u.m/u.s
+        self.V_drift = 0 * u.m/u.s
+        self.V_drift2 = 1e5 * u.m/u.s
+        self.distFuncTrue = 1.8057567503860518e-25
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
@@ -99,6 +207,101 @@ class Test_Maxwellian_speed_1D(object):
         integ = spint.trapz(y=yData1D, x=xData1D)
         exceptStr = "Integral of distribution function should be 1."
         assert np.isclose(integ.value, 1), exceptStr
+    def test_units_no_vTh(self):
+        """
+        Tests distribution function with units, but not passing vTh.
+        """
+        distFunc = Maxwellian_speed_1D(v=self.v,
+                                       T=self.T, 
+                                       particle=self.particle,
+                                       units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_units_vTh(self):
+        """
+        Tests distribution function with units and passing vTh.
+        """
+        distFunc = Maxwellian_speed_1D(v=self.v,
+                                       T=self.T,
+                                       vTh=self.vTh,
+                                       particle=self.particle,
+                                       units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_unitless_no_vTh(self):
+        """
+        Tests distribution function without units, and not passing vTh.
+        """
+        # converting T to SI then stripping units
+        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+        T = T.si.value
+        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
+                                       T=T, 
+                                       particle=self.particle,
+                                       units="unitless")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_unitless_vTh(self):
+        """
+        Tests distribution function without units, and with passing vTh.
+        """
+        # converting T to SI then stripping units
+        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+        T = T.si.value
+        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
+                                       T=T,
+                                       vTh=self.vTh.si.value,
+                                       particle=self.particle,
+                                       units="unitless")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_zero_drift_units(self):
+        """
+        Testing inputting drift equal to 0 with units. These should just
+        get passed and not have extra units applied to them.
+        """
+        distFunc = Maxwellian_speed_1D(v=self.v,
+                                       T=self.T,
+                                       particle=self.particle,
+                                       V_drift=self.V_drift,
+                                       units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_value_drift_units(self):
+        """
+        Testing vdrifts with values
+        """
+        distFunc = Maxwellian_speed_1D(v=self.v,
+                                       T=self.T,
+                                       particle=self.particle,
+                                       V_drift=self.V_drift2,
+                                       units="units")
+        errStr = (f"Distribution function should be 0.0 "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          0.0,
+                          rtol=1e-8,
+                          atol=0.0), errStr
     
     
 # test class for Maxwellian_velocity_3D function
@@ -111,6 +314,16 @@ class Test_Maxwellian_velocity_3D(object):
         self.vTh = thermal_speed(self.T,
                                  particle=self.particle,
                                  method="most_probable")
+        self.vx = 1e5 * u.m/u.s
+        self.vy = 1e5 * u.m/u.s
+        self.vz = 1e5 * u.m/u.s
+        self.Vx_drift = 0 * u.m/u.s
+        self.Vy_drift = 0 * u.m/u.s
+        self.Vz_drift = 0 * u.m/u.s
+        self.Vx_drift2 = 1e5 * u.m/u.s
+        self.Vy_drift2 = 1e5 * u.m/u.s
+        self.Vz_drift2 = 1e5 * u.m/u.s
+        self.distFuncTrue = 2.7654607627522045e-37
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
@@ -146,6 +359,118 @@ class Test_Maxwellian_velocity_3D(object):
                           1,
                           rtol=1e-3,
                           atol=0.0), exceptStr
+    def test_units_no_vTh(self):
+        """
+        Tests distribution function with units, but not passing vTh.
+        """
+        distFunc = Maxwellian_velocity_3D(vx=self.vx,
+                                          vy=self.vy,
+                                          vz=self.vz,
+                                          T=self.T, 
+                                          particle=self.particle,
+                                          units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_units_vTh(self):
+        """
+        Tests distribution function with units and passing vTh.
+        """
+        distFunc = Maxwellian_velocity_3D(vx=self.vx,
+                                          vy=self.vy,
+                                          vz=self.vz,
+                                          T=self.T,
+                                          vTh=self.vTh,
+                                          particle=self.particle,
+                                          units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_unitless_no_vTh(self):
+        """
+        Tests distribution function without units, and not passing vTh.
+        """
+        # converting T to SI then stripping units
+        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+        T = T.si.value
+        distFunc = Maxwellian_velocity_3D(vx=self.vx.si.value,
+                                          vy=self.vy.si.value,
+                                          vz=self.vz.si.value,
+                                          T=T, 
+                                          particle=self.particle,
+                                          units="unitless")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_unitless_vTh(self):
+        """
+        Tests distribution function without units, and with passing vTh.
+        """
+        # converting T to SI then stripping units
+        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+        T = T.si.value
+        distFunc = Maxwellian_velocity_3D(vx=self.vx.si.value,
+                                          vy=self.vy.si.value,
+                                          vz=self.vz.si.value,
+                                          T=T,
+                                          vTh=self.vTh.si.value,
+                                          particle=self.particle,
+                                          units="unitless")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_zero_drift_units(self):
+        """
+        Testing inputting drift equal to 0 with units. These should just
+        get passed and not have extra units applied to them.
+        """
+        distFunc = Maxwellian_velocity_3D(vx=self.vx,
+                                          vy=self.vy,
+                                          vz=self.vz,
+                                          T=self.T,
+                                          particle=self.particle,
+                                          Vx_drift=self.Vx_drift,
+                                          Vy_drift=self.Vy_drift,
+                                          Vz_drift=self.Vz_drift,
+                                          units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_value_drift_units(self):
+        """
+        Testing vdrifts with values
+        """
+        testVal = ((3 * self.vTh**2 * np.pi) ** (-3 / 2)).si.value
+        distFunc = Maxwellian_velocity_3D(vx=self.vx,
+                                          vy=self.vy,
+                                          vz=self.vz,
+                                          T=self.T,
+                                          particle=self.particle,
+                                          Vx_drift=self.Vx_drift2,
+                                          Vy_drift=self.Vy_drift2,
+                                          Vz_drift=self.Vz_drift2,
+                                          units="units")
+        errStr = (f"Distribution function should be {testVal} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          testVal,
+                          rtol=1e-8,
+                          atol=0.0), errStr
 
 
 # test class for Maxwellian_speed_3D function
@@ -308,7 +633,7 @@ class Test_Maxwellian_speed_3D(object):
                                        Vy_drift=self.Vy_drift2,
                                        Vz_drift=self.Vz_drift2,
                                        units="units")
-        errStr = (f"Distribution function should be {self.distFuncTrue} "
+        errStr = (f"Distribution function should be 0.0 "
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value, 
                           0.0,

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -158,12 +158,16 @@ class Test_Maxwellian_speed_3D(object):
         self.vTh = thermal_speed(self.T,
                                  particle=self.particle,
                                  method="most_probable")
-        self.vx = 1 * u.m/u.s
-        self.vy = 1 * u.m/u.s
-        self.vz = 1 * u.m/u.s
+        self.vx = 1e5 * u.m/u.s
+        self.vy = 1e5 * u.m/u.s
+        self.vz = 1e5 * u.m/u.s
         self.Vx_drift = 0 * u.m/u.s
         self.Vy_drift = 0 * u.m/u.s
         self.Vz_drift = 0 * u.m/u.s
+        self.Vx_drift2 = 1e5 * u.m/u.s
+        self.Vy_drift2 = 1e5 * u.m/u.s
+        self.Vz_drift2 = 1e5 * u.m/u.s
+        self.distFuncTrue = 5.888134761477178e-75
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
@@ -203,31 +207,35 @@ class Test_Maxwellian_speed_3D(object):
         """
         Tests distribution function with units, but not passing vTh.
         """
-        distFuncTrue = 1.2656798868233342e-51
         distFunc = Maxwellian_speed_3D(vx=self.vx,
                                        vy=self.vy,
                                        vz=self.vz,
                                        T=self.T, 
-                                       particle="e",
+                                       particle=self.particle,
                                        units="units")
-        errStr = (f"Distribution function should be {distFuncTrue} "
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
-        assert np.isclose(distFunc.value, distFuncTrue), errStr
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
     def test_units_vTh(self):
         """
         Tests distribution function with units and passing vTh.
         """
-        distFuncTrue = 1.2656798868233342e-51
         distFunc = Maxwellian_speed_3D(vx=self.vx,
                                        vy=self.vy,
                                        vz=self.vz,
                                        T=self.T,
                                        vTh=self.vTh,
-                                       particle="e",
+                                       particle=self.particle,
                                        units="units")
-        errStr = (f"Distribution function should be {distFuncTrue} "
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
-        assert np.isclose(distFunc.value, distFuncTrue), errStr
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
     def test_unitless_no_vTh(self):
         """
         Tests distribution function without units, and not passing vTh.
@@ -235,16 +243,18 @@ class Test_Maxwellian_speed_3D(object):
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
-        distFuncTrue = 1.2656798868233342e-51
         distFunc = Maxwellian_speed_3D(vx=self.vx.si.value,
                                        vy=self.vy.si.value,
                                        vz=self.vz.si.value,
                                        T=T, 
-                                       particle="e",
+                                       particle=self.particle,
                                        units="unitless")
-        errStr = (f"Distribution function should be {distFuncTrue} "
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
-        assert np.isclose(distFunc, distFuncTrue), errStr
+        assert np.isclose(distFunc, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
     def test_unitless_vTh(self):
         """
         Tests distribution function without units, and with passing vTh.
@@ -252,32 +262,55 @@ class Test_Maxwellian_speed_3D(object):
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
-        distFuncTrue = 1.2656798868233342e-51
         distFunc = Maxwellian_speed_3D(vx=self.vx.si.value,
                                        vy=self.vy.si.value,
                                        vz=self.vz.si.value,
                                        T=T,
                                        vTh=self.vTh.si.value,
-                                       particle="e",
+                                       particle=self.particle,
                                        units="unitless")
-        errStr = (f"Distribution function should be {distFuncTrue} "
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
-        assert np.isclose(distFunc, distFuncTrue), errStr
+        assert np.isclose(distFunc, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
     def test_zero_drift_units(self):
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
         """
-        distFuncTrue = 1.2656798868233342e-51
         distFunc = Maxwellian_speed_3D(vx=self.vx,
                                        vy=self.vy,
                                        vz=self.vz,
                                        T=self.T,
-                                       particle="e",
+                                       particle=self.particle,
                                        Vx_drift=self.Vx_drift,
                                        Vy_drift=self.Vy_drift,
                                        Vz_drift=self.Vz_drift,
                                        units="units")
-        errStr = (f"Distribution function should be {distFuncTrue} "
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
-        assert np.isclose(distFunc.value, distFuncTrue), errStr
+        assert np.isclose(distFunc.value, 
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+    def test_value_drift_units(self):
+        """
+        Testing vdrifts with values
+        """
+        distFunc = Maxwellian_speed_3D(vx=self.vx,
+                                       vy=self.vy,
+                                       vz=self.vz,
+                                       T=self.T,
+                                       particle=self.particle,
+                                       Vx_drift=self.Vx_drift2,
+                                       Vy_drift=self.Vy_drift2,
+                                       Vz_drift=self.Vz_drift2,
+                                       units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value, 
+                          0.0,
+                          rtol=1e-8,
+                          atol=0.0), errStr

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -24,101 +24,142 @@ dv = 10000 * u.m/u.s
 v_vect = np.arange(start, stop, dtype='float64') * dv
 
 
-def test_Maxwellian_1D():
-    r"""test the 1D maxwellian distribution function"""
+# test class for Maxwellian_1D (velocity) function:
+class Test_Maxwellian_1D(object):
+    def test_max_noDrift(self):
+        """
+        Checks maximum value of distribution function is in expected place,
+        when there is no drift applied.
+        """
+        max_index = Maxwellian_1D(v_vect, 
+                                  T=T_e, 
+                                  particle='e', 
+                                  V_drift=0*u.m/u.s
+                                  ).argmax()
+        assert np.isclose(v_vect[max_index].value, 0.0)
+    def test_max_drift(self):
+        """
+        Checks maximum value of distribution function is in expected place,
+        when there is drift applied.
+        """
+        max_index = Maxwellian_1D(v_vect,
+                                  T=T_e,
+                                  particle='e',
+                                  V_drift=V_drift
+                                  ).argmax()
+        assert np.isclose(v_vect[max_index].value, V_drift.value)
+    def test_norm(self):
+        """
+        Tests whether distribution function is normalized, and integrates to 1.
+        """
+        # integral of the distribution over v_vect
+        integral = (Maxwellian_1D(v_vect,
+                                  T=30000*u.K,
+                                  particle='e')).sum()*dv
+        assert np.isclose(integral, 1.0)
+    def test_std(self):
+        """
+        Tests standard deviation of function?
+        """
+        std = (Maxwellian_1D(v_vect,
+                             T=T_e,
+                             particle='e')*v_vect**2*dv).sum()
+        std = np.sqrt(std)
+        T_distri = (std**2/k_B*m_e).to(u.K)
+        assert np.isclose(T_distri.value, T_e.value)
+    def test_valErr(self):
+        """
+        Tests whether ValueError is raised when invalid particle name
+        string is passed.
+        """
+        with pytest.raises(ValueError):
+            Maxwellian_1D(1*u.m/u.s,
+                          T=1*u.K,
+                          particle='XXX')
 
-    max_index = Maxwellian_1D(v_vect, T=T_e, particle='e', V_drift=0*u.m/u.s
-                              ).argmax()
-    assert np.isclose(v_vect[max_index].value, 0.0)
-
-    max_index = Maxwellian_1D(v_vect, T=T_e, particle='e', V_drift=V_drift
-                              ).argmax()
-    assert np.isclose(v_vect[max_index].value, V_drift.value)
-
-    # integral of the distribution over v_vect
-    integral = (Maxwellian_1D(v_vect, T=30000*u.K, particle='e')).sum()*dv
-    assert np.isclose(integral, 1.0)
-
-    std = (Maxwellian_1D(v_vect, T=T_e, particle='e')*v_vect**2*dv).sum()
-    std = np.sqrt(std)
-    T_distri = (std**2/k_B*m_e).to(u.K)
-
-    assert np.isclose(T_distri.value, T_e.value)
-
-    with pytest.raises(ValueError):
-        Maxwellian_1D(1*u.m/u.s, T=1*u.K, particle='XXX')
-
-def test_Maxwellian_speed_1D():
-    r"""test the 1D Maxwellian speed distribution function"""
-    T = 1.0 * u.eV
-    particle = 'H'
-    # get thermal velocity and thermal velocity squared
-    vTh = thermal_speed(T, particle=particle, method="most_probable")
-    # setting up integration from 0 to 10*vTh
-    xData1D = np.arange(0, 10.01, 0.01) * vTh
-    yData1D = Maxwellian_speed_1D(v=xData1D,T=T,particle=particle)
-    # integrating, this should be close to 1
-    integ = spint.trapz(y=yData1D, x=xData1D)
-    exceptStr = "Integral of distribution function should be 1."
-    assert np.isclose(integ.value, 1), exceptStr
+# test class for Maxwellian_speed_1D function
+class Test_Maxwellian_speed_1D(object):
+    def test_norm(self):
+        """
+        Tests whether distribution function is normalized, and integrates to 1.
+        """
+        T = 1.0 * u.eV
+        particle = 'H'
+        # get thermal velocity and thermal velocity squared
+        vTh = thermal_speed(T, particle=particle, method="most_probable")
+        # setting up integration from 0 to 10*vTh
+        xData1D = np.arange(0, 10.01, 0.01) * vTh
+        yData1D = Maxwellian_speed_1D(v=xData1D,T=T,particle=particle)
+        # integrating, this should be close to 1
+        integ = spint.trapz(y=yData1D, x=xData1D)
+        exceptStr = "Integral of distribution function should be 1."
+        assert np.isclose(integ.value, 1), exceptStr
     
     
-def test_Maxwellian_velocity_3D():
-    r"""test the 3D Maxwellian velocity distribution function"""
-    T = 1.0 * u.eV
-    particle = 'H'
-    # get thermal velocity and thermal velocity squared
-    vTh = thermal_speed(T, particle=particle, method="most_probable")
-    vTh = vTh.si.value
-    # setting up integration from -10*vTh to 10*vTh, which is close to Inf
-    infApprox = (10 * vTh)
-    # integrating, this should be close to 1
-    integ = spint.tplquad(Maxwellian_velocity_3D,
-                          -infApprox,
-                          infApprox,
-                          lambda z: -infApprox,
-                          lambda z: infApprox,
-                          lambda z, y: -infApprox,
-                          lambda z, y: infApprox,
-                          args=(T,particle,0,0,0, vTh, "unitless"),
-                          epsabs=1e0,
-                          epsrel=1e0,
-                          )
-    # value returned from tplquad is (integral, error), we just need the 1st
-    integVal = integ[0]
-    exceptStr = ("Integral of distribution function should be 1 "
-                 f"and not {integVal}.")
-    assert np.isclose(integVal,
-                      1,
-                      rtol=1e-3,
-                      atol=0.0), exceptStr
-    
-def test_Maxwellian_speed_3D():
-    r"""test the 3D Maxwellian speed distribution function"""
-    T = 1.0 * u.eV
-    particle = 'H'
-    # get thermal velocity and thermal velocity squared
-    vTh = thermal_speed(T, particle=particle, method="most_probable")
-    vTh = vTh.si.value
-    # setting up integration from 0 to 10*vTh, which is close to Inf
-    infApprox = (10 * vTh)
-    # integral should be close to 1
-    integ = spint.tplquad(Maxwellian_speed_3D,
-                          0,
-                          infApprox,
-                          lambda z: 0,
-                          lambda z: infApprox,
-                          lambda z, y: 0,
-                          lambda z, y: infApprox,
-                          args=(T,particle,0,0,0, vTh, "unitless"),
-                          epsabs=1e0,
-                          epsrel=1e0,
-                          )
-    # value returned from tplquad is (integral, error), we just need the 1st
-    integVal = integ[0]
-    exceptStr = ("Integral of distribution function should be 1 "
-                 f"and not {integVal}")
-    assert np.isclose(integVal,
-                      1,
-                      rtol=1e-3,
-                      atol=0.0), exceptStr
+# test class for Maxwellian_velocity_3D function
+class Test_Maxwellian_velocity_3D(object):
+    def test_norm(self):
+        """
+        Tests whether distribution function is normalized, and integrates to 1.
+        """
+        T = 1.0 * u.eV
+        particle = 'H'
+        # get thermal velocity and thermal velocity squared
+        vTh = thermal_speed(T, particle=particle, method="most_probable")
+        vTh = vTh.si.value
+        # setting up integration from -10*vTh to 10*vTh, which is close to Inf
+        infApprox = (10 * vTh)
+        # integrating, this should be close to 1
+        integ = spint.tplquad(Maxwellian_velocity_3D,
+                              -infApprox,
+                              infApprox,
+                              lambda z: -infApprox,
+                              lambda z: infApprox,
+                              lambda z, y: -infApprox,
+                              lambda z, y: infApprox,
+                              args=(T,particle,0,0,0, vTh, "unitless"),
+                              epsabs=1e0,
+                              epsrel=1e0,
+                              )
+        # value returned from tplquad is (integral, error), we just need the 1st
+        integVal = integ[0]
+        exceptStr = ("Integral of distribution function should be 1 "
+                     f"and not {integVal}.")
+        assert np.isclose(integVal,
+                          1,
+                          rtol=1e-3,
+                          atol=0.0), exceptStr
+
+# test class for Maxwellian_speed_3D function
+class Test_Maxwellian_speed_3D(object):
+    def test_norm(self):
+        """
+        Tests whether distribution function is normalized, and integrates to 1.
+        """
+        T = 1.0 * u.eV
+        particle = 'H'
+        # get thermal velocity and thermal velocity squared
+        vTh = thermal_speed(T, particle=particle, method="most_probable")
+        vTh = vTh.si.value
+        # setting up integration from 0 to 10*vTh, which is close to Inf
+        infApprox = (10 * vTh)
+        # integral should be close to 1
+        integ = spint.tplquad(Maxwellian_speed_3D,
+                              0,
+                              infApprox,
+                              lambda z: 0,
+                              lambda z: infApprox,
+                              lambda z, y: 0,
+                              lambda z, y: infApprox,
+                              args=(T,particle,0,0,0, vTh, "unitless"),
+                              epsabs=1e0,
+                              epsrel=1e0,
+                              )
+        # value returned from tplquad is (integral, error), we just need the 1st
+        integVal = integ[0]
+        exceptStr = ("Integral of distribution function should be 1 "
+                     f"and not {integVal}")
+        assert np.isclose(integVal,
+                          1,
+                          rtol=1e-3,
+                          atol=0.0), exceptStr

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -14,59 +14,60 @@ from ..distribution import (Maxwellian_1D,
                             Maxwellian_speed_3D)
 from ..parameters import thermal_speed
 
-T_e = 30000*u.K
-V_drift = 1000000*u.m/u.s
 
-start = -5000
-stop = - start
-dv = 10000 * u.m/u.s
-
-v_vect = np.arange(start, stop, dtype='float64') * dv
 
 
 # test class for Maxwellian_1D (velocity) function:
 class Test_Maxwellian_1D(object):
+    def setup_method(self):
+        """initializing parameters for tests """
+        self.T_e = 30000*u.K
+        self.V_drift = 1000000*u.m/u.s
+        self.start = -5000
+        self.stop = - self.start
+        self.dv = 10000 * u.m/u.s
+        self.v_vect = np.arange(self.start, self.stop, dtype='float64') * self.dv
     def test_max_noDrift(self):
         """
         Checks maximum value of distribution function is in expected place,
         when there is no drift applied.
         """
-        max_index = Maxwellian_1D(v_vect, 
-                                  T=T_e, 
+        max_index = Maxwellian_1D(self.v_vect, 
+                                  T=self.T_e, 
                                   particle='e', 
                                   V_drift=0*u.m/u.s
                                   ).argmax()
-        assert np.isclose(v_vect[max_index].value, 0.0)
+        assert np.isclose(self.v_vect[max_index].value, 0.0)
     def test_max_drift(self):
         """
         Checks maximum value of distribution function is in expected place,
         when there is drift applied.
         """
-        max_index = Maxwellian_1D(v_vect,
-                                  T=T_e,
+        max_index = Maxwellian_1D(self.v_vect,
+                                  T=self.T_e,
                                   particle='e',
-                                  V_drift=V_drift
+                                  V_drift=self.V_drift
                                   ).argmax()
-        assert np.isclose(v_vect[max_index].value, V_drift.value)
+        assert np.isclose(self.v_vect[max_index].value, self.V_drift.value)
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
         # integral of the distribution over v_vect
-        integral = (Maxwellian_1D(v_vect,
+        integral = (Maxwellian_1D(self.v_vect,
                                   T=30000*u.K,
-                                  particle='e')).sum()*dv
+                                  particle='e')).sum()*self.dv
         assert np.isclose(integral, 1.0)
     def test_std(self):
         """
         Tests standard deviation of function?
         """
-        std = (Maxwellian_1D(v_vect,
-                             T=T_e,
-                             particle='e')*v_vect**2*dv).sum()
+        std = (Maxwellian_1D(self.v_vect,
+                             T=self.T_e,
+                             particle='e')*self.v_vect**2*self.dv).sum()
         std = np.sqrt(std)
         T_distri = (std**2/k_B*m_e).to(u.K)
-        assert np.isclose(T_distri.value, T_e.value)
+        assert np.isclose(T_distri.value, self.T_e.value)
     def test_valErr(self):
         """
         Tests whether ValueError is raised when invalid particle name
@@ -79,17 +80,23 @@ class Test_Maxwellian_1D(object):
 
 # test class for Maxwellian_speed_1D function
 class Test_Maxwellian_speed_1D(object):
+    def setup_method(self):
+        """initializing parameters for tests """
+        self.T = 1.0 * u.eV
+        self.particle = 'H'
+        # get thermal velocity and thermal velocity squared
+        self.vTh = thermal_speed(self.T,
+                                 particle=self.particle,
+                                 method="most_probable")
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
-        T = 1.0 * u.eV
-        particle = 'H'
-        # get thermal velocity and thermal velocity squared
-        vTh = thermal_speed(T, particle=particle, method="most_probable")
         # setting up integration from 0 to 10*vTh
-        xData1D = np.arange(0, 10.01, 0.01) * vTh
-        yData1D = Maxwellian_speed_1D(v=xData1D,T=T,particle=particle)
+        xData1D = np.arange(0, 10.01, 0.01) * self.vTh
+        yData1D = Maxwellian_speed_1D(v=xData1D,
+                                      T=self.T,
+                                      particle=self.particle)
         # integrating, this should be close to 1
         integ = spint.trapz(y=yData1D, x=xData1D)
         exceptStr = "Integral of distribution function should be 1."
@@ -98,15 +105,20 @@ class Test_Maxwellian_speed_1D(object):
     
 # test class for Maxwellian_velocity_3D function
 class Test_Maxwellian_velocity_3D(object):
+    def setup_method(self):
+        """initializing parameters for tests """
+        self.T = 1.0 * u.eV
+        self.particle = 'H'
+        # get thermal velocity and thermal velocity squared
+        self.vTh = thermal_speed(self.T,
+                                 particle=self.particle,
+                                 method="most_probable")
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
-        T = 1.0 * u.eV
-        particle = 'H'
-        # get thermal velocity and thermal velocity squared
-        vTh = thermal_speed(T, particle=particle, method="most_probable")
-        vTh = vTh.si.value
+        # converting vTh to unitless
+        vTh = self.vTh.si.value
         # setting up integration from -10*vTh to 10*vTh, which is close to Inf
         infApprox = (10 * vTh)
         # integrating, this should be close to 1
@@ -117,7 +129,13 @@ class Test_Maxwellian_velocity_3D(object):
                               lambda z: infApprox,
                               lambda z, y: -infApprox,
                               lambda z, y: infApprox,
-                              args=(T,particle,0,0,0, vTh, "unitless"),
+                              args=(self.T,
+                                    self.particle,
+                                    0,
+                                    0,
+                                    0,
+                                    vTh,
+                                    "unitless"),
                               epsabs=1e0,
                               epsrel=1e0,
                               )
@@ -132,15 +150,20 @@ class Test_Maxwellian_velocity_3D(object):
 
 # test class for Maxwellian_speed_3D function
 class Test_Maxwellian_speed_3D(object):
+    def setup_method(self):
+        """initializing parameters for tests """
+        self.T = 1.0 * u.eV
+        self.particle = 'H'
+        # get thermal velocity and thermal velocity squared
+        self.vTh = thermal_speed(self.T,
+                                 particle=self.particle,
+                                 method="most_probable")
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
-        T = 1.0 * u.eV
-        particle = 'H'
-        # get thermal velocity and thermal velocity squared
-        vTh = thermal_speed(T, particle=particle, method="most_probable")
-        vTh = vTh.si.value
+        # converting vTh to unitless
+        vTh = self.vTh.si.value
         # setting up integration from 0 to 10*vTh, which is close to Inf
         infApprox = (10 * vTh)
         # integral should be close to 1
@@ -151,7 +174,13 @@ class Test_Maxwellian_speed_3D(object):
                               lambda z: infApprox,
                               lambda z, y: 0,
                               lambda z, y: infApprox,
-                              args=(T,particle,0,0,0, vTh, "unitless"),
+                              args=(self.T,
+                                    self.particle,
+                                    0,
+                                    0,
+                                    0,
+                                    vTh,
+                                    "unitless"),
                               epsabs=1e0,
                               epsrel=1e0,
                               )
@@ -163,3 +192,19 @@ class Test_Maxwellian_speed_3D(object):
                           1,
                           rtol=1e-3,
                           atol=0.0), exceptStr
+    def test_units_no_vTh(self):
+        """
+        Tests distribution function with units, but not passing vTh.
+        """
+    def test_units_vTh(self):
+        """
+        Tests distribution function with units and passing vTh.
+        """
+    def test_unitless_no_vTh(self):
+        """
+        Tests distribution function without units, and not passing vTh.
+        """
+    def test_unitless_vTh(self):
+        """
+        Tests distribution function without units, and with passing vTh.
+        """

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -71,14 +71,17 @@ def test_Maxwellian_velocity_3D():
     vTh = thermal_speed(T, particle=particle, method="most_probable")
     # defining a closure with partially applied arguments
     def velDist3D(vx, vy, vz):
-        velDist = Maxwellian_velocity_3D(vx=vx,
-                                         vy=vy,
-                                         vz=vz,
+        # tplquad passes values without units, so we add units so that
+        # Maxwellian_velocity_3D can handle them
+        velDist = Maxwellian_velocity_3D(vx=vx*u.m/u.s,
+                                         vy=vy*u.m/u.s,
+                                         vz=vz*u.m/u.s,
                                          T=T, 
                                          particle=particle)
-        return velDist
+        # return value stripped of units so tplquad can handle it
+        return velDist.si.value
     # setting up integration from -10*vTh to 10*vTh, which is close to Inf
-    infApprox = 10 * vTh
+    infApprox = (10 * vTh).si.value
     # if I recall correctly, astropy.units may have trouble with
     # accounting for units in integrals, so this step currently fails when
     # tplquad tries to convert a quantity with units to a scalar.
@@ -90,10 +93,16 @@ def test_Maxwellian_velocity_3D():
                           lambda z: infApprox,
                           lambda z, y: -infApprox,
                           lambda z, y: infApprox,
-                          epsabs=1.49e-08*u.m/u.m, 
-                          epsrel=1.49e-08*u.m/u.m)
-    exceptStr = "Integral of distribution function should be 1."
-    assert np.isclose(integ.value, 1), exceptStr
+                          epsabs=0.0, 
+                          epsrel=5.0e-1)
+    # value returned from tplquad is (integral, error), we just need the 1st
+    integVal = integ[0]
+    exceptStr = ("Integral of distribution function should be 1 "
+                 f"and not {integVal}.")
+    assert np.isclose(integVal,
+                      1,
+                      rtol=1e-3,
+                      atol=0.0), exceptStr
     
 def test_Maxwellian_speed_3D():
     r"""test the 3D Maxwellian speed distribution function"""
@@ -104,26 +113,32 @@ def test_Maxwellian_speed_3D():
     # defining a closure with partially applied arguments so that we
     # can do a triple integral over vx, vy, vz
     def speedDist3D(vx, vy, vz):
-        speedDist = Maxwellian_speed_3D(vx=vx,
-                                        vy=vy,
-                                        vz=vz,
+        # tplquad passes values without units, so we add units so that
+        # Maxwellian_speed_3D can handle them
+        speedDist = Maxwellian_speed_3D(vx=vx*u.m/u.s,
+                                        vy=vy*u.m/u.s,
+                                        vz=vz*u.m/u.s,
                                         T=T, 
                                         particle=particle)
-        return speedDist
+        # return value stripped of units so tplquad can handle it
+        return speedDist.si.value
     # setting up integration from 0 to 10*vTh, which is close to Inf
-    infApprox = 10 * vTh
-    # if I recall correctly, astropy.units may have trouble with
-    # accounting for units in integrals, so this step currently fails when
-    # tplquad tries to convert a quantity with units to a scalar.
-    # integrating, this should be close to 1
+    infApprox = (10 * vTh).si.value
+    # integral should be close to 1
     integ = spint.tplquad(speedDist3D,
-                          0*u.m/u.s,
+                          0,
                           infApprox,
-                          lambda z: 0*u.m/u.s,
+                          lambda z: 0,
                           lambda z: infApprox,
-                          lambda z, y: 0*u.m/u.s,
+                          lambda z, y: 0,
                           lambda z, y: infApprox,
-                          epsabs=1.49e-08*u.m/u.m, 
-                          epsrel=1.49e-08*u.m/u.m)
-    exceptStr = "Integral of distribution function should be 1."
-    assert np.isclose(integ.value, 1), exceptStr
+                          epsabs=5.0e-1, 
+                          epsrel=5.0e-1)
+    # value returned from tplquad is (integral, error), we just need the 1st
+    integVal = integ[0]
+    exceptStr = ("Integral of distribution function should be 1 "
+                 f"and not {integVal}")
+    assert np.isclose(integVal,
+                      1,
+                      rtol=-3,
+                      atol=0.0), exceptStr


### PR DESCRIPTION
Added and modified 1D and 3D Maxwellian speed and velocity distribution functions. These functions also include optional drift velocities/speeds. I've included tests for these new functions, but the 3D tests fail because scipy's QUADPACK based triple integral doesn't play nice with units. I'm open to suggestions on how to work around this!

Contributions towards #101  and #141 