### PR TITLE
Fixing circleCI failing builds cython

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ deps-run: &deps-install
     python3 -m venv venv
     . venv/bin/activate
     pip install --user -r requirements/automated-documentation-tests.txt | cat
-    pip install --user . | cat
 
 plsma-run: &plsma-install
   name: Install PlasmaPy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,5 @@ install:
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% python setup.py -q install"
+  - "%CMD_IN_ENV% python setup.py -q install build_ext --inplace"
   - "%CMD_IN_ENV% pytest"


### PR DESCRIPTION
Fixes failing builds due to circleCI not having numpy available for Cython integration. Basically the dependencies and installation of PlasmaPy must be done in two separate steps.