### PR TITLE
Create exceptions and warnings for atomic subpackage

### DIFF
--- a/plasmapy/utils/exceptions.py
+++ b/plasmapy/utils/exceptions.py
@@ -36,7 +36,16 @@ class AtomicError(PlasmaPyError):
     pass
 
 
-class IonError(AtomicError):
+class MissingAtomicDataError(AtomicError):
+    """Error for use when atomic data is missing."""
+    pass
+
+
+class NoChargeInfoError(AtomicError):
+    """Error for use when charge information is needed but missing."""
+
+
+class IonError(NoChargeInfoError):
     """Error for use when an ion is invalid."""
     pass
 
@@ -84,4 +93,9 @@ class RelativityWarning(PhysicsWarning):
 
 class AtomicWarning(PlasmaPyWarning):
     """Warnings for use in the atomic subpackage."""
+    pass
+
+
+class MissingAtomicDataWarning(AtomicWarning):
+    """Warning for use when atomic data is missing."""
     pass

--- a/plasmapy/utils/exceptions.py
+++ b/plasmapy/utils/exceptions.py
@@ -18,14 +18,42 @@ class PlasmaPyError(Exception):
     already knows how to handle a ValueError, it won't need any specific
     modification.
     """
+    pass
 
 
 class PhysicsError(PlasmaPyError, ValueError):
     """Error for use of a physics value outside PlasmaPy theoretical bounds"""
+    pass
 
 
 class RelativityError(PhysicsError):
     """Error for use of a speed greater than or equal to the speed of light"""
+    pass
+
+
+class AtomicError(PlasmaPyError):
+    """Error for use by an atomic subpackage"""
+    pass
+
+
+class IonError(AtomicError):
+    """Error for use when an ion is invalid."""
+    pass
+
+
+class IsotopeError(IonError):
+    """Error for use when an isotope is invalid."""
+    pass
+
+
+class ElementError(IsotopeError):
+    """Error for use when an element is invalid."""
+    pass
+
+
+class ParticleError(ElementError):
+    """Error for use when a particle is invalid."""
+    pass
 
 
 # ----------
@@ -41,11 +69,19 @@ class PlasmaPyWarning(Warning):
     Warnings should be issued using warnings.warn, which will not break
     execution if unhandled.
     """
+    pass
 
 
 class PhysicsWarning(PlasmaPyWarning):
     """Warning for using a mildly worrisome physics value"""
+    pass
 
 
 class RelativityWarning(PhysicsWarning):
     """Warning for use of a speed quantity approaching the speed of light"""
+    pass
+
+
+class AtomicWarning(PlasmaPyWarning):
+    """Warnings for use in the atomic subpackage."""
+    pass

--- a/plasmapy/utils/exceptions.py
+++ b/plasmapy/utils/exceptions.py
@@ -41,12 +41,12 @@ class IonError(AtomicError):
     pass
 
 
-class IsotopeError(IonError):
+class IsotopeError(AtomicError):
     """Error for use when an isotope is invalid."""
     pass
 
 
-class ElementError(IsotopeError):
+class ElementError(IsotopeError, IonError):
     """Error for use when an element is invalid."""
     pass
 

--- a/plasmapy/utils/tests/test_exceptions.py
+++ b/plasmapy/utils/tests/test_exceptions.py
@@ -4,7 +4,11 @@ import warnings
 from .. import (PlasmaPyError,
                 PhysicsError,
                 RelativityError,
-                AtomicError)
+                AtomicError,
+                IonError,
+                IsotopeError,
+                ElementError,
+                ParticleError)
 
 from .. import (PlasmaPyWarning,
                 PhysicsWarning,
@@ -17,6 +21,10 @@ plasmapy_exceptions = [
     PhysicsError,
     RelativityError,
     AtomicError,
+    IonError,
+    IsotopeError,
+    ElementError,
+    ParticleError,
 ]
 
 plasmapy_warnings = [

--- a/plasmapy/utils/tests/test_exceptions.py
+++ b/plasmapy/utils/tests/test_exceptions.py
@@ -21,7 +21,7 @@ plasmapy_exceptions = [
 def test_exceptions(exception):
     r"""Test that custom PlasmaPy exceptions can be raised with an
     error message."""
-    with pytest.raises(exception):
+    with pytest.raises(exception, message=f"Problem raising {exception}"):
         raise exception("What an exceptionally exceptional exception!")
 
 
@@ -29,7 +29,8 @@ def test_exceptions(exception):
 def test_PlasmaPyError_subclassing(exception):
     r"""Test that each custom PlasmaPy exception can be caught
     as a PlasmaPyError."""
-    with pytest.raises(PlasmaPyError):
+    with pytest.raises(PlasmaPyError, message=(
+            f"Problem with subclassing of {exception}")):
         raise exception("I'm sorry, Dave.  I'm afraid I can't do that.")
 
 
@@ -46,7 +47,7 @@ plasmapy_warnings = [
 def test_warnings(warning):
     r"""Test that custom PlasmaPy warnings can be issued with a
     warning message."""
-    with pytest.warns(warning):
+    with pytest.warns(warning, message=f"Problem issuing {warning}"):
         warnings.warn("Coverage decreased (-0.00002%)", warning)
 
 
@@ -54,5 +55,6 @@ def test_warnings(warning):
 def test_PlasmaPyWarning_subclassing(warning):
     r"""Test that custom PlasmaPy warnings can all be caught
     as a PlasmaPyWarning."""
-    with pytest.warns(PlasmaPyWarning):
+    with pytest.warns(PlasmaPyWarning, message=(
+            f"Problem with subclassing of {warning}")):
         warnings.warn("Electrons are WEIRD.", warning)

--- a/plasmapy/utils/tests/test_exceptions.py
+++ b/plasmapy/utils/tests/test_exceptions.py
@@ -1,0 +1,59 @@
+import pytest
+import warnings
+
+from .. import (PlasmaPyError,
+                PhysicsError,
+                RelativityError,
+                AtomicError)
+
+from .. import (PlasmaPyWarning,
+                PhysicsWarning,
+                RelativityWarning,
+                AtomicWarning)
+
+
+plasmapy_exceptions = [
+    PlasmaPyError,
+    PhysicsError,
+    RelativityError,
+    AtomicError,
+]
+
+plasmapy_warnings = [
+    PlasmaPyWarning,
+    PhysicsWarning,
+    RelativityWarning,
+    AtomicWarning,
+]
+
+
+@pytest.mark.parametrize("exception", plasmapy_exceptions)
+def test_exceptions(exception):
+    r"""Test that custom PlasmaPy exceptions can be raised with an
+    error message."""
+    with pytest.raises(exception):
+        raise exception("What an exceptionally exceptional exception!")
+
+
+@pytest.mark.parametrize("warning", plasmapy_warnings)
+def test_warnings(warning):
+    r"""Test that custom PlasmaPy warnings can be issued with a
+    warning message."""
+    with pytest.warns(warning):
+        warnings.warn("Coverage decreased (-0.00002%)", warning)
+
+
+@pytest.mark.parametrize("exception", plasmapy_exceptions)
+def test_PlasmaPyError_subclassing(exception):
+    r"""Test that each custom PlasmaPy exception can be caught
+    as a PlasmaPyError."""
+    with pytest.raises(PlasmaPyError):
+        raise exception("I'm sorry, Dave.  I'm afraid I can't do that.")
+
+
+@pytest.mark.parametrize("warning", plasmapy_warnings)
+def test_PlasmaPyWarning_subclassing(warning):
+    r"""Test that custom PlasmaPy warnings can all be caught
+    as a PlasmaPyWarning."""
+    with pytest.warns(PlasmaPyWarning):
+        warnings.warn("Electrons are WEIRD.", warning)

--- a/plasmapy/utils/tests/test_exceptions.py
+++ b/plasmapy/utils/tests/test_exceptions.py
@@ -1,37 +1,19 @@
 import pytest
 import warnings
 
-from .. import (PlasmaPyError,
-                PhysicsError,
-                RelativityError,
-                AtomicError,
-                IonError,
-                IsotopeError,
-                ElementError,
-                ParticleError)
-
-from .. import (PlasmaPyWarning,
-                PhysicsWarning,
-                RelativityWarning,
-                AtomicWarning)
-
+from ..exceptions import *
 
 plasmapy_exceptions = [
     PlasmaPyError,
     PhysicsError,
     RelativityError,
     AtomicError,
+    MissingAtomicDataError,
+    NoChargeInfoError,
     IonError,
     IsotopeError,
     ElementError,
     ParticleError,
-]
-
-plasmapy_warnings = [
-    PlasmaPyWarning,
-    PhysicsWarning,
-    RelativityWarning,
-    AtomicWarning,
 ]
 
 
@@ -43,20 +25,29 @@ def test_exceptions(exception):
         raise exception("What an exceptionally exceptional exception!")
 
 
-@pytest.mark.parametrize("warning", plasmapy_warnings)
-def test_warnings(warning):
-    r"""Test that custom PlasmaPy warnings can be issued with a
-    warning message."""
-    with pytest.warns(warning):
-        warnings.warn("Coverage decreased (-0.00002%)", warning)
-
-
 @pytest.mark.parametrize("exception", plasmapy_exceptions)
 def test_PlasmaPyError_subclassing(exception):
     r"""Test that each custom PlasmaPy exception can be caught
     as a PlasmaPyError."""
     with pytest.raises(PlasmaPyError):
         raise exception("I'm sorry, Dave.  I'm afraid I can't do that.")
+
+
+plasmapy_warnings = [
+    PlasmaPyWarning,
+    PhysicsWarning,
+    RelativityWarning,
+    AtomicWarning,
+    MissingAtomicDataWarning,
+]
+
+
+@pytest.mark.parametrize("warning", plasmapy_warnings)
+def test_warnings(warning):
+    r"""Test that custom PlasmaPy warnings can be issued with a
+    warning message."""
+    with pytest.warns(warning):
+        warnings.warn("Coverage decreased (-0.00002%)", warning)
 
 
 @pytest.mark.parametrize("warning", plasmapy_warnings)


### PR DESCRIPTION
The atomic ⚛️ subpackage currently raises `ValueError` and `TypeError` a whole bunch of times.  These exceptions are appropriate but are not specific enough to distinguish between different types of problems and make use of exception subclassing.  For example, a particle such as `'Fe-56'` is an invalid ion but a valid isotope.  In this case, this particle should raise something like an `IonError` but not an `IsotopeError`.

I started out by adding `AtomicError`, `IonError`, `IsotopeError`, `ElementError`, and `ParticleError` as exceptions and `AtomicWarning` as a warning.  We will need to think more carefully about how to handle subclassing.

I also added "pass" to each of the exceptions and warnings.  This does not appear to be needed, but I was thinking that this line would show up in coverage tests for exceptions and warnings that are not being tested.  _(Update: This line does not actually show up in coverage tests.)_

This builds upon the work completed in #170 that closed #168.
