### PR TITLE
Correct annotation of atomic_number and isotopic_abundance

### DIFF
--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -29,7 +29,7 @@ from .symbols import atomic_symbol
 
 
 @particle_input
-def atomic_number(element: Particle) -> str:
+def atomic_number(element: Particle) -> int:
     """
     Return the number of protons in an atom, isotope, or ion.
 
@@ -423,7 +423,7 @@ def particle_mass(particle: Particle, *, Z: int = None, mass_numb: int = None) -
 
 
 @particle_input
-def isotopic_abundance(isotope: Particle, mass_numb: int = None) -> u.Quantity:
+def isotopic_abundance(isotope: Particle, mass_numb: int = None) -> float:
     """
     Return the isotopic abundances if known, and otherwise zero.
 


### PR DESCRIPTION
Hi, I'm looking through the codebase and find two small bugs.

The type annotations are inconsistent with their doc string, and I think the doc is more reasonable. 

I see the review issue #234 is still open, so you will probably notice anyhow. 😃