### PR TITLE
Add narrative documentation for atomic subpackage

### DIFF
--- a/docs/atomic/decorators.rst
+++ b/docs/atomic/decorators.rst
@@ -85,7 +85,7 @@ These keywords are used as in `~plasmapy.atomic.Particle.is_category`.
 
   @particle_input(any_of=['charged', 'uncharged'])
   def integer_charge(particle: Particle) -> int:
-      """Accepts only particles with charge information."""
+      """Accept only particles with charge information."""
       return particle.integer_charge
 
   @particle_input(exclude={'antineutrino', 'neutrino'})

--- a/docs/atomic/decorators.rst
+++ b/docs/atomic/decorators.rst
@@ -1,6 +1,12 @@
------------------------------------------------
-The `~plasmapy.atomic.particle_input` Decorator
------------------------------------------------
+.. _atomic-decorators
+
+Decorators
+**********
+
+.. _atomic-decorators
+
+`plasmapy.atomic.particle_input`
+================================
 
 When calculating plasma parameters, we very frequently need to access
 the properties of the particles that make up that plasma. The

--- a/docs/atomic/decorators.rst
+++ b/docs/atomic/decorators.rst
@@ -1,0 +1,97 @@
+-----------------------------------------------
+The `~plasmapy.atomic.particle_input` Decorator
+-----------------------------------------------
+
+When calculating plasma parameters, we very frequently need to access
+the properties of the particles that make up that plasma. The
+`~plasmapy.atomic.particle_input` decorator allows functions and
+methods to easily the properties of a particle.
+
+The `~plasmapy.atomic.particle_input` decorator takes valid
+representations of particles given in arguments to functions and passes
+through the corresponding instance of the `~plasmapy.atomic.Particle`
+class.  The arguments must be annotated with `~plasmapy.atomic.Particle`
+so that the decorator knows to create the `~plasmapy.atomic.Particle`
+instance.  The function can then access particle properties by using
+`~plasmapy.atomic.Particle` attributes.  This decorator will raise an
+`~plasmapy.utils.InvalidParticleError` if the input does not correspond
+to a valid particle.
+
+.. code-block:: python
+
+  from plasmapy.atomic import Particle, particle_input
+
+  @particle_input
+  def particle_mass(particle: Particle):
+      return particle.mass
+
+If only one positional or keyword argument is annotated with
+`~plasmapy.atomic.Particle`, then the keywords `mass_numb` and `Z` may
+be used when the decorated function is called.
+
+.. code-block:: python
+
+  @particle_input
+  def integer_charge(particle: Particle, Z: int = None, mass_numb: int = None) -> int:
+      return particle.integer_charge
+
+The above example includes optional type hint annotations for `Z` and
+`mass_numb` and the returned value.  The
+`~plasmapy.atomic.particle_input` decorator may be used in methods in
+classes as well:
+
+.. code-block:: python
+
+  class ExampleClass:
+      @particle_input
+      def particle_symbol(self, particle: Particle) -> str:
+          return particle.particle
+
+On occasion it is necessary for a function to accept only certain
+categories of particles.  The `~plasmapy.atomic.particle_input`
+decorator enables several ways to allow this.
+
+If an annotated keyword is named `element`, `isotope`, or `ion`; then
+`~plasmapy.atomic.particle_input` will raise an
+`~plasmapy.utils.InvalidElementError`,
+`~plasmapy.utils.InvalidIsotopeError`, or
+`~plasmapy.utils.InvalidIonError` if the particle is not associated with
+an element, isotope, or ion; respectively.
+
+.. code-block:: python
+
+  @particle_input
+  def capitalized_element_name(element: Particle):
+      return element.element_name
+
+  @particle_input
+  def number_of_neutrons(isotope: Particle):
+      return isotope.mass_number - isotope.atomic_number
+
+  @particle_input
+  def number_of_bound_electrons(ion: Particle):
+      return ion.atomic_number - ion.integer_charge
+
+The keywords `require`, `any_of`, and `exclude` to the decorator allow
+further customization of the particle categories allowed as inputs.
+These keywords are used as in `~plasmapy.atomic.Particle.is_category`.
+
+.. code-block:: python
+
+  @particle_input(require='charged')
+  def sign_of_charge(charged_particle: Particle):
+      """Require a charged particle."""
+      return '+' if charged_particle.integer_charge > 0 else '-'
+
+  @particle_input(any_of=['charged', 'uncharged'])
+  def integer_charge(particle: Particle) -> int:
+      """Accepts only particles with charge information."""
+      return particle.integer_charge
+
+  @particle_input(exclude={'antineutrino', 'neutrino'})
+  def particle_mass(particle: Particle):
+      """
+      Exclude neutrinos/antineutrinos because these particles have
+      weakly constrained masses.
+      """
+      return particle.mass

--- a/docs/atomic/functional.rst
+++ b/docs/atomic/functional.rst
@@ -1,0 +1,103 @@
+---------
+Functions
+---------
+
+In addition to the `~plasmapy.atomic.Particle` class, the
+`~plasmapy.atomic` subpackage has a functional interface.
+
+Symbols and Names
+-----------------
+
+Several functions in `~plasmapy.atomic` provide string representations
+of particles:
+
+Various string representations of elements, isotopes, ions, and other
+particles are available in the
+
+The `~plasmapy.atomic.atomic_symbol`
+
+>>> from plasmapy.atomic import *
+>>> atomic_symbol('alpha')
+'He'
+>>> isotope_symbol('alpha')
+'He-4'
+>>> ion_symbol('alpha')
+'He-4 2+'
+>>> particle_symbol('alpha')
+'He-4 2+
+>>> element_name('alpha')
+'helium'
+>>> particle_symbol('electron')
+'e-'
+
+Particle Properties
+-------------------
+
+>>> atomic_number('iron')
+26
+>>> mass_number('T+')
+3
+
+>>> integer_charge('H-')
+-1
+
+>>> electric_charge('muon antineutrino')
+<Quantity 0. C>
+
+>>> standard_atomic_weight('Pb').to('u')
+<Quantity 207.2 u>
+
+>>> particle_mass('deuteron')
+<Quantity 3.34358372e-27 kg>
+
+Isotopes
+--------
+
+>>> isotopic_abundance('H-1')
+0.999885
+>>> isotopic_abundance('D')
+0.000115
+
+>>> known_isotopes('H')
+['H-1', 'D', 'T', 'H-4', 'H-5', 'H-6', 'H-7']
+
+>>> common_isotopes('Fe')
+['Fe-56', 'Fe-54', 'Fe-57', 'Fe-58']
+
+>>> stable_isotopes('Pb')
+['Pb-204', 'Pb-206', 'Pb-207', 'Pb-208']
+
+Stability
+---------
+
+>>> is_stable('e-')
+True
+>>> is_stable('T')
+False
+
+The `~plasmapy.atomic.half_life` function returns the particle's
+half-life in seconds, if known.
+
+>>> half_life('n')
+<Quantity 881.5 s>
+
+For stable particles (or particles not experimentally determined to be
+unstable), `~plasmapy.atomic.half_life` returns infinity seconds.
+
+>>> half_life('p+')
+<Quantity inf s>
+
+If the particle's half-life is not known to sufficient precision, then
+`~plasmapy.atomic.half_life` returns a `str` with the estimated value
+while issuing a `~plasmapy.utils.MissingAtomicDataWarning`.
+
+Reduced Mass
+------------
+
+The reduced mass is
+
+>>> reduced_mass('e-', 'p+')
+<Quantity 9.10442514e-31 kg>
+
+>>> reduced_mass('D+', 'T+')
+<Quantity 2.00486597e-27 kg>

--- a/docs/atomic/functional.rst
+++ b/docs/atomic/functional.rst
@@ -8,13 +8,9 @@ In addition to the `~plasmapy.atomic.Particle` class, the
 Symbols and Names
 -----------------
 
-Several functions in `~plasmapy.atomic` provide string representations
-of particles:
-
-Various string representations of elements, isotopes, ions, and other
-particles are available in the
-
-The `~plasmapy.atomic.atomic_symbol`
+Several functions in `~plasmapy.atomic` return string representations
+of particles, including `~plasmapy.atomic.atomic_symbol`,
+`~plasmapy.atomic.isotope_symbol`, and `~plasmapy.atomic.element_name`.
 
 >>> from plasmapy.atomic import *
 >>> atomic_symbol('alpha')
@@ -27,25 +23,47 @@ The `~plasmapy.atomic.atomic_symbol`
 'He-4 2+
 >>> element_name('alpha')
 'helium'
+
+The full symbol of the particle can be found using
+`~plasmapy.atomic.particle_symbol`.
+
 >>> particle_symbol('electron')
 'e-'
 
 Particle Properties
 -------------------
 
+The `~plasmapy.atomic.atomic_number` and `~plasmapy.atomic.mass_number`
+functions are analogous to the corresponding attributes in the
+`~plasmapy.atomic.Particle` class.
+
 >>> atomic_number('iron')
 26
 >>> mass_number('T+')
 3
 
+Charge information may be found using `~plasmapy.atomic.integer_charge`
+and `~plasmapy.atomic.electric_charge`.
+
 >>> integer_charge('H-')
 -1
-
 >>> electric_charge('muon antineutrino')
 <Quantity 0. C>
 
+These functions will raise a `~plasmapy.utils.ChargeError` for
+elements and isotopes that lack explicit charge information.
+
+>>> electric_charge('H')
+ChargeError: Charge information is required for integer_charge.
+
+The standard atomic weight for the terrestrial environment may be
+accessed using `~plasmapy.atomic.standard_atomic_weight`.
+
 >>> standard_atomic_weight('Pb').to('u')
 <Quantity 207.2 u>
+
+The mass of a particle may be accessed through the
+`~plasmapy.atomic.particle_mass` function.
 
 >>> particle_mass('deuteron')
 <Quantity 3.34358372e-27 kg>
@@ -53,16 +71,28 @@ Particle Properties
 Isotopes
 --------
 
+The relative isotopic abundance of each isotope in the terrestrial
+environment may be found using `~plasmapy.atomic.isotopic_abundance`.
+
 >>> isotopic_abundance('H-1')
 0.999885
 >>> isotopic_abundance('D')
 0.000115
 
+A list of all discovered isotopes in order of increasing mass number
+can be found with `~plasmapy.atomic.known_isotopes`.
+
 >>> known_isotopes('H')
 ['H-1', 'D', 'T', 'H-4', 'H-5', 'H-6', 'H-7']
 
+The isotopes of an element with a non-zero isotopic abundance may be
+found with `~plasmapy.atomic.common_isotopes`.
+
 >>> common_isotopes('Fe')
 ['Fe-56', 'Fe-54', 'Fe-57', 'Fe-58']
+
+All stable isotopes of an element may be found with
+`~plasmapy.atomic.stable_isotopes`.
 
 >>> stable_isotopes('Pb')
 ['Pb-204', 'Pb-206', 'Pb-207', 'Pb-208']
@@ -70,18 +100,21 @@ Isotopes
 Stability
 ---------
 
+The `~plasmapy.atomic.is_stable` function returns `True` for stable
+particles and `False` for unstable particles.
+
 >>> is_stable('e-')
 True
 >>> is_stable('T')
 False
 
 The `~plasmapy.atomic.half_life` function returns the particle's
-half-life in seconds, if known.
+half-life as a `~astropy.units.Quantity` in units of seconds, if known.
 
 >>> half_life('n')
 <Quantity 881.5 s>
 
-For stable particles (or particles not experimentally determined to be
+For stable particles (or particles that have not been discovered to be
 unstable), `~plasmapy.atomic.half_life` returns infinity seconds.
 
 >>> half_life('p+')
@@ -94,10 +127,10 @@ while issuing a `~plasmapy.utils.MissingAtomicDataWarning`.
 Reduced Mass
 ------------
 
-The reduced mass is
+The `~plasmapy.atomic.reduced_mass` function is useful in cases of
+two-body collisions.
 
 >>> reduced_mass('e-', 'p+')
 <Quantity 9.10442514e-31 kg>
-
 >>> reduced_mass('D+', 'T+')
 <Quantity 2.00486597e-27 kg>

--- a/docs/atomic/functional.rst
+++ b/docs/atomic/functional.rst
@@ -1,12 +1,15 @@
----------
+.. _atomic-functions
+
 Functions
----------
+*********
 
 In addition to the `~plasmapy.atomic.Particle` class, the
 `~plasmapy.atomic` subpackage has a functional interface.
 
+.. _atomic-func-symbols
+
 Symbols and Names
------------------
+=================
 
 Several functions in `~plasmapy.atomic` return string representations
 of particles, including `~plasmapy.atomic.atomic_symbol`,
@@ -30,8 +33,10 @@ The full symbol of the particle can be found using
 >>> particle_symbol('electron')
 'e-'
 
+.. _atomic-func-properties
+
 Particle Properties
--------------------
+===================
 
 The `~plasmapy.atomic.atomic_number` and `~plasmapy.atomic.mass_number`
 functions are analogous to the corresponding attributes in the
@@ -68,8 +73,10 @@ The mass of a particle may be accessed through the
 >>> particle_mass('deuteron')
 <Quantity 3.34358372e-27 kg>
 
+.. atomic-func-isotopes
+
 Isotopes
---------
+========
 
 The relative isotopic abundance of each isotope in the terrestrial
 environment may be found using `~plasmapy.atomic.isotopic_abundance`.
@@ -97,8 +104,10 @@ All stable isotopes of an element may be found with
 >>> stable_isotopes('Pb')
 ['Pb-204', 'Pb-206', 'Pb-207', 'Pb-208']
 
+.. _atomic-func-stability
+
 Stability
----------
+=========
 
 The `~plasmapy.atomic.is_stable` function returns `True` for stable
 particles and `False` for unstable particles.
@@ -124,8 +133,8 @@ If the particle's half-life is not known to sufficient precision, then
 `~plasmapy.atomic.half_life` returns a `str` with the estimated value
 while issuing a `~plasmapy.utils.MissingAtomicDataWarning`.
 
-Reduced Mass
-------------
+Additional Properties
+=====================
 
 The `~plasmapy.atomic.reduced_mass` function is useful in cases of
 two-body collisions.

--- a/docs/atomic/index.rst
+++ b/docs/atomic/index.rst
@@ -2,14 +2,15 @@
 
 .. _plasmapy-atomic:
 
-******************************************
-Representing Particles (`plasmapy.atomic`)
-******************************************
+**************************************
+The Atomic Package (`plasmapy.atomic`)
+**************************************
 
 .. currentmodule:: plasmapy.atomic
 
 Introduction
 ============
+
 `plasmapy.atomic` provides access to information about atoms, ions,
 isotopes, and other particles.
 

--- a/docs/atomic/index.rst
+++ b/docs/atomic/index.rst
@@ -2,4 +2,36 @@
 
 .. _plasmapy-atomic:
 
+******************************************
+Representing Particles (`plasmapy.atomic`)
+******************************************
+
+.. currentmodule:: plasmapy.atomic
+
+Introduction
+============
+`plasmapy.atomic` provides access to information about atoms, ions,
+isotopes, and other particles.
+
+Using `plasmapy.atomic`
+=======================
+
+.. toctree::
+   :maxdepth: 2
+
+   particle_class
+   functional
+   nuclear
+   decorators
+
+See Also
+========
+
+- The `mendeleev <https://pypi.python.org/pypi/mendeleev>`_ Python
+  package provides access to properties of elements, isotopes, and ions
+  in the periodic table of elements.
+
+Reference/API
+=============
+
 .. automodapi:: plasmapy.atomic

--- a/docs/atomic/nuclear.rst
+++ b/docs/atomic/nuclear.rst
@@ -1,0 +1,28 @@
+-----------------
+Nuclear Reactions
+-----------------
+
+The binding energy of a nuclide may be accessed either as an
+attribute of a `~plasmapy.atomic.Particle` instance, or by using the
+`~plasmapy.atomic.nuclear_binding_energy` function.
+
+>>> from plasmapy.atomic import Particle, nuclear_binding_energy
+>>> D = Particle('deuterium')
+>>> D.binding_energy
+<Quantity 3.56414847e-13 J>
+>>> nuclear_binding_energy('D').to('GeV')
+<Quantity 2.22456652 MeV>
+
+The energy released from a nuclear reaction may be found using the
+`~plasmapy.atomic.nuclear_reaction_energy` function.  The input may be
+a `str` representing the reaction.
+
+>>> from plasmapy.atomic import nuclear_reaction_energy
+>>> nuclear_reaction_energy('Be-8 -> 2*alpha')
+<Quantity 1.47143078e-14 J>
+
+The reaction may also be inputted using the `reactants` and `products`
+keywords.
+
+>>> nuclear_reaction_energy(reactants=['D', 'T'], products=['alpha', 'n'])
+<Quantity 17.58932778 MeV>

--- a/docs/atomic/nuclear.rst
+++ b/docs/atomic/nuclear.rst
@@ -1,6 +1,8 @@
------------------
 Nuclear Reactions
------------------
+*****************
+
+Binding Energy
+==============
 
 The binding energy of a nuclide may be accessed either as an
 attribute of a `~plasmapy.atomic.Particle` instance, or by using the
@@ -12,6 +14,9 @@ attribute of a `~plasmapy.atomic.Particle` instance, or by using the
 <Quantity 3.56414847e-13 J>
 >>> nuclear_binding_energy('D').to('GeV')
 <Quantity 2.22456652 MeV>
+
+Nuclear Reactions
+=================
 
 The energy released from a nuclear reaction may be found using the
 `~plasmapy.atomic.nuclear_reaction_energy` function.  The input may be

--- a/docs/atomic/particle_class.rst
+++ b/docs/atomic/particle_class.rst
@@ -124,59 +124,24 @@ True
 >>> iron56.is_category(['element', 'isotope'])
 True
 
-The `require` keyword specifies categories that a particle must
-belong to in order for `is_category` to return `True`.
+The particle must be in all of the categories in the `require` keyword,
+at least one of the categories in the `any_of` keyword, and none of the
+categories in the `exclude` in order for it to return `True`.
 
 >>> deuteron.is_category(require={'element', 'isotope', 'ion'})
 True
-
-The particle must belong to at least one of the categories specified
-with the `any_of` keyword
-
-The `any_of` keyword specifies categories of which the particle must
-belong to at least one in order for `is_category` to return `True`.
-
 >>> Fe56.is_category(any_of=['charged', 'uncharged'])
 False
-
-The particle
-
-The `any_of` keyword specifies categories of which the particle must
-belong to
+>>> alpha.is_category(exclude='lepton')
+True
 
 Calling the `is_category` method with no arguments returns a set
-containing all of the valid categories for any particle.
-
->>> sorted(proton.is_category())  # all valid categories
-['actinide',
- 'alkali metal',
- 'alkaline earth metal',
- 'antibaryon',
- 'antilepton',
- 'antimatter',
- 'antineutrino',
- 'baryon',
- 'boson',
- 'charged',
- 'electron',
- 'element',
- 'fermion',
- 'halogen',
- 'ion',
- 'isotope',
- 'lanthanide',
- 'lepton',
- 'matter',
- 'metal',
- 'metalloid',
- 'neutrino',
- 'neutron',
- 'noble gas',
- 'nonmetal',
- 'positron',
- 'post-transition metal',
- 'proton',
- 'stable',
- 'transition metal',
- 'uncharged',
- 'unstable']
+containing all of the valid categories for any particle.  Valid
+categories include: `'actinide'`, `'alkali metal'`,
+`'alkaline earth metal'`, `'antibaryon'`, `'antilepton'`,
+`'antimatter'`, `'antineutrino'`, `'baryon'`, `'boson'`, `'charged'`,
+`'electron'`, `'element'`, `'fermion'`, `'halogen'`, `'ion'`,
+`'isotope'`, `'lanthanide'`, `'lepton'`, `'matter'`, `'metal'`,
+`'metalloid'`, `'neutrino'`, `'neutron'`, `'noble gas'`, `'nonmetal'`,
+`'positron'`, `'post-transition metal'`, `'proton'`, `'stable'`,
+`'transition metal'`, `'uncharged'`, and `'unstable'`.

--- a/docs/atomic/particle_class.rst
+++ b/docs/atomic/particle_class.rst
@@ -11,9 +11,14 @@ Particle Class
 --------------
 
 The `~plasmapy.atomic.Particle` class provides an object-oriented
-interface to particle information. The simplest way to create an
-instance of the `~plasmapy.atomic.Particle` class is to pass it a `str`
-representing a particle.
+interface to particle information.
+
+Creating a Particle Instance
+----------------------------
+
+The simplest way to create an instance of the
+`~plasmapy.atomic.Particle` class is to pass it a `str` representing a
+particle.
 
 >>> from plasmapy.atomic import Particle
 >>> electron = Particle('e-')
@@ -37,6 +42,9 @@ and ions, the mass number may be represented with the `mass_numb`
 keyword and the integer charge may be represented with the `Z` keyword.
 
 >>> proton = Particle(1, mass_numb=1, Z=1)
+
+Accessing Particle Properties
+-----------------------------
 
 The properties of each particle may be accessed using attributes of the
 `~plasmapy.atomic.Particle` instance.
@@ -72,41 +80,8 @@ Strings representing particles may be accessed using the `particle`,
 >>> deuteron.ion
 'D 1+'
 
-Equality between particles may be tested either between two
-`~plasmapy.atomic.Particle` instances, or between a
-`~plasmapy.atomic.Particle` instance and a `str`.
-
->>> Particle('H-1') == Particle('protium 1+')
-True
->>> alpha == 'He-4 1+'
-False
-
-The `is_electron` attribute provides a quick way to check whether or not
-a particle is an electron.
-
->>> electron.is_electron
-True
->>> hydride.is_electron
-False
-
-The `element`, `isotope`, and `ion` return `None` when the particle is
-not the respective category.  Because non-empty strings evaluate to
-`True` and `None` evaluates to `False` when converted to a `bool`, these
-attributes may be used in conditional statements to test whether or not
-a particle is in one of these categories.
-
-.. code-block:: python
-
-    particles = [Particle('e-'), Particle('Fe-56'), Particle('alpha')]
-
-    for particle in particles:
-        if particle.element:
-            print(f"{particle} corresponds to element {particle.element}")
-        if particle.isotope:
-            print(f"{particle} corresponds to isotope {particle.isotope}")
-        if particle.ion:
-            print(f"{particle} corresponds to ion {particle.ion}")
-
+Categories
+----------
 
 The `categories` attribute returns a `set` with the classification
 categories corresponding to the particle.
@@ -145,3 +120,41 @@ categories include: `'actinide'`, `'alkali metal'`,
 `'metalloid'`, `'neutrino'`, `'neutron'`, `'noble gas'`, `'nonmetal'`,
 `'positron'`, `'post-transition metal'`, `'proton'`, `'stable'`,
 `'transition metal'`, `'uncharged'`, and `'unstable'`.
+
+Particle Conditionals and Equality Properties
+---------------------------------------------
+
+Equality between particles may be tested either between two
+`~plasmapy.atomic.Particle` instances, or between a
+`~plasmapy.atomic.Particle` instance and a `str`.
+
+>>> Particle('H-1') == Particle('protium 1+')
+True
+>>> alpha == 'He-4 1+'
+False
+
+The `is_electron` attribute provides a quick way to check whether or not
+a particle is an electron.
+
+>>> electron.is_electron
+True
+>>> hydride.is_electron
+False
+
+The `element`, `isotope`, and `ion` return `None` when the particle is
+not the respective category.  Because non-empty strings evaluate to
+`True` and `None` evaluates to `False` when converted to a `bool`, these
+attributes may be used in conditional statements to test whether or not
+a particle is in one of these categories.
+
+.. code-block:: python
+
+    particles = [Particle('e-'), Particle('Fe-56'), Particle('alpha')]
+
+    for particle in particles:
+        if particle.element:
+            print(f"{particle} corresponds to element {particle.element}")
+        if particle.isotope:
+            print(f"{particle} corresponds to isotope {particle.isotope}")
+        if particle.ion:
+            print(f"{particle} corresponds to ion {particle.ion}")

--- a/docs/atomic/particle_class.rst
+++ b/docs/atomic/particle_class.rst
@@ -1,12 +1,13 @@
---------------
+.. _particle-class
+
 Particle Class
---------------
+**************
 
 The `~plasmapy.atomic.Particle` class provides an object-oriented
 interface to particle information.
 
 Creating a Particle Instance
-----------------------------
+============================
 
 The simplest way to create an instance of the
 `~plasmapy.atomic.Particle` class is to pass it a `str` representing a
@@ -36,7 +37,7 @@ keyword and the integer charge may be represented with the `Z` keyword.
 >>> proton = Particle(1, mass_numb=1, Z=1)
 
 Accessing Particle Properties
------------------------------
+=============================
 
 The properties of each particle may be accessed using attributes of the
 `~plasmapy.atomic.Particle` instance.
@@ -72,8 +73,10 @@ Strings representing particles may be accessed using the `particle`,
 >>> deuteron.ion
 'D 1+'
 
+.. _particle-class-categories
+
 Categories
-----------
+==========
 
 The `categories` attribute returns a `set` with the classification
 categories corresponding to the particle.
@@ -113,8 +116,10 @@ categories include: `'actinide'`, `'alkali metal'`,
 `'positron'`, `'post-transition metal'`, `'proton'`, `'stable'`,
 `'transition metal'`, `'uncharged'`, and `'unstable'`.
 
-Particle Conditionals and Equality Properties
----------------------------------------------
+.. _particle-class-conditionals
+
+Conditionals and Equality Properties
+====================================
 
 Equality between particles may be tested either between two
 `~plasmapy.atomic.Particle` instances, or between a

--- a/docs/atomic/particle_class.rst
+++ b/docs/atomic/particle_class.rst
@@ -1,0 +1,182 @@
+=================
+Atomic Subpackage
+=================
+
+The physics of plasmas depends heavily on the properties of the
+particles that make up the plasma.  The `~plasmapy.atomic` subpackage
+allows us to access necessary particle information.
+
+--------------
+Particle Class
+--------------
+
+The `~plasmapy.atomic.Particle` class provides an object-oriented
+interface to particle information. The simplest way to create an
+instance of the `~plasmapy.atomic.Particle` class is to pass it a `str`
+representing a particle.
+
+>>> from plasmapy.atomic import Particle
+>>> electron = Particle('e-')
+
+The `~plasmapy.atomic.Particle` class accepts a variety of different
+`str` formats to represent particles. Atomic symbols are case-sensitive,
+but element names and many aliases are not.
+
+>>> alpha = Particle('alpha')
+>>> deuteron = Particle('D+')
+>>> triton = Particle('tritium 1+')
+>>> iron56 = Particle('Fe-56')
+>>> helium = Particle('helium')
+>>> muon = Particle('mu-')
+>>> antimuon = Particle('antimuon')
+>>> hydride = Particle('H-')
+
+An `int` may be used as the first positional argument to
+`plasmapy.atomic.Particle` to represent an atomic number.  For isotopes
+and ions, the mass number may be represented with the `mass_numb`
+keyword and the integer charge may be represented with the `Z` keyword.
+
+>>> proton = Particle(1, mass_numb=1, Z=1)
+
+The properties of each particle may be accessed using attributes of the
+`~plasmapy.atomic.Particle` instance.
+
+>>> proton.atomic_number
+1
+>>> electron.integer_charge
+1
+>>> triton.mass_number
+3
+
+Some of these properties are returned as a `~astropy.units.Quantity` in
+SI units.
+
+>>> alpha.charge
+<Quantity 3.20435324e-19 C>
+>>> deuteron.mass
+<Quantity 3.34358372e-27 kg>
+>>> triton.half_life
+<Quantity 3.888e+08 s>
+>>> iron56.binding_energy.to('GeV')
+<Quantity 0.49225958 GeV>
+
+Strings representing particles may be accessed using the `particle`,
+`element`, `isotope`, and `ion` attributes.
+
+>>> antimuon.particle
+'mu-'
+>>> triton.element
+'H'
+>>> alpha.isotope
+'He-4'
+>>> deuteron.ion
+'D 1+'
+
+Equality between particles may be tested either between two
+`~plasmapy.atomic.Particle` instances, or between a
+`~plasmapy.atomic.Particle` instance and a `str`.
+
+>>> Particle('H-1') == Particle('protium 1+')
+True
+>>> alpha == 'He-4 1+'
+False
+
+The `is_electron` attribute provides a quick way to check whether or not
+a particle is an electron.
+
+>>> electron.is_electron
+True
+>>> hydride.is_electron
+False
+
+The `element`, `isotope`, and `ion` return `None` when the particle is
+not the respective category.  Because non-empty strings evaluate to
+`True` and `None` evaluates to `False` when converted to a `bool`, these
+attributes may be used in conditional statements to test whether or not
+a particle is in one of these categories.
+
+.. code-block:: python
+
+    particles = [Particle('e-'), Particle('Fe-56'), Particle('alpha')]
+
+    for particle in particles:
+        if particle.element:
+            print(f"{particle} corresponds to element {particle.element}")
+        if particle.isotope:
+            print(f"{particle} corresponds to isotope {particle.isotope}")
+        if particle.ion:
+            print(f"{particle} corresponds to ion {particle.ion}")
+
+
+The `categories` attribute returns a `set` with the classification
+categories corresponding to the particle.
+
+>>> sorted(electron.categories)
+['charged', 'electron', 'fermion', 'lepton', 'matter', 'stable']
+
+Membership of a particle within a category may be checked using the
+`~plasmapy.atomic.Particle.is_category` method.
+
+>>> alpha.is_category('lepton')
+False
+>>> electron.is_category('fermion', 'lepton', 'charged')
+True
+>>> iron56.is_category(['element', 'isotope'])
+True
+
+The `require` keyword specifies categories that a particle must
+belong to in order for `is_category` to return `True`.
+
+>>> deuteron.is_category(require={'element', 'isotope', 'ion'})
+True
+
+The particle must belong to at least one of the categories specified
+with the `any_of` keyword
+
+The `any_of` keyword specifies categories of which the particle must
+belong to at least one in order for `is_category` to return `True`.
+
+>>> Fe56.is_category(any_of=['charged', 'uncharged'])
+False
+
+The particle
+
+The `any_of` keyword specifies categories of which the particle must
+belong to
+
+Calling the `is_category` method with no arguments returns a set
+containing all of the valid categories for any particle.
+
+>>> sorted(proton.is_category())  # all valid categories
+['actinide',
+ 'alkali metal',
+ 'alkaline earth metal',
+ 'antibaryon',
+ 'antilepton',
+ 'antimatter',
+ 'antineutrino',
+ 'baryon',
+ 'boson',
+ 'charged',
+ 'electron',
+ 'element',
+ 'fermion',
+ 'halogen',
+ 'ion',
+ 'isotope',
+ 'lanthanide',
+ 'lepton',
+ 'matter',
+ 'metal',
+ 'metalloid',
+ 'neutrino',
+ 'neutron',
+ 'noble gas',
+ 'nonmetal',
+ 'positron',
+ 'post-transition metal',
+ 'proton',
+ 'stable',
+ 'transition metal',
+ 'uncharged',
+ 'unstable']

--- a/docs/atomic/particle_class.rst
+++ b/docs/atomic/particle_class.rst
@@ -1,11 +1,3 @@
-=================
-Atomic Subpackage
-=================
-
-The physics of plasmas depends heavily on the properties of the
-particles that make up the plasma.  The `~plasmapy.atomic` subpackage
-allows us to access necessary particle information.
-
 --------------
 Particle Class
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ Plasma Parameters
 -----------------
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    physics/index
 
@@ -77,7 +77,7 @@ The `plasmapy.mathematics` package contains mathematical functions
 commonly used by plasma physicists.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    mathematics/index
 
@@ -98,7 +98,7 @@ Utilities
 ---------
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    utils/index
 
@@ -107,7 +107,7 @@ Utilities
 Examples
 --------
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 3
 
     auto_examples/index
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,15 +7,16 @@
 PlasmaPy Documentation
 ######################
 
-PlasmaPy is an open source community-developed core Python package for
-plasma physics in the early stages of development.  The documentation
-contained on this page is in the process of being written.
+`PlasmaPy <http://www.plasmapy.org/`_ is an open source
+community-developed core `Python <https://www.python.org/>`_ 3.6+
+package for plasma physics in the early stages of development. The
+documentation contained on this page is in the process of being written.
 
 ***************
 Getting Started
 ***************
 
-* `Installation instructions
+* `Installing PlasmaPy
   <https://github.com/PlasmaPy/PlasmaPy/blob/master/INSTALL.md>`_
 * `Contributing to PlasmaPy
   <https://github.com/PlasmaPy/PlasmaPy/blob/master/CONTRIBUTING.md>`_
@@ -32,10 +33,10 @@ Getting Started
 User Documentation
 ******************
 
-.. representing-particles
+.. particles
 
-Representing Particles
-----------------------
+Particles
+---------
 
 .. toctree::
    :maxdepth: 2
@@ -136,6 +137,9 @@ Project Details
 
 .. toctree::
    :maxdepth: 2
+
+* `Vision Statement
+  <https://github.com/PlasmaPy/PlasmaPy/blob/master/VISION.md>`_
 
 .. _index:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,15 +3,17 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+######################
 PlasmaPy Documentation
-======================
+######################
 
 PlasmaPy is an open source community-developed core Python package for
 plasma physics in the early stages of development.  The documentation
 contained on this page is in the process of being written.
 
+***************
 Getting Started
-===============
+***************
 
 * `Installation instructions
   <https://github.com/PlasmaPy/PlasmaPy/blob/master/INSTALL.md>`_
@@ -24,26 +26,55 @@ Getting Started
 * `PlasmaPy website
   <http://www.plasmapy.org/>`_
 
-Examples
-========
+.. user-documentation
+
+******************
+User Documentation
+******************
+
+.. representing-particles
+
+Representing Particles
+----------------------
+
 .. toctree::
-    :maxdepth: 1
+   :maxdepth: 1
 
-    auto_examples/index
+   atomic/index
 
-Modules
-=======
+.. plasma-parameters
+
+Plasma Parameters
+-----------------
 
 .. toctree::
-    :maxdepth: 1
 
-    atomic/index
-    diagnostics/index
-    mathematics/index
-    physics/index
+   physics/index
 
-Classes
-=======
+.. _diagnostics
+
+Diagnostics
+-----------
+
+.. toctree::
+   :maxdepth: 1
+
+   diagnostics/index
+
+.. _mathematics
+
+Mathematics
+-----------
+
+.. toctree::
+   :maxdepth: 1
+
+   mathematics/index
+
+.. _data-structures
+
+Data Structures
+---------------
 
 .. toctree::
     :maxdepth: 1
@@ -51,16 +82,33 @@ Classes
     plasma/index
     species/index
 
+.. _utilities
+
 Utilities
-=========
+---------
 
 .. toctree::
    :maxdepth: 1
 
    utils/index
 
-Development
-===========
+.. _examples
+
+Examples
+--------
+.. toctree::
+    :maxdepth: 1
+
+    auto_examples/index
+
+.. _development-guide
+
+=================
+Development Guide
+=================
+
+The development guide contains information on how to contribute to
+PlasmaPy, along with guidelines for code, testing, and documentation.
 
 .. toctree::
     :maxdepth: 1
@@ -70,11 +118,26 @@ Development
     development/doc_guide
     development/release_guide
 
-Indices and tables
-==================
+.. _project_details:
+
+***************
+Project Details
+***************
+
+.. toctree::
+   :maxdepth: 1
+
+.. _index:
+
+*****
+Index
+*****
 
 * :ref:`genindex`
 * :ref:`modindex`
+* :ref:`search`
 
 .. Did not include one for `search` since that page didn't show up
    satisfactorily
+
+.. TODO: Add feedback link: .. _feedback@plasmapy.org: mailto:feedback@plasmapy.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,10 @@ Representing Particles
 .. toctree::
    :maxdepth: 2
 
-   atomic/index
+   atomic/particle_class
+   atomic/functional
+   atomic/nuclear
+   atomic/decorators
 
 .. plasma-parameters
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ Plasma Parameters
 -----------------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    physics/index
 
@@ -59,6 +59,9 @@ Plasma Parameters
 
 Diagnostics
 -----------
+
+The `~plasmapy.diagnostics` package is in the early stages of
+development.
 
 .. toctree::
    :maxdepth: 1
@@ -70,8 +73,11 @@ Diagnostics
 Mathematics
 -----------
 
+The `plasmapy.mathematics` package contains mathematical functions
+commonly used by plasma physicists.
+
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    mathematics/index
 
@@ -92,7 +98,7 @@ Utilities
 ---------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    utils/index
 
@@ -101,21 +107,21 @@ Utilities
 Examples
 --------
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     auto_examples/index
 
 .. _development-guide
 
-=================
+*****************
 Development Guide
-=================
+*****************
 
 The development guide contains information on how to contribute to
 PlasmaPy, along with guidelines for code, testing, and documentation.
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     development/code_guide
     development/testing_guide
@@ -129,7 +135,7 @@ Project Details
 ***************
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
 .. _index:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ Representing Particles
 ----------------------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    atomic/index
 
@@ -48,6 +48,7 @@ Plasma Parameters
 -----------------
 
 .. toctree::
+   :maxdepth: 1
 
    physics/index
 

--- a/plasmapy/atomic/__init__.py
+++ b/plasmapy/atomic/__init__.py
@@ -1,4 +1,7 @@
-"""Physical and mathematical constants for use within PlasmaPy."""
+"""
+The `plasmapy.atomic` subpackage provides access to information about
+atoms, isotopes, ions, and other particles.
+"""
 
 from .special_particles import ParticleZoo
 

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -36,6 +36,7 @@ _classification_categories = {
     'antilepton',
     'fermion',
     'boson',
+    'antibaryon',
     'baryon',
     'neutrino',
     'antineutrino',
@@ -162,19 +163,21 @@ class Particle:
     The `element`, `isotope`, and `ion` attributes return the symbols
     for each of these different types of particles.
 
-
     >>> proton.element
     'H'
     >>> alpha.isotope
     'He-4'
     >>> deuteron.ion
     'D 1+'
+
+    If the particle doesn't belong to one of those categories, then
+    these attributes return `None`.
+
     >>> positron.element is None
     True
 
-    Because these attributes return `None` if the particle does not
-    belong to that type of particle, these attributes can be used to
-    test whether or not a particle is an element, isotope, or ion.
+    These attributes may therefore be used to test whether or not a
+    particle is an element, isotope, or ion.
 
     >>> True if Particle('e-').element else False
     False
@@ -207,14 +210,40 @@ class Particle:
     The `~plasmapy.atomic.particle_class.Particle.categories` attribute
     and `~plasmapy.atomic.particle_class.Particle.is_category` method
     may be used to find and test particle membership in categories.
-    Valid categories include `'lepton'`, `'antilepton'`, `'fermion'`,
-    `'boson'`, `'baryon'`, `'neutrino'`, `'antineutrino'`, `'element'`,
-    `'isotope'`, `'ion'`, `'matter'`, `'antimatter'`, `'nonmetal'`,
-    `'metal'`, `'alkali metal'`, `'alkaline earth metal'`,
-    `'metalloid'`, `'transition metal'`, `'post-transition metal',
-    `'halogen'`, `'noble gas'`, `'actinide'`, `'lanthanide'`, 'stable'`,
-    `'unstable'`, `'charged'`, `'uncharged'`, `'electron'`,
-    `'positron'`, `'proton'`, and `'neutron'`.
+
+    >>> sorted(neutron.is_categories())  # list all valid categories
+    ['actinide',
+     'alkali metal',
+     'alkaline earth metal',
+     'antibaryon',
+     'antilepton',
+     'antimatter',
+     'antineutrino',
+     'baryon',
+     'boson',
+     'charged',
+     'electron',
+     'element',
+     'fermion',
+     'halogen',
+     'ion',
+     'isotope',
+     'lanthanide',
+     'lepton',
+     'matter',
+     'metal',
+     'metalloid',
+     'neutrino',
+     'neutron',
+     'noble gas',
+     'nonmetal',
+     'positron',
+     'post-transition metal',
+     'proton',
+     'stable',
+     'transition metal',
+     'uncharged',
+     'unstable']
 
     """
 

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -211,7 +211,7 @@ class Particle:
     and `~plasmapy.atomic.particle_class.Particle.is_category` method
     may be used to find and test particle membership in categories.
 
-    >>> sorted(neutron.is_categories())  # list all valid categories
+    >>> sorted(neutron.is_category())  # list all valid categories
     ['actinide',
      'alkali metal',
      'alkaline earth metal',

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -211,41 +211,18 @@ class Particle:
     and `~plasmapy.atomic.particle_class.Particle.is_category` method
     may be used to find and test particle membership in categories.
 
-    >>> sorted(neutron.is_category())  # list all valid categories
-    ['actinide',
-     'alkali metal',
-     'alkaline earth metal',
-     'antibaryon',
-     'antilepton',
-     'antimatter',
-     'antineutrino',
-     'baryon',
-     'boson',
-     'charged',
-     'electron',
-     'element',
-     'fermion',
-     'halogen',
-     'ion',
-     'isotope',
-     'lanthanide',
-     'lepton',
-     'matter',
-     'metal',
-     'metalloid',
-     'neutrino',
-     'neutron',
-     'noble gas',
-     'nonmetal',
-     'positron',
-     'post-transition metal',
-     'proton',
-     'stable',
-     'transition metal',
-     'uncharged',
-     'unstable']
+    Valid particle categories include: `'actinide'`, `'alkali
+    metal'`, `'alkaline earth metal'`, `'antibaryon'`,
+    `'antilepton'`, `'antimatter'`, `'antineutrino'`, `'baryon'`,
+    `'boson'`, `'charged'`, `'electron'`, `'element'`,
+    `'fermion'`, `'halogen'`, `'ion'`, `'isotope'`,
+    `'lanthanide'`, `'lepton'`, `'matter'`, `'metal'`,
+    `'metalloid'`, `'neutrino'`, `'neutron'`, `'noble gas'`,
+    `'nonmetal'`, `'positron'`, `'post-transition metal'`,
+    `'proton'`, `'stable'`, `'transition metal'`, `'uncharged'`,
+    and `'unstable'`.
 
-    """
+"""
 
     def __init__(self, argument: Union[str, int], mass_numb: int = None, Z: int = None):
         """

--- a/plasmapy/atomic/particle_input.py
+++ b/plasmapy/atomic/particle_input.py
@@ -263,8 +263,8 @@ def particle_input(wrapped_function: Callable = None,
                     new_kwargs[argname] = argval
                     continue
 
-                # Occasionally there will be functions where it will be useful
-                # to allow None as an argument.
+                # Occasionally there will be functions where it will be
+                # useful to allow None as an argument.
 
                 if none_shall_pass and argval is None:
                     new_kwargs[argname] = None
@@ -311,8 +311,8 @@ def particle_input(wrapped_function: Callable = None,
                             f"{funcname} does not correspond to a valid "
                             f"{argname}.")
 
-                # Some functions require that particles be charged, or at least
-                # that particles have charge information.
+                # Some functions require that particles be charged, or
+                # at least that particles have charge information.
 
                 _integer_charge = particle._attributes['integer charge']
 
@@ -323,21 +323,18 @@ def particle_input(wrapped_function: Callable = None,
                 lacks_charge_info = _integer_charge is None
 
                 if must_be_charged and (uncharged or must_have_charge_info):
-                    raise ChargeError(
-                        f"A charged particle is required for {funcname}.")
+                    raise ChargeError(f"A charged particle is required for {funcname}.")
 
                 if must_have_charge_info and lacks_charge_info:
-                    raise ChargeError(
-                        f"Charge information is required for {funcname}.")
+                    raise ChargeError(f"Charge information is required for {funcname}.")
 
                 # Some functions require particles that belong to more complex
                 # classification schemes.  Again, be sure to provide a
                 # maximally useful error message.
 
-                if not particle.is_category(
-                        require=require, exclude=exclude, any_of=any_of):
-                    raise AtomicError(_category_errmsg(
-                        particle, require, exclude, any_of, funcname))
+                if not particle.is_category(require=require, exclude=exclude, any_of=any_of):
+                    raise AtomicError(
+                        _category_errmsg(particle, require, exclude, any_of, funcname))
 
                 new_kwargs[argname] = particle
 


### PR DESCRIPTION
This pull request will include narrative documentation for the atomic subpackage.  I've written a first draft for the `Particle` class and still need to write stuff for the functional interface, `@particle_input`, and the nuclear reaction functionality.  I want to make sure to link to the `mendeleev` package for more detailed information about elements (as opposed to, e.g., ions).  I should also make it more clear what valid/standard particle names are being set as.

This PR addresses part of #91.  This is also a test of #291.
