### PR TITLE
Fixed math and minor errors in docstrings for Read the Docs

### DIFF
--- a/plasmapy/math/math.py
+++ b/plasmapy/math/math.py
@@ -35,9 +35,7 @@ def plasma_dispersion_func(zeta):
     -----
     The plasma dispersion function is defined as:
 
-    .. math::
-    Z(\zeta) = \sqrt{\pi}
-    \int_{-\infty}^{+\infty} dx \frac{e^{-x^2}}{x-\zeta}
+    :math:`Z(\zeta) = \sqrt{\pi} \int_{-\infty}^{+\infty} dx \frac{e^{-x^2}}{x-\zeta}`
 
     where the argument is a complex number [fried.conte-1961].
 
@@ -115,8 +113,7 @@ def plasma_dispersion_func_deriv(zeta):
     -----
     The plasma dispersion function is defined as:
 
-    .. math:: Z(\zeta) \equiv \sqrt{\pi}
-    \int_{-\infty}^{+\infty} dx \frac{e^{-x^2}}{x-\zeta}
+    :math:`Z(\zeta) \equiv \sqrt{\pi} \int_{-\infty}^{+\infty} dx \frac{e^{-x^2}}{x-\zeta}`
 
     where the argument is a complex number [fried.conte-1961].
 

--- a/plasmapy/math/math.py
+++ b/plasmapy/math/math.py
@@ -35,7 +35,8 @@ def plasma_dispersion_func(zeta):
     -----
     The plasma dispersion function is defined as:
 
-    :math:`Z(\zeta) = \sqrt{\pi} \int_{-\infty}^{+\infty} dx \frac{e^{-x^2}}{x-\zeta}`
+    .. math::
+        Z(\zeta) = \pi^{-0.5} \int_{-\infty}^{+\infty} \frac{e^{-x^2}}{x-\zeta} dx
 
     where the argument is a complex number [fried.conte-1961].
 
@@ -107,13 +108,14 @@ def plasma_dispersion_func_deriv(zeta):
 
     See also
     --------
-    plasma_dispersion_func_deriv
+    plasma_dispersion_func
 
     Notes
     -----
-    The plasma dispersion function is defined as:
+    The derivative of the plasma dispersion function is defined as:
 
-    :math:`Z(\zeta) \equiv \sqrt{\pi} \int_{-\infty}^{+\infty} dx \frac{e^{-x^2}}{x-\zeta}`
+    .. math::
+        Z'(\zeta) = \pi^{-0.5} \int_{-\infty}^{+\infty} \frac{e^{-x^2}}{(x-\zeta)^2} dx
 
     where the argument is a complex number [fried.conte-1961].
 

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -38,7 +38,7 @@ def Maxwellian_1D(v: units.m/units.s,
     -------
     f : Quantity
         probability in Velocity^-1, normized so that:
-        $\int_{- \infty}^{\infty} f(v) dv = 1}
+        :math:`\int_{-\infty}^{+\infty} f(v) dv = 1}`
 
     Raises
     ------
@@ -58,8 +58,7 @@ def Maxwellian_1D(v: units.m/units.s,
     In one dimension, the Maxwellian distribution function for a particle of
     mass m, velocity v, a drift velocity V and with temperature T is:
 
-    .. math::
-    f = \sqrt{\frac{m}{2 \pi k_B T}} \exp(-\frac{m}{2 k_B T} (v-V)^2)
+    :math:`f = \sqrt{\frac{m}{2 \pi k_B T}} \exp(-\frac{m}{2 k_B T} (v-V)^2)`
 
 
     Example

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -37,8 +37,7 @@ def Maxwellian_1D(v: units.m/units.s,
     Returns
     -------
     f : Quantity
-        probability in Velocity^-1, normized so that:
-        :math:`\int_{-\infty}^{+\infty} f(v) dv = 1}`
+        probability in Velocity^-1, normized so that: :math:`\int_{-\infty}^{+\infty} f(v) dv = 1`
 
     Raises
     ------
@@ -58,7 +57,7 @@ def Maxwellian_1D(v: units.m/units.s,
     In one dimension, the Maxwellian distribution function for a particle of
     mass m, velocity v, a drift velocity V and with temperature T is:
 
-    :math:`f = \sqrt{\frac{m}{2 \pi k_B T}} \exp(-\frac{m}{2 k_B T} (v-V)^2)`
+    :math:`f = \sqrt{\frac{m}{2 \pi k_B T}} \exp{-\frac{m}{2 k_B T} (v-V)^2}`
 
 
     Example

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -57,8 +57,8 @@ def Maxwellian_1D(v: units.m/units.s,
     In one dimension, the Maxwellian distribution function for a particle of
     mass m, velocity v, a drift velocity V and with temperature T is:
 
-    :math:`f = \sqrt{\frac{m}{2 \pi k_B T}} e^{-\frac{m}{2 k_B T} (v-V)^2}`
-
+    .. math::
+        f = \sqrt{\frac{m}{2 \pi k_B T}} e^{-\frac{m}{2 k_B T} (v-V)^2}
 
     Examples
     --------

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -57,10 +57,10 @@ def Maxwellian_1D(v: units.m/units.s,
     In one dimension, the Maxwellian distribution function for a particle of
     mass m, velocity v, a drift velocity V and with temperature T is:
 
-    :math:`f = \sqrt{\frac{m}{2 \pi k_B T}} \exp{-\frac{m}{2 k_B T} (v-V)^2}`
+    :math:`f = \sqrt{\frac{m}{2 \pi k_B T}} e^{-\frac{m}{2 k_B T} (v-V)^2}`
 
 
-    Example
+    Examples
     -------
     >>> from plasmapy.physics import Maxwellian_1D
     >>> from astropy import units as u

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -17,9 +17,9 @@ from ..utils import _check_quantity, check_relativistic, check_quantity
 def Maxwellian_1D(v: units.m/units.s,
                   T: units.K, particle="e",
                   V_drift=0*units.m/units.s):
-    r"""Return the probability at the velocity `v` in m/s
-     to find a particle `particle` in a plasma of temperature `T`
-     following the Maxwellian distribution function
+    r"""Returns the probability at the velocity `v` in m/s
+    to find a particle `particle` in a plasma of temperature `T`
+    following the Maxwellian distribution function.
 
     Parameters
     ----------
@@ -61,7 +61,7 @@ def Maxwellian_1D(v: units.m/units.s,
 
 
     Examples
-    -------
+    --------
     >>> from plasmapy.physics import Maxwellian_1D
     >>> from astropy import units as u
     >>> v=1*u.m/u.s

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -82,8 +82,8 @@ def Alfven_speed(B, density, ion="p"):
         The magnetic field magnitude in units convertible to tesla.
 
     density : Quantity
-        Either the ion number density in units convertible to 1 m:math:`^{-3}`,
-        or the mass density in units convertible to kg m:math:`^{-3}`.
+        Either the ion number density in units convertible to 1 / m**3,
+        or the mass density in units convertible to kg / m**3.
 
     ion : string, optional
         Representation of the ion species (e.g., 'p' for protons, 'D+'
@@ -448,7 +448,7 @@ def gyrofrequency(B, particle='e'):
     The particle gyrofrequency is the angular frequency of particle gyration
     around magnetic field lines and is given by:
 
-    :math:`omega_{ci} = \frac{Z e B}{m_i}`
+    :math:`\omega_{ci} = \frac{Z e B}{m_i}`
 
     The particle gyrofrequency is also known as the particle cyclotron
     frequency or the particle Larmor frequency.

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -118,7 +118,8 @@ def Alfven_speed(B, density, ion="p"):
     The Alfven velocity :math:`V_A` is the typical propagation speed
     of magnetic disturbances in a plasma, and is given by:
 
-    :math:`V_A = \frac{B}{\sqrt{\mu_0\rho}}`
+    .. math::
+        V_A = \frac{B}{\sqrt{\mu_0\rho}}
 
     where the mass density is :math:`\rho = n_i m_i + n_e m_e`.
 
@@ -238,7 +239,8 @@ def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
     -----
     The ion sound speed :math:`V_S` is approximately given by
 
-    :math:`V_S = \sqrt{\frac{\gamma_e Z k_B T_e + \gamma_i k_B T_i}{m_i}}`
+    .. math::
+        V_S = \sqrt{\frac{\gamma_e Z k_B T_e + \gamma_i k_B T_i}{m_i}}
 
     where :math:`\gamma_e` and :math:`\gamma_i` are the electron and
     ion adiabatic indices, :math:`k_B` is the Boltzmann constant,
@@ -358,7 +360,8 @@ def thermal_speed(T, particle="e", method="most_probable"):
     -----
     The particle thermal speed is given by:
 
-    :math:`V_{th,i} = \sqrt{\frac{2 k_B T_i}{m_i}}`
+    .. math::
+        V_{th,i} = \sqrt{\frac{2 k_B T_i}{m_i}}
 
     This function yields the most probable speed within a distribution
     function.  However, the definition of thermal velocity varies by
@@ -448,7 +451,8 @@ def gyrofrequency(B, particle='e'):
     The particle gyrofrequency is the angular frequency of particle gyration
     around magnetic field lines and is given by:
 
-    :math:`\omega_{ci} = \frac{Z e B}{m_i}`
+    .. math::
+        \omega_{ci} = \frac{Z e B}{m_i}
 
     The particle gyrofrequency is also known as the particle cyclotron
     frequency or the particle Larmor frequency.
@@ -554,7 +558,8 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
     The particle gyroradius is also known as the particle Larmor radius and is
     given by
 
-    :math:`r_{Li} = \frac{V_{\perp}}{omega_{ci}}`
+    .. math::
+        r_{Li} = \frac{V_{\perp}}{omega_{ci}}
 
     where :math:`V_{\perp}` is the component of particle velocity that is
     perpendicular to the magnetic field and :math:`\omega_{ci}` is the
@@ -663,7 +668,8 @@ def plasma_frequency(n, particle='e'):
     -----
     The particle plasma frequency is
 
-    :math:`\omega_{pi} = Z e \sqrt{\frac{n_i}{\epsilon_0 m_i}}`
+    .. math::
+        \omega_{pi} = Z e \sqrt{\frac{n_i}{\epsilon_0 m_i}}
 
     At present, astropy.units does not allow direct conversions from
     radians/second for angular frequency to 1/second or Hz for
@@ -738,7 +744,8 @@ def Debye_length(T_e, n_e):
     The Debye length is the exponential scale length for charge
     screening and is given by
 
-    :math:`\lambda_D = \sqrt{\frac{\epsilon_0 k_b T_e}{n_e e^2}}`
+    .. math::
+        \lambda_D = \sqrt{\frac{\epsilon_0 k_b T_e}{n_e e^2}}
 
     for an electron plasma with nearly stationary ions.
 
@@ -809,7 +816,8 @@ def Debye_number(T_e, n_e):
     The Debye number is the number of electrons contained within a sphere with
     a radius of a Debye length and is given by
 
-    :math:`N_D = \frac{4\pi}{3}n_e\lambda_D^3`
+    .. math::
+        N_D = \frac{4\pi}{3}n_e\lambda_D^3
 
     The Debye number is also known as the plasma parameter.
 
@@ -877,7 +885,8 @@ def inertial_length(n, particle='e'):
     The particle inertial length is also known as an particle skin depth and is
     given by:
 
-    :math:`d_i = \frac{c}{\omega_{pi}}`
+    .. math::
+        d_i = \frac{c}{\omega_{pi}}
 
     Example
     -------
@@ -938,7 +947,8 @@ def magnetic_pressure(B):
     -----
     The magnetic pressure is given by:
 
-    :math:`p_B = \frac{B^2}{2 \mu_0}`
+    .. math::
+        p_B = \frac{B^2}{2 \mu_0}
 
     The motivation behind having two separate functions for magnetic
     pressure and magnetic energy density is that it allows greater
@@ -998,7 +1008,8 @@ def magnetic_energy_density(B: units.T):
     -----
     The magnetic energy density is given by:
 
-    :math:`E_B = \frac{B^2}{2 \mu_0}`
+    .. math::
+        E_B = \frac{B^2}{2 \mu_0}
 
     The motivation behind having two separate functions for magnetic
     pressure and magnetic energy density is that it allows greater
@@ -1062,7 +1073,8 @@ def upper_hybrid_frequency(B, n_e):
     -----
     The upper hybrid frequency is given through the relation
 
-    :math:`\omega_{uh}^2 = \omega_{ce}^2 + \omega_{pe}^2`
+    .. math::
+        \omega_{uh}^2 = \omega_{ce}^2 + \omega_{pe}^2
 
     where :math:`\omega_{ce}` is the electron gyrofrequency and
     :math:`\omega_{pe}` is the electron plasma frequency.
@@ -1132,8 +1144,8 @@ def lower_hybrid_frequency(B, n_i, ion='p'):
     -----
     The lower hybrid frequency is given through the relation
 
-    :math:`\frac{1}{\omega_{lh}^2} = \frac{1}{\omega_{ci}^2 + \omega_{pi}^2}
-    + \frac{1}{\omega_{ci}\omega_{ce}}`
+    .. math::
+        \frac{1}{\omega_{lh}^2} = \frac{1}{\omega_{ci}^2 + \omega_{pi}^2} + \frac{1}{\omega_{ci}\omega_{ce}}
 
     where :math:`\omega_{ci}` is the ion gyrofrequency,
     :math:`\omega_{ce}` is the electron gyrofrequency, and

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -81,9 +81,9 @@ def Alfven_speed(B, density, ion="p"):
     B : Quantity
         The magnetic field magnitude in units convertible to tesla.
 
-    density: Quantity
-        Either the ion number density in units convertible to 1 / m**3,
-        or the mass density in units convertible to kg / m**3.
+    density : Quantity
+        Either the ion number density in units convertible to 1 m:math:`^{-3}`,
+        or the mass density in units convertible to kg m:math:`^{-3}`.
 
     ion : string, optional
         Representation of the ion species (e.g., 'p' for protons, 'D+'
@@ -118,8 +118,7 @@ def Alfven_speed(B, density, ion="p"):
     The Alfven velocity :math:`V_A` is the typical propagation speed
     of magnetic disturbances in a plasma, and is given by:
 
-    .. math::
-    V_A = \frac{B}{\sqrt{\mu_0\rho}}
+    :math:`V_A = \frac{B}{\sqrt{\mu_0\rho}}`
 
     where the mass density is :math:`\rho = n_i m_i + n_e m_e`.
 
@@ -239,8 +238,7 @@ def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
     -----
     The ion sound speed :math:`V_S` is approximately given by
 
-    .. math::
-    V_S = \sqrt{\frac{\gamma_e Z k_B T_e + \gamma_i k_B T_i}{m_i}}
+    :math:`V_S = \sqrt{\frac{\gamma_e Z k_B T_e + \gamma_i k_B T_i}{m_i}}`
 
     where :math:`\gamma_e` and :math:`\gamma_i` are the electron and
     ion adiabatic indices, :math:`k_B` is the Boltzmann constant,
@@ -330,6 +328,10 @@ def thermal_speed(T, particle="e", method="most_probable"):
         which defaults to electrons.  If no charge state information is
         provided, then the particles are assumed to be singly charged.
 
+    method : string, optional
+        Method to be used for calculating the thermal speed. Options are
+        'most_probable' (default), 'rms', and 'mean_magnitude'. 
+
     Returns
     -------
     V : Quantity
@@ -356,8 +358,7 @@ def thermal_speed(T, particle="e", method="most_probable"):
     -----
     The particle thermal speed is given by:
 
-    .. math::
-    V_{th,i} = \sqrt{\frac{2 k_B T_i}{m_i}}
+    :math:`V_{th,i} = \sqrt{\frac{2 k_B T_i}{m_i}}`
 
     This function yields the most probable speed within a distribution
     function.  However, the definition of thermal velocity varies by
@@ -415,7 +416,7 @@ def gyrofrequency(B, particle='e'):
 
     Parameters
     ----------
-    B: Quantity
+    B : Quantity
         The magnetic field magnitude in units convertible to tesla.
 
     particle : string, optional
@@ -426,7 +427,7 @@ def gyrofrequency(B, particle='e'):
 
     Returns
     -------
-    omega_ci: Quantity
+    omega_ci : Quantity
         The particle gyrofrequency in units of radians per second
 
     Raises
@@ -447,8 +448,7 @@ def gyrofrequency(B, particle='e'):
     The particle gyrofrequency is the angular frequency of particle gyration
     around magnetic field lines and is given by:
 
-    .. math::
-    omega_{ci} = \frac{Z e B}{m_i}
+    :math:`omega_{ci} = \frac{Z e B}{m_i}`
 
     The particle gyrofrequency is also known as the particle cyclotron
     frequency or the particle Larmor frequency.
@@ -499,14 +499,14 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
 
     Parameters
     ----------
-    B: Quantity
+    B : Quantity
         The magnetic field magnitude in units convertible to tesla.
 
-    Vperp: Quantity, optional
+    Vperp : Quantity, optional
         The component of particle velocity that is perpendicular to the
         magnetic field in units convertible to meters per second.
 
-    T_i: Quantity, optional
+    T_i : Quantity, optional
         The particle temperature in units convertible to kelvin.
 
     particle : string, optional
@@ -554,8 +554,7 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
     The particle gyroradius is also known as the particle Larmor radius and is
     given by
 
-    .. math::
-    r_{Li} = \frac{V_{\perp}}{omega_{ci}}
+    :math:`r_{Li} = \frac{V_{\perp}}{omega_{ci}}`
 
     where :math:`V_{\perp}` is the component of particle velocity that is
     perpendicular to the magnetic field and :math:`\omega_{ci}` is the
@@ -664,13 +663,12 @@ def plasma_frequency(n, particle='e'):
     -----
     The particle plasma frequency is
 
-    .. math::
-    \omega_{pi} = Z e \sqrt{\frac{n_i}{\epsilon_0 m_i}}
+    :math:`\omega_{pi} = Z e \sqrt{\frac{n_i}{\epsilon_0 m_i}}`
 
     At present, astropy.units does not allow direct conversions from
     radians/second for angular frequency to 1/second or Hz for
     frequency.  The dimensionless_angles equivalency allows that
-    conversion, but does not account for the factor of 2*pi.  The
+    conversion, but does not account for the factor of 2*pi. The
     alternatives are to convert to cycle/second or to do the
     conversion manually, as shown in the examples.
 
@@ -717,7 +715,7 @@ def Debye_length(T_e, n_e):
 
     Returns
     -------
-    lambda_D: Quantity
+    lambda_D : Quantity
         The Debye length in meters
 
     Raises
@@ -740,8 +738,7 @@ def Debye_length(T_e, n_e):
     The Debye length is the exponential scale length for charge
     screening and is given by
 
-    .. math::
-    \lambda_D = \sqrt{\frac{\epsilon_0 k_b T_e}{n_e e^2}}
+    :math:`\lambda_D = \sqrt{\frac{\epsilon_0 k_b T_e}{n_e e^2}}`
 
     for an electron plasma with nearly stationary ions.
 
@@ -782,10 +779,10 @@ def Debye_number(T_e, n_e):
 
     Parameters
     ----------
-    T_e: Quantity
+    T_e : Quantity
         Electron temperature
 
-    n_e: Quantity
+    n_e : Quantity
         Electron number density
 
     Raises
@@ -812,8 +809,7 @@ def Debye_number(T_e, n_e):
     The Debye number is the number of electrons contained within a sphere with
     a radius of a Debye length and is given by
 
-    .. math::
-    N_D = \frac{4\pi}{3}n_e\lambda_D^3
+    :math:`N_D = \frac{4\pi}{3}n_e\lambda_D^3`
 
     The Debye number is also known as the plasma parameter.
 
@@ -881,8 +877,7 @@ def inertial_length(n, particle='e'):
     The particle inertial length is also known as an particle skin depth and is
     given by:
 
-    .. math::
-    d_i = \frac{c}{\omega_{pi}}
+    :math:`d_i = \frac{c}{\omega_{pi}}`
 
     Example
     -------
@@ -916,12 +911,12 @@ def magnetic_pressure(B):
 
     Parameters
     ----------
-    B: Quantity
+    B : Quantity
         The magnetic field in units convertible to telsa
 
     Returns
     -------
-    p_B: Quantity
+    p_B : Quantity
         The magnetic pressure in units in pascals (newtons per square meter)
 
     Raises
@@ -943,8 +938,7 @@ def magnetic_pressure(B):
     -----
     The magnetic pressure is given by:
 
-    .. math::
-    p_B = \frac{B^2}{2 \mu_0}
+    :math:`p_B = \frac{B^2}{2 \mu_0}`
 
     The motivation behind having two separate functions for magnetic
     pressure and magnetic energy density is that it allows greater
@@ -977,12 +971,12 @@ def magnetic_energy_density(B: units.T):
 
     Parameters
     ----------
-    B: Quantity
+    B : Quantity
         The magnetic field in units convertible to tesla
 
     Returns
     -------
-    E_B: Quantity
+    E_B : Quantity
         The magnetic energy density in units of joules per cubic meter
 
     Raises
@@ -1004,8 +998,7 @@ def magnetic_energy_density(B: units.T):
     -----
     The magnetic energy density is given by:
 
-    .. math::
-    E_B = \frac{B^2}{2 \mu_0}
+    :math:`E_B = \frac{B^2}{2 \mu_0}`
 
     The motivation behind having two separate functions for magnetic
     pressure and magnetic energy density is that it allows greater
@@ -1069,8 +1062,7 @@ def upper_hybrid_frequency(B, n_e):
     -----
     The upper hybrid frequency is given through the relation
 
-    .. math::
-    \omega_{uh}^2 = \omega_{ce}^2 + \omega_{pe}^2
+    :math:`\omega_{uh}^2 = \omega_{ce}^2 + \omega_{pe}^2`
 
     where :math:`\omega_{ce}` is the electron gyrofrequency and
     :math:`\omega_{pe}` is the electron plasma frequency.
@@ -1140,13 +1132,12 @@ def lower_hybrid_frequency(B, n_i, ion='p'):
     -----
     The lower hybrid frequency is given through the relation
 
-    .. math::
-    \frac{1}{\omega_{lh}^2} = \frac{1}{\omega_{ci}^2 + \omega_{pi}^2}
-    + \frac{1}{\omega_{ci}\omega_{ce}}
+    :math:`\frac{1}{\omega_{lh}^2} = \frac{1}{\omega_{ci}^2 + \omega_{pi}^2}
+    + \frac{1}{\omega_{ci}\omega_{ce}}`
 
-    where .. math::`\omega_{ci}` is the ion gyrofrequency,
-    .. math::`\omega_{ce}` is the electron gyrofrequency, and
-    .. math::`\omega_{pi}` is the ion plasma frequency.
+    where :math:`\omega_{ci}` is the ion gyrofrequency,
+    :math:`\omega_{ce}` is the electron gyrofrequency, and
+    :math:`\omega_{pi}` is the ion plasma frequency.
 
     Example
     -------

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -44,8 +44,7 @@ def deBroglie_wavelength(V, particle):
     -----
     The de Broglie wavelength is given by
 
-    .. math::
-    \lambda_{dB} = \frac{h}{p} = \frac{h}{\gamma m V}.
+    :math:`\lambda_{dB} = \frac{h}{p} = \frac{h}{\gamma m V}`,
 
     where :math:`h` is the Planck constant, :math:`p` is the
     relativistic momentum of the particle, :math:`gamma` is the

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -44,7 +44,8 @@ def deBroglie_wavelength(V, particle):
     -----
     The de Broglie wavelength is given by
 
-    :math:`\lambda_{dB} = \frac{h}{p} = \frac{h}{\gamma m V}`,
+    .. math::
+        \lambda_{dB} = \frac{h}{p} = \frac{h}{\gamma m V}
 
     where :math:`h` is the Planck constant, :math:`p` is the
     relativistic momentum of the particle, :math:`gamma` is the

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -39,8 +39,7 @@ def Lorentz_factor(V):
     -----
     The Lorentz factor is a dimensionless number given by
 
-    .. math::
-    \gamma = \frac{1}{\sqrt{1-\frac{V^2}{c^2}}}
+    :math:`\gamma = \frac{1}{\sqrt{1-\frac{V^2}{c^2}}}`
 
     The Lorentz factor is approximately one for sub-relativistic
     velocities, and goes to infinity as the velocity approaches the

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -39,7 +39,8 @@ def Lorentz_factor(V):
     -----
     The Lorentz factor is a dimensionless number given by
 
-    :math:`\gamma = \frac{1}{\sqrt{1-\frac{V^2}{c^2}}}`
+    .. math::
+        \gamma = \frac{1}{\sqrt{1-\frac{V^2}{c^2}}}
 
     The Lorentz factor is approximately one for sub-relativistic
     velocities, and goes to infinity as the velocity approaches the

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -18,9 +18,9 @@ def Coulomb_logarithm(T, n_e, particles, V=None):
     ----------
 
     T : Quantity
-    Temperature in units of temperature or energy per particle,
-    which is assumed to be equal for both the test particle and
-    the target particle
+        Temperature in units of temperature or energy per particle,
+        which is assumed to be equal for both the test particle and
+        the target particle
 
     n_e : Quantity
         The electron density in units convertible to per cubic meter.
@@ -60,8 +60,7 @@ def Coulomb_logarithm(T, n_e, particles, V=None):
     -----
     The Coulomb logarithm is given by
 
-    .. math::
-    \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+    :math:`\ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)`
 
     where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
     impact parameters for Coulomb collisions _[1].

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -60,7 +60,8 @@ def Coulomb_logarithm(T, n_e, particles, V=None):
     -----
     The Coulomb logarithm is given by
 
-    :math:`\ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)`
+    .. math::
+        \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
 
     where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
     impact parameters for Coulomb collisions _[1].


### PR DESCRIPTION
Closes #155 
Changed some of the math formatting in the docstrings so that they appear correctly on Read the Docs, and fixed a few small other formatting errors too. A test version for the updated docs is [here](http://plasmapy-fixed-math-test.readthedocs.io/en/fixing_rtd_math/)!