### PR TITLE
Refactor nuclear_binding_energy and nuclear_reaction_rate

### DIFF
--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -1525,7 +1525,7 @@ def _is_electron(arg):
 
     if not isinstance(arg, str):
         return False
-   
+
     return arg in ['e', 'e-'] or arg.lower() == 'electron'
 
 
@@ -1542,7 +1542,7 @@ def _is_positron(arg):
 def _is_antiproton(arg):
     r"""Returns True if the argument corresponds to an antiproton, and
     False otherwise."""
-    
+
     if not isinstance(arg, str):
         return False
 
@@ -1552,7 +1552,7 @@ def _is_antiproton(arg):
 def _is_antineutron(arg):
     r"""Returns True if the argument corresponds to an antineutron, and
     False otherwise."""
-    
+
     if not isinstance(arg, str):
         return False
 

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -692,6 +692,7 @@ def isotope_mass(argument, mass_numb=None):
     <Quantity 4.00260325413 u>
     >>> isotope_mass(2, 4)
     <Quantity 4.00260325413 u>
+
     """
 
     argument, charge_state = _extract_charge_state(argument)
@@ -1147,6 +1148,7 @@ def stable_isotopes(argument=None, unstable=False):
 
     >>> stable_isotopes('U', unstable=True)[:5] # only first five
     ['U-217', 'U-218', 'U-219', 'U-220', 'U-221']
+
     """
 
     def stable_isotopes_for_element(argument, stable_only):
@@ -1568,7 +1570,8 @@ def _is_antiproton(argument):
 
 def _is_proton(argument):
     r"""Returns True if the argument corresponds to a proton, and
-    False otherwise."""
+    False otherwise.  This function returns False for 'H-1' if no
+    charge state is given."""
 
     if not isinstance(argument, str):
         return False

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -841,12 +841,6 @@ def ion_mass(argument, Z=None, mass_numb=None):
     else:
         Z_from_arg = None
 
-    if atomic_number(argument) == 1:
-        if isinstance(argument, str) and 'H-1' in str(argument) and Z is None:
-            return const.m_p
-        if mass_numb == 1 and Z == 1:
-            return const.m_p
-
     if Z is None and Z_from_arg is None:
         Z = 1
     elif Z is not None and Z_from_arg is not None and Z != Z_from_arg:

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -696,6 +696,9 @@ def isotope_mass(argument, mass_numb=None):
 
     argument, charge_state = _extract_charge_state(argument)
 
+    if _is_proton(argument) or _is_antiproton(argument):
+        return const.m_p
+
     if charge_state is not None and charge_state != 0:
         raise ValueError("Use ion_mass instead of isotope_mass for masses of "
                          "charged particles")
@@ -1558,6 +1561,19 @@ def _is_antiproton(argument):
         return False
 
     if argument == 'p-' or argument.lower() == 'antiproton':
+        return True
+    else:
+        return False
+
+
+def _is_proton(argument):
+    r"""Returns True if the argument corresponds to a proton, and
+    False otherwise."""
+
+    if not isinstance(argument, str):
+        return False
+
+    if argument in ['p', 'p+'] or argument.lower() == 'proton':
         return True
     else:
         return False

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -790,24 +790,22 @@ def ion_mass(argument, Z=None, mass_numb=None):
     --------
     >>> print(ion_mass('p').si.value)
     1.672621898e-27
-    >>> ion_mass('H')  # assumes terrestrial abundance of D
+    >>> ion_mass('H+')  # assumes terrestrial abundance of D
     <Quantity 1.672912413964e-27 kg>
-    >>> ion_mass('H') == ion_mass('p')
+    >>> ion_mass('H', Z=1) == ion_mass('p')
     False
-    >>> ion_mass('P')  # phosphorus
+    >>> ion_mass('P', Z=1)  # phosphorus
     <Quantity 5.14322300749914e-26 kg>
-    >>> ion_mass('He-4', 2)
+    >>> ion_mass('He-4', Z=2)
     <Quantity 6.644657088401906e-27 kg>
-    >>> ion_mass('T')
+    >>> ion_mass('T+')
     <Quantity 5.007356665e-27 kg>
     >>> ion_mass(26, Z=1, mass_numb=56)
     <Quantity 9.288123453752331e-26 kg>
-    >>> ion_mass('Fe-56')
+    >>> ion_mass('Fe-56', Z=1)
     <Quantity 9.288123453752331e-26 kg>
     >>> ion_mass(9.11e-31*u.kg).si.value
     9.10938356e-31
-    >>> ion_mass(1.67e-27*u.kg)
-    <Quantity 1.67e-27 kg>
 
     """
 
@@ -829,32 +827,22 @@ def ion_mass(argument, Z=None, mass_numb=None):
                  "electrons/ions.", UserWarning)
             return m_i
 
-    if isinstance(argument, str) and \
-            str(argument).lower() in ['e+', 'positron', 'e', 'e-', 'electron']:
+    if _is_electron(argument) or _is_positron(argument):
         return const.m_e
-
-    if argument in ['p', 'p+'] or str(argument).lower() in \
-            ['proton', 'protium'] and Z is None:
+    elif _is_proton(argument, Z, mass_numb) or _is_antiproton(argument):
         return const.m_p
-    elif _is_antiproton(argument) and Z is None:
-        return const.m_p
-
-    if _is_neutron(argument, mass_numb):
+    elif _is_neutron(argument, mass_numb):
         raise ValueError("Use isotope_mass or m_n to get mass of neutron")
 
     if isinstance(argument, str):
-        argument, Z_from_arg = _extract_charge_state(argument)
+        arg, Z_from_arg = _extract_charge_state(argument)
     else:
-        Z_from_arg = None
-
-    if atomic_number(argument) == 1:
-        if isinstance(argument, str) and 'H-1' in str(argument) and Z is None:
-            return const.m_p
-        if mass_numb == 1 and Z == 1:
-            return const.m_p
+        arg, Z_from_arg = argument, None
 
     if Z is None and Z_from_arg is None:
         Z = 1
+        warn(f"No charge state information is given for {argument}, so "
+             f"ion_mass is assuming that the species is singly ionized.")
     elif Z is not None and Z_from_arg is not None and Z != Z_from_arg:
         raise ValueError("Inconsistent charge state information in ion_mass")
     elif Z is None and Z_from_arg is not None:
@@ -873,12 +861,12 @@ def ion_mass(argument, Z=None, mass_numb=None):
         raise TypeError("In ion_mass, mass_numb must be an integer "
                         "representing the mass number of an isotope.")
 
-    if atomic_number(argument) < Z:
+    if atomic_number(arg) < Z:
         raise ValueError("The ionization state cannot exceed the "
                          "atomic number in ion_mass")
 
     try:
-        isotope = isotope_symbol(argument, mass_numb)
+        isotope = isotope_symbol(arg, mass_numb)
     except Exception:
         is_isotope = False
     else:
@@ -896,7 +884,7 @@ def ion_mass(argument, Z=None, mass_numb=None):
     else:
 
         try:
-            atomic_mass = standard_atomic_weight(argument)
+            atomic_mass = standard_atomic_weight(arg)
         except Exception:  # coveralls: ignore
 
             errormessage = ("No isotope mass or standard atomic weight is "
@@ -1565,23 +1553,25 @@ def _is_antiproton(argument):
         return False
 
 
-def _is_proton(argument):
+def _is_proton(argument, Z=None, mass_numb=None):
     r"""Returns True if the argument corresponds to a proton, and
     False otherwise.  This function returns False for 'H-1' if no
     charge state is given."""
 
-    if not isinstance(argument, str):
-        return False
+    try:
 
-    proton_aliases = ['p', 'p+', 'H-1 1+', 'H-1 +1', 'H-1+']
-    proton_aliases_case_insensitive = ['hydrogen-1 1+', 'hydrogen-1 +1',
-                                       'hydrogen-1+', 'proton']
+        isotope = isotope_symbol(argument, mass_numb)
 
-    if argument in proton_aliases:
-        return True
-    elif argument.lower() in proton_aliases_case_insensitive:
-        return True
-    else:
+        if Z is None:
+            Z = charge_state(argument)
+
+        if isotope == 'H-1' and Z == 1:
+            return True
+        else:
+            return False
+
+    except Exception:
+
         return False
 
 
@@ -1602,7 +1592,6 @@ def _is_alpha(argument):
         elif argument[-2:] != '-4':
             is_alpha = False
         else:
-
             dash_position = argument.find('-')
             argument = argument[:dash_position]
 

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -80,6 +80,8 @@ def atomic_symbol(argument):
 
     if _is_neutron(argument):
         raise ValueError("Neutrons do not have an atomic symbol")
+    elif _is_antiproton(argument):
+        raise ValueError("Antiprotons do not have an atomic symbol")
 
     argument, Z = _extract_charge_state(argument)
 
@@ -239,7 +241,7 @@ def isotope_symbol(argument, mass_numb=None):
     try:
         element = atomic_symbol(argument)
     except Exception:
-        raise ValueError(f"The first argument of isotope_symbol ({argument})"
+        raise ValueError(f"The first argument of isotope_symbol ({argument}) "
                          "does not correspond to a valid element or isotope.")
 
     # Get mass number from argument, check for redundancies, and take
@@ -1275,7 +1277,7 @@ def charge_state(argument):
 
     """
 
-    if _is_electron(argument):
+    if _is_electron(argument) or _is_antiproton(argument):
         return -1
     elif _is_positron(argument):
         return 1
@@ -1411,6 +1413,8 @@ def _extract_charge_state(argument):
         return argument, 2
     elif argument == 'e+' or argument.lower() == 'positron':
         return argument, 1
+    elif _is_antiproton(argument):
+        return argument, -1
 
     if argument.count(' ') == 1:  # For cases like 'Fe +2' and 'Fe-56 2+'
 

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -790,22 +790,24 @@ def ion_mass(argument, Z=None, mass_numb=None):
     --------
     >>> print(ion_mass('p').si.value)
     1.672621898e-27
-    >>> ion_mass('H+')  # assumes terrestrial abundance of D
+    >>> ion_mass('H')  # assumes terrestrial abundance of D
     <Quantity 1.672912413964e-27 kg>
-    >>> ion_mass('H', Z=1) == ion_mass('p')
+    >>> ion_mass('H') == ion_mass('p')
     False
-    >>> ion_mass('P', Z=1)  # phosphorus
+    >>> ion_mass('P')  # phosphorus
     <Quantity 5.14322300749914e-26 kg>
-    >>> ion_mass('He-4', Z=2)
+    >>> ion_mass('He-4', 2)
     <Quantity 6.644657088401906e-27 kg>
-    >>> ion_mass('T+')
+    >>> ion_mass('T')
     <Quantity 5.007356665e-27 kg>
     >>> ion_mass(26, Z=1, mass_numb=56)
     <Quantity 9.288123453752331e-26 kg>
-    >>> ion_mass('Fe-56', Z=1)
+    >>> ion_mass('Fe-56')
     <Quantity 9.288123453752331e-26 kg>
     >>> ion_mass(9.11e-31*u.kg).si.value
     9.10938356e-31
+    >>> ion_mass(1.67e-27*u.kg)
+    <Quantity 1.67e-27 kg>
 
     """
 
@@ -827,22 +829,32 @@ def ion_mass(argument, Z=None, mass_numb=None):
                  "electrons/ions.", UserWarning)
             return m_i
 
-    if _is_electron(argument) or _is_positron(argument):
+    if isinstance(argument, str) and \
+            str(argument).lower() in ['e+', 'positron', 'e', 'e-', 'electron']:
         return const.m_e
-    elif _is_proton(argument, Z, mass_numb) or _is_antiproton(argument):
+
+    if argument in ['p', 'p+'] or str(argument).lower() in \
+            ['proton', 'protium'] and Z is None:
         return const.m_p
-    elif _is_neutron(argument, mass_numb):
+    elif _is_antiproton(argument) and Z is None:
+        return const.m_p
+
+    if _is_neutron(argument, mass_numb):
         raise ValueError("Use isotope_mass or m_n to get mass of neutron")
 
     if isinstance(argument, str):
-        arg, Z_from_arg = _extract_charge_state(argument)
+        argument, Z_from_arg = _extract_charge_state(argument)
     else:
-        arg, Z_from_arg = argument, None
+        Z_from_arg = None
+
+    if atomic_number(argument) == 1:
+        if isinstance(argument, str) and 'H-1' in str(argument) and Z is None:
+            return const.m_p
+        if mass_numb == 1 and Z == 1:
+            return const.m_p
 
     if Z is None and Z_from_arg is None:
         Z = 1
-        warn(f"No charge state information is given for {argument}, so "
-             f"ion_mass is assuming that the species is singly ionized.")
     elif Z is not None and Z_from_arg is not None and Z != Z_from_arg:
         raise ValueError("Inconsistent charge state information in ion_mass")
     elif Z is None and Z_from_arg is not None:
@@ -861,12 +873,12 @@ def ion_mass(argument, Z=None, mass_numb=None):
         raise TypeError("In ion_mass, mass_numb must be an integer "
                         "representing the mass number of an isotope.")
 
-    if atomic_number(arg) < Z:
+    if atomic_number(argument) < Z:
         raise ValueError("The ionization state cannot exceed the "
                          "atomic number in ion_mass")
 
     try:
-        isotope = isotope_symbol(arg, mass_numb)
+        isotope = isotope_symbol(argument, mass_numb)
     except Exception:
         is_isotope = False
     else:
@@ -884,7 +896,7 @@ def ion_mass(argument, Z=None, mass_numb=None):
     else:
 
         try:
-            atomic_mass = standard_atomic_weight(arg)
+            atomic_mass = standard_atomic_weight(argument)
         except Exception:  # coveralls: ignore
 
             errormessage = ("No isotope mass or standard atomic weight is "
@@ -1553,25 +1565,23 @@ def _is_antiproton(argument):
         return False
 
 
-def _is_proton(argument, Z=None, mass_numb=None):
+def _is_proton(argument):
     r"""Returns True if the argument corresponds to a proton, and
     False otherwise.  This function returns False for 'H-1' if no
     charge state is given."""
 
-    try:
+    if not isinstance(argument, str):
+        return False
 
-        isotope = isotope_symbol(argument, mass_numb)
+    proton_aliases = ['p', 'p+', 'H-1 1+', 'H-1 +1', 'H-1+']
+    proton_aliases_case_insensitive = ['hydrogen-1 1+', 'hydrogen-1 +1',
+                                       'hydrogen-1+', 'proton']
 
-        if Z is None:
-            Z = charge_state(argument)
-
-        if isotope == 'H-1' and Z == 1:
-            return True
-        else:
-            return False
-
-    except Exception:
-
+    if argument in proton_aliases:
+        return True
+    elif argument.lower() in proton_aliases_case_insensitive:
+        return True
+    else:
         return False
 
 
@@ -1592,6 +1602,7 @@ def _is_alpha(argument):
         elif argument[-2:] != '-4':
             is_alpha = False
         else:
+
             dash_position = argument.find('-')
             argument = argument[:dash_position]
 

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -794,6 +794,8 @@ def ion_mass(argument, Z=None, mass_numb=None):
     <Quantity 1.672912413964e-27 kg>
     >>> ion_mass('H+') == ion_mass('p')
     False
+    >>> ion_mass('H-1') == ion_mass('p')
+    True
     >>> ion_mass('P+')  # phosphorus
     <Quantity 5.14322300749914e-26 kg>
     >>> ion_mass('He-4', Z=2)
@@ -874,7 +876,9 @@ def ion_mass(argument, Z=None, mass_numb=None):
 
     if is_isotope:
 
-        if isotope == 'D' and Z == 1:
+        if isotope == 'H-1' and Z == 1:
+            return const.m_p
+        elif isotope == 'D' and Z == 1:
             return 3.343583719e-27 * u.kg
         elif isotope == 'T' and Z == 1:
             return 5.007356665e-27 * u.kg

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -1490,9 +1490,6 @@ def _is_hydrogen(argument, can_be_atomic_number=False):
     r"""Returns True if the argument corresponds to hydrogen, and False
     otherwise."""
 
-    if argument == 'p-':
-        return False
-
     case_sensitive_aliases = ['p', 'p+', 'H', 'D', 'T']
 
     case_insensitive_aliases = ['proton', 'protium', 'deuterium',
@@ -1508,10 +1505,8 @@ def _is_hydrogen(argument, can_be_atomic_number=False):
 
         if argument in case_sensitive_aliases:
             is_hydrogen = True
-        elif argument.lower() in case_insensitive_aliases:
-            is_hydrogen = True
         else:
-            is_hydrogen = False
+            is_hydrogen = argument.lower() in case_insensitive_aliases
 
         if is_hydrogen and Z is not None and Z > 1:
             raise ValueError("Invalid charge state of hydrogen")
@@ -1524,101 +1519,82 @@ def _is_hydrogen(argument, can_be_atomic_number=False):
     return is_hydrogen
 
 
-def _is_electron(argument):
+def _is_electron(arg):
     r"""Returns True if the argument corresponds to an electron, and False
     otherwise."""
 
-    if not isinstance(argument, str):
+    if not isinstance(arg, str):
         return False
-
-    if argument in ['e', 'e-'] or argument.lower() == 'electron':
-        return True
-    else:
-        return False
+   
+    return arg in ['e', 'e-'] or arg.lower() == 'electron'
 
 
-def _is_positron(argument):
+def _is_positron(arg):
     r"""Returns True if the argument corresponds to a positron, and False
     otherwise."""
 
-    if not isinstance(argument, str):
+    if not isinstance(arg, str):
         return False
 
-    if argument == 'e+' or argument.lower() == 'positron':
-        return True
-    else:
-        return False
+    return arg == 'e+' or arg.lower() == 'positron'
 
 
-def _is_antiproton(argument):
+def _is_antiproton(arg):
     r"""Returns True if the argument corresponds to an antiproton, and
     False otherwise."""
-
-    if not isinstance(argument, str):
+    
+    if not isinstance(arg, str):
         return False
 
-    if argument == 'p-' or argument.lower() == 'antiproton':
-        return True
-    else:
-        return False
+    return arg == 'p-' or arg.lower() == 'antiproton'
 
 
-def _is_antineutron(argument):
+def _is_antineutron(arg):
     r"""Returns True if the argument corresponds to an antineutron, and
     False otherwise."""
-
-    if argument.lower() == 'antineutron':
-        return True
-    else:
+    
+    if not isinstance(arg, str):
         return False
 
+    return arg.lower() == 'antineutron'
 
-def _is_proton(argument, Z=None, mass_numb=None):
+
+def _is_proton(arg, Z=None, mass_numb=None):
     r"""Returns True if the argument corresponds to a proton, and
     False otherwise.  This function returns False for 'H-1' if no
     charge state is given."""
 
     try:
 
-        isotope = isotope_symbol(argument, mass_numb)
+        isotope = isotope_symbol(arg, mass_numb)
 
         if Z is None:
-            Z = charge_state(argument)
+            Z = charge_state(arg)
 
-        if isotope == 'H-1' and Z == 1:
-            return True
-        else:
-            return False
+        return isotope == 'H-1' and Z == 1
 
     except Exception:
 
         return False
 
 
-def _is_alpha(argument):
+def _is_alpha(arg):
     r"""Returns True if the argument corresponds to an alpha particle,
     and False otherwise."""
 
-    if not isinstance(argument, str):
+    if not isinstance(arg, str):
         return False
 
-    if argument.lower() == 'alpha':
-        is_alpha = True
+    if arg.lower() == 'alpha':
+        return True
     else:
-        argument, Z = _extract_charge_state(argument)
+        arg, Z = _extract_charge_state(arg)
 
-        if Z != 2:
-            is_alpha = False
-        elif argument[-2:] != '-4':
-            is_alpha = False
+        if Z != 2 or arg[-2:] != '-4':
+            return False
         else:
 
-            dash_position = argument.find('-')
-            argument = argument[:dash_position]
+            dash_position = arg.find('-')
+            arg = arg[:dash_position]
 
-            if argument.lower() == 'helium' or argument == 'He':
-                is_alpha = True
-            else:
-                is_alpha = False
-
-    return is_alpha
+            return arg.lower() == 'helium' or arg == 'He'

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -790,19 +790,19 @@ def ion_mass(argument, Z=None, mass_numb=None):
     --------
     >>> print(ion_mass('p').si.value)
     1.672621898e-27
-    >>> ion_mass('H')  # assumes terrestrial abundance of D
+    >>> ion_mass('H+')  # assumes terrestrial abundance of D
     <Quantity 1.672912413964e-27 kg>
-    >>> ion_mass('H') == ion_mass('p')
+    >>> ion_mass('H+') == ion_mass('p')
     False
-    >>> ion_mass('P')  # phosphorus
+    >>> ion_mass('P+')  # phosphorus
     <Quantity 5.14322300749914e-26 kg>
-    >>> ion_mass('He-4', 2)
+    >>> ion_mass('He-4', Z=2)
     <Quantity 6.644657088401906e-27 kg>
-    >>> ion_mass('T')
+    >>> ion_mass('T+')
     <Quantity 5.007356665e-27 kg>
     >>> ion_mass(26, Z=1, mass_numb=56)
     <Quantity 9.288123453752331e-26 kg>
-    >>> ion_mass('Fe-56')
+    >>> ion_mass('Fe-56 1+')
     <Quantity 9.288123453752331e-26 kg>
     >>> ion_mass(9.11e-31*u.kg).si.value
     9.10938356e-31
@@ -829,17 +829,11 @@ def ion_mass(argument, Z=None, mass_numb=None):
                  "electrons/ions.", UserWarning)
             return m_i
 
-    if isinstance(argument, str) and \
-            str(argument).lower() in ['e+', 'positron', 'e', 'e-', 'electron']:
+    if _is_electron(argument) or _is_positron(argument):
         return const.m_e
-
-    if argument in ['p', 'p+'] or str(argument).lower() in \
-            ['proton', 'protium'] and Z is None:
+    elif _is_proton(argument, Z, mass_numb) or _is_antiproton(argument):
         return const.m_p
-    elif _is_antiproton(argument) and Z is None:
-        return const.m_p
-
-    if _is_neutron(argument, mass_numb):
+    elif _is_neutron(argument, mass_numb):
         raise ValueError("Use isotope_mass or m_n to get mass of neutron")
 
     if isinstance(argument, str):
@@ -1565,23 +1559,25 @@ def _is_antiproton(argument):
         return False
 
 
-def _is_proton(argument):
+def _is_proton(argument, Z=None, mass_numb=None):
     r"""Returns True if the argument corresponds to a proton, and
     False otherwise.  This function returns False for 'H-1' if no
     charge state is given."""
 
-    if not isinstance(argument, str):
-        return False
+    try:
 
-    proton_aliases = ['p', 'p+', 'H-1 1+', 'H-1 +1', 'H-1+']
-    proton_aliases_case_insensitive = ['hydrogen-1 1+', 'hydrogen-1 +1',
-                                       'hydrogen-1+', 'proton']
+        isotope = isotope_symbol(argument, mass_numb)
 
-    if argument in proton_aliases:
-        return True
-    elif argument.lower() in proton_aliases_case_insensitive:
-        return True
-    else:
+        if Z is None:
+            Z = charge_state(argument)
+
+        if isotope == 'H-1' and Z == 1:
+            return True
+        else:
+            return False
+
+    except Exception:
+
         return False
 
 

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -1573,7 +1573,13 @@ def _is_proton(argument):
     if not isinstance(argument, str):
         return False
 
-    if argument in ['p', 'p+'] or argument.lower() == 'proton':
+    proton_aliases = ['p', 'p+', 'H-1 1+', 'H-1 +1', 'H-1+']
+    proton_aliases_case_insensitive = ['hydrogen-1 1+', 'hydrogen-1 +1',
+                                       'hydrogen-1+', 'proton']
+
+    if argument in proton_aliases:
+        return True
+    elif argument.lower() in proton_aliases_case_insensitive:
         return True
     else:
         return False

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -1350,7 +1350,7 @@ def electric_charge(argument):
     try:
         charge = charge_state(argument) * const.e.to('C')
         return charge
-    except Exception:
+    except Exception:  # coveralls: ignore
         raise ValueError("Invalid input to electric_charge")
 
 

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -697,9 +697,6 @@ def isotope_mass(argument, mass_numb=None):
 
     argument, charge_state = _extract_charge_state(argument)
 
-    if _is_proton(argument) or _is_antiproton(argument):
-        return const.m_p
-
     if charge_state is not None and charge_state != 0:
         raise ValueError("Use ion_mass instead of isotope_mass for masses of "
                          "charged particles")

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -1351,7 +1351,7 @@ def electric_charge(argument):
         charge = charge_state(argument) * const.e.to('C')
         return charge
     except Exception:  # coveralls: ignore
-        raise ValueError("Invalid input to electric_charge")
+        raise ValueError(f"{argument} is an invalid input to electric_charge")
 
 
 def _extract_charge_state(argument):

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -1224,14 +1224,13 @@ def isotopic_abundance(argument, mass_numb=None):
     return iso_comp
 
 
-def charge_state(argument):
+def charge_state(particle):
     r"""Returns the charge state of an ion or other particle.
 
     Parameters
     ----------
-    argument : string
-        String representing an element or isotope followed by charge
-        state information.
+    particle : string
+        String representing a particle.
 
     Returns
     -------
@@ -1277,17 +1276,17 @@ def charge_state(argument):
 
     """
 
-    if _is_electron(argument) or _is_antiproton(argument):
+    if _is_electron(particle) or _is_antiproton(particle):
         return -1
-    elif _is_positron(argument):
+    elif _is_positron(particle):
         return 1
-    elif _is_neutron(argument):
+    elif _is_neutron(particle) or _is_antineutron(particle):
         return 0
 
-    argument, Z = _extract_charge_state(argument)
+    particle, Z = _extract_charge_state(particle)
 
     try:
-        atomic_numb = atomic_number(argument)
+        atomic_numb = atomic_number(particle)
     except Exception:
         raise ValueError("Invalid element or isotope information in "
                          "charge_state")
@@ -1297,19 +1296,22 @@ def charge_state(argument):
                          "number.")
 
     if Z is not None and (Z < -atomic_numb-1 or Z < -3):
-        warn(f"Element {atomic_symbol(argument)} has a charge of {Z}"
+        warn(f"Element {atomic_symbol(particle)} has a charge of {Z}"
              " which is unlikely to occur in nature.", UserWarning)
+
+    if Z is None:
+        raise ValueError(f"Unable to find charge of {particle}")
 
     return Z
 
 
-def electric_charge(argument):
+def electric_charge(particle):
     r"""Returns the electric charge (in coulombs) of an ion or other
     particle
 
     Parameters
     ----------
-    argument : string
+    particle : string
         String representing an element or isotope followed by charge
         state information.
 
@@ -1354,10 +1356,10 @@ def electric_charge(argument):
     """
 
     try:
-        charge = charge_state(argument) * const.e.to('C')
+        charge = charge_state(particle) * const.e.to('C')
         return charge
     except Exception:  # coveralls: ignore
-        raise ValueError(f"{argument} is an invalid input to electric_charge")
+        raise ValueError(f"{particle} is an invalid input to electric_charge")
 
 
 def _extract_charge_state(argument):
@@ -1556,6 +1558,16 @@ def _is_antiproton(argument):
         return False
 
     if argument == 'p-' or argument.lower() == 'antiproton':
+        return True
+    else:
+        return False
+
+
+def _is_antineutron(argument):
+    r"""Returns True if the argument corresponds to an antineutron, and
+    False otherwise."""
+
+    if argument.lower() == 'antineutron':
         return True
     else:
         return False

--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -1265,7 +1265,8 @@ def charge_state(argument):
     The second format is a string containing element information at
     the beginning, following by one or more plus or minus signs.
 
-    This function returns -1 for electrons and +1 for positrons.
+    This function returns -1 for electrons, +1 for positrons, and 0
+    for neutrons.
 
     Examples
     --------
@@ -1284,6 +1285,8 @@ def charge_state(argument):
         return -1
     elif _is_positron(argument):
         return 1
+    elif _is_neutron(argument):
+        return 0
 
     argument, Z = _extract_charge_state(argument)
 

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -101,8 +101,6 @@ def nuclear_reaction_energy(*args, **kwargs):
         not conserved, or the charge is not conserved.
 
     TypeError:
-        If a positional input is given for the reaction
-
         If the positional input for reaction is not a string.
 
     See also
@@ -236,6 +234,6 @@ def nuclear_reaction_energy(*args, **kwargs):
         released_energy = _mass_energy(reactants) - _mass_energy(products)
 
     except Exception:
-        raise ValueError("Invalid reactant or product")
+        raise ValueError("Invalid reactant(s) and/or product(s)")
 
     return released_energy.to(units.J)

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -33,28 +33,28 @@ def nuclear_binding_energy(argument, mass_numb=None):
 
     Examples
     --------
-    >>> nuclear_binding_energy('Fe-56')
-    <Quantity 7.674003137600576e-11 J>
+    >>> from astropy import units as u
+    >>> nuclear_binding_energy('Fe-56').to(u.MeV)
+    <Quantity 492.25957875689096 MeV>
     >>> nuclear_binding_energy(26, 56)
-    <Quantity 7.674003137600576e-11 J>
+    <Quantity 7.88686788449147e-11 J>
     >>> nuclear_binding_energy('p')  # proton
     <Quantity 0.0 J>
-
     >>> from astropy import units as u
     >>> before = nuclear_binding_energy("D") + nuclear_binding_energy("T")
     >>> after = nuclear_binding_energy("alpha")
     >>> (after - before).to(u.MeV)  # released energy from D + T --> alpha + n
-    <Quantity 17.58929687252852 MeV>
+    <Quantity 17.58932777775092 MeV>
 
     """
 
     if _is_neutron(argument) and mass_numb is None or mass_numb == 1:
         return 0.0 * units.J
 
-    isotopic_symbol = isotope_symbol(argument, mass_numb)
+    isotope = isotope_symbol(argument, mass_numb)
 
-    isotopic_mass = isotope_mass(isotopic_symbol)
     number_of_protons = atomic_number(argument)
+    nuclide_mass = ion_mass(isotope, Z=number_of_protons)
 
     if mass_numb is None:
         mass_numb = mass_number(argument)
@@ -65,7 +65,7 @@ def nuclear_binding_energy(argument, mass_numb=None):
     else:
         mass_of_nucleons = (number_of_protons * constants.m_p +
                             number_of_neutrons * constants.m_n)
-        mass_defect = mass_of_nucleons - isotopic_mass
+        mass_defect = mass_of_nucleons - nuclide_mass
         binding_energy = mass_defect * constants.c**2
 
     return binding_energy.to(units.J)

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -193,8 +193,8 @@ def nuclear_reaction_energy(*args, **kwargs):
 
         for particle in particles:
             try:
-                nucleon_number += mass_number(particles)
-            except Exception:
+                nucleon_number += mass_number(particle)
+            except ValueError:
                 pass
 
         return nucleon_number

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -105,7 +105,8 @@ def nuclear_reaction_energy(*args, **kwargs):
         not conserved, or the charge is not conserved.
 
     TypeError:
-        If the positional input for reaction is not a string, or
+        If the positional input for the reaction is not a string, or
+        reactants and/or products is not of an appropriate type.
 
     See also
     --------

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -131,7 +131,7 @@ def nuclear_reaction_energy(*args, **kwargs):
     >>> energy_triplealpha2.to(u.MeV)
     <Quantity 7.366587037597284 MeV>
     >>> nuclear_reaction_energy(reactants=['n'], products=['p', 'e-'])
-    <Quantity 1.25343510874046e-13 J>
+    <Quantity 1.2534574417523367e-13 J>
 
     """
 

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -225,7 +225,7 @@ def nuclear_reaction_energy(*args, **kwargs):
         try:
             reactants = _get_species(LHS_list)
             products = _get_species(RHS_list)
-        except Exception:
+        except Exception:  # coveralls: ignore
             raise ValueError(input_err_msg)
 
     else:
@@ -239,7 +239,7 @@ def nuclear_reaction_energy(*args, **kwargs):
 
     try:
         released_energy = _mass_energy(reactants) - _mass_energy(products)
-    except Exception:
+    except Exception:  # coveralls: ignore
         raise ValueError("Invalid reactant(s) and/or product(s)")
 
     return released_energy.to(units.J)

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -2,7 +2,7 @@
 
 from astropy import units, constants
 import re
-from .atomic import (isotope_symbol, mass_number, isotope_mass, ion_mass, 
+from .atomic import (isotope_symbol, mass_number, isotope_mass, ion_mass,
                      atomic_number, charge_state, _is_neutron, _is_electron,
                      _is_positron)
 
@@ -209,7 +209,7 @@ def nuclear_reaction_energy(*args, **kwargs):
         try:
             reactants = _get_species(list(kwargs['reactants']))
             products = _get_species(list(kwargs['products']))
-        except:
+        except Exception:
             raise ValueError(input_err_msg)
 
     elif args and not kwargs and len(args) == 1:  # reaction string input

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -231,15 +231,14 @@ def nuclear_reaction_energy(*args, **kwargs):
     else:
         raise ValueError(input_err_msg)
 
+    if _nucleon_number(reactants) != _nucleon_number(products):
+        raise ValueError("The number of nucleons is not conserved")
+
+    if _total_charge(reactants) != _total_charge(products):
+        raise ValueError("Total charge is not conserved")
+
     try:
-        if _nucleon_number(reactants) != _nucleon_number(products):
-            raise ValueError("The number of nucleons is not conserved")
-
-        if _total_charge(reactants) != _total_charge(products):
-            raise ValueError("Total charge is not conserved")
-
         released_energy = _mass_energy(reactants) - _mass_energy(products)
-
     except Exception:
         raise ValueError("Invalid reactant(s) and/or product(s)")
 

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -131,7 +131,7 @@ def nuclear_reaction_energy(*args, **kwargs):
     >>> energy_triplealpha2.to(u.MeV)
     <Quantity 7.366587037597284 MeV>
     >>> nuclear_reaction_energy(reactants=['n'], products=['p', 'e-'])
-    <Quantity 1.2534574417523367e-13 J>
+    <Quantity 1.25343510874046e-13 J>
 
     """
 

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -10,7 +10,7 @@ from ..atomic import (atomic_symbol, isotope_symbol, atomic_number,
                       electric_charge, Elements, Isotopes,
                       _is_neutron, _is_hydrogen, _is_electron,
                       _is_positron, _is_antiproton, _is_alpha,
-                      _extract_charge_state)
+                      _extract_charge_state, _is_proton)
 
 from ..nuclear import (nuclear_binding_energy, nuclear_reaction_energy)
 
@@ -881,6 +881,25 @@ def test_is_electron(test_input, expected):
                           (57, False)])
 def test_is_positron(test_input, expected):
     assert _is_positron(test_input) == expected
+
+
+@pytest.mark.parametrize("test_input,expected",
+                          [('p', True),
+                           ('p+', True),
+                           ('hydrogen-1+', True),
+                           ('H-1 1+', True),
+                           ('H-1', False),
+                           ('H', False),
+                           ('p-', False),
+                           ('antiproton', False),
+                           ('Antiproton', False),
+                           ('proton', True),
+                           ('Proton', True),
+                           ('P', False),
+                           ('P+', False),
+                           ])
+def test_is_proton(test_input, expected):
+    assert _is_proton(test_input) == expected
 
 
 @pytest.mark.parametrize("test_input,expected",

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -842,7 +842,7 @@ def test_is_neutron(test_input, kwargs, expected):
                           ('p-', False, False)])
 def test_is_hydrogen(test_input, can_be_atom_numb, expected):
     assert _is_hydrogen(test_input,
-                         can_be_atomic_number=can_be_atom_numb) == expected
+                        can_be_atomic_number=can_be_atom_numb) == expected
 
 
 @pytest.mark.parametrize("test_input,kwargs,expected_error",

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -1,6 +1,7 @@
 from itertools import product
 from astropy import units as u, constants as const
 import numpy as np
+import warnings
 
 from ..atomic import (atomic_symbol, isotope_symbol, atomic_number,
                       mass_number, element_name, standard_atomic_weight,
@@ -57,8 +58,7 @@ atomic_symbol_table = [
 
 
 @pytest.mark.parametrize(
-    'argument, expected', atomic_symbol_table
-)
+    'argument, expected', atomic_symbol_table)
 def test_atomic_symbol(argument, expected):
     assert atomic_symbol(argument) == expected
 
@@ -429,8 +429,8 @@ def test_isotope_mass_error(argument, expected_error):
 
 
 def test_ion_mass_hydrogen():
-    assert ion_mass('H') > const.m_p, "Use standard_atomic_weight of 'H'"
-    assert ion_mass('hydrogen') > const.m_p
+    assert ion_mass('H', Z=1) > const.m_p, "Use standard_atomic_weight of 'H'"
+    assert ion_mass('hydrogen', Z=1) > const.m_p
 
 
 def test_ion_mass_unit():
@@ -440,13 +440,16 @@ def test_ion_mass_unit():
 
 def test_ion_mass():
     assert ion_mass('proton') == const.m_p
-    assert ion_mass('e+') == ion_mass('positron') == const.m_e
-    assert np.isclose(ion_mass('alpha') / ion_mass('He-4', 2), 1.0)
-    assert ion_mass('protium') == const.m_p
-    assert ion_mass('Ne-22', 2) == 21.991385114 * u.u - 2 * const.m_e
     assert ion_mass('H-1+') == const.m_p
-    assert ion_mass('He+') == ion_mass('He')
-    assert ion_mass('He 1+') == ion_mass('He')
+    assert ion_mass('hydrogen-1+') == const.m_p
+    assert ion_mass('H-1', Z=1) == const.m_p
+    assert ion_mass('p') == const.m_p
+    assert ion_mass('p+') == const.m_p
+    assert ion_mass('p-') == const.m_p
+    assert ion_mass('e+') == ion_mass('positron') == const.m_e
+    assert np.isclose(ion_mass('alpha') / ion_mass('He-4', Z=2), 1.0)
+    assert ion_mass('Ne-22', Z=2) == 21.991385114 * u.u - 2 * const.m_e
+    assert ion_mass('H-1+') == const.m_p
     assert ion_mass('He-4 2+') == ion_mass('alpha')
     assert np.isclose(ion_mass('Fe 1-').value,
                       (ion_mass('Fe 1+') + 2 * const.m_e).value, rtol=1e-14)
@@ -459,7 +462,8 @@ def test_ion_mass():
     assert ion_mass(1, Z=1, mass_numb=1) == ion_mass('p')
     assert ion_mass('deuteron') == ion_mass('D +1')
     assert ion_mass('T', Z=1) == ion_mass('T +1')
-    assert ion_mass('Fe', mass_numb=56) == ion_mass('Fe', mass_numb='56')
+    assert ion_mass('Fe', mass_numb=56, Z=2) == \
+        ion_mass('Fe', mass_numb='56', Z=2)
     assert np.isclose(ion_mass(9.11e-31 * u.kg).value, 9.10938291e-31,
                       atol=1e-37)
     assert ion_mass(1.67e-27 * u.kg) == 1.67e-27 * u.kg
@@ -470,7 +474,7 @@ def test_ion_mass():
 
 # (argument, kwargs, expected_error)
 ion_mass_error_table = [
-    ('0g', {}, ValueError),  # since it has no standard atomic weight
+    ('0g 1+', {}, ValueError),  # since it has no standard atomic weight
     ('Fe-56', {"Z": 1.4}, TypeError),
     ('n', {}, ValueError),
     ('H-1 +1', {"Z": 0}, ValueError),
@@ -479,7 +483,7 @@ ion_mass_error_table = [
     ('Og', {"Z": 1}, ValueError),
     ('Og', {"mass_numb": 296, "Z": 1}, ValueError),
     ('n', {}, ValueError),
-    ('He', {"mass_numb": 99}, ValueError),
+    ('He 1+', {"mass_numb": 99}, ValueError),
     (1 * u.m, {}, u.UnitConversionError),
     ('Og', {"Z": 1}, ValueError),
     ('fe-56 1+', {}, ValueError)]
@@ -522,7 +526,8 @@ is_isotope_stable_table = [
     ('Fe-56',),
     ('iron-56',),
     ('Iron-56',),
-    (26, 56)]
+    (26, 56),
+    ]
 
 
 @pytest.mark.parametrize("argument", is_isotope_stable_table)
@@ -604,11 +609,9 @@ def test_half_life_u_220():
 
 
 atomic_TypeError_funcs_table = [
-    atomic_symbol, isotope_symbol, atomic_number,
-    is_isotope_stable, half_life, mass_number,
-    element_name, standard_atomic_weight, isotope_mass,
-    ion_mass, nuclear_binding_energy,
-    nuclear_reaction_energy]
+    atomic_symbol, isotope_symbol, atomic_number, is_isotope_stable, half_life,
+    mass_number, element_name, standard_atomic_weight, isotope_mass, ion_mass,
+    nuclear_binding_energy, nuclear_reaction_energy]
 atomic_TypeError_bad_arguments = [1.1, {'cats': 'bats'}, 1 + 1j]
 
 
@@ -618,7 +621,9 @@ atomic_TypeError_bad_arguments = [1.1, {'cats': 'bats'}, 1 + 1j]
             atomic_TypeError_bad_arguments))
 def test_atomic_TypeErrors(function, argument):
     with pytest.raises(TypeError):
-        function(argument)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            function(argument)
 
 
 atomic_ValueErrors_funcs_table = [
@@ -884,24 +889,28 @@ def test_is_positron(test_input, expected):
     assert _is_positron(test_input) == expected
 
 
-@pytest.mark.parametrize("test_input,expected",
-                         [('p', True),
-                          ('p+', True),
-                          ('hydrogen-1+', True),
-                          ('H-1 1+', True),
-                          ('H-1', False),
-                          ('H', False),
-                          ('p-', False),
-                          ('antiproton', False),
-                          ('Antiproton', False),
-                          ('proton', True),
-                          ('Proton', True),
-                          ('P', False),
-                          ('P+', False),
-                          (1, False),
-                          ])
-def test_is_proton(test_input, expected):
-    assert _is_proton(test_input) == expected
+@pytest.mark.parametrize("test_input,kwargs,expected",
+                         [('p', {}, True),
+                          ('p+', {}, True),
+                          ('hydrogen-1+', {}, True),
+                          ('H-1 1+', {}, True),
+                          ('H-1', {}, False),
+                          ('H', {}, False),
+                          ('p-', {}, False),
+                          ('antiproton', {}, False),
+                          ('Antiproton', {}, False),
+                          ('proton', {}, True),
+                          ('Proton', {}, True),
+                          ('P', {}, False),
+                          ('P+', {}, False),
+                          (1, {}, False),
+                          (1, {"mass_numb": 1, "Z": 1}, True),
+                          ('H', {"mass_numb": 1, "Z": 1}, True),
+                          ('H-1', {"Z": 1}, True),
+                          ('H', {"Z": 1}, False),
+                          ('H-1', {"Z": 0}, False)])
+def test_is_proton(test_input, kwargs, expected):
+    assert _is_proton(test_input, **kwargs) == expected
 
 
 @pytest.mark.parametrize("test_input,expected",

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -414,13 +414,11 @@ isotope_mass_error_table = [
     ('alpha', ValueError),
     ('He-4 2+', ValueError),
     ('he-4', ValueError),
-    ('p', ValueError),
     ('Fe 2+', ValueError),
     ('Fe -2', ValueError),
     ('deuteron', ValueError),
     ('triton', ValueError),
-    ('alpha', ValueError),
-    ('p', ValueError)]
+    ('alpha', ValueError)]
 
 
 @pytest.mark.parametrize("argument, expected_error", isotope_mass_error_table)

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -722,7 +722,9 @@ charge_state_table = [
     ('electron', -1),
     ('e-', -1),
     ('e+', 1),
-    ('positron', 1)]
+    ('positron', 1),
+    ('n', 0),
+    ('neutron', 0)]
 
 
 @pytest.mark.parametrize("argument, expected", charge_state_table)
@@ -765,6 +767,7 @@ def test_electric_charge():
     assert electric_charge('p').unit == 'C'
     assert electric_charge('e').value == -1.6021766208e-19
     assert electric_charge('alpha').value == 3.2043532416e-19
+    assert electric_charge('n').value == 0
 
 
 # (argument, expected_error)

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -80,7 +80,10 @@ atomic_symbol_error_table = [
     ('h', ValueError),
     ('d', ValueError),
     ('he', ValueError),
-    ('au', ValueError)]
+    ('au', ValueError),
+    ('p-', ValueError),
+    ('antiproton', ValueError),
+]
 
 
 @pytest.mark.parametrize(
@@ -728,7 +731,10 @@ charge_state_table = [
     ('e+', 1),
     ('positron', 1),
     ('n', 0),
-    ('neutron', 0)]
+    ('neutron', 0),
+    ('p-', -1),
+    ('antiproton', -1),
+]
 
 
 @pytest.mark.parametrize("argument, expected", charge_state_table)

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -357,7 +357,7 @@ def test_standard_atomic_weight(argument, expected):
 # (argument, expected_error)
 standard_atomic_weight_error_table = [
     ('H-1', ValueError),
-    ('wrong input', ValueError),
+    ("help i'm trapped in a unit test", ValueError),
     (1.1, TypeError),
     ('n', ValueError),
     ('p', ValueError),
@@ -418,7 +418,8 @@ isotope_mass_error_table = [
     ('Fe -2', ValueError),
     ('deuteron', ValueError),
     ('triton', ValueError),
-    ('alpha', ValueError)]
+    ('H-1 +1', ValueError),
+    ('H-1+', ValueError)]
 
 
 @pytest.mark.parametrize("argument, expected_error", isotope_mass_error_table)

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -1,7 +1,6 @@
 from itertools import product
 from astropy import units as u, constants as const
 import numpy as np
-import warnings
 
 from ..atomic import (atomic_symbol, isotope_symbol, atomic_number,
                       mass_number, element_name, standard_atomic_weight,
@@ -58,7 +57,8 @@ atomic_symbol_table = [
 
 
 @pytest.mark.parametrize(
-    'argument, expected', atomic_symbol_table)
+    'argument, expected', atomic_symbol_table
+)
 def test_atomic_symbol(argument, expected):
     assert atomic_symbol(argument) == expected
 
@@ -429,8 +429,8 @@ def test_isotope_mass_error(argument, expected_error):
 
 
 def test_ion_mass_hydrogen():
-    assert ion_mass('H', Z=1) > const.m_p, "Use standard_atomic_weight of 'H'"
-    assert ion_mass('hydrogen', Z=1) > const.m_p
+    assert ion_mass('H') > const.m_p, "Use standard_atomic_weight of 'H'"
+    assert ion_mass('hydrogen') > const.m_p
 
 
 def test_ion_mass_unit():
@@ -440,16 +440,13 @@ def test_ion_mass_unit():
 
 def test_ion_mass():
     assert ion_mass('proton') == const.m_p
-    assert ion_mass('H-1+') == const.m_p
-    assert ion_mass('hydrogen-1+') == const.m_p
-    assert ion_mass('H-1', Z=1) == const.m_p
-    assert ion_mass('p') == const.m_p
-    assert ion_mass('p+') == const.m_p
-    assert ion_mass('p-') == const.m_p
     assert ion_mass('e+') == ion_mass('positron') == const.m_e
-    assert np.isclose(ion_mass('alpha') / ion_mass('He-4', Z=2), 1.0)
-    assert ion_mass('Ne-22', Z=2) == 21.991385114 * u.u - 2 * const.m_e
+    assert np.isclose(ion_mass('alpha') / ion_mass('He-4', 2), 1.0)
+    assert ion_mass('protium') == const.m_p
+    assert ion_mass('Ne-22', 2) == 21.991385114 * u.u - 2 * const.m_e
     assert ion_mass('H-1+') == const.m_p
+    assert ion_mass('He+') == ion_mass('He')
+    assert ion_mass('He 1+') == ion_mass('He')
     assert ion_mass('He-4 2+') == ion_mass('alpha')
     assert np.isclose(ion_mass('Fe 1-').value,
                       (ion_mass('Fe 1+') + 2 * const.m_e).value, rtol=1e-14)
@@ -462,8 +459,7 @@ def test_ion_mass():
     assert ion_mass(1, Z=1, mass_numb=1) == ion_mass('p')
     assert ion_mass('deuteron') == ion_mass('D +1')
     assert ion_mass('T', Z=1) == ion_mass('T +1')
-    assert ion_mass('Fe', mass_numb=56, Z=2) == \
-        ion_mass('Fe', mass_numb='56', Z=2)
+    assert ion_mass('Fe', mass_numb=56) == ion_mass('Fe', mass_numb='56')
     assert np.isclose(ion_mass(9.11e-31 * u.kg).value, 9.10938291e-31,
                       atol=1e-37)
     assert ion_mass(1.67e-27 * u.kg) == 1.67e-27 * u.kg
@@ -474,7 +470,7 @@ def test_ion_mass():
 
 # (argument, kwargs, expected_error)
 ion_mass_error_table = [
-    ('0g 1+', {}, ValueError),  # since it has no standard atomic weight
+    ('0g', {}, ValueError),  # since it has no standard atomic weight
     ('Fe-56', {"Z": 1.4}, TypeError),
     ('n', {}, ValueError),
     ('H-1 +1', {"Z": 0}, ValueError),
@@ -483,7 +479,7 @@ ion_mass_error_table = [
     ('Og', {"Z": 1}, ValueError),
     ('Og', {"mass_numb": 296, "Z": 1}, ValueError),
     ('n', {}, ValueError),
-    ('He 1+', {"mass_numb": 99}, ValueError),
+    ('He', {"mass_numb": 99}, ValueError),
     (1 * u.m, {}, u.UnitConversionError),
     ('Og', {"Z": 1}, ValueError),
     ('fe-56 1+', {}, ValueError)]
@@ -526,8 +522,7 @@ is_isotope_stable_table = [
     ('Fe-56',),
     ('iron-56',),
     ('Iron-56',),
-    (26, 56),
-    ]
+    (26, 56)]
 
 
 @pytest.mark.parametrize("argument", is_isotope_stable_table)
@@ -609,9 +604,11 @@ def test_half_life_u_220():
 
 
 atomic_TypeError_funcs_table = [
-    atomic_symbol, isotope_symbol, atomic_number, is_isotope_stable, half_life,
-    mass_number, element_name, standard_atomic_weight, isotope_mass, ion_mass,
-    nuclear_binding_energy, nuclear_reaction_energy]
+    atomic_symbol, isotope_symbol, atomic_number,
+    is_isotope_stable, half_life, mass_number,
+    element_name, standard_atomic_weight, isotope_mass,
+    ion_mass, nuclear_binding_energy,
+    nuclear_reaction_energy]
 atomic_TypeError_bad_arguments = [1.1, {'cats': 'bats'}, 1 + 1j]
 
 
@@ -621,9 +618,7 @@ atomic_TypeError_bad_arguments = [1.1, {'cats': 'bats'}, 1 + 1j]
             atomic_TypeError_bad_arguments))
 def test_atomic_TypeErrors(function, argument):
     with pytest.raises(TypeError):
-        with warnings.catch_warnings():  # for ion_mass warnings if Z not given
-            warnings.simplefilter('ignore')  
-            function(argument)
+        function(argument)
 
 
 atomic_ValueErrors_funcs_table = [
@@ -889,28 +884,24 @@ def test_is_positron(test_input, expected):
     assert _is_positron(test_input) == expected
 
 
-@pytest.mark.parametrize("test_input,kwargs,expected",
-                         [('p', {}, True),
-                          ('p+', {}, True),
-                          ('hydrogen-1+', {}, True),
-                          ('H-1 1+', {}, True),
-                          ('H-1', {}, False),
-                          ('H', {}, False),
-                          ('p-', {}, False),
-                          ('antiproton', {}, False),
-                          ('Antiproton', {}, False),
-                          ('proton', {}, True),
-                          ('Proton', {}, True),
-                          ('P', {}, False),
-                          ('P+', {}, False),
-                          (1, {}, False),
-                          (1, {"mass_numb": 1, "Z": 1}, True),
-                          ('H', {"mass_numb": 1, "Z": 1}, True),
-                          ('H-1', {"Z": 1}, True),
-                          ('H', {"Z": 1}, False),
-                          ('H-1', {"Z": 0}, False)])
-def test_is_proton(test_input, kwargs, expected):
-    assert _is_proton(test_input, **kwargs) == expected
+@pytest.mark.parametrize("test_input,expected",
+                         [('p', True),
+                          ('p+', True),
+                          ('hydrogen-1+', True),
+                          ('H-1 1+', True),
+                          ('H-1', False),
+                          ('H', False),
+                          ('p-', False),
+                          ('antiproton', False),
+                          ('Antiproton', False),
+                          ('proton', True),
+                          ('Proton', True),
+                          ('P', False),
+                          ('P+', False),
+                          (1, False),
+                          ])
+def test_is_proton(test_input, expected):
+    assert _is_proton(test_input) == expected
 
 
 @pytest.mark.parametrize("test_input,expected",

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -863,7 +863,7 @@ def test_is_hydrogen_errors(test_input, kwargs, expected_error):
                           ('E', False),
                           ('E-', False),
                           ('beta', False),
-                          (57, False)])
+                          (-1, False)])
 def test_is_electron(test_input, expected):
     assert _is_electron(test_input) == expected
 
@@ -878,26 +878,27 @@ def test_is_electron(test_input, expected):
                           ('E', False),
                           ('E-', False),
                           ('beta', False),
-                          (57, False)])
+                          (1, False)])
 def test_is_positron(test_input, expected):
     assert _is_positron(test_input) == expected
 
 
 @pytest.mark.parametrize("test_input,expected",
-                          [('p', True),
-                           ('p+', True),
-                           ('hydrogen-1+', True),
-                           ('H-1 1+', True),
-                           ('H-1', False),
-                           ('H', False),
-                           ('p-', False),
-                           ('antiproton', False),
-                           ('Antiproton', False),
-                           ('proton', True),
-                           ('Proton', True),
-                           ('P', False),
-                           ('P+', False),
-                           ])
+                         [('p', True),
+                          ('p+', True),
+                          ('hydrogen-1+', True),
+                          ('H-1 1+', True),
+                          ('H-1', False),
+                          ('H', False),
+                          ('p-', False),
+                          ('antiproton', False),
+                          ('Antiproton', False),
+                          ('proton', True),
+                          ('Proton', True),
+                          ('P', False),
+                          ('P+', False),
+                          (1, False),
+                          ])
 def test_is_proton(test_input, expected):
     assert _is_proton(test_input) == expected
 

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -749,7 +749,9 @@ charge_state_error_table = [
     ('h+', ValueError),
     ('fe 1+', ValueError),
     ('d+', ValueError),
-    ('Fe 29+', ValueError)]
+    ('Fe 29+', ValueError),
+    ('H-1', ValueError),
+]
 
 
 @pytest.mark.parametrize("argument, expected_error", charge_state_error_table)

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -624,9 +624,7 @@ atomic_TypeError_bad_arguments = [1.1, {'cats': 'bats'}, 1 + 1j]
             atomic_TypeError_bad_arguments))
 def test_atomic_TypeErrors(function, argument):
     with pytest.raises(TypeError):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            function(argument)
+        function(argument)
 
 
 atomic_ValueErrors_funcs_table = [

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -40,7 +40,8 @@ def test_nuclear_reaction_energy():
     released_energy2 = nuclear_reaction_energy(reaction2)
     assert np.isclose((released_energy1.to(u.MeV)).value, 17.58, rtol=0.01)
     assert released_energy1 == released_energy2
-
+    nuclear_reaction_energy('n + p+ --> n + p+ + p- + p+')
+    nuclear_reaction_energy('neutron + antineutron --> neutron + antineutron')
 
 def test_nuclear_reaction_energy_triple_alpha():
     triple_alpha1 = 'alpha + He-4 --> Be-8'

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -77,18 +77,19 @@ def test_nuclear_reaction_energy_beta():
     assert np.isclose(energy2.to(u.MeV).value, 3.034591, atol=1e-5)
 
 
-# (reaction, expected_error)
+# (reaction, kwargs, expected_error)
 nuclear_reaction_energy_error_table = [
-    ('H + H --> H', ValueError),
-    (1, TypeError),
-    ('H-1 + H-1 --> H-1', ValueError),
-    ("I didn't like unstable eigenfunctions "
-     "at first, but then they grew on me", ValueError)
+    ('H + H --> H', {}, ValueError),
+    (1, {}, TypeError),
+    ('H-1 + H-1 --> H-1', {}, ValueError),
+    ("invalid input", {}, ValueError),
+    ('p --> n', {}, ValueError),
+    ('p --> p', {'reactants': ['p'], 'products': ['p']}, ValueError),
 ]
 
 
 @pytest.mark.parametrize(
-    "reaction, expected_error", nuclear_reaction_energy_error_table)
-def test_nuclear_reaction_energy_error(reaction, expected_error):
+    "reaction, kwargs, expected_error", nuclear_reaction_energy_error_table)
+def test_nuclear_reaction_energy_error(reaction, kwargs, expected_error):
     with pytest.raises(expected_error):
-        nuclear_reaction_energy(reaction)
+        nuclear_reaction_energy(reaction, **kwargs)

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -50,6 +50,11 @@ def test_nuclear_reaction_energy_triple_alpha():
     assert np.isclose(energy_triplealpha1.to(u.keV).value, -91.8, atol=0.1)
     assert np.isclose(energy_triplealpha2.to(u.MeV).value, 7.367, atol=0.1)
 
+    reactants = ['He-4', 'alpha']
+    products = ['Be-8']
+    energy = nuclear_reaction_energy(reactants=reactants, products=products)
+    assert np.isclose(energy.to(u.keV).value, -91.8, atol=0.1)
+
 
 def test_nuclear_reaction_energy_alpha_decay():
     alpha_decay_example = 'U-238 --> Th-234 + alpha'
@@ -63,6 +68,13 @@ def test_nuclear_reaction_energy_triple_alpha_r():
     assert np.isclose(energy_triplealpha1_r.to(u.keV).value,
                       -91.8 * 2, atol=0.1)
 
+
+def test_nuclear_reaction_energy_beta():
+    energy1 = nuclear_reaction_energy(reactants=['n'], products=['p', 'e-'])
+    assert np.isclose(energy1.to(u.MeV).value, 0.78, atol=0.01)
+    energy2 = nuclear_reaction_energy(
+        reactants=['Mg-23'], products=['Na-23', 'e+'])
+    assert np.isclose(energy2.to(u.MeV).value, 3.034591, atol=1e-5)
 
 # (reaction, expected_error)
 nuclear_reaction_energy_error_table = [

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -43,6 +43,7 @@ def test_nuclear_reaction_energy():
     nuclear_reaction_energy('n + p+ --> n + p+ + p- + p+')
     nuclear_reaction_energy('neutron + antineutron --> neutron + antineutron')
 
+    
 def test_nuclear_reaction_energy_triple_alpha():
     triple_alpha1 = 'alpha + He-4 --> Be-8'
     triple_alpha2 = 'Be-8 + alpha --> carbon-12'

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -129,6 +129,7 @@ nuclear_reaction_energy_kwerrors_table = [
     (['e+', 'n'], ['p-'], ValueError),
     (['kljsdf'], 'H-3', ValueError),
     (['H'], ['H-1'], ValueError),
+    (['p'], ['n', 'n', 'e+'], ValueError),
 ]
 
 

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -43,7 +43,7 @@ def test_nuclear_reaction_energy():
     nuclear_reaction_energy('n + p+ --> n + p+ + p- + p+')
     nuclear_reaction_energy('neutron + antineutron --> neutron + antineutron')
 
-    
+
 def test_nuclear_reaction_energy_triple_alpha():
     triple_alpha1 = 'alpha + He-4 --> Be-8'
     triple_alpha2 = 'Be-8 + alpha --> carbon-12'

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -38,7 +38,7 @@ def test_nuclear_reaction_energy():
     reaction2 = 'T + D -> n + alpha'
     released_energy1 = nuclear_reaction_energy(reaction1)
     released_energy2 = nuclear_reaction_energy(reaction2)
-    assert np.isclose(released_energy1.to(u.MeV).value, 17.58, rtol=0.01)
+    assert np.isclose((released_energy1.to(u.MeV)).value, 17.58, rtol=0.01)
     assert released_energy1 == released_energy2
 
 

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -93,3 +93,47 @@ nuclear_reaction_energy_error_table = [
 def test_nuclear_reaction_energy_error(reaction, kwargs, expected_error):
     with pytest.raises(expected_error):
         nuclear_reaction_energy(reaction, **kwargs)
+
+
+# (reactants, products, expectedMeV, tol)
+nuclear_reaction_energy_kwargs_table = [
+    ('H-1', 'p', 0.0, 0.0),
+    (['B-10', 'n'], ['Li-7', 'He-4'], 2.8, 0.06),
+    (['Li-6', 'D'], ['2alpha'], 22.2, 0.06),
+    (['C-12', 'p'], 'N-13', 1.95, 0.006),
+    (['N-13'], ['C-13', 'e+'], 1.20, 0.006),
+    (['C-13', 'hydrogen-1'], ['Nitrogen-14'], 7.54, 0.006),
+    (['N-14', 'H-1'], ['O-15'], 7.35, 0.006),
+    (['O-15'], ['N-15', 'e+'], 1.73, 0.006),
+    (('N-15', 'H-1'), ('C-12', 'He-4'), 4.96, 0.006),
+]
+
+
+@pytest.mark.parametrize(
+    "reactants, products, expectedMeV, tol",
+    nuclear_reaction_energy_kwargs_table)
+def test_nuclear_reaction_energy_kwargs(reactants, products, expectedMeV, tol):
+    energy = nuclear_reaction_energy(reactants=reactants, products=products).si
+    expected = (expectedMeV*u.MeV).si
+    assert np.isclose(expected.value, energy.value, atol=tol)
+
+
+# (reactants, products, expected_error)
+nuclear_reaction_energy_kwerrors_table = [
+    ('n', 3, TypeError),
+    ('n', [3], ValueError),
+    (['n'], ['p'], ValueError),
+    (['n'], ['He-4'], ValueError),
+    (['h'], ['H-1'], ValueError),
+    (['e-', 'n'], 'p', ValueError),
+    (['e+', 'n'], ['p-'], ValueError),
+    (['kljsdf'], 'H-3', ValueError),
+    (['H'], ['H-1'], ValueError),
+]
+
+
+@pytest.mark.parametrize("reactants, products, expected_error",
+                         nuclear_reaction_energy_kwerrors_table)
+def test_nuclear_reaction_energy_kwerrors(reactants, products, expected_error):
+    with pytest.raises(expected_error):
+        nuclear_reaction_energy(reactants=reactants, products=products)

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -76,6 +76,7 @@ def test_nuclear_reaction_energy_beta():
         reactants=['Mg-23'], products=['Na-23', 'e+'])
     assert np.isclose(energy2.to(u.MeV).value, 3.034591, atol=1e-5)
 
+
 # (reaction, expected_error)
 nuclear_reaction_energy_error_table = [
     ('H + H --> H', ValueError),

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -335,7 +335,7 @@ def thermal_speed(T, particle="e", method="most_probable"):
 
     method : string, optional
         Method to be used for calculating the thermal speed. Options are
-        'most_probable' (default), 'rms', and 'mean_magnitude'. 
+        'most_probable' (default), 'rms', and 'mean_magnitude'.
 
     Returns
     -------

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -472,7 +472,7 @@ def gyrofrequency(B, particle='e'):
     <Quantity 957883.3224148067 rad / s>
     >>> gyrofrequency(0.01*u.T, 'p')
     <Quantity 957883.3224148067 rad / s>
-    >>> gyrofrequency(0.01*u.T, particle='T')
+    >>> gyrofrequency(0.01*u.T, particle='T+')
     <Quantity 319964.54975910933 rad / s>
     >>> omega_ce = gyrofrequency(0.1*u.T)
     >>> print(omega_ce)

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -157,8 +157,9 @@ def Alfven_speed(B, density, ion="p"):
     if density.unit == units.m**-3:
         try:
             m_i = ion_mass(ion)
-            Z = charge_state(ion)
-            if Z is None:
+            try:
+                Z = charge_state(ion)
+            except ValueError:
                 Z = 1
         except Exception:
             raise ValueError("Invalid ion in Alfven_speed.")
@@ -279,8 +280,10 @@ def ion_sound_speed(*ignore, T_e=0*units.K, T_i=0*units.K,
 
     try:
         m_i = ion_mass(ion)
-        Z = charge_state(ion)
-        if Z is None:
+
+        try:
+            Z = charge_state(ion)
+        except ValueError:
             Z = 1
     except Exception:
         raise ValueError("Invalid ion in ion_sound_speed.")
@@ -485,8 +488,9 @@ def gyrofrequency(B, particle='e'):
 
     try:
         m_i = ion_mass(particle)
-        Z = charge_state(particle)
-        if Z is None:
+        try:
+            Z = charge_state(particle)
+        except ValueError:
             Z = 1
         Z = abs(Z)
     except Exception:
@@ -692,8 +696,9 @@ def plasma_frequency(n, particle='e'):
 
     try:
         m = ion_mass(particle)
-        Z = charge_state(particle)
-        if Z is None:
+        try:
+            Z = charge_state(particle)
+        except ValueError:
             Z = 1
     except Exception:
         raise ValueError("Invalid particle {} in gyrofrequency"

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -67,7 +67,7 @@ def test_Alfven_speed():
 
     assert Alfven_speed(2*B, rho) == 2*Alfven_speed(B, rho)
 
-    assert Alfven_speed(5*u.T, 5e19*u.m**-3, ion='H-1') == \
+    assert Alfven_speed(5*u.T, 5e19*u.m**-3, ion='H-1+') == \
         Alfven_speed(5*u.T, 5e19*u.m**-3, ion='p')
 
     # Case where magnetic field and density are Quantity arrays
@@ -143,7 +143,7 @@ def test_ion_sound_speed():
                       193328.52857788358)
 
     assert ion_sound_speed(T_i=T_i, T_e=T_e, ion='p') == \
-        ion_sound_speed(T_i=T_i, T_e=T_e, ion='H-1')
+        ion_sound_speed(T_i=T_i, T_e=T_e, ion='H-1+')
 
     assert ion_sound_speed(T_i=T_i, ion='p').unit == u.m/u.s
 
@@ -243,7 +243,7 @@ def test_thermal_speed():
                       128486.56960876315)
 
     assert thermal_speed(T_i, particle='p') == \
-        thermal_speed(T_i, particle='H-1')
+        thermal_speed(T_i, particle='H-1+')
 
     assert thermal_speed(1*u.MK, particle='e+') == \
         thermal_speed(1*u.MK)
@@ -324,7 +324,7 @@ def test_gyrofrequency():
     assert gyrofrequency(-5*u.T, 'p') == gyrofrequency(5*u.T, 'p')
 
     assert gyrofrequency(B, particle='p') == \
-        gyrofrequency(B, particle='H-1')
+        gyrofrequency(B, particle='H-1+')
 
     assert gyrofrequency(B, particle='e+') == \
         gyrofrequency(B)
@@ -398,7 +398,7 @@ def test_gyroradius():
     assert gyroradius(B, 25*u.m/u.s, particle="p").unit == u.m
 
     assert gyroradius(B, T_i, particle='p') == \
-        gyroradius(B, T_i, particle='H-1')
+        gyroradius(B, T_i, particle='H-1+')
 
     assert gyroradius(T_i, B, particle="p") == gyroradius(B, T_i, particle="p")
 
@@ -472,7 +472,7 @@ def test_plasma_frequency():
 
         assert plasma_frequency(n_i, particle='p').unit == u.rad/u.s
 
-    assert plasma_frequency(n_i, particle='H-1') == \
+    assert plasma_frequency(n_i, particle='H-1+') == \
         plasma_frequency(n_i, particle='p')
 
     assert np.isclose(plasma_frequency(mu*u.cm**-3, particle='p').value,
@@ -565,9 +565,6 @@ def test_inertial_length():
 
     assert inertial_length(5.351*u.m**-3, particle='e+') == \
         inertial_length(5.351*u.m**-3, particle='e')
-
-    assert inertial_length(n_i, particle='p') == \
-        inertial_length(n_i, particle='H-1')
 
     with pytest.raises(UserWarning):
         inertial_length(4, particle='p')

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -67,7 +67,8 @@ def test_Alfven_speed():
 
     assert Alfven_speed(2*B, rho) == 2*Alfven_speed(B, rho)
 
-    assert Alfven_speed(5*u.T, 5e19*u.m**-3, ion='H-1+') == \
+    # Case when Z=1 is assumed
+    assert Alfven_speed(5*u.T, 5e19*u.m**-3, ion='H-1') == \
         Alfven_speed(5*u.T, 5e19*u.m**-3, ion='p')
 
     # Case where magnetic field and density are Quantity arrays
@@ -142,8 +143,9 @@ def test_ion_sound_speed():
                                       gamma_e=1.2, gamma_i=3.4).value,
                       193328.52857788358)
 
+    # case when Z=1 is assumed
     assert ion_sound_speed(T_i=T_i, T_e=T_e, ion='p') == \
-        ion_sound_speed(T_i=T_i, T_e=T_e, ion='H-1+')
+        ion_sound_speed(T_i=T_i, T_e=T_e, ion='H-1')
 
     assert ion_sound_speed(T_i=T_i, ion='p').unit == u.m/u.s
 
@@ -242,8 +244,9 @@ def test_thermal_speed():
     assert np.isclose(thermal_speed(1*u.MK, particle='p').si.value,
                       128486.56960876315)
 
+    # Case when Z=1 is assumed
     assert thermal_speed(T_i, particle='p') == \
-        thermal_speed(T_i, particle='H-1+')
+        thermal_speed(T_i, particle='H-1')
 
     assert thermal_speed(1*u.MK, particle='e+') == \
         thermal_speed(1*u.MK)
@@ -323,8 +326,9 @@ def test_gyrofrequency():
 
     assert gyrofrequency(-5*u.T, 'p') == gyrofrequency(5*u.T, 'p')
 
+    # Case when Z=1 is assumed
     assert gyrofrequency(B, particle='p') == \
-        gyrofrequency(B, particle='H-1+')
+        gyrofrequency(B, particle='H-1')
 
     assert gyrofrequency(B, particle='e+') == \
         gyrofrequency(B)
@@ -397,8 +401,9 @@ def test_gyroradius():
 
     assert gyroradius(B, 25*u.m/u.s, particle="p").unit == u.m
 
+    # Case when Z=1 is assumed
     assert gyroradius(B, T_i, particle='p') == \
-        gyroradius(B, T_i, particle='H-1+')
+        gyroradius(B, T_i, particle='H-1')
 
     assert gyroradius(T_i, B, particle="p") == gyroradius(B, T_i, particle="p")
 
@@ -472,7 +477,8 @@ def test_plasma_frequency():
 
         assert plasma_frequency(n_i, particle='p').unit == u.rad/u.s
 
-    assert plasma_frequency(n_i, particle='H-1+') == \
+    # Case where Z=1 is assumed
+    assert plasma_frequency(n_i, particle='H-1') == \
         plasma_frequency(n_i, particle='p')
 
     assert np.isclose(plasma_frequency(mu*u.cm**-3, particle='p').value,

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -67,7 +67,7 @@ def test_Alfven_speed():
 
     assert Alfven_speed(2*B, rho) == 2*Alfven_speed(B, rho)
 
-    assert Alfven_speed(5*u.T, 5e19*u.m**-3, ion='H-1') == \
+    assert Alfven_speed(5*u.T, 5e19*u.m**-3, ion='H-1 1+') == \
         Alfven_speed(5*u.T, 5e19*u.m**-3, ion='p')
 
     # Case where magnetic field and density are Quantity arrays
@@ -143,7 +143,7 @@ def test_ion_sound_speed():
                       193328.52857788358)
 
     assert ion_sound_speed(T_i=T_i, T_e=T_e, ion='p') == \
-        ion_sound_speed(T_i=T_i, T_e=T_e, ion='H-1')
+        ion_sound_speed(T_i=T_i, T_e=T_e, ion='H-1+')
 
     assert ion_sound_speed(T_i=T_i, ion='p').unit == u.m/u.s
 
@@ -243,7 +243,7 @@ def test_thermal_speed():
                       128486.56960876315)
 
     assert thermal_speed(T_i, particle='p') == \
-        thermal_speed(T_i, particle='H-1')
+        thermal_speed(T_i, particle='H-1+')
 
     assert thermal_speed(1*u.MK, particle='e+') == \
         thermal_speed(1*u.MK)
@@ -324,7 +324,7 @@ def test_gyrofrequency():
     assert gyrofrequency(-5*u.T, 'p') == gyrofrequency(5*u.T, 'p')
 
     assert gyrofrequency(B, particle='p') == \
-        gyrofrequency(B, particle='H-1')
+        gyrofrequency(B, particle='H-1+')
 
     assert gyrofrequency(B, particle='e+') == \
         gyrofrequency(B)
@@ -398,7 +398,7 @@ def test_gyroradius():
     assert gyroradius(B, 25*u.m/u.s, particle="p").unit == u.m
 
     assert gyroradius(B, T_i, particle='p') == \
-        gyroradius(B, T_i, particle='H-1')
+        gyroradius(B, T_i, particle='H-1+')
 
     assert gyroradius(T_i, B, particle="p") == gyroradius(B, T_i, particle="p")
 
@@ -472,7 +472,7 @@ def test_plasma_frequency():
 
         assert plasma_frequency(n_i, particle='p').unit == u.rad/u.s
 
-    assert plasma_frequency(n_i, particle='H-1') == \
+    assert plasma_frequency(n_i, particle='H-1+') == \
         plasma_frequency(n_i, particle='p')
 
     assert np.isclose(plasma_frequency(mu*u.cm**-3, particle='p').value,
@@ -567,7 +567,7 @@ def test_inertial_length():
         inertial_length(5.351*u.m**-3, particle='e')
 
     assert inertial_length(n_i, particle='p') == \
-        inertial_length(n_i, particle='H-1')
+        inertial_length(n_i, particle='H-1+')
 
     with pytest.raises(UserWarning):
         inertial_length(4, particle='p')

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -67,7 +67,7 @@ def test_Alfven_speed():
 
     assert Alfven_speed(2*B, rho) == 2*Alfven_speed(B, rho)
 
-    assert Alfven_speed(5*u.T, 5e19*u.m**-3, ion='H-1 1+') == \
+    assert Alfven_speed(5*u.T, 5e19*u.m**-3, ion='H-1') == \
         Alfven_speed(5*u.T, 5e19*u.m**-3, ion='p')
 
     # Case where magnetic field and density are Quantity arrays
@@ -143,7 +143,7 @@ def test_ion_sound_speed():
                       193328.52857788358)
 
     assert ion_sound_speed(T_i=T_i, T_e=T_e, ion='p') == \
-        ion_sound_speed(T_i=T_i, T_e=T_e, ion='H-1+')
+        ion_sound_speed(T_i=T_i, T_e=T_e, ion='H-1')
 
     assert ion_sound_speed(T_i=T_i, ion='p').unit == u.m/u.s
 
@@ -243,7 +243,7 @@ def test_thermal_speed():
                       128486.56960876315)
 
     assert thermal_speed(T_i, particle='p') == \
-        thermal_speed(T_i, particle='H-1+')
+        thermal_speed(T_i, particle='H-1')
 
     assert thermal_speed(1*u.MK, particle='e+') == \
         thermal_speed(1*u.MK)
@@ -324,7 +324,7 @@ def test_gyrofrequency():
     assert gyrofrequency(-5*u.T, 'p') == gyrofrequency(5*u.T, 'p')
 
     assert gyrofrequency(B, particle='p') == \
-        gyrofrequency(B, particle='H-1+')
+        gyrofrequency(B, particle='H-1')
 
     assert gyrofrequency(B, particle='e+') == \
         gyrofrequency(B)
@@ -398,7 +398,7 @@ def test_gyroradius():
     assert gyroradius(B, 25*u.m/u.s, particle="p").unit == u.m
 
     assert gyroradius(B, T_i, particle='p') == \
-        gyroradius(B, T_i, particle='H-1+')
+        gyroradius(B, T_i, particle='H-1')
 
     assert gyroradius(T_i, B, particle="p") == gyroradius(B, T_i, particle="p")
 
@@ -472,7 +472,7 @@ def test_plasma_frequency():
 
         assert plasma_frequency(n_i, particle='p').unit == u.rad/u.s
 
-    assert plasma_frequency(n_i, particle='H-1+') == \
+    assert plasma_frequency(n_i, particle='H-1') == \
         plasma_frequency(n_i, particle='p')
 
     assert np.isclose(plasma_frequency(mu*u.cm**-3, particle='p').value,
@@ -567,7 +567,7 @@ def test_inertial_length():
         inertial_length(5.351*u.m**-3, particle='e')
 
     assert inertial_length(n_i, particle='p') == \
-        inertial_length(n_i, particle='H-1+')
+        inertial_length(n_i, particle='H-1')
 
     with pytest.raises(UserWarning):
         inertial_length(4, particle='p')


### PR DESCRIPTION
Prior to now, `nuclear_binding_energy` used `isotope_mass` to get the mass of the nuclide.  This is incorrect since `isotope_mass` gives the mass including the bound electrons.  Now `nuclear_binding_energy` uses `ion_mass` instead, and assumes that isotope is fully ionized to get the mass of the nucleus.

This pull request also implements the great suggestion by @jessicalostinspace in #110 to represent the reactants and products in a nuclear reaction as lists:
```Python
>>> nuclear_reaction_energy(reactants=['He-4', 'He-4'], products=['Be-8'])
```
For the time being, I decided to still allow the old API which has the argument being a string representing the reaction (e.g., `'He-4 + He-4 -> Be-8'`).  The advantage of allowing the old API is that it is more human readable.  The disadvantages are that it makes the implementation much more complex.  Do we want to continue to allow having a string representing the reaction as an input to `nuclear_reaction_energy`?  Also, should we require that `reactants` and `products` be keyword-only arguments?  I did enforce keyword-only arguments to make sure which is which is explicit, and because the minus sign really does matter, though maybe this isn't needed.  Suggestions, opinions, and cat emoji would be greatly appreciated! :cat2: :cat2: :cat2: :cat2: :cat2: :cat2:

`nuclear_reaction_energy` also now allows for electrons and positrons, which are important for beta decays.  It's also updated to use the masses of nuclei rather than the isotopic masses, as described above.

Cross-references: #24, #110, #122 