### PR TITLE
First draft of wrapper for quantity_input

### DIFF
--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -365,21 +365,16 @@ def _check_relativistic(V, funcname, betafrac=0.1):
                       RelativityWarning)
 
 
-def quantity_input():
+def temperature_input(wrapped_function=None, **kwargs):
     """Wrapper on top of astropy.units.quantity_input"""
-    eq = u.temperature_energy()
-    K_to_J =(u.K, # from_unit
-              u.J, # to_unit
-              lambda x: x * (k_B.si.value), # forward conversion
-              lambda x: x / (k_B.si.value)) # backward conversion
-    eq.append(K_to_J)
-    # print(u.J.find_equivalent_units(equivalencies=eq))
-    # print(u.K.find_equivalent_units(equivalencies=eq))
-    def decorator(f):
-        @functools.wraps(f)
-        def wrapper(*args, **kwargs):
-            qi = QuantityInput(equivalencies=eq)
-            return qi(f)(*args, **kwargs)
-        return wrapper
-    return decorator
+    equiv = kwargs.pop('equivalencies', [])
+    equiv += u.temperature_energy()
+    kwargs['equivalencies'] = equiv
+    # print(u.J.find_equivalent_units(equivalencies=equiv))
+    # print(u.K.find_equivalent_units(equivalencies=equiv))
+    decorator = u.quantity_input(**kwargs)
+    if wrapped_function is not None:
+        return decorator(wrapped_function)
+    else:
+        return decorator
 

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -8,7 +8,7 @@ from ...utils.exceptions import RelativityWarning, RelativityError
 from ...constants import c, k_B, m_e, e
 from ..checks import (
     _check_quantity, _check_relativistic, check_relativistic,
-    check_quantity, quantity_input
+    check_quantity, temperature_input
 )
 
 
@@ -311,18 +311,20 @@ def test_check_relativistic_decorator_errors(speed, betafrac, error):
     with pytest.raises(error):
         speed_func()
 
-def test_our_quantity_input():
-    @quantity_input()
-    def electron_thermal_velocity(T: u.K) -> u.m/u.s:
-        return np.sqrt(2 * k_B * T / m_e)
+@temperature_input
+def electron_thermal_velocity(T: u.K) -> u.m/u.s:
+    return np.sqrt(2 * k_B * T / m_e)
 
-    value = electron_thermal_velocity(2*u.K)
-    assert value.unit == u.m/u.s
+class Test_temperature_input():
+    def test_kelvin_input(self):
+        assert electron_thermal_velocity(2*u.K).unit == u.m/u.s
 
-    value2 = electron_thermal_velocity(1*u.eV)
-    assert value2.unit == u.m/u.s
+    def test_ev_input(self):
+        assert electron_thermal_velocity(1*u.eV).unit == u.m/u.s
 
+    def test_J_input(self):
+        assert  electron_thermal_velocity(1*u.J).unit == u.m/u.s
 
-
-    with pytest.raises(TypeError):
-        electron_thermal_velocity(2)
+    def test_number_input(self):
+        with pytest.raises(TypeError):
+            electron_thermal_velocity(2)

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -5,10 +5,10 @@ from astropy import units as u
 import pytest
 
 from ...utils.exceptions import RelativityWarning, RelativityError
-from ...constants import c
+from ...constants import c, k_B, m_e, e
 from ..checks import (
     _check_quantity, _check_relativistic, check_relativistic,
-    check_quantity
+    check_quantity, quantity_input
 )
 
 
@@ -310,3 +310,19 @@ def test_check_relativistic_decorator_errors(speed, betafrac, error):
 
     with pytest.raises(error):
         speed_func()
+
+def test_our_quantity_input():
+    @quantity_input()
+    def electron_thermal_velocity(T: u.K) -> u.m/u.s:
+        return np.sqrt(2 * k_B * T / m_e)
+
+    value = electron_thermal_velocity(2*u.K)
+    assert value.unit == u.m/u.s
+
+    value2 = electron_thermal_velocity(1*u.eV)
+    assert value2.unit == u.m/u.s
+
+
+
+    with pytest.raises(TypeError):
+        electron_thermal_velocity(2)


### PR DESCRIPTION
I'm trying to make a wrapper to `astropy.units.quantity_input` that would basically do the conversions we need via the `u.temperature_energy` equivalency (re: today's discussion with @lemmatum). In a sense, I'm trying to do
```python
quantity_input = u.quantity_input(equivalencies = u.temperature_energy())
```
plus whatever other equivalencies we'd need. I was trying to add something between J to K but I think `temperature_energy` already handles that.

I'm still trying to figure this out, but here's what I've got out of my (admittedly ugly) tests:

```python

plasmapy/utils/tests/test_checks.py:313 (test_our_quantity_input)
def test_our_quantity_input():
        @quantity_input()
        def electron_thermal_velocity(T: u.K) -> u.m/u.s:
            return np.sqrt(2 * k_B * T / m_e)
    
        value = electron_thermal_velocity(2*u.K)
        assert value.unit == u.m/u.s
    
>       value2 = electron_thermal_velocity(1*u.eV)

plasmapy/utils/tests/test_checks.py:322: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
plasmapy/utils/checks.py:382: in wrapper
    return qi(f)(*args, **kwargs)
../../.anaconda3/envs/plasmapy/lib/python3.6/site-packages/astropy/utils/decorators.py:868: in electron_thermal_velocity
    func = make_function_with_signature(func, name=name, **wrapped_args)
../../.anaconda3/envs/plasmapy/lib/python3.6/site-packages/astropy/units/decorators.py:225: in wrapper
    return return_.to(wrapped_signature.return_annotation)
../../.anaconda3/envs/plasmapy/lib/python3.6/site-packages/astropy/units/quantity.py:844: in to
    return self._new_view(self._to_value(unit, equivalencies), unit)
../../.anaconda3/envs/plasmapy/lib/python3.6/site-packages/astropy/units/quantity.py:816: in _to_value
    equivalencies=equivalencies)
../../.anaconda3/envs/plasmapy/lib/python3.6/site-packages/astropy/units/core.py:979: in to
    return self._get_converter(other, equivalencies=equivalencies)(value)
../../.anaconda3/envs/plasmapy/lib/python3.6/site-packages/astropy/units/core.py:913: in _get_converter
    raise exc
../../.anaconda3/envs/plasmapy/lib/python3.6/site-packages/astropy/units/core.py:899: in _get_converter
    self, other, self._normalize_equivalencies(equivalencies))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Unit("eV(1/2) J(1/2) / (K(1/2) kg(1/2))")
unit = Unit("eV(1/2) J(1/2) / (K(1/2) kg(1/2))"), other = Unit("m / s")
equivalencies = []

    def _apply_equivalencies(self, unit, other, equivalencies):
        """
            Internal function (used from `_get_converter`) to apply
            equivalence pairs.
            """
        def make_converter(scale1, func, scale2):
            def convert(v):
                return func(_condition_arg(v) / scale1) * scale2
            return convert
    
        for funit, tunit, a, b in equivalencies:
            if tunit is None:
                try:
                    ratio_in_funit = (other.decompose() /
                                      unit.decompose()).decompose([funit])
                    return make_converter(ratio_in_funit.scale, a, 1.)
                except UnitsError:
                    pass
            else:
                try:
                    scale1 = funit._to(unit)
                    scale2 = tunit._to(other)
                    return make_converter(scale1, a, scale2)
                except UnitsError:
                    pass
                try:
                    scale1 = tunit._to(unit)
                    scale2 = funit._to(other)
                    return make_converter(scale1, b, scale2)
                except UnitsError:
                    pass
    
        def get_err_str(unit):
            unit_str = unit.to_string('unscaled')
            physical_type = unit.physical_type
            if physical_type != 'unknown':
                unit_str = "'{0}' ({1})".format(
                    unit_str, physical_type)
            else:
                unit_str = "'{0}'".format(unit_str)
            return unit_str
    
        unit_str = get_err_str(unit)
        other_str = get_err_str(other)
    
        raise UnitConversionError(
            "{0} and {1} are not convertible".format(
>               unit_str, other_str))
E       astropy.units.core.UnitConversionError: 'eV(1/2) J(1/2) / (K(1/2) kg(1/2))' and 'm / s' (speed) are not convertible
```
So, my question to @Cadair: `u.quantity_input` sees this (from the log):
```python
self = Unit("eV(1/2) J(1/2) / (K(1/2) kg(1/2))")
unit = Unit("eV(1/2) J(1/2) / (K(1/2) kg(1/2))"), other = Unit("m / s")
equivalencies = []
```
Is it failing to break down the mess in the `self` part? If so, is there any way I could get into the definition for the wrapped function, get the arguments I need and update them (admittedly I haven't yet looked closely at @namurphy's #242)?

Otherwise, is it that I'm somehow incorrectly applying the decorator in L382 of `plasmapy/utils/checks.py`, and this is why this shows `equivalencies` as empty?