### PR TITLE
Average ionization

### DIFF
--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -650,7 +650,6 @@ def gyrofrequency(B, particle='e', signed=False, z_mean=None):
                 Z = atomic.charge_state(particle)
             except ValueError:
                 Z = 1
-            Z = abs(Z)
         else:
             # using user provided average ionization
             Z = z_mean

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -866,6 +866,7 @@ def plasma_frequency(n, particle='e', z_mean=None):
         else:
             # using user provided average ionization
             Z = z_mean
+        Z = np.abs(Z)
     except Exception:
         raise ValueError(f"Invalid particle, {particle}, in "
                          "plasma_frequency.")

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -9,12 +9,13 @@ import plasmapy.atomic as atomic
 # from plasmapy.atomic import ion_mass, charge_state
 
 import numpy as np
+import warnings
 
 # For future: change these into decorators.  _check_quantity does a
 # bit more than @quantity_input as it can allow
 import plasmapy.utils as utils
 from plasmapy.utils.checks import _check_quantity
-from plasmapy.utils.exceptions import PhysicsError
+from plasmapy.utils.exceptions import PhysicsError, PhysicsWarning
 
 
 r"""
@@ -176,6 +177,8 @@ def Alfven_speed(B, density, ion="p", z_mean=None):
         try:
             m_i = atomic.ion_mass(ion)
             if z_mean == None:
+                warnings.warn("No z_mean given, defaulting to atomic charge",
+                              PhysicsWarning)
                 try:
                     Z = atomic.charge_state(ion)
                 except ValueError:
@@ -183,6 +186,8 @@ def Alfven_speed(B, density, ion="p", z_mean=None):
             else:
                 # using average ionization provided by user
                 Z = z_mean
+            # ensuring positive value of Z
+            Z = np.abs(Z)
         except Exception:
             raise ValueError("Invalid ion in Alfven_speed.")
         rho = density * m_i + Z * density * m_e
@@ -318,15 +323,11 @@ def ion_sound_speed(*ignore,
 
     try:
         m_i = atomic.ion_mass(ion)
-
-        try:
-            Z = atomic.charge_state(ion)
-        except ValueError:
-            Z = 1
-        m_i = ion_mass(ion)
         if z_mean == None:
+            warnings.warn("No z_mean given, defaulting to atomic charge",
+                          PhysicsWarning)
             try:
-                Z = charge_state(ion)
+                Z = atomic.charge_state(ion)
             except ValueError:
                 Z = 1
         else:
@@ -643,6 +644,8 @@ def gyrofrequency(B, particle='e', signed=False, z_mean=None):
     try:
         m_i = atomic.ion_mass(particle)
         if z_mean == None:
+            warnings.warn("No z_mean given, defaulting to atomic charge",
+                          PhysicsWarning)
             try:
                 Z = atomic.charge_state(particle)
             except ValueError:
@@ -859,6 +862,8 @@ def plasma_frequency(n, particle='e', z_mean=None):
     try:
         m = atomic.ion_mass(particle)
         if z_mean == None:
+            warnings.warn("No z_mean given, defaulting to atomic charge",
+                          PhysicsWarning)
             try:
                 Z = atomic.charge_state(particle)
             except ValueError:

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -9,13 +9,13 @@ import plasmapy.atomic as atomic
 # from plasmapy.atomic import ion_mass, charge_state
 
 import numpy as np
-import warnings
+# import warnings
 
 # For future: change these into decorators.  _check_quantity does a
 # bit more than @quantity_input as it can allow
 import plasmapy.utils as utils
 from plasmapy.utils.checks import _check_quantity
-from plasmapy.utils.exceptions import PhysicsError, PhysicsWarning
+from plasmapy.utils.exceptions import PhysicsError # , PhysicsWarning
 
 
 r"""
@@ -177,8 +177,8 @@ def Alfven_speed(B, density, ion="p", z_mean=None):
         try:
             m_i = atomic.ion_mass(ion)
             if z_mean == None:
-                warnings.warn("No z_mean given, defaulting to atomic charge",
-                              PhysicsWarning)
+                # warnings.warn("No z_mean given, defaulting to atomic charge",
+                #               PhysicsWarning)
                 try:
                     Z = atomic.charge_state(ion)
                 except ValueError:
@@ -324,8 +324,8 @@ def ion_sound_speed(*ignore,
     try:
         m_i = atomic.ion_mass(ion)
         if z_mean == None:
-            warnings.warn("No z_mean given, defaulting to atomic charge",
-                          PhysicsWarning)
+            # warnings.warn("No z_mean given, defaulting to atomic charge",
+            #               PhysicsWarning)
             try:
                 Z = atomic.charge_state(ion)
             except ValueError:
@@ -644,8 +644,8 @@ def gyrofrequency(B, particle='e', signed=False, z_mean=None):
     try:
         m_i = atomic.ion_mass(particle)
         if z_mean == None:
-            warnings.warn("No z_mean given, defaulting to atomic charge",
-                          PhysicsWarning)
+            # warnings.warn("No z_mean given, defaulting to atomic charge",
+            #               PhysicsWarning)
             try:
                 Z = atomic.charge_state(particle)
             except ValueError:
@@ -861,8 +861,8 @@ def plasma_frequency(n, particle='e', z_mean=None):
     try:
         m = atomic.ion_mass(particle)
         if z_mean == None:
-            warnings.warn("No z_mean given, defaulting to atomic charge",
-                          PhysicsWarning)
+            # warnings.warn("No z_mean given, defaulting to atomic charge",
+            #               PhysicsWarning)
             try:
                 Z = atomic.charge_state(particle)
             except ValueError:

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -75,7 +75,7 @@ by an angular frequency to get a length scale:
 
 
 @utils.check_relativistic
-def Alfven_speed(B, density, ion="p"):
+def Alfven_speed(B, density, ion="p", z_mean=None):
     r"""
     Returns the Alfven speed.
 
@@ -93,6 +93,12 @@ def Alfven_speed(B, density, ion="p"):
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to protons.  If no charge state information is
         provided, then the ions are assumed to be singly charged.
+
+    z_mean : Quantity, optional
+        The average ionization (arithmetic mean) for a plasma where the
+        a macroscopic description is valid. If this quantity is not
+        given then the atomic charge state (integer) of the ion
+        is used.
 
     Returns
     -------
@@ -169,10 +175,14 @@ def Alfven_speed(B, density, ion="p"):
     if density.unit == units.m**-3:
         try:
             m_i = atomic.ion_mass(ion)
-            try:
-                Z = atomic.charge_state(ion)
-            except ValueError:
-                Z = 1
+            if z_mean == None:
+                try:
+                    Z = atomic.charge_state(ion)
+                except ValueError:
+                    Z = 1
+            else:
+                # using average ionization provided by user
+                Z = z_mean
         except Exception:
             raise ValueError("Invalid ion in Alfven_speed.")
         rho = density * m_i + Z * density * m_e
@@ -193,8 +203,13 @@ def Alfven_speed(B, density, ion="p"):
     'T_i': {'units': units.K, 'can_be_negative': False},
     'T_e': {'units': units.K, 'can_be_negative': False}
 })
-def ion_sound_speed(*ignore, T_e=0 * units.K, T_i=0 * units.K,
-                    gamma_e=1, gamma_i=3, ion='p'):
+def ion_sound_speed(*ignore,
+                    T_e=0 * units.K,
+                    T_i=0 * units.K,
+                    gamma_e=1,
+                    gamma_i=3,
+                    ion='p',
+                    z_mean=None):
     r"""
     Returns the ion sound speed for an electron-ion plasma.
 
@@ -227,6 +242,12 @@ def ion_sound_speed(*ignore, T_e=0 * units.K, T_i=0 * units.K,
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to protons.  If no charge state information is
         provided, then the ions are assumed to be singly charged.
+
+    z_mean : Quantity, optional
+        The average ionization (arithmetic mean) for a plasma where the
+        a macroscopic description is valid. If this quantity is not
+        given then the atomic charge state (integer) of the ion
+        is used.
 
     Returns
     -------
@@ -302,6 +323,15 @@ def ion_sound_speed(*ignore, T_e=0 * units.K, T_i=0 * units.K,
             Z = atomic.charge_state(ion)
         except ValueError:
             Z = 1
+        m_i = ion_mass(ion)
+        if z_mean == None:
+            try:
+                Z = charge_state(ion)
+            except ValueError:
+                Z = 1
+        else:
+            # using average ionization provided by user
+            Z = z_mean
     except Exception:
         raise ValueError("Invalid ion in ion_sound_speed.")
 
@@ -527,7 +557,7 @@ def kappa_thermal_speed(T, kappa, particle="e", method="most_probable"):
 @utils.check_quantity({
     'B': {'units': units.T}
 })
-def gyrofrequency(B, particle='e', signed=False):
+def gyrofrequency(B, particle='e', signed=False, z_mean=None):
     r"""Calculate the particle gyrofrequency in units of radians per second.
 
     Parameters
@@ -540,6 +570,12 @@ def gyrofrequency(B, particle='e', signed=False):
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to electrons.  If no charge state information is
         provided, then the particles are assumed to be singly charged.
+
+    z_mean : Quantity, optional
+        The average ionization (arithmetic mean) for a plasma where the
+        a macroscopic description is valid. If this quantity is not
+        given then the atomic charge state (integer) of the ion
+        is used.
 
     signed : boolean, optional
         The gyrofrequency can be defined as signed (negative for electron,
@@ -606,10 +642,15 @@ def gyrofrequency(B, particle='e', signed=False):
 
     try:
         m_i = atomic.ion_mass(particle)
-        try:
-            Z = atomic.charge_state(particle)
-        except ValueError:
-            Z = 1
+        if z_mean == None:
+            try:
+                Z = atomic.charge_state(particle)
+            except ValueError:
+                Z = 1
+            Z = abs(Z)
+        else:
+            # using user provided average ionization
+            Z = z_mean
     except Exception:
         raise ValueError("Invalid particle {} in gyrofrequency"
                          .format(particle))
@@ -750,7 +791,7 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e'):
 @utils.check_quantity({
     'n': {'units': units.m**-3, 'can_be_negative': False}
 })
-def plasma_frequency(n, particle='e'):
+def plasma_frequency(n, particle='e', z_mean=None):
     r"""Calculates the particle plasma frequency.
 
     Parameters
@@ -763,6 +804,12 @@ def plasma_frequency(n, particle='e'):
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to electrons.  If no charge state information is
         provided, then the particles are assumed to be singly charged.
+
+    z_mean : Quantity, optional
+        The average ionization (arithmetic mean) for a plasma where the
+        a macroscopic description is valid. If this quantity is not
+        given then the atomic charge state (integer) of the ion
+        is used.
 
     Returns
     -------
@@ -811,11 +858,19 @@ def plasma_frequency(n, particle='e'):
 
     try:
         m = atomic.ion_mass(particle)
+        if z_mean == None:
+            try:
+                Z = atomic.charge_state(particle)
+            except ValueError:
+                Z = 1
+        else:
+            # using user provided average ionization
+            Z = z_mean
     except Exception:
         raise ValueError(f"Invalid particle, {particle}, in "
                          "plasma_frequency.")
 
-    omega_p = units.rad * e * np.sqrt(n / (eps0 * m))
+    omega_p = units.rad * Z * e * np.sqrt(n / (eps0 * m))
 
     return omega_p.si
 
@@ -886,7 +941,7 @@ def Debye_length(T_e, n_e):
     T_e = T_e.to(units.K, equivalencies=units.temperature_energy())
 
     try:
-        lambda_D = ((eps0 * k_B * T_e / (n_e * e**2))**0.5).to(units.m)
+        lambda_D = ((eps0 * k_B * T_e / (n_e * e ** 2)) ** 0.5).to(units.m)
     except Exception:
         raise ValueError("Unable to find Debye length.")
 
@@ -953,7 +1008,7 @@ def Debye_number(T_e, n_e):
 
     try:
         lambda_D = Debye_length(T_e, n_e)
-        N_D = (4 / 3) * np.pi * n_e * lambda_D**3
+        N_D = (4 / 3) * np.pi * n_e * lambda_D ** 3
     except Exception:
         raise ValueError("Unable to find Debye number")
 
@@ -1017,8 +1072,7 @@ def inertial_length(n, particle='e'):
     try:
         Z = atomic.charge_state(particle)
     except Exception:
-        raise ValueError("Invalid particle {} in inertial_length."
-                         .format(particle))
+        raise ValueError(f"Invalid particle {particle} in inertial_length.")
     if Z:
         Z = abs(Z)
 
@@ -1038,7 +1092,7 @@ def magnetic_pressure(B):
     Parameters
     ----------
     B : ~astropy.units.Quantity
-        The magnetic field in units convertible to telsa.
+        The magnetic field in units convertible to tesla.
 
     Returns
     -------
@@ -1085,7 +1139,7 @@ def magnetic_pressure(B):
 
     """
 
-    p_B = (B**2 / (2 * mu0)).to(units.Pa)
+    p_B = (B ** 2 / (2 * mu0)).to(units.Pa)
 
     return p_B
 
@@ -1147,7 +1201,7 @@ def magnetic_energy_density(B: units.T):
 
     """
 
-    E_B = (B**2 / (2 * mu0)).to(units.J / units.m**3)
+    E_B = (B ** 2 / (2 * mu0)).to(units.J / units.m ** 3)
 
     return E_B
 
@@ -1291,7 +1345,7 @@ def lower_hybrid_frequency(B, n_i, ion='p'):
         omega_ci = gyrofrequency(B, particle=ion)
         omega_pi = plasma_frequency(n_i, particle=ion)
         omega_ce = gyrofrequency(B)
-        omega_lh = 1 / np.sqrt((omega_ci * omega_ce)**-1 + omega_pi**-2)
+        omega_lh = 1 / np.sqrt((omega_ci * omega_ce) ** -1 + omega_pi ** -2)
         omega_lh = omega_lh.to(units.rad / units.s)
     except Exception:
         raise ValueError("Unable to find lower hybrid frequency.")

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -97,7 +97,8 @@ def Alfven_speed(B, density, ion="p", z_mean=None):
         The average ionization (arithmetic mean) for a plasma where the
         a macroscopic description is valid. If this quantity is not
         given then the atomic charge state (integer) of the ion
-        is used.
+        is used. This is effectively an average Alfven speed for the
+        plasma where multiple charge states are present.
 
     Returns
     -------
@@ -250,7 +251,8 @@ def ion_sound_speed(*ignore,
         The average ionization (arithmetic mean) for a plasma where the
         a macroscopic description is valid. If this quantity is not
         given then the atomic charge state (integer) of the ion
-        is used.
+        is used. This is effectively an average ion sound speed for the
+        plasma where multiple charge states are present.
 
     Returns
     -------
@@ -574,7 +576,9 @@ def gyrofrequency(B, particle='e', signed=False, z_mean=None):
         The average ionization (arithmetic mean) for a plasma where the
         a macroscopic description is valid. If this quantity is not
         given then the atomic charge state (integer) of the ion
-        is used.
+        is used. This is effectively an average gyrofrequency for the
+        plasma where multiple charge states are present, and should
+        not be interpreted as the gyrofrequency for any single particle.
 
     signed : boolean, optional
         The gyrofrequency can be defined as signed (negative for electron,
@@ -809,7 +813,8 @@ def plasma_frequency(n, particle='e', z_mean=None):
         The average ionization (arithmetic mean) for a plasma where the
         a macroscopic description is valid. If this quantity is not
         given then the atomic charge state (integer) of the ion
-        is used.
+        is used. This is effectively an average plasma frequency for the
+        plasma where multiple charge states are present. 
 
     Returns
     -------

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -2,9 +2,7 @@
 
 from astropy import units
 
-from astropy.units import (UnitConversionError, UnitsError, Quantity)
-
-from ..constants import (m_p, m_e, c, mu0, k_B, e, eps0, pi)
+from ..constants import (m_e, c, mu0, k_B, e, eps0)
 import plasmapy.atomic as atomic
 # from plasmapy.atomic import ion_mass, charge_state
 
@@ -15,7 +13,7 @@ import numpy as np
 # bit more than @quantity_input as it can allow
 import plasmapy.utils as utils
 from plasmapy.utils.checks import _check_quantity
-from plasmapy.utils.exceptions import PhysicsError # , PhysicsWarning
+from plasmapy.utils.exceptions import PhysicsError  # , PhysicsWarning
 
 
 r"""
@@ -176,7 +174,7 @@ def Alfven_speed(B, density, ion="p", z_mean=None):
     if density.unit == units.m**-3:
         try:
             m_i = atomic.ion_mass(ion)
-            if z_mean == None:
+            if z_mean is None:
                 # warnings.warn("No z_mean given, defaulting to atomic charge",
                 #               PhysicsWarning)
                 try:
@@ -323,7 +321,7 @@ def ion_sound_speed(*ignore,
 
     try:
         m_i = atomic.ion_mass(ion)
-        if z_mean == None:
+        if z_mean is None:
             # warnings.warn("No z_mean given, defaulting to atomic charge",
             #               PhysicsWarning)
             try:
@@ -643,7 +641,7 @@ def gyrofrequency(B, particle='e', signed=False, z_mean=None):
 
     try:
         m_i = atomic.ion_mass(particle)
-        if z_mean == None:
+        if z_mean is None:
             # warnings.warn("No z_mean given, defaulting to atomic charge",
             #               PhysicsWarning)
             try:
@@ -860,7 +858,7 @@ def plasma_frequency(n, particle='e', z_mean=None):
 
     try:
         m = atomic.ion_mass(particle)
-        if z_mean == None:
+        if z_mean is None:
             # warnings.warn("No z_mean given, defaulting to atomic charge",
             #               PhysicsWarning)
             try:

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -136,7 +136,7 @@ def test_Alfven_speed():
 
     with pytest.raises(UserWarning):
         assert Alfven_speed(1.0, n_i) == Alfven_speed(1.0 * u.T, n_i)
-        
+
     # tests for z_mean functionality
     # testing if warning is signaled for default value
     with pytest.warns(PhysicsWarning):
@@ -152,7 +152,6 @@ def test_Alfven_speed():
                       testTrue1,
                       atol=0.0,
                       rtol=1e-15), errStr
-    
 
 
 def test_ion_sound_speed():
@@ -247,6 +246,7 @@ def test_ion_sound_speed():
                       atol=0.0,
                       rtol=1e-15), errStr
 
+
 def test_thermal_speed():
     r"""Test the thermal_speed function in parameters.py"""
     assert thermal_speed(T_e).unit == u.m / u.s
@@ -329,6 +329,7 @@ class Test_kappa_thermal_speed(object):
         self.probable1True = 24467.878463594963
         self.rms1True = 37905.474322612165
         self.mean1True = 34922.98563039583
+
     def test_invalid_kappa(self):
         """
         Checks if function raises error when kappa <= 3/2 is passed as an
@@ -339,6 +340,7 @@ class Test_kappa_thermal_speed(object):
                                 self.kappaInvalid,
                                 particle=self.particle)
         return
+
     def test_invalid_method(self):
         """
         Checks if function raises error when invalid method is passed as an
@@ -350,6 +352,7 @@ class Test_kappa_thermal_speed(object):
                                 particle=self.particle,
                                 method="invalid")
         return
+
     def test_probable1(self):
         """
         Tests if expected value is returned for a set of regular inputs.
@@ -365,6 +368,7 @@ class Test_kappa_thermal_speed(object):
                           rtol=1e-8,
                           atol=0.0), errStr
         return
+
     def test_rms1(self):
         """
         Tests if expected value is returned for a set of regular inputs.
@@ -380,6 +384,7 @@ class Test_kappa_thermal_speed(object):
                           rtol=1e-8,
                           atol=0.0), errStr
         return
+
     def test_mean1(self):
         """
         Tests if expected value is returned for a set of regular inputs.
@@ -395,8 +400,6 @@ class Test_kappa_thermal_speed(object):
                           rtol=1e-8,
                           atol=0.0), errStr
         return
-    
-    
 
 
 def test_gyrofrequency():
@@ -465,7 +468,7 @@ def test_gyrofrequency():
 
     with pytest.raises(UserWarning):
         assert gyrofrequency(5.0, 'p') == gyrofrequency(5.0 * u.T, 'p')
-        
+
     # tests for z_mean functionality
     # testing if warning is signaled for default value
     with pytest.warns(PhysicsWarning):
@@ -624,7 +627,7 @@ def test_plasma_frequency():
     with pytest.raises(UserWarning):
         assert plasma_frequency(1e19, particle='p') ==\
             plasma_frequency(1e19 * u.m**-3, particle='p')
-            
+
     # tests for z_mean functionality
     # testing if warning is signaled for default value
     with pytest.warns(PhysicsWarning):

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -6,7 +6,7 @@ from astropy import units as u
 from warnings import simplefilter
 
 from ...utils.exceptions import RelativityWarning, RelativityError
-from ...utils.exceptions import PhysicsError
+from ...utils.exceptions import PhysicsError, PhysicsWarning
 from ...constants import c, m_p, m_e, e, mu0
 
 from ..parameters import (Alfven_speed,
@@ -136,6 +136,23 @@ def test_Alfven_speed():
 
     with pytest.raises(UserWarning):
         assert Alfven_speed(1.0, n_i) == Alfven_speed(1.0 * u.T, n_i)
+        
+    # tests for z_mean functionality
+    # testing if warning is signaled for default value
+    with pytest.warns(PhysicsWarning):
+        Alfven_speed(1 * u.T, 5e19 * u.m**-3, ion='p')
+    # testing for user input z_mean
+    testMeth1 = Alfven_speed(1 * u.T,
+                             5e19 * u.m**-3,
+                             ion='p',
+                             z_mean=0.8).si.value
+    testTrue1 = 3084015.75214846
+    errStr = (f"Alfven_speed() gave {testMeth1}, should be {testTrue1}.")
+    assert np.isclose(testMeth1,
+                      testTrue1,
+                      atol=0.0,
+                      rtol=1e-15), errStr
+    
 
 
 def test_ion_sound_speed():
@@ -217,6 +234,18 @@ def test_ion_sound_speed():
     with pytest.raises(UserWarning):
         assert ion_sound_speed(T_i=1.3e6) == ion_sound_speed(T_i=1.3e6 * u.K)
 
+    # tests for z_mean functionality
+    # testing if warning is signaled for default value
+    with pytest.warns(PhysicsWarning):
+        ion_sound_speed(T_e=1.2e6 * u.K)
+    # testing for user input z_mean
+    testMeth1 = ion_sound_speed(T_e=1.2e6 * u.K, z_mean=0.8).si.value
+    testTrue1 = 89018.0944146141
+    errStr = (f"ion_sound_speed() gave {testMeth1}, should be {testTrue1}.")
+    assert np.isclose(testMeth1,
+                      testTrue1,
+                      atol=0.0,
+                      rtol=1e-15), errStr
 
 def test_thermal_speed():
     r"""Test the thermal_speed function in parameters.py"""
@@ -436,6 +465,19 @@ def test_gyrofrequency():
 
     with pytest.raises(UserWarning):
         assert gyrofrequency(5.0, 'p') == gyrofrequency(5.0 * u.T, 'p')
+        
+    # tests for z_mean functionality
+    # testing if warning is signaled for default value
+    with pytest.warns(PhysicsWarning):
+        gyrofrequency(1 * u.T, particle='p')
+    # testing for user input z_mean
+    testMeth1 = gyrofrequency(1 * u.T, particle='p', z_mean=0.8).si.value
+    testTrue1 = 76630665.79318453
+    errStr = (f"gyrofrequency() gave {testMeth1}, should be {testTrue1}.")
+    assert np.isclose(testMeth1,
+                      testTrue1,
+                      atol=0.0,
+                      rtol=1e-15), errStr
 
 
 def test_gyroradius():
@@ -582,6 +624,21 @@ def test_plasma_frequency():
     with pytest.raises(UserWarning):
         assert plasma_frequency(1e19, particle='p') ==\
             plasma_frequency(1e19 * u.m**-3, particle='p')
+            
+    # tests for z_mean functionality
+    # testing if warning is signaled for default value
+    with pytest.warns(PhysicsWarning):
+        plasma_frequency(1e17 * u.cm**-3, particle='p')
+    # testing for user input z_mean
+    testMeth1 = plasma_frequency(1e17 * u.cm**-3,
+                                 particle='p',
+                                 z_mean=0.8).si.value
+    testTrue1 = 333063562455.4028
+    errStr = (f"plasma_frequency() gave {testMeth1}, should be {testTrue1}.")
+    assert np.isclose(testMeth1,
+                      testTrue1,
+                      atol=0.0,
+                      rtol=1e-15), errStr
 
 
 def test_Debye_length():

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -6,7 +6,7 @@ from astropy import units as u
 from warnings import simplefilter
 
 from ...utils.exceptions import RelativityWarning, RelativityError
-from ...utils.exceptions import PhysicsError, PhysicsWarning
+from ...utils.exceptions import PhysicsError
 from ...constants import c, m_p, m_e, e, mu0
 
 from ..parameters import (Alfven_speed,
@@ -137,10 +137,7 @@ def test_Alfven_speed():
     with pytest.raises(UserWarning):
         assert Alfven_speed(1.0, n_i) == Alfven_speed(1.0 * u.T, n_i)
 
-    # tests for z_mean functionality
-    # testing if warning is signaled for default value
-    with pytest.warns(PhysicsWarning):
-        Alfven_speed(1 * u.T, 5e19 * u.m**-3, ion='p')
+    Alfven_speed(1 * u.T, 5e19 * u.m**-3, ion='p')
     # testing for user input z_mean
     testMeth1 = Alfven_speed(1 * u.T,
                              5e19 * u.m**-3,
@@ -233,10 +230,7 @@ def test_ion_sound_speed():
     with pytest.raises(UserWarning):
         assert ion_sound_speed(T_i=1.3e6) == ion_sound_speed(T_i=1.3e6 * u.K)
 
-    # tests for z_mean functionality
-    # testing if warning is signaled for default value
-    with pytest.warns(PhysicsWarning):
-        ion_sound_speed(T_e=1.2e6 * u.K)
+    ion_sound_speed(T_e=1.2e6 * u.K)
     # testing for user input z_mean
     testMeth1 = ion_sound_speed(T_e=1.2e6 * u.K, z_mean=0.8).si.value
     testTrue1 = 89018.0944146141
@@ -469,10 +463,7 @@ def test_gyrofrequency():
     with pytest.raises(UserWarning):
         assert gyrofrequency(5.0, 'p') == gyrofrequency(5.0 * u.T, 'p')
 
-    # tests for z_mean functionality
-    # testing if warning is signaled for default value
-    with pytest.warns(PhysicsWarning):
-        gyrofrequency(1 * u.T, particle='p')
+    gyrofrequency(1 * u.T, particle='p')
     # testing for user input z_mean
     testMeth1 = gyrofrequency(1 * u.T, particle='p', z_mean=0.8).si.value
     testTrue1 = 76630665.79318453
@@ -628,10 +619,7 @@ def test_plasma_frequency():
         assert plasma_frequency(1e19, particle='p') ==\
             plasma_frequency(1e19 * u.m**-3, particle='p')
 
-    # tests for z_mean functionality
-    # testing if warning is signaled for default value
-    with pytest.warns(PhysicsWarning):
-        plasma_frequency(1e17 * u.cm**-3, particle='p')
+    plasma_frequency(1e17 * u.cm**-3, particle='p')
     # testing for user input z_mean
     testMeth1 = plasma_frequency(1e17 * u.cm**-3,
                                  particle='p',


### PR DESCRIPTION
Added optional argument `z_mean=None` to a bunch of functions in `parameters.py`. When value is `None` it defaults to using atomic charge state and signals a `PhysicsWarning`. These warnings may get annoying, so either tests need to be changed to use some value, like `z_mean=1` to avoid the warnings during pytest or can remove the warnings entirely.

I also added tests for `z_mean` under `test_parameters.py`.

Addresses #184 