### PR TITLE
Shallow clone astropy ci-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ git:
 
 # Install dependencies
 install:
-        - git clone git://github.com/astropy/ci-helpers.git
+        - git clone git://github.com/astropy/ci-helpers.git --depth 1
         - source ci-helpers/travis/setup_conda.sh
         - "pip install -r requirements/automated-code-tests.txt"
 


### PR DESCRIPTION
This should *in theory* decrease the time needed to run Travis CI tests, as we're not cloning the entire history of that repo.

A small change to be merged soon.