### PR TITLE
Update ReST formatting in docstrings

### DIFF
--- a/plasmapy/classes/plasma.py
+++ b/plasmapy/classes/plasma.py
@@ -9,7 +9,8 @@ mu0 = np.pi * 4.0e-7 * (u.newton / (u.amp**2))
 
 
 class Plasma():
-    """Core class for describing and calculating plasma parameters.
+    """
+    Core class for describing and calculating plasma parameters.
 
     Attributes
     ----------
@@ -49,6 +50,7 @@ class Plasma():
     domain_z : `astropy.units.Quantity`
         1D array of z-coordinates for the plasma domain. Must have
         units convertable to length.
+
     """
     @u.quantity_input(domain_x=u.m, domain_y=u.m, domain_z=u.m)
     def __init__(self, domain_x, domain_y, domain_z):

--- a/plasmapy/constants/__init__.py
+++ b/plasmapy/constants/__init__.py
@@ -1,10 +1,36 @@
-"""Physical and mathematical constants for use within PlasmaPy"""
+"""Physical and mathematical constants."""
 
 from numpy import pi
 
-from astropy.constants.si import (h, hbar, k_B, c, G, g0, m_p, m_n, m_e,
-                                  u, sigma_sb, e, eps0, N_A, R, Ryd, a0,
-                                  muB, mu0, sigma_T, au, pc, kpc, L_sun,
-                                  M_sun, R_sun, M_earth, R_earth)
+from astropy.constants.si import (
+    e,
+    mu0,
+    eps0,
+    k_B,
+    c,
+    G,
+    h,
+    hbar,
+    m_p,
+    m_n,
+    m_e,
+    u,
+    sigma_sb,
+    N_A,
+    R,
+    Ryd,
+    a0,
+    muB,
+    sigma_T,
+    au,
+    pc,
+    kpc,
+    g0,
+    L_sun,
+    M_sun,
+    R_sun,
+    M_earth,
+    R_earth,
+)
 
 from astropy.constants import atm

--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -7,19 +7,22 @@ import astropy.units as u
 
 
 class Probe():
-    r"""Class containing various Langmuir probe properties. For the moment
-    cylindrical probes are assumed as spherical ones are generally impractical
-    to make.
+    r"""
+    Class containing various Langmuir probe properties.
+
+    For the moment cylindrical probes are assumed as spherical ones are
+    generally impractical to make.
 
     Attributes
     ----------
-    area : Quantity or array
+    area : ~astropy.units.Quantity or ~numpy.ndarray
         Area or array of areas of the probe(s) in units convertible to m^2.
 
-    config : string, optional
-        Electrode configuration. Possible options are 'single' (default),
-        'double', 'double-asym', 'triple', 'tetra', 'penta'. The electrode
-        configuration must correspond to the number of areas provided.
+    config : str, optional
+        Electrode configuration. Possible options are `'single'`
+        (default), `'double'`, `'double-asym'`, `'triple'`, `'tetra'`,
+        `'penta'`. The electrode configuration must correspond to the
+        number of areas provided.
 
     """
     def __init__(self, area=u.m**2, config='single'):
@@ -31,33 +34,34 @@ class Probe():
 def swept_probe_analysis(potential_sweep,
                          measured_current,
                          probe,
-                         ion='H',
+                         ion='p+',
                          method='maxwellian',
                          smoothing=None,
                          polyorder=3):
-    r"""Performs a Langmuir analysis of a given probe V-I profile in order to
+    r"""
+    Perform a Langmuir analysis of a given probe V-I profile in order to
     obtain various plasma parameters.
 
     Parameters
     ----------
-    potential_sweep : Quantity
+    potential_sweep : ~astropy.units.Quantity
         The swept electric potential applied to the probe in units
         convertible to V.
 
-    measured_current : Quantity
+    measured_current : ~astropy.units.Quantity
         The corresponding measured current in units convertible to A.
 
-    probe : Probe
+    probe : ~plasmapy.diagnostics.langmuir.Probe
         An instance of the Probe class containing probe properties.
 
-    ion : string, optional
+    ion : str, optional
         Representation of the ion species. Defaults to Hydrogen.
 
-    method : string, optional
+    method : str, optional
         The preferred analysis method. Options are 'maxwellian' (default) and
         'OML', which applies Orbital Motion Limit theory.
 
-    smoothing : string, optional
+    smoothing : str, optional
         The smoothing method applied to the measured current in order to
         obtain clean derivatives. Options are None (default) and 'savgol',
         which uses scipy.signal.savgol_filter. When `smoothing` is 'savgol',
@@ -69,77 +73,81 @@ def swept_probe_analysis(potential_sweep,
 
     Returns
     -------
-    T_e : Quantity
+    T_e : ~astropy.units.Quantity
         Best estimate of the electron temperature in units of eV.
 
-    n_e : Quantity
+    n_e : ~astropy.units.Quantity
         Best estimate of the electron density in units of m^-3.
 
-    n_i : Quantity
+    n_i : ~astropy.units.Quantity
         Best estimate of the ion density in units of m^-3. Equal to n_e
         unless the OML method is used.
 
-    V_F : Quantity
+    V_F : ~astropy.units.Quantity
         Best estimate of the floating potential in units of V.
 
-    V_P : Quantity
+    V_P : ~astropy.units.Quantity
         Best estimate of the plasma potential in units of V.
 
     Notes
     -----
-    Due to the use of different methods to obtain n_e and n_i, the ratio
+    Due to the use of different methods to obtain `n_e` and `n_i`, the ratio
     between these does not necessarily give an accurate average ionization.
     """
-    return
+    raise NotImplementedError
 
 
 def obtain_EEDF(potential_sweep, measured_current, probe):
-    r"""Obtains the Electron Energy Distribution Function of the plasma
+    r"""
+    Obtain the Electron Energy Distribution Function of the plasma
     from the second derivative of the measured current response using
     Druyvestein's equations.
 
     Parameters
     ----------
-    potential_sweep : Quantity
+    potential_sweep : ~astropy.units.Quantity
         The swept electric potential applied to the probe in units
         convertible to V.
 
-    measured_current : Quantity
+    measured_current : ~astropy.units.Quantity
         The corresponding measured current in units convertible to A.
 
-    probe : Probe
+    probe : ~plasmapy.diagnostics.langmuir.Probe
         An instance of the Probe class containing probe properties.
 
     Returns
     -------
-    EEDF : ndarray
+    EEDF : numpy.ndarray
         Array containing electron energies in units of eV and their
         corresponding probabilities in units of eV^-1 m^-3.
     """
-    return
+    raise NotImplementedError
 
 
 def obtain_EEPF(potential_sweep, measured_current, probe):
-    r"""Obtains the Electron Energy Probability Function of the plasma
+    r"""
+    Obtain the Electron Energy Probability Function of the plasma
     from the second derivative of the measured current response using
     Druyvestein's equations.
 
     Parameters
     ----------
-    potential_sweep : Quantity
+    potential_sweep : ~astropy.units.Quantity
         The swept electric potential applied to the probe in units
         convertible to V.
 
-    measured_current : Quantity
+    measured_current : ~astropy.units.Quantity
         The corresponding measured current in units convertible to A.
 
-    probe : Probe
-        An instance of the Probe class containing probe properties.
+    probe : ~plasmapy.diagnostics.langmuir.Probe
+        An instance of the `~plasmapy.diagnostics.langmuir.Probe`
+        class containing probe properties.
 
     Returns
     -------
-    EEPF : ndarray
+    EEPF : numpy.ndarray
         Array of shape (2, N) containing electron energies in units of eV and
         their corresponding probabilities in units of eV^-3/2 m^-3.
+
     """
-    return
+    raise NotImplementedError

--- a/plasmapy/mathematics/mathematics.py
+++ b/plasmapy/mathematics/mathematics.py
@@ -6,6 +6,8 @@ from astropy import units as u
 from mpmath import polylog
 from scipy.special import wofz as Faddeeva_function
 
+# TODO: Add type hint annotations to this module.
+
 
 def plasma_dispersion_func(zeta):
     r"""
@@ -13,24 +15,27 @@ def plasma_dispersion_func(zeta):
 
     Parameters
     ----------
-    zeta : complex, int, float, ndarray, or Quantity
+    zeta : complex, int, float, ~numpy.ndarray, or ~astropy.units.Quantity
         Argument of plasma dispersion function.
 
     Returns
     -------
-    Z : complex, float, or ndarray
+    Z : complex, float, or ~numpy.ndarray
         Value of plasma dispersion function.
 
     Raises
     ------
     TypeError
-        If the argument is invalid.
-    UnitsError
-        If the argument is a Quantity but is not dimensionless
-    ValueError
-        If the argument is not entirely finite
+        If the argument is of an invalid type.
 
-    See also
+    ~astropy.units.UnitsError
+        If the argument is a `~astropy.units.Quantity` but is not
+        dimensionless.
+
+    ValueError
+        If the argument is not entirely finite.
+
+    See Also
     --------
     plasma_dispersion_func_deriv
 
@@ -88,28 +93,32 @@ def plasma_dispersion_func(zeta):
 
 
 def plasma_dispersion_func_deriv(zeta):
-    r"""Calculate the derivative of the plasma dispersion function
+    r"""
+    Calculate the derivative of the plasma dispersion function.
 
     Parameters
     ----------
-    zeta : complex, int, float, ndarray, or Quantity
+    zeta : complex, int, float, ~numpy.ndarray, or ~astropy.units.Quantity
         Argument of plasma dispersion function.
 
     Returns
     -------
-    Zprime : complex, int, float, or ndarray
+    Zprime : complex, int, float, or ~numpy.ndarray
         First derivative of plasma dispersion function.
 
     Raises
     ------
     TypeError
         If the argument is invalid.
-    UnitsError
-        If the argument is a Quantity but is not dimensionless
-    ValueError
-        If the argument is not entirely finite
 
-    See also
+    ~astropy.units.UnitsError
+        If the argument is a `~astropy.units.Quantity` but is not
+        dimensionless.
+
+    ValueError
+        If the argument is not entirely finite.
+
+    See Also
     --------
     plasma_dispersion_func
 
@@ -157,29 +166,33 @@ def plasma_dispersion_func_deriv(zeta):
 
 
 def Fermi_integral(x, j):
-    r"""Calculate the complete Fermi-Dirac integral.
+    r"""
+    Calculate the complete Fermi-Dirac integral.
 
     Parameters
     ----------
-    x : Quantity
+    x : ~astropy.units.Quantity
         Argument of the Fermi-Dirac integral function.
 
-    j : Quantity
+    j : ~astropy.units.Quantity
         Order/index of the Fermi-Dirac integral function.
 
     Returns
     -------
-    integral : Quantity, complex
+    integral : ~astropy.units.Quantity, complex
         Complete Fermi-Dirac integral for given argument and order.
 
     Raises
     ------
     TypeError
         If the argument is invalid.
-    UnitsError
-        If the argument is a Quantity but is not dimensionless
+
+    ~astropy.units.UnitsError
+        If the argument is a `~astropy.units.Quantity` but is not
+        dimensionless.
+
     ValueError
-        If the argument is not entirely finite
+        If the argument is not entirely finite.
 
     See also
     --------

--- a/plasmapy/physics/__init__.py
+++ b/plasmapy/physics/__init__.py
@@ -1,6 +1,3 @@
-# 'physics' is a tentative name for this subpackage.  Another
-# possibility is 'plasma'.  The organization is to be decided by v0.1.
-
 from .parameters import (Alfven_speed,
                          ion_sound_speed,
                          thermal_speed,

--- a/plasmapy/physics/dielectric.py
+++ b/plasmapy/physics/dielectric.py
@@ -7,7 +7,7 @@ from ..constants import (pi, m_e, c, mu0, e, eps0)
 from .parameters import gyrofrequency, plasma_frequency
 
 r"""
-Values should be returned as an Astropy Quantity in SI units.
+Values should be returned as a `~astropy.units.Quantity` in SI units.
 """
 
 
@@ -18,37 +18,37 @@ Values should be returned as an Astropy Quantity in SI units.
 def cold_plasma_permittivity_SDP(B, species, n, omega):
     r"""
     Magnetized Cold Plasma Dielectric Permittivity Tensor Elements.
+
     Elements (S, D, P) are given in the "Stix" frame, ie. with B // z.
 
     The :math:`\exp(-i \omega t)` time-harmonic convention is assumed.
-
 
     Parameters
     ----------
     B : ~astropy.units.Quantity
         Magnetic field magnitude in units convertible to tesla.
 
-    species : List of string
+    species : list of str
         List of the plasma particle species
         e.g.: ['e', 'D+'] or ['e', 'D+', 'He+'].
 
-    n : List of ~astropy.units.Quantity
-        List of species density in units convertible to per cubic meter
+    n : list of ~astropy.units.Quantity
+        `list` of species density in units convertible to per cubic meter
         The order of the species densities should follow species.
 
     omega : ~astropy.units.Quantity
-        Electromagnetic wave frequency in rad/s
+        Electromagnetic wave frequency in rad/s.
 
     Returns
     -------
     S : ~astropy.units.Quantity
-        S ("Sum") dielectric tensor element
+        S ("Sum") dielectric tensor element.
 
     D : ~astropy.units.Quantity
-        D ("Difference") dielectric tensor element
+        D ("Difference") dielectric tensor element.
 
     P : ~astropy.units.Quantity
-        P ("Plasma") dielectric tensor element
+        P ("Plasma") dielectric tensor element.
 
     Notes
     -----
@@ -111,46 +111,46 @@ def cold_plasma_permittivity_SDP(B, species, n, omega):
 def cold_plasma_permittivity_LRP(B, species, n, omega):
     r"""
     Magnetized Cold Plasma Dielectric Permittivity Tensor Elements.
+
     Elements (L, R, P) are given in the "rotating" basis, ie. in the basis
     :math:`(\mathbf{u}_{+}, \mathbf{u}_{-}, \mathbf{u}_z)`,
     where the tensor is diagonal and with B // z.
 
     The :math:`\exp(-i \omega t)` time-harmonic convention is assumed.
 
-
     Parameters
     ----------
     B : ~astropy.units.Quantity
         Magnetic field magnitude in units convertible to tesla.
 
-    species : List of string
-        List of the plasma particle species
-        e.g.: ['e', 'D+'] or ['e', 'D+', 'He+'].
+    species : list of str
+        The plasma particle species (e.g.: `['e', 'D+']` or
+        `['e', 'D+', 'He+']`.
 
-    n : List of ~astropy.units.Quantity
-        List of species density in units convertible to per cubic meter
+    n : list of ~astropy.units.Quantity
+        `list` of species density in units convertible to per cubic meter.
         The order of the species densities should follow species.
 
     omega : ~astropy.units.Quantity
-        Electromagnetic wave frequency in rad/s
+        Electromagnetic wave frequency in rad/s.
 
     Returns
     -------
     L : ~astropy.units.Quantity
-        L ("Left") Left-handed circularly polarization tensor element
+        L ("Left") Left-handed circularly polarization tensor element.
 
     R : ~astropy.units.Quantity
-        R ("Right") Right-handed circularly polarization tensor element
+        R ("Right") Right-handed circularly polarization tensor element.
 
     P : ~astropy.units.Quantity
-        P ("Plasma") dielectric tensor element
+        P ("Plasma") dielectric tensor element.
 
     Notes
     -----
     In the rotating frame defined by
-     :math:`(\mathbf{u}_{+}, \mathbf{u}_{-}, \mathbf{u}_z)`
+    :math:`(\mathbf{u}_{+}, \mathbf{u}_{-}, \mathbf{u}_z)`
     with :math:`\mathbf{u}_{\pm}=(\mathbf{u}_x \pm \mathbf{u}_y)/\sqrt{2}`,
-     the dielectric tensor takes a diagonal form with elements L, R, P with:
+    the dielectric tensor takes a diagonal form with elements L, R, P with:
 
     .. math::
         L = 1 - \sum_s

--- a/plasmapy/physics/dimensionless.py
+++ b/plasmapy/physics/dimensionless.py
@@ -1,6 +1,7 @@
 """ 
-Module of dimensionless plasma parameters. These are especially
-important for determining what regime a plasma is in. (e.g., turbulent,
-quantum, collisional, etc.)
-"""
+Module of dimensionless plasma parameters.
 
+These are especially important for determining what regime a plasma is
+in. (e.g., turbulent, quantum, collisional, etc.).
+
+"""

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -19,27 +19,27 @@ def Maxwellian_1D(v,
 
     Parameters
     ----------
-    v: Quantity
+    v: ~astropy.units.Quantity
         The velocity in units convertible to m/s.
 
-    T: Quantity
+    T: ~astropy.units.Quantity
         The temperature in Kelvin.
 
-    particle: string, optional
-        Representation of the particle species(e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for :math:`He_4^{+1}`
+    particle: str, optional
+        Representation of the particle species(e.g., `'p'` for protons, `'D+'`
+        for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4),
         which defaults to electrons.
 
-    V_drift: Quantity, optional
+    V_drift: ~astropy.units.Quantity, optional
         The drift velocity in units convertible to m/s.
 
-    vTh: Quantity, optional
+    vTh: ~astropy.units.Quantity, optional
         Thermal velocity (most probable) in m/s. This is used for
         optimization purposes to avoid re-calculating vTh, for example
         when integrating over velocity-space.
 
-    units: string, optional
+    units: str, optional
         Selects whether to run function with units and unit checks (when
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
@@ -47,7 +47,7 @@ def Maxwellian_1D(v,
 
     Returns
     -------
-    f : Quantity
+    f : ~astropy.units.Quantity
         Probability in Velocity^-1, normalized so that
         :math:`\int_{-\infty}^{+\infty} f(v) dv = 1`.
 
@@ -57,7 +57,7 @@ def Maxwellian_1D(v,
         The parameter arguments are not Quantities and
         cannot be converted into Quantities.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the parameters are not in appropriate units.
 
     ValueError
@@ -136,44 +136,44 @@ def Maxwellian_velocity_3D(vx,
                            units="units"):
     r"""
     Return the probability of finding a particle with velocity components
-    `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature
+    `vx`, `vy`, and `vz`in m/s in an equilibrium plasma of temperature
     `T` which follows the 3D Maxwellian distribution function. This
     function assumes Cartesian coordinates.
 
     Parameters
     ----------
-    vx: Quantity
-        The velocity in x-direction units convertible to m/s
+    vx: ~astropy.units.Quantity
+        The velocity in x-direction units convertible to m/s.
 
-    vy: Quantity
-        The velocity in y-direction units convertible to m/s
+    vy: ~astropy.units.Quantity
+        The velocity in y-direction units convertible to m/s.
 
-    vz: Quantity
-        The velocity in z-direction units convertible to m/s
+    vz: ~astropy.units.Quantity
+        The velocity in z-direction units convertible to m/s.
 
-    T: Quantity
-        The temperature, preferably in Kelvin
+    T: ~astropy.units.Quantity
+        The temperature, preferably in Kelvin.
 
-    particle: string, optional
-        Representation of the particle species (e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for :math:`He_4^{+1}`
+    particle: str, optional
+        Representation of the particle species (e.g., `'p'` for protons, `'D+'`
+        for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4), which defaults to electrons.
 
-    Vx_drift: Quantity, optional
-        The drift velocity in x-direction units convertible to m/s
+    Vx_drift: ~astropy.units.Quantity, optional
+        The drift velocity in x-direction units convertible to m/s.
 
-    Vy_drift: Quantity, optional
-        The drift velocity in y-direction units convertible to m/s
+    Vy_drift: ~astropy.units.Quantity, optional
+        The drift velocity in y-direction units convertible to m/s.
 
-    Vz_drift: Quantity, optional
-        The drift velocity in z-direction units convertible to m/s
+    Vz_drift: ~astropy.units.Quantity, optional
+        The drift velocity in z-direction units convertible to m/s.
 
-    vTh: Quantity, optional
+    vTh: ~astropy.units.Quantity, optional
         Thermal velocity (most probable) in m/s. This is used for
-        optimization purposes to avoid re-calculating vTh, for example
+        optimization purposes to avoid re-calculating `vTh`, for example
         when integrating over velocity-space.
 
-    units: string, optional
+    units: str, optional
         Selects whether to run function with units and unit checks (when
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
@@ -181,17 +181,17 @@ def Maxwellian_velocity_3D(vx,
 
     Returns
     -------
-    f : Quantity
-        probability in Velocity^-1, normalized so that
+    f : ~astropy.units.Quantity
+        Probability in Velocity^-1, normalized so that
         :math:`\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1`.
 
     Raises
     ------
     TypeError
-        The parameter arguments are not Quantities and
-        cannot be converted into Quantities.
+        A parameter argument is not a `~astropy.units.Quantity` and
+        cannot be converted into a `~astropy.units.Quantity`.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the parameters is not in appropriate units.
 
     ValueError
@@ -201,8 +201,8 @@ def Maxwellian_velocity_3D(vx,
     Notes
     -----
     In one dimension, the Maxwellian speed distribution function describing
-    the distribution of particles with speed v in a plasma with temperature T
-    is given by:
+    the distribution of particles with speed :math:`v` in a plasma with
+    temperature :math:`T` is given by:
 
     .. math::
 
@@ -294,26 +294,26 @@ def Maxwellian_speed_1D(v,
 
     Parameters
     ----------
-    v: Quantity
+    v: ~astropy.units.Quantity
         The speed in units convertible to m/s.
 
-    T: Quantity
+    T: ~astropy.units.Quantity
         The temperature, preferably in Kelvin.
 
-    particle: string, optional
-        Representation of the particle species(e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for :math:`He_4^{+1}`
+    particle: str, optional
+        Representation of the particle species(e.g., `'p'` for protons, `'D+'`
+        for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4), which defaults to electrons.
 
-    V_drift: Quantity
+    V_drift: ~astropy.units.Quantity
         The drift speed in units convertible to m/s.
 
-    vTh: Quantity, optional
+    vTh: ~astropy.units.Quantity, optional
         Thermal velocity (most probable) in m/s. This is used for
         optimization purposes to avoid re-calculating vTh, for example
         when integrating over velocity-space.
 
-    units: string, optional
+    units: str, optional
         Selects whether to run function with units and unit checks (when
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
@@ -321,7 +321,7 @@ def Maxwellian_speed_1D(v,
 
     Returns
     -------
-    f : Quantity
+    f : ~astropy.units.Quantity
         Probability in speed^-1, normalized so that
         :math:`\int_{0}^{\infty} f(v) dv = 1`.
 
@@ -331,7 +331,7 @@ def Maxwellian_speed_1D(v,
         The parameter arguments are not Quantities and
         cannot be converted into Quantities.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the parameters is not in appropriate units.
 
     ValueError
@@ -349,7 +349,6 @@ def Maxwellian_speed_1D(v,
        f(v) = 4 \pi v^2 (\pi * v_Th^2)^{-3/2} \exp(-(v - V_{drift})^2 / v_Th^2)
 
     where :math:`v_Th = \sqrt(2 k_B T / m)` is the thermal speed.
-
 
     Example
     -------
@@ -413,44 +412,44 @@ def Maxwellian_speed_3D(vx,
                         units="units"):
     r"""
     Return the probability of finding a particle with speed components
-    `v_x`, `v_y`, and `v_z`in m/s in an equilibrium plasma of temperature
+    `vx`, `vy`, and `vz`in m/s in an equilibrium plasma of temperature
     `T` which follows the 3D Maxwellian distribution function. This
     function assumes Cartesian coordinates.
 
     Parameters
     ----------
-    vx: Quantity
+    vx: ~astropy.units.Quantity
         The speed in x-direction units convertible to m/s.
 
-    vy: Quantity
+    vy: ~astropy.units.Quantity
         The speed in y-direction units convertible to m/s.
 
-    vz: Quantity
+    vz: ~astropy.units.Quantity
         The speed in z-direction units convertible to m/s.
 
-    T: Quantity
+    T: ~astropy.units.Quantity
         The temperature, preferably in Kelvin.
 
-    particle: string, optional
+    particle: str, optional
         Representation of the particle species(e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for :math:`He_4^{+1}`
         (singly ionized helium-4), which defaults to electrons.
 
-    Vx_drift: Quantity
+    Vx_drift: ~astropy.units.Quantity
         The drift speed in x-direction units convertible to m/s.
 
-    Vy_drift: Quantity
+    Vy_drift: ~astropy.units.Quantity
         The drift speed in y-direction units convertible to m/s.
 
-    Vz_drift: Quantity
+    Vz_drift: ~astropy.units.Quantity
         The drift speed in z-direction units convertible to m/s.
 
-    vTh: Quantity, optional
+    vTh: ~astropy.units.Quantity, optional
         Thermal velocity (most probable) in m/s. This is used for
         optimization purposes to avoid re-calculating vTh, for example
         when integrating over velocity-space.
 
-    units: string, optional
+    units: str, optional
         Selects whether to run function with units and unit checks (when
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
@@ -458,17 +457,17 @@ def Maxwellian_speed_3D(vx,
 
     Returns
     -------
-    f : Quantity
+    f : ~astropy.units.Quantity
         Probability in speed^-1, normalized so that:
         :math:`\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1`.
 
     Raises
     ------
     TypeError
-        The parameter arguments are not Quantities and
-        cannot be converted into Quantities.
+        A parameter argument is not a `~astropy.units.Quantity` and
+        cannot be converted into a `~astropy.units.Quantity`.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the parameters is not in appropriate units.
 
     ValueError
@@ -478,8 +477,8 @@ def Maxwellian_speed_3D(vx,
     Notes
     -----
     In one dimension, the Maxwellian speed distribution function describing
-    the distribution of particles with speed v in a plasma with temperature T
-    is given by:
+    the distribution of particles with speed :math:`v` in a plasma with
+    temperature :math:`T` is given by:
 
     .. math::
 
@@ -578,40 +577,40 @@ def kappa_velocity_1D(v,
                       vTh=np.nan,
                       units="units"):
     r"""
-    Returns the probability at the velocity `v` in m/s
+    Return the probability at the velocity `v` in m/s
     to find a particle `particle` in a plasma of temperature `T`
     following the Kappa distribution function. The slope of the
     tail of the Kappa distribution function is set by 'kappa', which
-    must be greater than 1/2.
+    must be greater than :math:`1/2`.
 
     Parameters
     ----------
-    v: Quantity
+    v: ~astropy.units.Quantity
         The velocity in units convertible to m/s.
 
-    T: Quantity
+    T: ~astropy.units.Quantity
         The temperature in Kelvin.
 
-    kappa: Quantity
+    kappa: ~astropy.units.Quantity
         The kappa parameter is a dimensionless number which sets the slope
         of the energy spectrum of suprathermal particles forming the tail
         of the Kappa velocity distribution function. Kappa must be greater
-        than 3/2.
+        than :math:`3/2`.
 
-    particle: string, optional
-        Representation of the particle species(e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for :math:`He_4^{+1}`
+    particle: str, optional
+        Representation of the particle species(e.g., `'p` for protons, `'D+'`
+        for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4), which defaults to electrons.
 
-    V_drift: Quantity, optional
-        The drift velocity in units convertible to m/s
+    V_drift: ~astropy.units.Quantity, optional
+        The drift velocity in units convertible to m/s.
 
-    vTh: Quantity, optional
+    vTh: ~astropy.units.Quantity, optional
         Thermal velocity (most probable) in m/s. This is used for
-        optimization purposes to avoid re-calculating vTh, for example
+        optimization purposes to avoid re-calculating `vTh`, for example
         when integrating over velocity-space.
 
-    units: string, optional
+    units: str, optional
         Selects whether to run function with units and unit checks (when
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
@@ -619,17 +618,17 @@ def kappa_velocity_1D(v,
 
     Returns
     -------
-    f : Quantity
+    f : ~astropy.units.Quantity
         probability in Velocity^-1, normalized so that
         :math:`\int_{-\infty}^{+\infty} f(v) dv = 1`.
 
     Raises
     ------
     TypeError
-        The parameter arguments are not Quantities and
-        cannot be converted into Quantities.
+        A parameter argument is not a `~astropy.units.Quantity` and
+        cannot be converted into a `~astropy.units.Quantity`.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the parameters is not in appropriate units.
 
     ValueError
@@ -639,8 +638,9 @@ def kappa_velocity_1D(v,
     Notes
     -----
     In one dimension, the Kappa velocity distribution function describing
-    the distribution of particles with speed v in a plasma with temperature T
-    and suprathermal parameter kappa is given by:
+    the distribution of particles with speed :math:`v` in a plasma with
+    temperature :math:`T` and suprathermal parameter :math:`\kappa` is
+    given by:
 
     .. math::
 
@@ -650,10 +650,10 @@ def kappa_velocity_1D(v,
     where :math:`v_Th,\kappa` is the kappa thermal speed
     and :math:`A_\kappa = \frac{1}{\sqrt{\pi} \kappa^{3/2} v_Th,\kappa^2
     \frac{\Gamma(\kappa + 1)}{\Gamma(\kappa - 1/2)}}`
-    is the normalization constant
+    is the normalization constant.
 
-    As kappa approaches infinity, the kappa distribution function converges
-    to the Maxwellian distribution function.
+    As :math:`\kappa` approaches infinity, the kappa distribution function
+    converges to the Maxwellian distribution function.
 
     Examples
     --------
@@ -726,44 +726,44 @@ def kappa_velocity_3D(vx,
 
     Parameters
     ----------
-    vx: Quantity
+    vx: ~astropy.units.Quantity
         The velocity in x-direction units convertible to m/s.
 
-    vy: Quantity
+    vy: ~astropy.units.Quantity
         The velocity in y-direction units convertible to m/s.
 
-    vz: Quantity
+    vz: ~astropy.units.Quantity
         The velocity in z-direction units convertible to m/s.
 
-    T: Quantity
+    T: ~astropy.units.Quantity
         The temperature, preferably in Kelvin.
 
-    kappa: Quantity
+    kappa: ~astropy.units.Quantity
         The kappa parameter is a dimensionless number which sets the slope
         of the energy spectrum of suprathermal particles forming the tail
         of the Kappa velocity distribution function. Kappa must be greater
-        than 3/2.
+        than :math:`3/2`.
 
-    particle: string, optional
+    particle: str, optional
         Representation of the particle species(e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for :math:`He_4^{+1}` : singly ionized
         helium-4), which defaults to electrons.
 
-    Vx_drift: Quantity, optional
+    Vx_drift: ~astropy.units.Quantity, optional
         The drift velocity in x-direction units convertible to m/s.
 
-    Vy_drift: Quantity, optional
+    Vy_drift: ~astropy.units.Quantity, optional
         The drift velocity in y-direction units convertible to m/s.
 
-    Vz_drift: Quantity, optional
+    Vz_drift: ~astropy.units.Quantity, optional
         The drift velocity in z-direction units convertible to m/s.
 
-    vTh: Quantity, optional
+    vTh: ~astropy.units.Quantity, optional
         Thermal velocity (most probable) in m/s. This is used for
-        optimization purposes to avoid re-calculating vTh, for example
+        optimization purposes to avoid re-calculating `vTh`, for example
         when integrating over velocity-space.
 
-    units: string, optional
+    units: str, optional
         Selects whether to run function with units and unit checks (when
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
@@ -771,7 +771,7 @@ def kappa_velocity_3D(vx,
 
     Returns
     -------
-    f : Quantity
+    f : ~astropy.units.Quantity
         probability in Velocity^-1, normalized so that:
         :math:`\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1`
 
@@ -781,7 +781,7 @@ def kappa_velocity_3D(vx,
         The parameter arguments are not Quantities and
         cannot be converted into Quantities.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the parameters is not in appropriate units.
 
     ValueError
@@ -791,8 +791,8 @@ def kappa_velocity_3D(vx,
     Notes
     -----
     In three dimensions, the Kappa velocity distribution function describing
-    the distribution of particles with speed v in a plasma with temperature T
-    and suprathermal parameter kappa is given by:
+    the distribution of particles with speed :math:`v` in a plasma with
+    temperature :math:`T` and suprathermal parameter :math:`\kappa` is given by:
 
     .. math::
 
@@ -804,8 +804,8 @@ def kappa_velocity_3D(vx,
     \frac{\Gamma(\kappa + 1)}{\Gamma(\kappa - 1/2) \Gamma(3/2)}` is the
     normalization constant.
 
-    As kappa approaches infinity, the kappa distribution function converges
-    to the Maxwellian distribution function.
+    As :math:`\kappa` approaches infinity, the kappa distribution function
+    converges to the Maxwellian distribution function.
 
     See also
     --------

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -87,13 +87,14 @@ def Alfven_speed(B, density, ion="p+", z_mean=None):
         Either the ion number density in units convertible to 1 / m**3,
         or the mass density in units convertible to kg / m**3.
 
-    ion : string, optional
-        Representation of the ion species (e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for singly ionized helium-4),
-        which defaults to protons.  If no charge state information is
-        provided, then the ions are assumed to be singly charged.
+    ion : str, optional
+        Representation of the ion species (e.g., `'p'` for protons,
+        `'D+'` for deuterium, or `'He-4 +1'` for singly ionized
+        helium-4), which defaults to protons.  If no charge state
+        information is provided, then the ions are assumed to be
+        singly charged.
 
-    z_mean : Quantity, optional
+    z_mean : ~astropy.units.Quantity, optional
         The average ionization (arithmetic mean) for a plasma where the
         a macroscopic description is valid. If this quantity is not
         given then the atomic charge state (integer) of the ion
@@ -102,7 +103,7 @@ def Alfven_speed(B, density, ion="p+", z_mean=None):
 
     Returns
     -------
-    V_A : Quantity with units of velocity
+    V_A : ~astropy.units.Quantity with units of velocity
         The Alfven velocity of the plasma in units of meters per second.
 
     Raises
@@ -111,10 +112,10 @@ def Alfven_speed(B, density, ion="p+", z_mean=None):
         The magnetic field and density arguments are not Quantities and
         cannot be converted into Quantities.
 
-    u.UnitConversionError
+    ~astropy.units.UnitConversionError
         If the magnetic field or density is not in appropriate units.
 
-    RelativityError
+    ~plasmapy.utils.RelativityError
         If the Alfven velocity is greater than or equal to the speed of light
 
     ValueError
@@ -126,7 +127,7 @@ def Alfven_speed(B, density, ion="p+", z_mean=None):
 
     Warns
     -----
-    RelativityWarning
+    ~plasmapy.utils.RelativityWarning
         If the Alfven velocity exceeds 10% of the speed of light
 
 
@@ -220,35 +221,35 @@ def ion_sound_speed(*ignore,
 
     Parameters
     ----------
-    T_e : ~astropy.units.Quantity, optional
+    T_e : ~astropy.units.Quantity, optional, keyword-only
         Electron temperature in units of temperature or energy per
         particle.  If this is not given, then the electron temperature
-        is assumed to be zero.  If only one temperature is entered, it
-        is assumed to be the electron temperature.
+        is assumed to be zero.
 
-    T_i : ~astropy.units.Quantity, optional
+    T_i : ~astropy.units.Quantity, optional, keyword-only
         Ion temperature in units of temperature or energy per
         particle.  If this is not given, then the ion temperature is
         assumed to be zero.
 
-    gamma_e : float or int
+    gamma_e : float or int, keyword-only
         The adiabatic index for electrons, which defaults to 1.  This
         value assumes that the electrons are able to equalize their
         temperature rapidly enough that the electrons are effectively
         isothermal.
 
-    gamma_i : float or int
+    gamma_i : float or int, keyword-only
         The adiabatic index for ions, which defaults to 3.  This value
         assumes that ion motion has only one degree of freedom, namely
         along magnetic field lines.
 
-    ion : string, optional
-        Representation of the ion species (e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for singly ionized helium-4),
-        which defaults to protons.  If no charge state information is
-        provided, then the ions are assumed to be singly charged.
+    ion : str, optional, keyword-only
+        Representation of the ion species (e.g., `'p'` for protons,
+        `'D+'` for deuterium, or 'He-4 +1' for singly ionized
+        helium-4), which defaults to protons.  If no charge state
+        information is provided, then the ions are assumed to be
+        singly charged.
 
-    z_mean : Quantity, optional
+    z_mean : ~astropy.units.Quantity, optional, keyword-only
         The average ionization (arithmetic mean) for a plasma where the
         a macroscopic description is valid. If this quantity is not
         given then the atomic charge state (integer) of the ion
@@ -269,10 +270,10 @@ def ion_sound_speed(*ignore,
     ValueError
         If the ion mass, adiabatic index, or temperature are invalid.
 
-    plasmapy.utils.PhysicsError
+    ~plasmapy.utils.PhysicsError
         If an adiabatic index is less than one.
 
-    units.UnitConversionError
+    ~astropy.units.UnitConversionError
         If the temperature is in incorrect units.
 
     UserWarning
@@ -379,15 +380,15 @@ def thermal_speed(T, particle="e-", method="most_probable"):
     T : ~astropy.units.Quantity
         The particle temperature in either kelvin or energy per particle
 
-    particle : string, optional
-        Representation of the particle species (e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for singly ionized helium-4),
+    particle : str, optional
+        Representation of the particle species (e.g., `'p'` for protons, `'D+'`
+        for deuterium, or `'He-4 +1'` for singly ionized helium-4),
         which defaults to electrons.  If no charge state information is
         provided, then the particles are assumed to be singly charged.
 
-    method : string, optional
+    method : str, optional
         Method to be used for calculating the thermal speed. Options are
-        'most_probable' (default), 'rms', and 'mean_magnitude'.
+        `'most_probable'` (default), `'rms'`, and `'mean_magnitude'`.
 
     Returns
     -------
@@ -397,9 +398,9 @@ def thermal_speed(T, particle="e-", method="most_probable"):
     Raises
     ------
     TypeError
-        The particle temperature is not a Quantity
+        The particle temperature is not a ~astropy.units.Quantity
 
-    u.UnitConversionError
+    ~astropy.units.UnitConversionError
         If the particle temperature is not in units of temperature or
         energy per particle
 
@@ -483,33 +484,33 @@ def kappa_thermal_speed(T, kappa, particle="e-", method="most_probable"):
         of the Kappa velocity distribution function. Kappa must be greater
         than 3/2.
 
-    particle : string, optional
+    particle : str, optional
         Representation of the particle species (e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to electrons.  If no charge state information is
         provided, then the particles are assumed to be singly charged.
 
-    method : string, optional
+    method : str, optional
         Method to be used for calculating the thermal speed. Options are
         'most_probable' (default), 'rms', and 'mean_magnitude'.
 
     Returns
     -------
     V : ~astropy.units.Quantity
-        particle thermal speed
+        Particle thermal speed
 
     Raises
     ------
     TypeError
-        The particle temperature is not a Quantity
+        The particle temperature is not a ~astropy.units.Quantity.
 
-    u.UnitConversionError
+    astropy.units.UnitConversionError
         If the particle temperature is not in units of temperature or
-        energy per particle
+        energy per particle.
 
     ValueError
         The particle temperature is invalid or particle cannot be used to
-        identify an isotope or particle
+        identify an isotope or particle.
 
     UserWarning
         If the particle thermal speed exceeds 10% of the speed of light, or
@@ -568,7 +569,7 @@ def collision_rate_electron_ion(T_e,
                                 coulomb_log=None,
                                 V=None):
     r"""
-    momentum relaxation electron-ion collision rate
+    Momentum relaxation electron-ion collision rate
 
     From [3]_, equations (2.17) and (2.120)
 
@@ -590,14 +591,14 @@ def collision_rate_electron_ion(T_e,
     n_e : ~astropy.units.Quantity
         The number density of the Maxwellian test electrons
 
-    ion_particle: string
+    ion_particle: str
         String signifying a particle type of the field ions, including charge
         state information.
 
     coulomb_log : float or dimensionless ~astropy.units.Quantity, optional
-        option to specify a Coulomb logarithm of the electrons on the ions.
+        Option to specify a Coulomb logarithm of the electrons on the ions.
         If not specified, the Coulomb log will is calculated using the
-        .transport/Coulomb_logarithm function.
+        `~plasmapy.physics.transport.Coulomb_logarithm` function.
 
     References
     ----------
@@ -628,7 +629,7 @@ def collision_rate_electron_ion(T_e,
 def collision_rate_ion_ion(T_i, n_i, ion_particle,
                            coulomb_log=None, V=None):
     r"""
-    momentum relaxation ion-ion collision rate
+    Momentum relaxation ion-ion collision rate
 
     From [3]_, equations (2.36) and (2.122)
 
@@ -654,15 +655,15 @@ def collision_rate_ion_ion(T_i, n_i, ion_particle,
     n_i : ~astropy.units.Quantity
         The number density of the Maxwellian test ions
 
-    ion_particle: string
+    ion_particle: str
         String signifying a particle type of the test and field ions,
         including charge state information. This function assumes the test
         and field ions are the same species.
 
     coulomb_log : float or dimensionless ~astropy.units.Quantity, optional
-        option to specify a Coulomb logarithm of the electrons on the ions.
+        Option to specify a Coulomb logarithm of the electrons on the ions.
         If not specified, the Coulomb log will is calculated using the
-        .transport/Coulomb_logarithm function.
+        ~plasmapy.physics.transport.Coulomb_logarithm function.
 
     References
     ----------
@@ -721,13 +722,13 @@ def gyrofrequency(B, particle='e-', signed=False, z_mean=None):
     B : ~astropy.units.Quantity
         The magnetic field magnitude in units convertible to tesla.
 
-    particle : string, optional
+    particle : str, optional
         Representation of the particle species (e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to electrons.  If no charge state information is
         provided, then the particles are assumed to be singly charged.
 
-    z_mean : Quantity, optional
+    z_mean : float or ~astropy.units.Quantity, optional
         The average ionization (arithmetic mean) for a plasma where the
         a macroscopic description is valid. If this quantity is not
         given then the atomic charge state (integer) of the ion
@@ -735,9 +736,10 @@ def gyrofrequency(B, particle='e-', signed=False, z_mean=None):
         plasma where multiple charge states are present, and should
         not be interpreted as the gyrofrequency for any single particle.
 
-    signed : boolean, optional
+    signed : bool, optional
         The gyrofrequency can be defined as signed (negative for electron,
-        positive for ion). Default is False (unsigned, ie. always positive).
+        positive for ion). Default is `False` (unsigned, i.e. always
+        positive).
 
     Returns
     -------
@@ -777,7 +779,6 @@ def gyrofrequency(B, particle='e-', signed=False, z_mean=None):
 
     Examples
     --------
-    >>> from numpy import pi
     >>> from astropy import units as u
     >>> gyrofrequency(0.1*u.T)
     <Quantity 1.75882002e+10 rad / s>
@@ -835,31 +836,32 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e-'):
     T_i : ~astropy.units.Quantity, optional
         The particle temperature in units convertible to kelvin.
 
-    particle : string, optional
-        Representation of the particle species (e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for singly ionized helium-4),
+    particle : str, optional
+        Representation of the particle species (e.g., `'p'` for protons, `'D+'`
+        for deuterium, or `'He-4 +1'` for singly ionized helium-4),
         which defaults to electrons.  If no charge state information is
         provided, then the particles are assumed to be singly charged.
 
     args : ~astropy.units.Quantity
-        If the second positional argument is a Quantity with units
-        appropriate to Vperp or T_i, then this argument will take the
-        place of that keyword argument.
+        If the second positional argument is a ~astropy.units.Quantity
+        with units appropriate to `Vperp` or `T_i`, then this argument
+        will take the place of that keyword argument.
 
     Returns
     -------
     r_Li : ~astropy.units.Quantity
-        The particle gyroradius in units of meters.  This Quantity will be
-        based on either the perpendicular component of particle velocity as
-        inputted, or the most probable speed for an particle within a
-        Maxwellian distribution for the particle temperature.
+        The particle gyroradius in units of meters.  This
+        ~astropy.units.Quantity will be based on either the
+        perpendicular component of particle velocity as inputted, or
+        the most probable speed for an particle within a Maxwellian
+        distribution for the particle temperature.
 
     Raises
     ------
     TypeError
         The arguments are of an incorrect type
 
-    u.UnitConversionError
+    ~astropy.units.UnitConversionError
         The arguments do not have appropriate units
 
     ValueError
@@ -870,13 +872,14 @@ def gyroradius(B, *args, Vperp=None, T_i=None, particle='e-'):
 
     Notes
     -----
-    One but not both of Vperp and T_i must be inputted.
+    One but not both of `Vperp` and `T_i` must be inputted.
 
-    If any of B, Vperp, or T_i is a number rather than a Quantity,
-    then SI units will be assumed and a warning will be raised.
+    If any of `B`, `Vperp`, or `T_i` is a number rather than a
+    `~astropy.units.Quantity`, then SI units will be assumed and a
+    warning will be raised.
 
-    The particle gyroradius is also known as the particle Larmor radius and is
-    given by
+    The particle gyroradius is also known as the particle Larmor
+    radius and is given by
 
     .. math::
         r_{Li} = \frac{V_{\perp}}{omega_{ci}}
@@ -956,16 +959,16 @@ def plasma_frequency(n, particle='e-', z_mean=None):
     n : ~astropy.units.Quantity
         Particle number density in units convertible to per cubic meter
 
-    particle : string, optional
+    particle : str, optional
         Representation of the particle species (e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to electrons.  If no charge state information is
         provided, then the particles are assumed to be singly charged.
 
-    z_mean : Quantity, optional
+    z_mean : ~astropy.units.Quantity, optional
         The average ionization (arithmetic mean) for a plasma where the
         a macroscopic description is valid. If this quantity is not
-        given then the atomic charge state (integer) of the ion
+        given then the atomic charge state (`int`) of the ion
         is used. This is effectively an average plasma frequency for the
         plasma where multiple charge states are present.
 
@@ -977,13 +980,14 @@ def plasma_frequency(n, particle='e-', z_mean=None):
     Raises
     ------
     TypeError
-        If n_i is not a Quantity or particle is not of an appropriate type
+        If n_i is not a `~astropy.units.Quantity` or particle is not of
+        an appropriate type.
 
     UnitConversionError
-        If n_i is not in correct units
+        If `n_i` is not in correct units
 
     ValueError
-        If n_i contains invalid values or particle cannot be used to
+        If `n_i` contains invalid values or particle cannot be used to
         identify an particle or isotope.
 
     UserWarning
@@ -1061,7 +1065,7 @@ def Debye_length(T_e, n_e):
     TypeError
         If either argument is not a ~astropy.units.Quantity
 
-    units.UnitConversionError
+    ~astropy.units.UnitConversionError
         If either argument is in incorrect units
 
     ValueError
@@ -1127,9 +1131,9 @@ def Debye_number(T_e, n_e):
     Raises
     ------
     TypeError
-        If either argument is not a Quantity
+        If either argument is not a `~astropy.units.Quantity`
 
-    u.UnitConversionError
+    `astropy.units.UnitConversionError
         If either argument is in incorrect units
 
     ValueError
@@ -1187,7 +1191,7 @@ def inertial_length(n, particle='e-'):
     n_i : ~astropy.units.Quantity
         Particle number density in units convertible to m**-3.
 
-    particle : string, optional
+    particle : str, optional
         Representation of the particle species (e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to electrons.  If no charge state information is
@@ -1203,7 +1207,7 @@ def inertial_length(n, particle='e-'):
     TypeError
         If n_i not a Quantity or particle is not a string.
 
-    units.UnitConversionError
+    ~astropy.units.UnitConversionError
         If n_i is not in units of a number density.
 
     ValueError
@@ -1263,14 +1267,14 @@ def magnetic_pressure(B):
     Raises
     ------
     TypeError
-        If the input is not a Quantity.
+        If the input is not a `~astropy.units.Quantity`.
 
     UnitConversionError
         If the input is not in units convertible to tesla.
 
     ValueError
-        If the magnetic field strength is not a real number between.
-        +/- infinity
+        If the magnetic field strength is not a real number between
+        +/- infinity.
 
     UserWarning
         If units are not provided and SI units are assumed.
@@ -1289,8 +1293,8 @@ def magnetic_pressure(B):
 
     See also
     --------
-    magnetic_energy_density : returns an equivalent Quantity, except in
-        units of joules per cubic meter.
+    magnetic_energy_density : returns an equivalent `~astropy.units.Quantity`,
+        except in units of joules per cubic meter.
 
     Example
     -------
@@ -1327,7 +1331,7 @@ def magnetic_energy_density(B: u.T):
     TypeError
         If the input is not a Quantity.
 
-    u.UnitConversionError
+    ~astropy.units.UnitConversionError
         If the input is not in units convertible to tesla.
 
     ValueError
@@ -1393,7 +1397,7 @@ def upper_hybrid_frequency(B, n_e):
     TypeError
         If either of B or n_e is not a Quantity.
 
-    units.UnitConversionError
+    ~astropy.units.UnitConversionError
         If either of B or n_e is in incorrect units.
 
     ValueError
@@ -1447,7 +1451,7 @@ def lower_hybrid_frequency(B, n_i, ion='p+'):
     n_i : ~astropy.units.Quantity
         Ion number density.
 
-    ion : string, optional
+    ion : str, optional
         Representation of the ion species (e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for singly ionized helium-4),
         which defaults to protons.  If no charge state information is
@@ -1461,14 +1465,14 @@ def lower_hybrid_frequency(B, n_i, ion='p+'):
     Raises
     ------
     TypeError
-        If either of B or n_i is not a Quantity, or ion is of an
-        inappropriate type.
+        If either of `B` or `n_i` is not a `~astropy.units.Quantity`,
+        or ion is of an inappropriate type.
 
-    u.UnitConversionError
-        If either of B or n_i is in incorrect units.
+    ~astropy.units.UnitConversionError
+        If either of `B` or `n_i` is in incorrect units.
 
     ValueError
-        If either of B or n_i contains invalid values or are of
+        If either of `B` or `n_i` contains invalid values or are of
         incompatible dimensions, or ion cannot be used to identify an
         ion or isotope.
 

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -378,7 +378,6 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
     T : ~astropy.units.Quantity
         The temperature.
 
-
     Returns
     -------
     beta_mu: ~astropy.units.Quantity

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -50,6 +50,8 @@ def deBroglie_wavelength(V, particle):
     ~plasmapy.utils.RelativityError
         If the magnitude of `V` is faster than the speed of light.
 
+    Warns
+    -----
     UserWarning
         If `V` is not a `~astropy.units.Quantity`, then a `UserWarning`
         will be raised and units of meters per second will be assumed.
@@ -146,6 +148,8 @@ def thermal_deBroglie_wavelength(T_e):
     ValueError
         If argument contains invalid values.
 
+    Warns
+    -----
     UserWarning
         If units are not provided and SI units are assumed.
 
@@ -197,6 +201,8 @@ def Fermi_energy(n_e):
     ValueError
         If argument contains invalid values.
 
+    Warns
+    -----
     UserWarning
         If units are not provided and SI units are assumed.
 
@@ -256,6 +262,8 @@ def Thomas_Fermi_length(n_e):
     ValueError
         If argument contains invalid values.
 
+    Warns
+    -----
     UserWarning
         If units are not provided and SI units are assumed.
 
@@ -311,26 +319,28 @@ def Wigner_Seitz_radius(n: u.m**-3):
     Parameters
     ----------
     n: ~astropy.units.Quantity
-        Particle number density
+        Particle number density.
 
     Returns
     -------
     radius: ~astropy.units.Quantity
-        The Wigner-Seitz radius in meters
+        The Wigner-Seitz radius in meters.
 
     Raises
     ------
     TypeError
-        If argument is not a ~astropy.units.Quantity
+        If argument is not a ~astropy.units.Quantity.
 
     ~astropy.units.UnitConversionError
-        If argument is in incorrect units
+        If argument is in incorrect units.
 
     ValueError
-        If argument contains invalid values
+        If argument contains invalid values.
 
+    Warns
+    -----
     UserWarning
-        If units are not provided and SI units are assumed
+        If units are not provided and SI units are assumed.
 
     Notes
     -----
@@ -363,10 +373,10 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
     Parameters
     ----------
     n_e: ~astropy.units.Quantity
-        Electron number density
+        Electron number density.
 
     T : ~astropy.units.Quantity
-        The temperature,
+        The temperature.
 
 
     Returns
@@ -386,6 +396,8 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
     ValueError
         If argument contains invalid values.
 
+    Warns
+    -----
     UserWarning
         If units are not provided and SI units are assumed.
 
@@ -414,7 +426,8 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
 
     Warning: at present this function is limited to relatively small
     arguments due to limitations in the `~mpmath` package's implementation
-    of polylog, which PlasmaPy uses in calculating the Fermi integral.
+    of `~mpmath.polylog`, which PlasmaPy uses in calculating the Fermi
+    integral.
 
     References
     ----------
@@ -476,23 +489,27 @@ def chemical_potential_interp(n_e, T):
     Raises
     ------
     TypeError
-        If argument is not a Quantity
+        If argument is not a ~astropy.units.Quantity.
 
     ~astropy.units.UnitConversionError
-        If argument is in incorrect units
+        If argument is in incorrect units.
 
     ValueError
-        If argument contains invalid values
+        If argument contains invalid values.
 
+    Warnings
+    --------
     UserWarning
-        If units are not provided and SI units are assumed
+        If units are not provided and SI units are assumed.
 
     Notes
     -----
     The ideal chemical potential is given by [1]_:
 
     .. math::
-        \frac{\mu}{k_B T_e} = - \frac{3}{2} \ln \Theta + \ln \frac{4}{3 \sqrt{\pi}} + \frac{A \Theta^{-b - 1} + B \Theta^{-(b + 1) / 2}}{1 + A \Theta^{-b}}
+        \frac{\mu}{k_B T_e} = - \frac{3}{2} \ln \Theta + \ln
+        \frac{4}{3 \sqrt{\pi}} +
+        \frac{A \Theta^{-b - 1} + B \Theta^{-(b + 1) / 2}}{1 + A \Theta^{-b}}
 
     where
 
@@ -502,7 +519,6 @@ def chemical_potential_interp(n_e, T):
     is the degeneracy parameter, comparing the thermal energy to the Fermi
     energy, and the coefficients for the fitting formula
     are A=0.25945, B=0.0072, b=0.858.
-
 
     References
     ----------

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -17,6 +17,8 @@ from ..constants import c, h, hbar, m_e, eps0, e, k_B
 from ..mathematics import Fermi_integral
 
 
+# TODO: Use @check_relativistic and @particle_input
+
 def deBroglie_wavelength(V, particle):
     r"""
     Calculates the de Broglie wavelength.
@@ -26,9 +28,9 @@ def deBroglie_wavelength(V, particle):
     V : ~astropy.units.Quantity
         Particle velocity in units convertible to meters per second.
 
-    particle : string or ~astropy.units.Quantity
-        Representation of the particle species (e.g., 'e', 'p', 'D+',
-        or 'He-4 1+', or the particle mass in units convertible to
+    particle : str or ~astropy.units.Quantity
+        Representation of the particle species (e.g., `'e'`, `'p'`, `'D+'`,
+        or `'He-4 1+'`, or the particle mass in units convertible to
         kilograms.
 
     Returns
@@ -39,18 +41,18 @@ def deBroglie_wavelength(V, particle):
     Raises
     ------
     TypeError
-        The velocity is not a Quantity and cannot be converted into a
-        Quantity.
+        The velocity is not a `~astropy.units.Quantity` and cannot be
+        converted into a ~astropy.units.Quantity.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the velocity is not in appropriate units.
 
-    utils.RelativityError
-        If the magnitude of V is faster than the speed of light.
+    ~plasmapy.utils.RelativityError
+        If the magnitude of `V` is faster than the speed of light.
 
     UserWarning
-        If V is not a Quantity, then a UserWarning will be raised and
-        units of meters per second will be assumed.
+        If `V` is not a `~astropy.units.Quantity`, then a `UserWarning`
+        will be raised and units of meters per second will be assumed.
 
     Notes
     -----
@@ -136,9 +138,9 @@ def thermal_deBroglie_wavelength(T_e):
     Raises
     ------
     TypeError
-        If argument is not a Quantity.
+        If argument is not a `~astropy.units.Quantity`.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If argument is in incorrect units.
 
     ValueError
@@ -172,7 +174,7 @@ def thermal_deBroglie_wavelength(T_e):
 })
 def Fermi_energy(n_e):
     r"""
-    Calculate the Fermi energy.
+    Calculate the kinetic energy in a degenerate electron gas.
 
     Parameters
     ----------
@@ -187,9 +189,9 @@ def Fermi_energy(n_e):
     Raises
     ------
     TypeError
-        If argument is not a Quantity.
+        If argument is not a `~astropy.units.Quantity`.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If argument is in incorrect units.
 
     ValueError
@@ -231,7 +233,7 @@ def Fermi_energy(n_e):
 })
 def Thomas_Fermi_length(n_e):
     r"""
-    Calculate the Thomas-Fermi screening length.
+    Calculate the exponential scale length for charge screening.
 
     Parameters
     ----------
@@ -246,9 +248,9 @@ def Thomas_Fermi_length(n_e):
     Raises
     ------
     TypeError
-        If argument is not a Quantity.
+        If argument is not a `~astropy.units.Quantity`.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If argument is in incorrect units.
 
     ValueError
@@ -297,7 +299,8 @@ def Thomas_Fermi_length(n_e):
     'n': {'units': u.m**-3, 'can_be_negative': False}
 })
 def Wigner_Seitz_radius(n: u.m**-3):
-    r"""Calculate the Wigner-Seitz radius, which approximates the inter-
+    r"""
+    Calculate the Wigner-Seitz radius, which approximates the inter-
     particle spacing. It is the radius of a sphere whose volume is
     equal to the mean volume per atom in a solid. This parameter is
     often used to calculate the coupling parameter.
@@ -318,9 +321,9 @@ def Wigner_Seitz_radius(n: u.m**-3):
     Raises
     ------
     TypeError
-        If argument is not a Quantity
+        If argument is not a ~astropy.units.Quantity
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If argument is in incorrect units
 
     ValueError
@@ -354,7 +357,8 @@ def Wigner_Seitz_radius(n: u.m**-3):
 
 
 def chemical_potential(n_e: u.m ** -3, T: u.K):
-    r"""Calculate the ideal chemical potential
+    r"""
+    Calculate the ideal chemical potential.
 
     Parameters
     ----------
@@ -367,23 +371,23 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
 
     Returns
     -------
-    beta_mu: Quantity
+    beta_mu: ~astropy.units.Quantity
         The dimensionless ideal chemical potential. That is the ratio of
         the ideal chemical potential to the thermal energy.
 
     Raises
     ------
     TypeError
-        If argument is not a Quantity
+        If argument is not a `~astropy.units.Quantity`.
 
-    UnitConversionError
-        If argument is in incorrect units
+    ~astropy.units.UnitConversionError
+        If argument is in incorrect units.
 
     ValueError
-        If argument contains invalid values
+        If argument contains invalid values.
 
     UserWarning
-        If units are not provided and SI units are assumed
+        If units are not provided and SI units are assumed.
 
     Notes
     -----
@@ -409,7 +413,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
     ideal chemical potential.
 
     Warning: at present this function is limited to relatively small
-    arguments due to limitations in the mpmath package's implementation
+    arguments due to limitations in the `~mpmath` package's implementation
     of polylog, which PlasmaPy uses in calculating the Fermi integral.
 
     References
@@ -421,6 +425,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
     >>> from astropy import units as u
     >>> chemical_potential(n_e=1e21*u.cm**-3,T=11000*u.K)
     <Quantity 2.00039985e-12>
+
     """
     # deBroglie wavelength
     lambdaDB = thermal_deBroglie_wavelength(T)
@@ -428,7 +433,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
     degen = (n_e * lambdaDB ** 3).to(u.dimensionless_unscaled)
 
     def residual(params, data, eps_data):
-        """residual function for fitting parameters to Fermi_integral"""
+        """Residual function for fitting parameters to Fermi_integral."""
         alpha = params['alpha'].value
         # note that alpha = mu / (k_B * T)
         model = Fermi_integral(alpha, 0.5)
@@ -457,10 +462,10 @@ def chemical_potential_interp(n_e, T):
     Parameters
     ----------
     n_e: ~astropy.units.Quantity
-        Electron number density
+        Electron number density.
 
     T : ~astropy.units.Quantity
-        Temperature in units of temperature or energy
+        Temperature in units of temperature or energy.
 
     Returns
     -------
@@ -473,7 +478,7 @@ def chemical_potential_interp(n_e, T):
     TypeError
         If argument is not a Quantity
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If argument is in incorrect units
 
     ValueError
@@ -512,6 +517,7 @@ def chemical_potential_interp(n_e, T):
     >>> from astropy import units as u
     >>> chemical_potential_interp(n_e=1e23*u.cm**-3, T=11000*u.K)
     <Quantity 8.17649673>
+
     """
     A = 0.25945
     B = 0.072

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -7,33 +7,33 @@ from plasmapy import atomic, utils
 
 def Lorentz_factor(V):
     r"""
-    Returns the Lorentz factor.
+    Return the Lorentz factor.
 
     Parameters
     ----------
-    V : Quantity
+    V : ~astropy.units.Quantity
         The velocity in units convertible to meters per second.
 
     Returns
     -------
-    gamma : float or ndarray
+    gamma : float or ~numpy.ndarray
         The Lorentz factor associated with the inputted velocities.
 
     Raises
     ------
     TypeError
-        The velocity is not a Quantity and cannot be converted into a
-        Quantity.
+        The `V` is not a `~astropy.units.Quantity` and cannot be
+        converted into a ~astropy.units.Quantity.
 
-    UnitConversionError
-        If the velocity is not in appropriate units.
+    ~astropy.units.UnitConversionError
+        If the `V` is not in appropriate units.
 
     ValueError
-        If the magnitude of V is faster than the speed of light.
+        If the magnitude of `V` is faster than the speed of light.
 
     UserWarning
-        If V is not a Quantity, then a UserWarning will be raised and
-        units of meters per second will be assumed.
+        If `V` is not a `~astropy.units.Quantity`, then a `UserWarning`
+        will be raised and units of meters per second will be assumed.
 
     Notes
     -----

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -11,7 +11,8 @@ from plasmapy.utils.exceptions import RelativityWarning, RelativityError
 def check_quantity(validations):
     r"""
     Raises exceptions if `argname` in decorated function is not an
-    astropy Quantity with correct units and valid numerical values.
+    `~astropy.units.Quantity` with correct units and valid numerical
+    values.
 
     Parameters
     ----------
@@ -21,15 +22,15 @@ def check_quantity(validations):
     Raises
     ------
     TypeError
-        If the argument is not a Quantity, units is not entirely units or
-        `argname` does not have a type annotation.
+        If the argument is not a `~astropy.units.Quantity`, units is
+        not entirely units or `argname` does not have a type annotation.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the argument is not in acceptable units.
 
     ValueError
-        If the argument contains NaNs or other invalid values as
-        determined by the keywords.
+        If the argument contains `~numpy.nan` or other invalid values
+        as determined by the keywords.
 
     Returns
     -------
@@ -114,9 +115,10 @@ def check_relativistic(func=None, betafrac=0.1):
     ----------
     func : function, optional
         The function to decorate.
+
     betafrac : float, optional
         The minimum fraction of the speed of light that will raise a
-        UserWarning. Defaults to 0.1.
+        `~plasmapy.utils.RelativityWarning`. Defaults to 0.1.
 
     Returns
     -------
@@ -126,21 +128,21 @@ def check_relativistic(func=None, betafrac=0.1):
     Raises
     ------
     TypeError
-        If V is not a Quantity.
+        If `V` is not a `~astropy.units.Quantity`.
 
-    UnitConversionError
-        If V is not in units of velocity.
+    ~astropy.units.UnitConversionError
+        If `V` is not in units of velocity.
 
     ValueError
-        If V contains any NaNs.
+        If `V` contains any `~numpy.nan` values.
 
-    RelativityError
-        If V is greater than or equal to the speed of light.
+    ~plasmapy.utils.RelativityError
+        If `V` is greater than or equal to the speed of light.
 
     Warns
     -----
-    RelativityWarning
-        If V is greater than or equal to betafrac times the speed of light,
+    ~plasmapy.utils.RelativityWarning
+        If `V` is greater than or equal to `betafrac` times the speed of light,
         but less than the speed of light.
 
     Examples
@@ -148,13 +150,13 @@ def check_relativistic(func=None, betafrac=0.1):
     >>> from astropy import units as u
     >>> @check_relativistic
     ... def speed():
-    ...     return 1*u.m/u.s
+    ...     return 1 * u.m / u.s
 
-    Passing in a custom `betafrac`
+    Passing in a custom `betafrac`:
 
     >>> @check_relativistic(betafrac=0.01)
     ... def speed():
-    ...     return 1*u.m/u.s
+    ...     return 1 * u.m / u.s
 
     """
     def decorator(f):
@@ -173,51 +175,52 @@ def check_relativistic(func=None, betafrac=0.1):
 def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
                     can_be_complex=False, can_be_inf=True):
     """
-    Raises exceptions if an object is not an astropy Quantity with
-    correct units and valid numerical values.
+    Raise an exception if an object is not a `~astropy.units.Quantity`
+    withmcorrect units and valid numerical values.
 
     Parameters
     ----------
-    arg : Quantity
+    arg : ~astropy.units.Quantity
         The object to be tested.
 
-    argname : string
+    argname : str
         The name of the argument to be printed in error messages.
 
-    funcname : string
+    funcname : str
         The name of the original function to be printed in error messages.
 
-    units : Unit or list of Units
-        Acceptable units for arg.
+    units : ~astropy.units.Unit or list with ~astropy.units.Unit items
+        Acceptable units for `arg`.
 
-    can_be_negative : boolean, optional
-        True if the Quantity can be negative, False otherwise.
-        Defaults to True.
+    can_be_negative : bool, optional
+        `True` if the `~astropy.units.Quantity` can be negative,
+        `False` otherwise. Defaults to `True`.
 
-    can_be_complex : boolean, optional
-        True if the Quantity can be a complex number, False otherwise.
-        Defaults to False.
+    can_be_complex : bool, optional
+        `True` if the `~astropy.units.Quantity` can be a complex
+        number, `False` otherwise. Defaults to `False`.
 
-    can_be_inf : boolean, optional
-        True if the Quantity can contain infinite values, False
-        otherwise.  Defaults to True.
+    can_be_inf : bool, optional
+        `True` if the `~astropy.units.Quantity` can contain infinite
+        values, `False` otherwise.  Defaults to `True`.
 
     Raises
     ------
     TypeError
-        If the argument is not a Quantity or units is not entirely units.
+        If the argument is not a `~astropy.units.Quantity` or units is
+        not entirely units.
 
-    UnitConversionError
+    ~astropy.units.UnitConversionError
         If the argument is not in acceptable units.
 
     ValueError
-        If the argument contains NaNs or other invalid values as
-        determined by the keywords.
+        If the argument contains any `~numpy.nan` or other invalid
+        values as determined by the keywords.
 
     UserWarning
-        If a Quantity is not provided and unique units are provided, a
-        UserWarning will be raised and the inputted units will be
-        assumed.
+        If a `~astropy.units.Quantity` is not provided and unique units
+        are provided, a `UserWarning` will be raised and the inputted
+        units will be assumed.
 
     Examples
     --------
@@ -225,6 +228,8 @@ def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
     >>> _check_quantity(4*u.T, 'B', 'f', u.T)
 
     """
+
+    # TODO: Replace `funcname` with func.__name__?
 
     if not isinstance(units, list):
         units = [units]
@@ -296,14 +301,14 @@ def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
 
 def _check_relativistic(V, funcname, betafrac=0.1):
     r"""
-    Warn or raise error if a velocity is relativistic or superrelativistic
+    Warn or raise error for relativistic or superrelativistic velocities.
 
     Parameters
     ----------
-    V : Quantity
+    V : ~astropy.units.Quantity
         A velocity.
 
-    funcname : string
+    funcname : str
         The name of the original function to be printed in the error messages.
 
     betafrac : float
@@ -313,22 +318,22 @@ def _check_relativistic(V, funcname, betafrac=0.1):
     Raises
     ------
     TypeError
-        If V is not a Quantity.
+        If `V` is not a `~astropy.units.Quantity`.
 
-    UnitConversionError
-        If V is not in units of velocity.
+    ~astropy.units.UnitConversionError
+        If `V` is not in units of velocity.
 
     ValueError
-        If V contains any NaNs.
+        If `V` contains any `~numpy.nan` values.
 
     RelativityError
-        If V is greater than or equal to the speed of light.
+        If `V` is greater than or equal to the speed of light.
 
     Warns
     -----
     RelativityWarning
-        If V is greater than or equal to the specified fraction of the speed of
-        light.
+        If `V` is greater than or equal to the specified fraction of
+        the speed of light.
 
     Examples
     --------
@@ -336,6 +341,8 @@ def _check_relativistic(V, funcname, betafrac=0.1):
     >>> _check_relativistic(1*u.m/u.s, 'function_calling_this')
 
     """
+
+    # TODO: Replace `funcname` with func.__name__?
 
     errmsg = ("V must be a Quantity with units of velocity in"
               "_check_relativistic")

--- a/plasmapy/utils/exceptions.py
+++ b/plasmapy/utils/exceptions.py
@@ -1,77 +1,80 @@
-"""
-Custom Error and Warning names to improve readability
-"""
+"""Exceptions and warnings specific to PlasmaPy."""
 
 
 # ----------
-# Exceptions:
+# Exceptions
 # ----------
 
 class PlasmaPyError(Exception):
-    r"""
+    """
     Base class of PlasmaPy custom errors.
 
     All custom exceptions raised by PlasmaPy should inherit from this
     class and be defined in this module.
-
-    Custom exceptions can inherit from other exception types too.
-    Thus, if code already knows how to handle a ValueError, it won't
-    need any specific modification.
     """
     pass
 
 
 class PhysicsError(PlasmaPyError, ValueError):
-    r"""Error for use of a physics value outside PlasmaPy theoretical
-    bounds"""
+    """
+    The base exception for physics-related errors.
+    """
     pass
 
 
 class RelativityError(PhysicsError):
-    r"""Error for use of a speed greater than or equal to the speed of
-    light"""
+    """
+    An exception for speeds greater than the speed of light.
+    """
     pass
 
 
 class AtomicError(PlasmaPyError):
-    r"""An exception for errors occurring in the atomic subpackage."""
+    """An exception for errors in the `~plasmapy.atomic` subpackage."""
     pass
 
 
 class MissingAtomicDataError(AtomicError):
-    r"""An exception for when atomic data is missing."""
+    """An exception for missing atomic or particle data."""
     pass
 
 
 class ChargeError(AtomicError):
-    r"""An exception for when charge information is incorrect or
-    missing."""
+    """An exception for incorrect or missing charge information."""
     pass
 
 
 class UnexpectedParticleError(AtomicError):
-    r"""An exception for when a particle is not of the expected
-    category."""
+    """An exception for when a particle is not of the expected category."""
     pass
 
 
 class InvalidIonError(UnexpectedParticleError):
-    r"""An exception for when an argument is not an ion."""
+    """
+    An exception for when an argument is a valid particle but not a
+    valid ion.
+    """
     pass
 
 
 class InvalidIsotopeError(UnexpectedParticleError):
-    r"""An exception for when an argument is not an isotope."""
+    """
+    An exception for when an argument is a valid particle but not a
+    valid isotope.
+    """
     pass
 
 
 class InvalidElementError(UnexpectedParticleError):
-    r"""An exception for when an argument is not an element."""
+    """
+    An exception for when an argument is a valid particle is not a
+    valid element.
+    """
     pass
 
 
 class InvalidParticleError(AtomicError):
-    r"""An exception for when a particle is invalid."""
+    """An exception for when a particle is invalid."""
     pass
 
 
@@ -80,32 +83,37 @@ class InvalidParticleError(AtomicError):
 # ----------
 
 class PlasmaPyWarning(Warning):
-    r"""Base class of PlasmaPy custom warnings.
+    """
+    Base class of PlasmaPy custom warnings.
 
-    All PlasmaPy custom warnings should inherit from this class and be defined
-    in this module.
+    All PlasmaPy custom warnings should inherit from this class and be
+    defined in this module.
 
-    Warnings should be issued using warnings.warn, which will not break
+    Warnings should be issued using `~warnings.warn`, which will not break
     execution if unhandled.
+
     """
     pass
 
 
 class PhysicsWarning(PlasmaPyWarning):
-    r"""Warning for using a mildly worrisome physics value"""
+    """The base warning for `~plasmapy.physics` related warnings."""
     pass
 
 
 class RelativityWarning(PhysicsWarning):
-    r"""Warning for use of a speed quantity approaching the speed of light"""
+    """
+    A warning for when relativistic velocities are being used in or are
+    returned by non-relativistic functionality.
+    """
     pass
 
 
 class AtomicWarning(PlasmaPyWarning):
-    r"""Warnings for use in the atomic subpackage."""
+    """The base warning for the `~plasmapy.atomic` subpackage."""
     pass
 
 
 class MissingAtomicDataWarning(AtomicWarning):
-    r"""Warning for use when atomic data is missing."""
+    """Warning for use when atomic or particle data is missing."""
     pass

--- a/plasmapy/utils/import_helpers.py
+++ b/plasmapy/utils/import_helpers.py
@@ -1,12 +1,16 @@
 import importlib
 import warnings
 import distutils.version as dv
+from .exceptions import PlasmaPyWarning
 
 
 def check_versions(minimum_versions):
-    """Raises an ImportError if a dependent package is not installed
-    and at the required version number, or provides a warning if the
-    version of the dependent package cannot be found."""
+    """
+    Raise an `ImportError` if a dependent package is not installed and
+    at the required version number, or issue a
+    `~plasmapy.utils.PlasmaPyWarning` if the version of the dependent
+    package cannot be found.
+    """
 
     for module_name in minimum_versions.keys():
         minimum_version = dv.LooseVersion(minimum_versions[module_name])
@@ -15,13 +19,14 @@ def check_versions(minimum_versions):
             module = importlib.import_module(module_name)
             module_version = dv.LooseVersion(module.__version__)
         except ImportError:
-            raise ImportError(f"Unable to import {module_name} while "
-                              "importing PlasmaPy.") from None
+            raise ImportError(
+                f"Unable to import {module_name} while importing PlasmaPy.") from None
         except AttributeError:  # coveralls: ignore
-            warnings.warn(f"{module_name} version {minimum_version.vstring} "
-                          "is required for PlasmaPy.  However, the version of "
-                          f"{module_name} could not be determined to check if "
-                          "this requirement is met.")
+            warnings.warn(
+                f"{module_name} version {minimum_version.vstring} "
+                "is required for PlasmaPy.  However, the version of "
+                f"{module_name} could not be determined to check if "
+                "this requirement is met.", PlasmaPyWarning)
         else:
             if minimum_version > module_version:
                 raise ImportError(


### PR DESCRIPTION
I am going through and doing things like changing `Quantity` to `~astropy.units.Quantity` so that the links work on our Read the Docs page.  This PR is to make some changes in preparation for code review.  

I also just noticed that we don't have anything in `dimensionless.py`.  I guess that will go in `v0.2.0`!