### PR TITLE
Add giles to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,3 +55,7 @@ workflows:
     jobs:
       - test-latex
       - test-html
+
+notify:
+  webhooks:
+    - url: https://giles.cadair.com/circleci


### PR DESCRIPTION
I have written a little bot that will add documentation preview links to your PRs. If you want to use it you need to merge this PR and go here: https://github.com/apps/giles and add the app to the repository.

It gives you a thing that looks like this:

![screenshot_20180306_184829](https://user-images.githubusercontent.com/1391051/37051656-fe416856-216e-11e8-90d7-28ec2dc9472d.png)

Like this PR: https://github.com/Cadair/giles/pull/3
