### PR TITLE
Test against python 3.7-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
         - chmod u+x requirements/dev_version_hack.sh
         - source requirements/dev_version_hack.sh
         - git clone git://github.com/astropy/ci-helpers.git --depth 1
+        - export DEBUG=True
         - source ci-helpers/travis/setup_conda.sh
         - "pip install -r requirements/automated-code-tests.txt"
         # building so that we have cython files compiled for tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@
 language: python
 python:
         - "3.6"
-	- "nightly"
+	- "3.7-dev"
 
 git:
     submodules: false
 
 # Install dependencies
 install:
+        - ./requirements/dev_version_hack.sh
         - git clone git://github.com/astropy/ci-helpers.git --depth 1
         - source ci-helpers/travis/setup_conda.sh
         - "pip install -r requirements/automated-code-tests.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ git:
 # Install dependencies
 install:
         - chmod u+x requirements/dev_version_hack.sh
-        - ./requirements/dev_version_hack.sh
+        - source requirements/dev_version_hack.sh
         - git clone git://github.com/astropy/ci-helpers.git --depth 1
         - source ci-helpers/travis/setup_conda.sh
         - "pip install -r requirements/automated-code-tests.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ git:
 
 # Install dependencies
 install:
+        - chmod u+x /requirements/dev_version_hack.sh
         - ./requirements/dev_version_hack.sh
         - git clone git://github.com/astropy/ci-helpers.git --depth 1
         - source ci-helpers/travis/setup_conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: python
 python:
         - "3.6"
+        - "3.7-dev"
 
 git:
     submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ git:
 
 # Install dependencies
 install:
-        - chmod u+x /requirements/dev_version_hack.sh
+        - chmod u+x requirements/dev_version_hack.sh
         - ./requirements/dev_version_hack.sh
         - git clone git://github.com/astropy/ci-helpers.git --depth 1
         - source ci-helpers/travis/setup_conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 python:
         - "3.6"
-        - "3.7-dev"
+        - "3.7.0b1"
 
 git:
     submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@
 language: python
 python:
         - "3.6"
-	- "3.7-dev"
-        - "3.7.0b1"
-	- "3.7"
+	- "nightly"
 
 git:
     submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 python:
         - "3.6"
-	- "3.7-dev"
+        - "3.7-dev"
 
 git:
     submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@
 language: python
 python:
         - "3.6"
+	- "3.7-dev"
         - "3.7.0b1"
+	- "3.7"
 
 git:
     submodules: false

--- a/requirements/dev_version_hack.sh
+++ b/requirements/dev_version_hack.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# verbose printing of executed commands for debugging
+if [[ $DEBUG == True ]]; then
+    set -x
+fi
+
+# checking if PYTHON_VERSION variable is set
 if [[ -z $PYTHON_VERSION ]]; then
     # fetches python --version output
     version="$(python --version 2>&1)"

--- a/requirements/dev_version_hack.sh
+++ b/requirements/dev_version_hack.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [[ -z $PYTHON_VERSION ]]; then
+    # fetches python --version output
+    version="$(python --version 2>&1)"
+    echo "Current version is $version"
+    # binds output of python --version to PYTHON_VERSION
+    PYTHON_VERSION="$version"
+    echo "PYTHON_VERSION is now $PYTHON_VERSION"
+fi

--- a/requirements/dev_version_hack.sh
+++ b/requirements/dev_version_hack.sh
@@ -2,8 +2,8 @@
 if [[ -z $PYTHON_VERSION ]]; then
     # fetches python --version output
     version="$(python --version 2>&1)"
-    echo "Current version is $version"
+    >&2 echo "Current version is $version"
     # binds output of python --version to PYTHON_VERSION
     PYTHON_VERSION="$version"
-    echo "PYTHON_VERSION is now $PYTHON_VERSION"
+    >&2 echo "PYTHON_VERSION is now $PYTHON_VERSION"
 fi

--- a/requirements/dev_version_hack.sh
+++ b/requirements/dev_version_hack.sh
@@ -13,8 +13,12 @@ if [[ -z $PYTHON_VERSION ]]; then
     # fetches python --version output
     version="$(python --version 2>&1)"
     echo "Current version is $version"
+    # grabbing just the number
+    versionArr=($version)
+    versionNum=${versionArr[1]}
+    echo "Version num is $versionNum"
     # binds output of python --version to PYTHON_VERSION
-    PYTHON_VERSION="$version"
+    PYTHON_VERSION="$versionNum"
     echo "PYTHON_VERSION is now $PYTHON_VERSION"
 fi
 

--- a/requirements/dev_version_hack.sh
+++ b/requirements/dev_version_hack.sh
@@ -9,8 +9,11 @@ fi
 if [[ -z $PYTHON_VERSION ]]; then
     # fetches python --version output
     version="$(python --version 2>&1)"
-    >&2 echo "Current version is $version"
+    echo "Current version is $version"
     # binds output of python --version to PYTHON_VERSION
     PYTHON_VERSION="$version"
-    >&2 echo "PYTHON_VERSION is now $PYTHON_VERSION"
+    echo "PYTHON_VERSION is now $PYTHON_VERSION"
 fi
+
+# disables debug if it was set
+set +x

--- a/requirements/dev_version_hack.sh
+++ b/requirements/dev_version_hack.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# message for when hack starts executing
+echo "================ Starting execution of dev_version_hack script ================="
+
 # verbose printing of executed commands for debugging
 if [[ $DEBUG == True ]]; then
     set -x
@@ -17,3 +20,6 @@ fi
 
 # disables debug if it was set
 set +x
+
+# message for when script is done
+echo "================ Finished execution of dev_version_hack script ================="


### PR DESCRIPTION
Python 3.7 is now in beta, and is likely to be released around this summer.  We should make sure our 0.1.0 release works with the most recent development version of Python 3.7 since our 0.2.0 release will probably not occur until a few months after the Python 3.7 release.  This pull request adds a line in `.travis.yml` to test against Python 3.7-dev.