### PR TITLE
Doc testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+
+deps-run: &deps-install
+  name: Install Python dependencies
+  command: |
+    python3 -m venv venv
+    . venv/bin/activate
+    pip install --user -r doc-requirements.txt
+    pip install --user .
+
+doc-run: &doc-build
+  name: Build documentation
+  command: make html SPHINXOPTS='-W'
+  working_directory: docs
+
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run: *deps-install
+      - run: *doc-build

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+numpy
+scipy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,7 @@ todo_include_todos = False
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/development/release_guide.rst
+++ b/docs/development/release_guide.rst
@@ -12,8 +12,7 @@ Release Tasks
 The following is a partial list of tasks to be performed for each
 release.  This list is currently under development.  Developers should
 expand the instructions while performing each release, and may use
-`Astropy's release
-procedures`<https://github.com/astropy/astropy/blob/master/docs/development/releasing.rst>
+`Astropy's release procedures`<https://github.com/astropy/astropy/blob/master/docs/development/releasing.rst>
 for guidance.
 
 * Update ``CHANGE_LOG.rst``
@@ -38,4 +37,3 @@ for guidance.
 * Mint a release on Zenodo and get a digital object identifier (DOI)
 
 * Alert plasma physics communities about the release
-

--- a/docs/development/release_guide.rst
+++ b/docs/development/release_guide.rst
@@ -12,7 +12,7 @@ Release Tasks
 The following is a partial list of tasks to be performed for each
 release.  This list is currently under development.  Developers should
 expand the instructions while performing each release, and may use
-`Astropy's release procedures`<https://github.com/astropy/astropy/blob/master/docs/development/releasing.rst>
+`Astropy's release procedures <https://github.com/astropy/astropy/blob/master/docs/development/releasing.rst>`
 for guidance.
 
 * Update ``CHANGE_LOG.rst``

--- a/docs/mathematics/index.rst
+++ b/docs/mathematics/index.rst
@@ -2,9 +2,9 @@
 
 .. _plasmapy-mathematics:
 
-****
+***********
 Mathematics
-****
+***********
 
 .. automodule:: plasmapy.mathematics
 

--- a/plasmapy/mathematics/mathematics.py
+++ b/plasmapy/mathematics/mathematics.py
@@ -6,7 +6,8 @@ from astropy import units as u
 
 
 def plasma_dispersion_func(zeta):
-    r"""Calculate the plasma dispersion function
+    r"""
+    Calculate the plasma dispersion function
 
     Parameters
     ----------
@@ -38,7 +39,7 @@ def plasma_dispersion_func(zeta):
     .. math::
         Z(\zeta) = \pi^{-0.5} \int_{-\infty}^{+\infty} \frac{e^{-x^2}}{x-\zeta} dx
 
-    where the argument is a complex number [fried.conte-1961].
+    where the argument is a complex number [fried.conte-1961]_.
 
     In plasma wave theory, the plasma dispersion function appears
     frequently when the background medium has a Maxwellian
@@ -47,10 +48,9 @@ def plasma_dispersion_func(zeta):
 
     References
     ----------
-    .. [fried.conte-1961]
-    Fried, Burton D. and Samuel D. Conte. 1961. The Plasma Dispersion
-    Function: The Hilbert Transformation of the Gaussian. Academic
-    Press (New York and London).
+    .. [fried.conte-1961] Fried, Burton D. and Samuel D. Conte. 1961.
+       The Plasma Dispersion Function: The Hilbert Transformation of the
+       Gaussian. Academic Press (New York and London).
 
     Examples
     --------
@@ -117,14 +117,7 @@ def plasma_dispersion_func_deriv(zeta):
     .. math::
         Z'(\zeta) = \pi^{-0.5} \int_{-\infty}^{+\infty} \frac{e^{-x^2}}{(x-\zeta)^2} dx
 
-    where the argument is a complex number [fried.conte-1961].
-
-    References
-    ----------
-    .. [fried.conte-1961]
-    Fried, Burton D. and Samuel D. Conte. 1961. The Plasma Dispersion
-    Function: The Hilbert Transformation of the Gaussian. Academic
-    Press (New York and London).
+    where the argument is a complex number [fried.conte-1961]_.
 
     Examples
     --------

--- a/plasmapy/physics/transport.py
+++ b/plasmapy/physics/transport.py
@@ -64,7 +64,7 @@ def Coulomb_logarithm(T, n_e, particles, V=None):
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
 
     where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
-    impact parameters for Coulomb collisions _[1].
+    impact parameters for Coulomb collisions [1]_.
 
     The outer impact parameter is given by the Debye length:
     :math:`b_{min} = \lambda_D` which is a function of electron
@@ -81,7 +81,7 @@ def Coulomb_logarithm(T, n_e, particles, V=None):
     relative velocity between collisions.  This function uses the
     standard practice of choosing the inner impact parameter to be the
     maximum of these two possibilities.  Some inconsistencies exist in
-    the literature on how to define the inner impact parameter _[2].
+    the literature on how to define the inner impact parameter [2]_.
 
     Errors associated with the Coulomb logarithm are of order its
     inverse If the Coulomb logarithm is of order unity, then the
@@ -104,9 +104,9 @@ def Coulomb_logarithm(T, n_e, particles, V=None):
     .. [1] Physics of Fully Ionized Gases, L. Spitzer (1962)
 
     .. [2] Comparison of Coulomb Collision Rates in the Plasma Physics
-    and Magnetically Confined Fusion Literature, W. Fundamenski and
-    O.E. Garcia, EFDA–JET–R(07)01
-    (http://www.euro-fusionscipub.org/wp-content/uploads/2014/11/EFDR07001.pdf)
+       and Magnetically Confined Fusion Literature, W. Fundamenski and
+       O.E. Garcia, EFDA–JET–R(07)01
+       (http://www.euro-fusionscipub.org/wp-content/uploads/2014/11/EFDR07001.pdf)
 
     """
 


### PR DESCRIPTION
Fixes #197. I think this will need someone who is a member of the PlasmaPy organisation to enable circleci at https://circleci.com if/once this PR is merged.

I had to fix a few documentation warnings, but now the build will fail if sphinx finds anything wrong with the docs that causes it to warn. Just calling `make html` will build regardless of warnings, which will show up in red in the terminal.

My branch builds here: https://circleci.com/gh/dstansby/PlasmaPy/9