### PR TITLE
Test against astropy dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
         - "3.6"
 
+env:
+        - ASTROPY_VERSION='dev'
+
 git:
     submodules: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: python
 python:
         - "3.6"
 
-env:
-        - ASTROPY_VERSION='dev'
+matrix:
+    include:
+        - env: ASTROPY_VERSION='dev'
 
 git:
     submodules: false


### PR DESCRIPTION
Added a parameter in .travis.yml so that Travis will build and test against the development version of astropy as well as the released version.