### PR TITLE
Accept Roman numerals when specifying charge states

### DIFF
--- a/plasmapy/atomic/parsing.py
+++ b/plasmapy/atomic/parsing.py
@@ -1,5 +1,6 @@
 """Functionality to parse representations of particles into standard form."""
 
+import roman
 import numpy as np
 import re
 import warnings
@@ -205,13 +206,19 @@ def _parse_and_check_atomic_input(argument: Union[str, int], mass_numb: int = No
             if not sign_indicator_only_on_one_end and just_one_sign_indicator:
                 raise InvalidParticleError(invalid_charge_errmsg) from None
 
-            if '-' in charge_info:
-                sign = -1
-            elif '+' in charge_info:
-                sign = 1
-
             charge_str = charge_info.strip('+-')
-            Z_from_arg = sign * int(charge_str)
+
+            try:
+                if roman.romanNumeralPattern.match(charge_info):
+                    Z_from_arg = roman.fromRoman(charge_info) - 1
+                elif '-' in charge_info:
+                    Z_from_arg = - int(charge_str)
+                elif '+' in charge_info:
+                    Z_from_arg = int(charge_str)
+                else:
+                    raise InvalidParticleError(invalid_charge_errmsg) from None
+            except ValueError:
+                raise InvalidParticleError(invalid_charge_errmsg) from None
 
         elif arg.endswith(('-', '+')):  # Cases like 'H-' and 'Pb-209+++'
             char = arg[-1]

--- a/plasmapy/atomic/tests/test_parsing.py
+++ b/plasmapy/atomic/tests/test_parsing.py
@@ -242,6 +242,10 @@ invalid_particles_table = [
     ('He-99', {}),
     ('H-2+', {'Z': 0}),
     ('H-', {'Z': 1}),
+    ('C VX', {}),
+    ('Rh XXXX', {}),
+    ('Li -II', {}),
+    ('B +IV', {}),
 ]
 
 

--- a/requirements/automated-code-tests.txt
+++ b/requirements/automated-code-tests.txt
@@ -3,6 +3,7 @@ scipy (>= 0.19)
 cython
 astropy (>= 2.0)
 mpmath (>=1.0.0)
+roman (>=2.0.0)
 lmfit (>=0.9.7)
 flake8
 coveralls

--- a/requirements/automated-documentation-tests.txt
+++ b/requirements/automated-documentation-tests.txt
@@ -1,6 +1,7 @@
 astropy
 coveralls
 mpmath
+roman
 lmfit
 matplotlib
 numpy

--- a/requirements/environment.txt
+++ b/requirements/environment.txt
@@ -6,6 +6,7 @@ pytest
 cython
 coveralls
 mpmath
+roman
 lmfit
 matplotlib
 sphinx

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -14,6 +14,7 @@ dependencies:
     - pytest
     - coveralls
     - mpmath
+    - roman
     - lmfit
     - matplotlib
     - sphinx

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,7 @@ numpy (>= 1.13)
 scipy (>= 0.19)
 astropy (>= 2.0)
 mpmath (>=1.0.0)
+roman (>=2.0.0)
 lmfit (>=0.9.7)
 matplotlib
 cython


### PR DESCRIPTION
Closes #286.

This PR uses the [roman](https://pypi.python.org/pypi/roman) package to parse Roman numerals.

Some examples (same as in https://github.com/PlasmaPy/PlasmaPy/issues/286#issue-301633568):
```python
>>> from plasmapy.atomic import *
>>> integer_charge('Fe X')
9
>>> Particle('O VI').ion
'O 5+'
```

It may raise a `ValueError` with strings like `O -VI` or `O +VI` as `-VI` and `+VI` won't be recognized as roman numerals. So, I've added a try-except block to supress `ValueError` and raise an `InvalidParticleError` instead.