### PR TITLE
Pre-create commonly used Particle instances

### DIFF
--- a/docs/atomic/particle_class.rst
+++ b/docs/atomic/particle_class.rst
@@ -36,6 +36,15 @@ keyword and the integer charge may be represented with the `Z` keyword.
 
 >>> proton = Particle(1, mass_numb=1, Z=1)
 
+The most frequently used `~plasmapy.atomic.Particle` instances may be
+imported directly from the atomic subpackage.  
+
+>>> from plasmapy.atomic import proton, electron
+
+The `~plasmapy.atomic.Particle` instances that may be imported
+directly are: `proton`, `electron`, `neutron`, `positron`, `deuteron`,
+`triton`, and `alpha`.
+
 Accessing Particle Properties
 =============================
 

--- a/plasmapy/atomic/__init__.py
+++ b/plasmapy/atomic/__init__.py
@@ -38,3 +38,11 @@ from .nuclear import (
     nuclear_binding_energy,
     nuclear_reaction_energy,
 )
+
+proton = Particle("p+")
+electron = Particle("e-")
+neutron = Particle("n")
+positron = Particle("e+")
+deuteron = Particle("D 1+")
+triton = Particle("T 1+")
+alpha = Particle("He-4 2+")


### PR DESCRIPTION
I added `proton`, `electron`, `neutron`, `positron`, `deuteron`, `triton`, and `alpha` as pre-created instances of the `Particle` class in `atomic/__init__.py`.  This change allows us to import these `Particle` instances directly from the atomic subpackage, e.g.:
```Python
from plasmapy.atomic import proton, electron
```
These are the most frequently used particles in plasma physics, so I suspect that it will be a useful shortcut for many of us.