### PR TITLE
Increase pycodestyle maximum line length to 99

### DIFF
--- a/docs/development/code_guide.rst
+++ b/docs/development/code_guide.rst
@@ -214,12 +214,12 @@ Coding Style
   * PEP 8 compliance may be checked locally using
     [pycodestyle](http://pycodestyle.pycqa.org/en/latest/).
 
-  * PEP 8 limits lines of code to 79 characters in order to improve
-    readability and allow side-by-side comparisons between code
-    displayed in different windows.  The maximum line length for Python
-    code in PlasmaPy is 89 characters, though lines longer than 79
-    characters should be used sparingly.  Docstrings and comments
-    should generally be limited to 72 characters.
+  * Line lengths should be chosen to maximize the readability and
+    elegance of the code.  The maximum line length for Python code in
+    PlasmaPy is 99 characters.
+
+  * Docstrings and comments should generally be limited to
+    72 characters.
 
 * Follow the existing coding style within a subpackage.
 

--- a/docs/development/code_guide.rst
+++ b/docs/development/code_guide.rst
@@ -8,7 +8,7 @@ followed during the development of PlasmaPy and affiliated packages.
 Code written for PlasmaPy must be compatible with Python 3.6 and
 later. Python 2 is not supported by PlasmaPy.
 
-PlasmaPy requires 
+PlasmaPy requires
 
 * Python 3.6 or later
 * Astropy 2.0 or later
@@ -104,7 +104,7 @@ You may now enter the environment via
 .. code-block:: bash
 
     source activate plasmapy
-  
+
 On Windows, skip the `source` part of the previous command.
 
 Virtualenv
@@ -214,14 +214,14 @@ Coding Style
   * PEP 8 compliance may be checked locally using
     [pycodestyle](http://pycodestyle.pycqa.org/en/latest/).
 
-  * Departures from PEP 8 compliance should be used sparingly and only
-    if there is a good reason.  A physics formula might be most
-    readable if the line exceeds the 79 character limit, for example,
-    if there are inconveniently placed parentheses that complicated
-    indenting.  However, departures from PEP 8 compliance should be
-    considered a last resort.
+  * PEP 8 limits lines of code to 79 characters in order to improve
+    readability and allow side-by-side comparisons between code
+    displayed in different windows.  The maximum line length for Python
+    code in PlasmaPy is 89 characters, though lines longer than 79
+    characters should be used sparingly.  Docstrings and comments
+    should generally be limited to 72 characters.
 
-* Follow the existing coding style within a subpackage.  
+* Follow the existing coding style within a subpackage.
 
 * Use standard abbreviations for imported packages when possible, such
   as ``import numpy as np``, ``import matplotlib as mpl``, ``import
@@ -231,7 +231,7 @@ Coding Style
   implementation code, but it can contain a docstring describing the
   module and code related to importing the module.  Any substantial
   functionality should be put into a separate file.
-  
+
 * There should be at most one pun per 1284 lines of code.
 
 Branches, commits, and pull requests
@@ -304,7 +304,7 @@ GitHub fork of PlasmaPy using
 
 .. code-block:: bash
 
-  git push origin *your-new-feature* 
+  git push origin *your-new-feature*
 
 or, more simply,
 
@@ -344,7 +344,7 @@ Suggestions on `how to write a git commit message
 * Wrap the body at 72 characters
 
 * Use the body to explain what and why vs. how
-  
+
 Documentation
 =============
 
@@ -381,7 +381,7 @@ Units
 
   * Functions should not accept floats when an Astropy Quantity is
     expected.  In particular, functions should not accept floats and
-    make the assumption that the value will be in SI units.  
+    make the assumption that the value will be in SI units.
 
   * A common convention among plasma physicists is to use
     electron-volts (eV) as a unit of temperature.  Strictly speaking,
@@ -391,7 +391,7 @@ Units
     ambiguity.
 
 * PlasmaPy uses the astropy.units package to give physical units to
-  values.  
+  values.
 
   * All units packages available in Python presently have some
     limitations, including incompatibility with some NumPy and SciPy

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ astropy-package-template-example = packagename.example_mod:main
 
 select = E226,E241,E242,E704,W504
 exclude = astropy_helpers,ah_bootstrap.py,ez_setup.py,version.py,build
-max-line-length = 89
+max-line-length = 99
 
 [pydocstyle]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ astropy-package-template-example = packagename.example_mod:main
 
 select = E226,E241,E242,E704,W504
 exclude = astropy_helpers,ah_bootstrap.py,ez_setup.py,version.py,build
+max-line-length = 89
 
 [pydocstyle]
 


### PR DESCRIPTION
The topic of the maximum line length came up in a recent code review session.  The PEP 8 limit is 79 characters because (1) really long lines adversely impact readability, (2) wrapping of long lines by editors disrupts the flow, and (3) this line length makes it easier to display two windows of code side by side.  The 79 character limit resulted in some awkward line breaks using backslashes in the Particle
class, whereas the code would be more readable were it just be on the same line.  Those of us who were present came to a consensus that we should increase the line length so that we can avoid awkward line breaks.

This commit increases the maximum line length by ten characters so that we can avoid these awkward line breaks while still avoiding really long lines.  Comments and docstrings should continue to be wrapped at 72 characters to make things more readable, and the 79 character limit is still suggested.