### PR TITLE
Customize pycodestyle, pydocstyle, and pep8speaks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,14 @@
+message:
+    opened:
+        header: "Hello @{name}! Thanks for submitting your pull request."
+        footer: "PlasmaPy follows the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/), which may be checked locally using [pycodestyle](http://pycodestyle.pycqa.org/en/latest/intro.html)"
+    updated:
+        header: "Hello @{name}! Thanks for updating your pull request."
+        footer: ""
+    no_errors: "Congratulations! There are no PEP8 issues in this pull request. :smile_cat:"
+
+scanner:
+    diff_only: True
+
+only_mention_files_with_errors: True
+descending_issues_order: False

--- a/docs/development/code_guide.rst
+++ b/docs/development/code_guide.rst
@@ -13,8 +13,11 @@ PlasmaPy requires
 * Python 3.6 or later
 * Astropy 2.0 or later
 * NumPy 1.13 or later
-* scipy 0.19 or later
+* SciPy 0.19 or later
 * matplotlib 2.0 or later
+* Cython
+* mpmath 1.0 or later
+* lmfit 0.9.7 or later
 
 Obtaining PlasmaPy source code
 =========================================
@@ -23,7 +26,8 @@ After creating your GitHub account, go to the [main
 repository](https://github.com/PlasmaPy/PlasmaPy) and **fork a copy of
 PlasmaPy to your account**.
 
-To access Git commands on Windows, try `Git Bash <https://git-scm.com/downloads>`_.
+To access Git commands on Windows, try `Git Bash
+<https://git-scm.com/downloads>`_.
 
 Next you must **clone your fork to your computer**.  Go to the
 directory that will host your PlasmaPy directory, and run one of the
@@ -56,16 +60,16 @@ something like this:
 
 .. code-block:: bash
 
-  origin		git@github.com:namurphy/PlasmaPy.git (fetch)
-  origin		git@github.com:namurphy/PlasmaPy.git (push)
+  origin	git@github.com:namurphy/PlasmaPy.git (fetch)
+  origin	git@github.com:namurphy/PlasmaPy.git (push)
   upstream	git@github.com:PlasmaPy/PlasmaPy.git (fetch)
   upstream	git@github.com:PlasmaPy/PlasmaPy.git (push)
 
 Setting up an environment for development
 =========================================
 
-Setup procedures for the two most popular virtual
-environments, conda and virtualenv, are listed below.
+Setup procedures for the two most popular virtual environments, conda
+and virtualenv, are listed below.
 
 Conda
 -----
@@ -74,20 +78,22 @@ To set up a development environment for PlasmaPy, `the Anaconda
 distribution <https://www.anaconda.com/download/>`_ is strongly
 recommended.
 
-After installing Anaconda, launch any conda environment. By default, conda installs a `root`
-environment, which you should be able to activate via
+After installing Anaconda, launch any conda environment. By default,
+conda installs a `root` environment, which you should be able to
+activate via
 
 .. code-block:: bash
 
   source /home/user/anaconda3/bin/activate root
 
-where `/home/user/anaconda3/` can be swapped to wherever your anaconda installation
-was resides.
+where `/home/user/anaconda3/` can be swapped to wherever your anaconda
+installation was resides.
 
 On Windows, the way to do this is via running `Anaconda Prompt` from the
 Start Menu. `Git Bash` may also work if you have added Anaconda to `PATH`.
 
-Afterwards, enter PlasmaPy's repository root directory and execute the following:
+Afterwards, enter PlasmaPy's repository root directory and execute the
+following:
 
 .. code-block:: bash
 
@@ -104,78 +110,81 @@ On Windows, skip the `source` part of the previous command.
 Virtualenv
 ----------
 
-Create a directory for holding the PlasmaPy repository, move into it and
-create the virtual environment
+Create a directory for holding the PlasmaPy repository, move into it
+and create the virtual environment
 
 .. code-block:: bash
 
     virtualenv -p python3 .
 
-You may need to make sure that this directory's path doesn't contain any spaces, otherwise virtualenv may throw an error.
+You may need to make sure that this directory's path doesn't contain
+any spaces, otherwise virtualenv may throw an error.
 
-Your virtual environment should now be created. If you run `ls` you will notice
-that virtualenv has created a number of subdirectories: `bin/`, `lib/`, and
-`include/`. This is why we're not creating the virtualenv within the
-repository itself - so as to not pollute it. To activate
-the virtualenv you will run:
+Your virtual environment should now be created. If you run `ls` you
+will notice that virtualenv has created a number of subdirectories:
+`bin/`, `lib/`, and `include/`. This is why we're not creating the
+virtualenv within the repository itself - so as to not pollute it. To
+activate the virtualenv you will run:
 
 .. code-block:: bash
 
     source ./bin/activate
 
-You should now see that your shell session is prepended with (plasmapy), like so:
+You should now see that your shell session is prepended with
+(plasmapy), like so:
 
 .. code-block:: bash
 
     (plasmapy) user@name:~/programming/plasmapy$
 
-This indicates that the virtualenv is running. Congratulations!
-When your're done working on PlasmaPy, you can deactivate the virtualenv by
+This indicates that the virtualenv is running. Congratulations!  When
+your're done working on PlasmaPy, you can deactivate the virtualenv by
 running
 
 .. code-block:: bash
 
     source deactivate
 
-Now that you have plasmapy on your local computer and you have a virtual
-environment, you will want to "install" this development version of PlasmaPy
-along with its dependencies. Start by activating your virtual environment. Next
-you want install the PlasmaPy dependencies. One way to do this is to do
+Now that you have plasmapy on your local computer and you have a
+virtual environment, you will want to "install" this development
+version of PlasmaPy along with its dependencies. Start by activating
+your virtual environment. Next you want install the PlasmaPy
+dependencies. One way to do this is to do
 
 .. code-block:: bash
 
     (plasmapy) user@name:~/programming/plasmapy$ pip install -r requirements/environment.txt
 
-Next, setup the development version of PlasmaPy which you just cloned by moving
-into the root directory of the cloned repo and running the setup.py script
-there:
+Next, setup the development version of PlasmaPy which you just cloned
+by moving into the root directory of the cloned repo and running the
+setup.py script there:
 
 .. code-block:: bash
 
     (plasmapy) user@name:~/programming/plasmapy/PlasmaPy$ pip install -e .
 
 
-You should now be all set to run development versions of PlasmaPy modules via
-`import PlasmaPy` in your test scripts!
+You should now be all set to run development versions of PlasmaPy
+modules via `import PlasmaPy` in your test scripts!
 
 Running anaconda with virtualenv
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are running the Anaconda suite and want to use virtualenv to setup your
-virtual environment, you will have to let the system know where the Python
-interpreter can be found. On Linux this is done with (for example, assuming
-having installed Anaconda into `~/anaconda3`):
+If you are running the Anaconda suite and want to use virtualenv to
+setup your virtual environment, you will have to let the system know
+where the Python interpreter can be found. On Linux this is done with
+(for example, assuming having installed Anaconda into `~/anaconda3`):
 
 .. code-block:: bash
 
     export LD_LIBRARY_PATH="$HOME/anaconda3/lib/"
 
-Exporting the library path to the dynamic linker will only last for the
-duration of the current shell session.
+Exporting the library path to the dynamic linker will only last for
+the duration of the current shell session.
 
-You will have to add the python library directory to LD_LIBRARY_PATH, as
-described in a previous step, prior to activating the virtualenv for every new
-shell session.
+You will have to add the python library directory to LD_LIBRARY_PATH,
+as described in a previous step, prior to activating the virtualenv
+for every new shell session.
 
 Installing your own dev version
 ===============================
@@ -185,10 +194,12 @@ To be able to import PlasmaPy from your source version:
 
   pip install -e {plasmapy-repository-root}
 
-Where `{plasmapy-repository-root}` is the directory resulting from `git clone`.
+Where `{plasmapy-repository-root}` is the directory resulting from
+`git clone`.
 
 If you are not working within a virtual environment, this may end in a
-permission error - this can be avoided via also adding the `--user` flag.
+permission error - this can be avoided via also adding the `--user`
+flag.
 
 Coding Style
 ============
@@ -200,7 +211,8 @@ Coding Style
   * The PEP 8 Speaks integration on GitHub will comment when there are
     any departures from the PEP 8 style guide.
 
-  * PEP 8 compliance may be checked locally using the pep8 package.
+  * PEP 8 compliance may be checked locally using
+    [pycodestyle](http://pycodestyle.pycqa.org/en/latest/).
 
   * Departures from PEP 8 compliance should be used sparingly and only
     if there is a good reason.  A physics formula might be most
@@ -218,7 +230,7 @@ Coding Style
 * ``__init__.py`` files for modules should not contain any significant
   implementation code, but it can contain a docstring describing the
   module and code related to importing the module.  Any substantial
-  functionality should be put into a separate file.g
+  functionality should be put into a separate file.
   
 * There should be at most one pun per 1284 lines of code.
 
@@ -266,18 +278,19 @@ make edits to PlasmaPy.  Switch to your new branch by running:
   git checkout *your-new-feature*
 
 Go ahead and modify files with your favorite text editor.  Be sure to
-include tests and documentation with any new functionality.  We also
-recommend reading about `best practices for scientific
-computing <https://doi.org/10.1371/journal.pbio.1001745>`_.  PlasmaPy
-uses the `PEP 8 style guide for Python
-code <https://www.python.org/dev/peps/pep-0008/>`_ and the `numpydoc
-format for
-docstrings <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_
-to maintain consistency and readability.  New contributors should not 
-worry too much about precisely matching these styles when first 
-submitting a pull request, as the `PEP8 Speaks <http://pep8speaks.com/>`_
-GitHub integration will check pull requests for PEP 8 compatibility, and
-further changes to the style can be suggested during code review.
+include tests and documentation with any new functionality.  We
+recommend reading about `best practices for scientific computing
+<https://doi.org/10.1371/journal.pbio.1001745>`_.  PlasmaPy uses the
+`PEP 8 style guide for Python code
+<https://www.python.org/dev/peps/pep-0008/>`_ and the `numpydoc format
+for docstrings
+<https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_
+to maintain consistency and readability.  New contributors should not
+worry too much about precisely matching these styles when first
+submitting a pull request, as the `PEP8 Speaks
+<http://pep8speaks.com/>`_ GitHub integration will check pull requests
+for PEP 8 compatibility, and further changes to the style can be
+suggested during code review.
 
 You may periodically commit changes to your branch by running
 
@@ -287,7 +300,7 @@ You may periodically commit changes to your branch by running
   git commit -m "*brief description of changes*"
 
 Committed changes may be pushed to the corresponding branch on your
-GitHub fork of PlasmaPy using 
+GitHub fork of PlasmaPy using
 
 .. code-block:: bash
 
@@ -312,6 +325,8 @@ code, you may delete the branch you created for that pull request.
 Commit Messages
 ---------------
 
+Commit messages should be 
+
 From `How to Write a Git Commit Message
 <https://chris.beams.io/posts/git-commit/>`_:
 
@@ -334,6 +349,9 @@ Documentation
 
 * All public classes, methods, and functions should have docstrings
   using the numpydoc format.
+
+* Docstrings may be checked locally using
+  [pydocstyle](http://www.pydocstyle.org/en/latest/).
 
 * These docstrings should include usage examples.
 
@@ -437,8 +455,3 @@ However, ``dimensionless_angles`` does work when dividing a velocity
 by an angular frequency to get a length scale:
 
 >>> d_i = (c/omega_pi).to(u.m, equivalencies=u.dimensionless_angles())
-
-
-.. TODO add note on energies in K, eV
-
-

--- a/docs/development/code_guide.rst
+++ b/docs/development/code_guide.rst
@@ -324,10 +324,11 @@ code, you may delete the branch you created for that pull request.
 
 Commit Messages
 ---------------
+Good commit messages communicate context and intention to other
+developers and to our future selves.  They provide insight into why we
+chose a particular implementation, and help us avoid past mistakes.
 
-Commit messages should be 
-
-From `How to Write a Git Commit Message
+Suggestions on `how to write a git commit message
 <https://chris.beams.io/posts/git-commit/>`_:
 
 * Separate subject from body with a blank line

--- a/docs/development/doc_guide.rst
+++ b/docs/development/doc_guide.rst
@@ -8,14 +8,15 @@ packages.
 
 Building documentation
 ======================
-Documentation is built from the master branch on every commit pushed to it.
+Documentation is built from the master branch on every commit pushed
+to it.
 
 
 Using sphinx within the project
 -------------------------------
-To build docs locally, run ``sphinx-build docs docs/_build`` from within the main
-PlasmaPy repository directory, then open ``docs/_build/index.html`` with your
-browser of choice.
+To build docs locally, run ``sphinx-build docs docs/_build`` from
+within the main PlasmaPy repository directory, then open
+``docs/_build/index.html`` with your browser of choice.
 
 Do try to solve warnings in documentation when writing your code.
 
@@ -28,13 +29,15 @@ Docstrings
   <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_
   standard for docstrings.
 
-* Docstrings should generally be raw string `literals
-  <https://docs.python.org/3/reference/lexical_analysis.html#literals>`_:
+* Docstrings must be raw string `literals
+  <https://docs.python.org/3/reference/lexical_analysis.html#literals>`_
+  if they contain backslashes.  A raw string literal is denoted by
+  having an `r` immediately precede quotes or triple quotes:
   
 .. code-block:: python
 
-   r""" I did not like unstable eigenfunctions at first, but then
-   they grew on me.
+   r""" I did not like unstable eigenfunctions at first, but then they
+   grew on me.
    
    """
     

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -23,13 +23,13 @@ A few guidelines to on writing neat, readable and useful tests:
 
 * Solved bugs should be turned into test cases.
   
-* The Travis CI, CircleCI, and AppVeyor integrations on GitHub run tests whenever pull
-  requests to PlasmaPy are updated.  The pytest module may used on a
-  local computer.
+* The Travis CI, CircleCI, and AppVeyor integrations on GitHub run
+  tests whenever pull requests to PlasmaPy are updated.  The pytest
+  module may used on a local computer.
   
 * Tests are run frequently during code development, and slow tests may
-  interrupt the flow of a contributor.  Tests should be minimal, sufficient enough to
-  be complete and as efficient as possible.
+  interrupt the flow of a contributor.  Tests should be minimal,
+  sufficient enough to be complete, and as efficient as possible.
 
 
 Assert statements
@@ -58,8 +58,10 @@ pytest should display the value of the ``2 + 2`` expression, but the value can b
 A note on test independence and parametrization
 ===============================================
 
-In this section, we'll discuss the issue of parametrization based on an example
-of a `proof <https://en.wikipedia.org/wiki/Riemann\_hypothesis#Excluded\_middle>`_ of Gauss's class number conjecture.
+In this section, we'll discuss the issue of parametrization based on
+an example of a `proof
+<https://en.wikipedia.org/wiki/Riemann\_hypothesis#Excluded\_middle>`_
+of Gauss's class number conjecture.
 
 The proof goes along these lines: 
 * If the generalized Riemann hypothesis is true, the conjecture is true.
@@ -76,7 +78,8 @@ One way to use pytest for testing is to write continuous assertions:
        # and you have to run this again
        assert proof_by_riemann(True) 
 
-To do this the right way, what you technically should do to make the tests independent:
+To do this the right way, what you technically should do to make the
+tests independent:
 
 .. code-block:: python
 
@@ -93,9 +96,12 @@ but that's a lot of typing so what you actually do is use pytest parametrization
   def test_proof_if_riemann(truth):
        assert proof_by_riemann(truth)
 
-And both of these are going to run regardless of failures, which is awesome!
+And both of these are going to run regardless of failures, which is
+awesome!
 
-Of course, with qualitatively different tests you would use either separate functions or you'd pass in pairs of inputs and expected values:
+Of course, with qualitatively different tests you would use either
+separate functions or you'd pass in pairs of inputs and expected
+values:
 
 .. code-block:: python
 
@@ -106,22 +112,22 @@ Of course, with qualitatively different tests you would use either separate func
 Code coverage
 =============
 
-PlasmaPy uses the coverage.py addon via Coveralls.io. At the end of every
-Travis CI testing session, information on which lines were executed in the test
-is sent to Coveralls.io. At the very least, try to avoid test coverage
-decreasing if possible.
+PlasmaPy uses the coverage.py addon via Coveralls.io. At the end of
+every Travis CI testing session, information on which lines were
+executed in the test is sent to Coveralls.io. At the very least, try
+to avoid test coverage decreasing if possible.
 
-To run coverage.py locally, run ``coverage run -m pytest``, then generate a HTML
-description with ``coverage html``.
+To run coverage.py locally, run ``coverage run -m pytest``, then
+generate a HTML description with ``coverage html``.
 
 At the time of writing this, coverage.py has a known issue with being
 unable to check lines executed in Numba JIT compiled functions.
   
-Occasionally there will be some lines that do not require testing.  For
-example, testing exception handling for an `ImportError` when importing an
-external package would usually be impractical.  In these instances, we may end
-a line with `# coveralls: ignore` to indicate that these lines should be
-excluded from coverage reports (or add a line to `.coveragerc`).  This strategy
-should be used sparingly, since it is often better to explicitly test
-exceptions and warnings and to show the lines of code that are not tested.  
-
+Occasionally there will be some lines that do not require testing.
+For example, testing exception handling for an `ImportError` when
+importing an external package would usually be impractical.  In these
+instances, we may end a line with `# coveralls: ignore` to indicate
+that these lines should be excluded from coverage reports (or add a
+line to `.coveragerc`).  This strategy should be used sparingly, since
+it is often better to explicitly test exceptions and warnings and to
+show the lines of code that are not tested.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,8 @@ exclude = astropy_helpers,ah_bootstrap.py,ez_setup.py,setup.py,version.py,build
 
 [pydocstyle]
 convention = numpy
-add-select = D404
-source = 1
+add-select = D212,D402,D413
+add-ignore = D202,D302,D412
 
 [ah_bootstrap]
 auto_use = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,15 +34,31 @@ filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
 
-[pycodestyle]
-select = E226,E241,E242,E704,W504
-exclude = astropy_helpers,ah_bootstrap.py,ez_setup.py,setup.py,version.py,build
-
 [ah_bootstrap]
 auto_use = True
 
 [entry_points]
 astropy-package-template-example = packagename.example_mod:main
+
+[pycodestyle]
+
+# The error codes for pycodestyle include:
+#
+#  *E121: continuation line under-indented for hanging indent
+#  *E123: closing bracket does not match indentation of opening bracket’s line
+#  *E126: continuation line over-indented for hanging indent
+#  *E133: closing bracket is missing indentation
+#  *E226: missing whitespace around arithmetic operator
+#  *E241: multiple spaces after ","
+#  *E242: tab after ","
+#  *E704: multiple statements on one line (def)
+#  *W503: line break before binary operator
+#  *W504: line break after binary operator
+#
+# The error codes marked with an asterisk are ignored by default.
+
+select = E226,E241,E242,E704,W504
+exclude = astropy_helpers,ah_bootstrap.py,ez_setup.py,version.py,build
 
 [pydocstyle]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,18 @@
+[metadata]
+package_name = plasmapy
+description = "Python package for plasma physics"
+long_description = "PlasmaPy is a community-developed and community-driven Python package for plasma physics."
+author = PlasmaPy Community
+license = BSD 3-Clause
+url = http://www.plasmapy.org
+edit_on_github = False
+github_project = PlasmaPy/plasmapy
+# install_requires should be formatted as a comma-separated list, e.g.:
+# install_requires = astropy, scipy, matplotlib
+install_requires = numpy, scipy, astropy, cython, lmfit, matplotlib
+# version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
+version = 0.1.0dev0
+
 [build_sphinx]
 source-dir = docs
 build-dir = docs/_build
@@ -19,25 +34,17 @@ filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
 
+[pycodestyle]
+select = E226,E241,E242,E704,W504
+exclude = astropy_helpers,ah_bootstrap.py,ez_setup.py,setup.py,version.py,build
+
+[pydocstyle]
+convention = numpy
+add-select = D404
+source = 1
+
 [ah_bootstrap]
 auto_use = True
 
-[metadata]
-package_name = plasmapy
-description = "Python package for plasma physics"
-long_description = "PlasmaPy is a community-developed and community-driven Python package for plasma physics."
-author = The PlasmaPy Community
-license = BSD 3-Clause
-url = http://plasmapy.org
-edit_on_github = False
-github_project = plasmapy/plasmapy
-# install_requires should be formatted as a comma-separated list, e.g.:
-# install_requires = astropy, scipy, matplotlib
-install_requires = numpy, scipy, astropy, cython
-# version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 0.1.dev0
-
 [entry_points]
-
 astropy-package-template-example = packagename.example_mod:main
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,13 +38,40 @@ filterwarnings =
 select = E226,E241,E242,E704,W504
 exclude = astropy_helpers,ah_bootstrap.py,ez_setup.py,setup.py,version.py,build
 
-[pydocstyle]
-convention = numpy
-add-select = D212,D402,D413
-add-ignore = D202,D302,D412
-
 [ah_bootstrap]
 auto_use = True
 
 [entry_points]
 astropy-package-template-example = packagename.example_mod:main
+
+[pydocstyle]
+
+# The error codes for pydocstyle include:
+#
+#  *D107: Missing docstring in __init__
+#   D202: No blank lines allowed after function docstring
+#  *D203: 1 blank line required before class docstring
+#   D205: 1 blank line required between summary line and description
+#  *D212: Multi-line docstring summary should start at the first line
+#   D213: Multi-line docstring summary should start at the second line
+#   D302: Use u""" for Unicode docstrings
+#   D400: First line should end with a period
+#  *D402: First line should not be the function's "signature"
+#   D405: Section name should be properly capitalized
+#   D412: No blank lines allowed between a section header and its content
+#  *D413: Missing blank line after last section
+#
+# The error codes marked with an asterisk are ignored by default when
+# using the numpy convention. The full set of error codes are available at:
+#
+#    http://www.pydocstyle.org/en/latest/error_codes.html
+#
+# D302 is unnecessary as we are using Python 3.6+. Ignoring D202 allows blank
+# lines to be put on either side of code "paragraphs" at the beginning of a
+# function. D205 and D400 are ignored to allow the "one-liner" to exceed one
+# line, which is sometimes necessary for even concise descriptions of plasma
+# physics functions and classes.
+
+convention = numpy
+add-select = D402,D413
+add-ignore = D202,D205,D302,D400


### PR DESCRIPTION
The [pycodestyle](http://pycodestyle.readthedocs.io/en/latest/) and [pydocstyle](http://www.pydocstyle.org/en/2.1.1/) packages check code and docstrings against style guidelines.  This PR updates `setup.cfg` to include some configuration options for these two packages.  The code and docstring style customizations that I chose are not the ones that we want to go with, so other suggestions on ones to include or exclude would be great.  Alternatively, we could try these out and see how much we like or dislike them.  The most important things are consistency and readability.

The extra [pycodestyle error codes](http://pycodestyle.pycqa.org/en/latest/intro.html#error-codes) are:

>  - E226: missing whitespace around arithmetic operator
>  - E241: multiple spaces after ‘,’
>  - E242: tab after ','
>  - E704: multiple statements on one line (def)
>  - W504: line break after binary operator

The extra [pydocstyle error codes](http://www.pydocstyle.org/en/2.1.1/error_codes.html) are:
    
> Include:
>  - D212: Multi-line docstring summary should start at the first line
>  - D402: First line should not be the function's "signature"
>  - D413: Missing blank line after last section
>    
> Ignore:
>  - D202: No blank lines allowed after function docstring
>  - D302: Use u""" for Unicode docstrings  (not necessary for Python 3.6+)
>  - D412: No blank lines allowed between a section header and its content