### PR TITLE
Fix check_quantity casting to default provided SI's

### DIFF
--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -147,10 +147,10 @@ def Alfven_speed(B, density, ion="p+", z_mean=None):
     Warns
     -----
     ~plasmapy.utils.RelativityWarning
-        If the Alfven velocity exceeds 10% of the speed of light
+        If the Alfven velocity exceeds 5% of the speed of light
 
     ~astropy.units.UnitsWarning
-        if units are not provided and SI units are assumed.
+        if units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -269,10 +269,10 @@ def ion_sound_speed(T_e,
     Warns
     -----
     RelativityWarning
-        If the ion sound speed exceeds 10% of the speed of light, or
+        If the ion sound speed exceeds 5% of the speed of light.
 
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -377,10 +377,10 @@ def thermal_speed(T, particle="e-", method="most_probable"):
     Warns
     -----
     RelativityWarning
-        If the ion sound speed exceeds 10% of the speed of light, or
+        If the ion sound speed exceeds 5% of the speed of light, or
 
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -485,10 +485,10 @@ def kappa_thermal_speed(T, kappa, particle="e-", method="most_probable"):
     Warns
     -----
     RelativityWarning
-        If the particle thermal speed exceeds 10% of the speed of light, or
+        If the particle thermal speed exceeds 5% of the speed of light, or
 
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -862,7 +862,7 @@ def gyrofrequency(B, particle='e-', signed=False, Z=None):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -963,7 +963,7 @@ def gyroradius(B, particle='e-', *, Vperp=np.nan * u.m / u.s, T_i=np.nan * u.K):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -1068,7 +1068,7 @@ def plasma_frequency(n, particle='e-', z_mean=None):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -1154,7 +1154,7 @@ def Debye_length(T_e, n_e):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -1219,7 +1219,7 @@ def Debye_number(T_e, n_e):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Returns
     -------
@@ -1293,7 +1293,7 @@ def inertial_length(n, particle='e-'):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -1351,7 +1351,7 @@ def magnetic_pressure(B):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -1415,7 +1415,7 @@ def magnetic_energy_density(B: u.T):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -1483,7 +1483,7 @@ def upper_hybrid_frequency(B, n_e):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -1554,7 +1554,7 @@ def lower_hybrid_frequency(B, n_i, ion='p+'):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -149,7 +149,7 @@ def Alfven_speed(B, density, ion="p+", z_mean=None):
     ~plasmapy.utils.RelativityWarning
         If the Alfven velocity exceeds 10% of the speed of light
 
-    UserWarning
+    ~astropy.units.UnitsWarning
         if units are not provided and SI units are assumed.
 
     Notes
@@ -271,7 +271,7 @@ def ion_sound_speed(T_e,
     RelativityWarning
         If the ion sound speed exceeds 10% of the speed of light, or
 
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
 
     Notes
@@ -379,9 +379,8 @@ def thermal_speed(T, particle="e-", method="most_probable"):
     RelativityWarning
         If the ion sound speed exceeds 10% of the speed of light, or
 
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
-       if units are not provided and SI units are assumed.
 
     Notes
     -----
@@ -483,9 +482,13 @@ def kappa_thermal_speed(T, kappa, particle="e-", method="most_probable"):
         The particle temperature is invalid or particle cannot be used to
         identify an isotope or particle.
 
-    UserWarning
+    Warns
+    -----
+    RelativityWarning
         If the particle thermal speed exceeds 10% of the speed of light, or
-        if units are not provided and SI units are assumed.
+
+    UserWarning
+        If units are not provided and SI units are assumed.
 
     Notes
     -----

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -1471,13 +1471,13 @@ def upper_hybrid_frequency(B, n_e):
     Raises
     ------
     TypeError
-        If either of B or n_e is not a Quantity.
+        If either of `B` or `n_e` is not a Quantity.
 
     ~astropy.units.UnitConversionError
-        If either of B or n_e is in incorrect units.
+        If either of `B` or `n_e` is in incorrect units.
 
     ValueError
-        If either of B or n_e contains invalid values or are of
+        If either of `B` or `n_e` contains invalid values or are of
         incompatible dimensions.
 
     Warns

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -487,7 +487,7 @@ def kappa_thermal_speed(T, kappa, particle="e-", method="most_probable"):
     RelativityWarning
         If the particle thermal speed exceeds 10% of the speed of light, or
 
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
 
     Notes
@@ -859,7 +859,9 @@ def gyrofrequency(B, particle='e-', signed=False, Z=None):
         If the magnetic field contains invalid values or particle cannot be
         used to identify an particle or isotope
 
-    UserWarning
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed
 
     Notes
@@ -958,7 +960,9 @@ def gyroradius(B, particle='e-', *, Vperp=np.nan * u.m / u.s, T_i=np.nan * u.K):
     ValueError
         If any argument contains invalid values
 
-    UserWarning
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed
 
     Notes
@@ -1061,7 +1065,9 @@ def plasma_frequency(n, particle='e-', z_mean=None):
         If `n_i` contains invalid values or particle cannot be used to
         identify an particle or isotope.
 
-    UserWarning
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed
 
     Notes
@@ -1145,7 +1151,9 @@ def Debye_length(T_e, n_e):
     ValueError
         If either argument contains invalid values
 
-    UserWarning
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed
 
     Notes
@@ -1208,7 +1216,9 @@ def Debye_number(T_e, n_e):
     ValueError
         If either argument contains invalid values
 
-    UserWarning
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed
 
     Returns
@@ -1280,8 +1290,10 @@ def inertial_length(n, particle='e-'):
     ValueError
         The particle density does not have an appropriate value.
 
-    UserWarning
-        If units are not provided and SI units are assumed.
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
 
     Notes
     -----
@@ -1336,8 +1348,10 @@ def magnetic_pressure(B):
         If the magnetic field strength is not a real number between
         +/- infinity.
 
-    UserWarning
-        If units are not provided and SI units are assumed.
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
 
     Notes
     -----
@@ -1398,8 +1412,10 @@ def magnetic_energy_density(B: u.T):
         If the magnetic field strength does not have an appropriate.
         value.
 
-    UserWarning
-        If units are not provided and SI units are assumed.
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
 
     Notes
     -----
@@ -1464,8 +1480,10 @@ def upper_hybrid_frequency(B, n_e):
         If either of B or n_e contains invalid values or are of
         incompatible dimensions.
 
-    UserWarning
-        If units are not provided and SI units are assumed.
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
 
     Notes
     -----
@@ -1533,8 +1551,10 @@ def lower_hybrid_frequency(B, n_i, ion='p+'):
         incompatible dimensions, or ion cannot be used to identify an
         ion or isotope.
 
-    UserWarning
-        If units are not provided and SI units are assumed.
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
 
     Notes
     -----

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -144,13 +144,13 @@ def Alfven_speed(B, density, ion="p+", z_mean=None):
         If the density is negative, or the ion mass or charge state
         cannot be found.
 
-    UserWarning
-        if units are not provided and SI units are assumed.
-
     Warns
     -----
     ~plasmapy.utils.RelativityWarning
         If the Alfven velocity exceeds 10% of the speed of light
+
+    UserWarning
+        if units are not provided and SI units are assumed.
 
     Notes
     -----
@@ -266,9 +266,13 @@ def ion_sound_speed(T_e,
     ~astropy.units.UnitConversionError
         If the temperature is in incorrect units.
 
-    UserWarning
+    Warns
+    -----
+    RelativityWarning
         If the ion sound speed exceeds 10% of the speed of light, or
-        if units are not provided and SI units are assumed.
+
+    UserWarning
+        If units are not provided and SI units are assumed.
 
     Notes
     -----
@@ -370,9 +374,14 @@ def thermal_speed(T, particle="e-", method="most_probable"):
         The particle temperature is invalid or particle cannot be used to
         identify an isotope or particle
 
+    Warns
+    -----
+    RelativityWarning
+        If the ion sound speed exceeds 10% of the speed of light, or
+
     UserWarning
-        If the particle thermal speed exceeds 10% of the speed of light, or
-        if units are not provided and SI units are assumed.
+        If units are not provided and SI units are assumed.
+       if units are not provided and SI units are assumed.
 
     Notes
     -----

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -56,8 +56,7 @@ def deBroglie_wavelength(V, particle):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If `V` is not a `~astropy.units.Quantity`, then a `UserWarning`
-        will be raised and units of meters per second will be assumed.
+        If units are not provided and SI units are assumed
 
     Notes
     -----
@@ -153,7 +152,7 @@ def thermal_deBroglie_wavelength(T_e):
 
     Warns
     -----
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
 
     Notes
@@ -206,7 +205,7 @@ def Fermi_energy(n_e):
 
     Warns
     -----
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
 
     Notes
@@ -267,7 +266,7 @@ def Thomas_Fermi_length(n_e):
 
     Warns
     -----
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
 
     Notes
@@ -342,7 +341,7 @@ def Wigner_Seitz_radius(n: u.m**-3):
 
     Warns
     -----
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
 
     Notes
@@ -400,7 +399,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
 
     Warns
     -----
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
 
     Notes
@@ -501,7 +500,7 @@ def chemical_potential_interp(n_e, T):
 
     Warnings
     --------
-    UserWarning
+    ~astropy.units.UnitsWarning
         If units are not provided and SI units are assumed.
 
     Notes

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -19,6 +19,9 @@ from ..mathematics import Fermi_integral
 
 # TODO: Use @check_relativistic and @particle_input
 
+@utils.check_quantity({
+    'V': {'units': u.m/u.s, 'can_be_negative': True}
+    })
 def deBroglie_wavelength(V, particle):
     r"""
     Calculates the de Broglie wavelength.
@@ -52,7 +55,7 @@ def deBroglie_wavelength(V, particle):
 
     Warns
     -----
-    UserWarning
+    ~astropy.units.UnitsWarning
         If `V` is not a `~astropy.units.Quantity`, then a `UserWarning`
         will be raised and units of meters per second will be assumed.
 

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -56,7 +56,7 @@ def deBroglie_wavelength(V, particle):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     Notes
     -----
@@ -153,7 +153,7 @@ def thermal_deBroglie_wavelength(T_e):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -206,7 +206,7 @@ def Fermi_energy(n_e):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -267,7 +267,7 @@ def Thomas_Fermi_length(n_e):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -342,7 +342,7 @@ def Wigner_Seitz_radius(n: u.m**-3):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -400,7 +400,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----
@@ -501,7 +501,7 @@ def chemical_potential_interp(n_e, T):
     Warnings
     --------
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed.
+        If units are not provided, SI units are assumed.
 
     Notes
     -----

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -5,7 +5,10 @@ from ..constants import c
 from plasmapy import atomic, utils
 
 
-def Lorentz_factor(V):
+@utils.check_quantity({
+    'V': {'units': u.m/u.s, 'can_be_negative': True}
+    })
+def Lorentz_factor(V: u.m/u.s):
     r"""
     Return the Lorentz factor.
 

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -37,7 +37,7 @@ def Lorentz_factor(V: u.m/u.s):
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed.
 
     Notes
     -----

--- a/plasmapy/physics/relativity.py
+++ b/plasmapy/physics/relativity.py
@@ -34,9 +34,10 @@ def Lorentz_factor(V: u.m/u.s):
     ValueError
         If the magnitude of `V` is faster than the speed of light.
 
-    UserWarning
-        If `V` is not a `~astropy.units.Quantity`, then a `UserWarning`
-        will be raised and units of meters per second will be assumed.
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
 
     Notes
     -----

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -148,7 +148,7 @@ def test_Alfven_speed():
         assert Alfven_speed(-np.inf * u.T, 1 * u.m ** -3,
                             ion='p') == np.inf * u.m / u.s
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert Alfven_speed(1.0, n_i) == Alfven_speed(1.0 * u.T, n_i)
 
     Alfven_speed(1 * u.T, 5e19 * u.m ** -3, ion='p')
@@ -234,11 +234,11 @@ def test_ion_sound_speed():
     with pytest.raises(ValueError):
         ion_sound_speed(T_e=T_negarr, T_i=0 * u.K)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert ion_sound_speed(T_e=1.2e6, T_i=0 * u.K) == ion_sound_speed(T_e=1.2e6 * u.K,
                                                                           T_i=0 * u.K)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert ion_sound_speed(T_i=1.3e6, T_e=0 * u.K) == ion_sound_speed(T_i=1.3e6 * u.K,
                                                                           T_e=0 * u.K)
 
@@ -276,7 +276,7 @@ def test_thermal_speed():
     with pytest.raises(RelativityError):
         thermal_speed(5e19 * u.K)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert thermal_speed(1e5) == thermal_speed(1e5 * u.K)
 
     assert thermal_speed(T_i, particle='p').unit.is_equivalent(u.m / u.s)
@@ -306,7 +306,7 @@ def test_thermal_speed():
     with pytest.raises(ValueError):
         thermal_speed(T_i, particle='asdfasd')
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert thermal_speed(1e6, particle='p') == thermal_speed(1e6 * u.K, particle='p')
 
     assert np.isclose(thermal_speed(1e6 * u.K,
@@ -438,7 +438,7 @@ def test_gyrofrequency():
     f_ce_use_equiv = omega_ce.to(u.Hz, equivalencies=[(u.cy / u.s, u.Hz)])
     assert np.isclose(f_ce.value, f_ce_use_equiv.value)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert gyrofrequency(5.0) == gyrofrequency(5.0 * u.T)
 
     assert gyrofrequency(B, particle=ion).unit.is_equivalent(u.rad / u.s)
@@ -459,7 +459,7 @@ def test_gyrofrequency():
 
     assert gyrofrequency(B, particle='e+') == gyrofrequency(B)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         gyrofrequency(8, 'p')
 
     with pytest.raises(u.UnitConversionError):
@@ -468,7 +468,7 @@ def test_gyrofrequency():
     with pytest.raises(InvalidParticleError):
         gyrofrequency(8 * u.T, particle='asdfasd')
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         # TODO this should be WARNS, not RAISES. and it's probably still raised
         assert gyrofrequency(5.0, 'p') == gyrofrequency(5.0 * u.T, 'p')
 
@@ -514,10 +514,10 @@ def test_gyroradius():
     with pytest.raises(ValueError):
         gyroradius(3.14159 * u.T, T_i=-1 * u.K)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert gyroradius(1.0, Vperp=1.0) == gyroradius(1.0 * u.T, Vperp=1.0 * u.m / u.s)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert gyroradius(1.1, T_i=1.2) == gyroradius(1.1 * u.T, T_i=1.2 * u.K)
 
     with pytest.raises(ValueError):
@@ -564,12 +564,12 @@ def test_gyroradius():
     with pytest.raises(ValueError):
         gyroradius(B, particle='p', T_i=-1 * u.K)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         gyro_without_units = gyroradius(1.0, particle="p", Vperp=1.0)
         gyro_with_units = gyroradius(1.0 * u.T, particle="p", Vperp=1.0 * u.m / u.s)
         assert gyro_without_units == gyro_with_units
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         gyro_t_without_units = gyroradius(1.1, particle="p", T_i=1.2)
         gyro_t_with_units = gyroradius(1.1 * u.T, particle="p", T_i=1.2 * u.K)
         assert gyro_t_with_units == gyro_t_without_units
@@ -600,7 +600,7 @@ def test_plasma_frequency():
     with pytest.raises(ValueError):
         plasma_frequency(np.nan * u.m ** -3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert plasma_frequency(1e19) == plasma_frequency(1e19 * u.m ** -3)
 
         assert plasma_frequency(n_i, particle='p').unit.is_equivalent(u.rad / u.s)
@@ -614,7 +614,7 @@ def test_plasma_frequency():
     with pytest.raises(ValueError):
         plasma_frequency(n=5 * u.m ** -3, particle='sdfas')
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         plasma_freq_no_units = plasma_frequency(1e19, particle='p')
         assert plasma_freq_no_units == plasma_frequency(1e19 * u.m ** -3, particle='p')
 
@@ -639,7 +639,7 @@ def test_Debye_length():
     assert np.isclose(Debye_length(
         1 * u.eV, 1 * u.cm ** -3).value, 7.43, atol=0.005)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         Debye_length(5, 5 * u.m ** -3)
 
     with pytest.raises(u.UnitConversionError):
@@ -656,10 +656,10 @@ def test_Debye_length():
     with pytest.raises(ValueError):
         Debye_length(Tarr2, narr3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert Debye_length(2.0, 2.0) == Debye_length(2.0 * u.K, 2.0 * u.m ** -3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert Debye_length(2.0 * u.K, 2.0) == Debye_length(2.0, 2.0 * u.m ** -3)
 
 
@@ -674,7 +674,7 @@ def test_Debye_number():
 
     assert np.isclose(Debye_number(1 * u.eV, 1 * u.cm ** -3).value, 1720862385.43342)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         Debye_number(T_e, 4)
 
     with pytest.raises(TypeError):
@@ -694,10 +694,10 @@ def test_Debye_number():
     with pytest.raises(ValueError):
         Debye_number(Tarr2, narr3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert Debye_number(1.1, 1.1) == Debye_number(1.1 * u.K, 1.1 * u.m ** -3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert Debye_number(1.1 * u.K, 1.1) == Debye_number(1.1, 1.1 * u.m ** -3)
 
 
@@ -714,7 +714,7 @@ def test_inertial_length():
 
     assert inertial_length(n_i, particle='p') == inertial_length(n_i, particle='p')
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         inertial_length(4, particle='p')
 
     with pytest.raises(u.UnitConversionError):
@@ -726,7 +726,7 @@ def test_inertial_length():
     with pytest.raises(ValueError):
         inertial_length(n_i, particle=-135)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         inertial_length_no_units = inertial_length(1e19, particle='p')
         assert inertial_length_no_units == inertial_length(1e19 * u.m ** -3, particle='p')
 
@@ -734,7 +734,7 @@ def test_inertial_length():
 
     assert np.isclose(inertial_length(1 * u.cm ** -3).cgs.value, 5.31e5, rtol=1e-3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         inertial_length(5)
 
     with pytest.raises(u.UnitConversionError):
@@ -743,7 +743,7 @@ def test_inertial_length():
     with pytest.raises(ValueError):
         inertial_length(-5 * u.m ** -3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert inertial_length(1e19) == inertial_length(1e19 * u.m ** -3)
 
 
@@ -762,7 +762,7 @@ def test_magnetic_pressure():
 
     assert np.isclose(magnetic_pressure(B).value, 397887.35772973835)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         magnetic_pressure(5)
 
     with pytest.raises(u.UnitConversionError):
@@ -777,7 +777,7 @@ def test_magnetic_pressure():
     with pytest.raises(ValueError):
         magnetic_pressure(B_nanarr)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert magnetic_pressure(22.2) == magnetic_pressure(22.2 * u.T)
 
 
@@ -800,7 +800,7 @@ def test_magnetic_energy_density():
 
     assert magnetic_energy_density(B_arr)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         magnetic_energy_density(5)
 
     with pytest.raises(u.UnitConversionError):
@@ -815,7 +815,7 @@ def test_magnetic_energy_density():
     with pytest.raises(ValueError):
         magnetic_energy_density(B_nanarr)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert magnetic_energy_density(22.2) == magnetic_energy_density(22.2 * u.T)
 
 
@@ -835,11 +835,11 @@ def test_upper_hybrid_frequency():
     with pytest.raises(ValueError):
         upper_hybrid_frequency(5 * u.T, n_e=-1 * u.m ** -3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert upper_hybrid_frequency(1.2, 1.3) == upper_hybrid_frequency(1.2 * u.T,
                                                                           1.3 * u.m ** -3)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert upper_hybrid_frequency(1.4 * u.T, 1.3) == upper_hybrid_frequency(1.4,
                                                                                 1.3 * u.m ** -3)
 
@@ -870,6 +870,6 @@ def test_lower_hybrid_frequency():
         lower_hybrid_frequency(
             np.nan * u.T, n_i=-5e19 * u.m ** -3, ion='asdfasd')
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         assert lower_hybrid_frequency(1.3, 1e19) == lower_hybrid_frequency(1.3 * u.T,
                                                                            1e19 * u.m ** -3)

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -148,7 +148,7 @@ def test_Alfven_speed():
         assert Alfven_speed(-np.inf * u.T, 1 * u.m ** -3,
                             ion='p') == np.inf * u.m / u.s
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert Alfven_speed(1.0, n_i) == Alfven_speed(1.0 * u.T, n_i)
 
     Alfven_speed(1 * u.T, 5e19 * u.m ** -3, ion='p')
@@ -234,11 +234,11 @@ def test_ion_sound_speed():
     with pytest.raises(ValueError):
         ion_sound_speed(T_e=T_negarr, T_i=0 * u.K)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert ion_sound_speed(T_e=1.2e6, T_i=0 * u.K) == ion_sound_speed(T_e=1.2e6 * u.K,
                                                                           T_i=0 * u.K)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert ion_sound_speed(T_i=1.3e6, T_e=0 * u.K) == ion_sound_speed(T_i=1.3e6 * u.K,
                                                                           T_e=0 * u.K)
 
@@ -276,7 +276,7 @@ def test_thermal_speed():
     with pytest.raises(RelativityError):
         thermal_speed(5e19 * u.K)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert thermal_speed(1e5) == thermal_speed(1e5 * u.K)
 
     assert thermal_speed(T_i, particle='p').unit.is_equivalent(u.m / u.s)
@@ -306,7 +306,7 @@ def test_thermal_speed():
     with pytest.raises(ValueError):
         thermal_speed(T_i, particle='asdfasd')
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert thermal_speed(1e6, particle='p') == thermal_speed(1e6 * u.K, particle='p')
 
     assert np.isclose(thermal_speed(1e6 * u.K,
@@ -438,7 +438,7 @@ def test_gyrofrequency():
     f_ce_use_equiv = omega_ce.to(u.Hz, equivalencies=[(u.cy / u.s, u.Hz)])
     assert np.isclose(f_ce.value, f_ce_use_equiv.value)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert gyrofrequency(5.0) == gyrofrequency(5.0 * u.T)
 
     assert gyrofrequency(B, particle=ion).unit.is_equivalent(u.rad / u.s)
@@ -459,7 +459,7 @@ def test_gyrofrequency():
 
     assert gyrofrequency(B, particle='e+') == gyrofrequency(B)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         gyrofrequency(8, 'p')
 
     with pytest.raises(u.UnitConversionError):
@@ -468,7 +468,7 @@ def test_gyrofrequency():
     with pytest.raises(InvalidParticleError):
         gyrofrequency(8 * u.T, particle='asdfasd')
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         # TODO this should be WARNS, not RAISES. and it's probably still raised
         assert gyrofrequency(5.0, 'p') == gyrofrequency(5.0 * u.T, 'p')
 
@@ -514,10 +514,10 @@ def test_gyroradius():
     with pytest.raises(ValueError):
         gyroradius(3.14159 * u.T, T_i=-1 * u.K)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert gyroradius(1.0, Vperp=1.0) == gyroradius(1.0 * u.T, Vperp=1.0 * u.m / u.s)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert gyroradius(1.1, T_i=1.2) == gyroradius(1.1 * u.T, T_i=1.2 * u.K)
 
     with pytest.raises(ValueError):
@@ -564,12 +564,12 @@ def test_gyroradius():
     with pytest.raises(ValueError):
         gyroradius(B, particle='p', T_i=-1 * u.K)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         gyro_without_units = gyroradius(1.0, particle="p", Vperp=1.0)
         gyro_with_units = gyroradius(1.0 * u.T, particle="p", Vperp=1.0 * u.m / u.s)
         assert gyro_without_units == gyro_with_units
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         gyro_t_without_units = gyroradius(1.1, particle="p", T_i=1.2)
         gyro_t_with_units = gyroradius(1.1 * u.T, particle="p", T_i=1.2 * u.K)
         assert gyro_t_with_units == gyro_t_without_units
@@ -600,7 +600,7 @@ def test_plasma_frequency():
     with pytest.raises(ValueError):
         plasma_frequency(np.nan * u.m ** -3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert plasma_frequency(1e19) == plasma_frequency(1e19 * u.m ** -3)
 
         assert plasma_frequency(n_i, particle='p').unit.is_equivalent(u.rad / u.s)
@@ -614,7 +614,7 @@ def test_plasma_frequency():
     with pytest.raises(ValueError):
         plasma_frequency(n=5 * u.m ** -3, particle='sdfas')
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         plasma_freq_no_units = plasma_frequency(1e19, particle='p')
         assert plasma_freq_no_units == plasma_frequency(1e19 * u.m ** -3, particle='p')
 
@@ -639,7 +639,7 @@ def test_Debye_length():
     assert np.isclose(Debye_length(
         1 * u.eV, 1 * u.cm ** -3).value, 7.43, atol=0.005)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         Debye_length(5, 5 * u.m ** -3)
 
     with pytest.raises(u.UnitConversionError):
@@ -656,10 +656,10 @@ def test_Debye_length():
     with pytest.raises(ValueError):
         Debye_length(Tarr2, narr3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert Debye_length(2.0, 2.0) == Debye_length(2.0 * u.K, 2.0 * u.m ** -3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert Debye_length(2.0 * u.K, 2.0) == Debye_length(2.0, 2.0 * u.m ** -3)
 
 
@@ -674,7 +674,7 @@ def test_Debye_number():
 
     assert np.isclose(Debye_number(1 * u.eV, 1 * u.cm ** -3).value, 1720862385.43342)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         Debye_number(T_e, 4)
 
     with pytest.raises(TypeError):
@@ -694,10 +694,10 @@ def test_Debye_number():
     with pytest.raises(ValueError):
         Debye_number(Tarr2, narr3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert Debye_number(1.1, 1.1) == Debye_number(1.1 * u.K, 1.1 * u.m ** -3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert Debye_number(1.1 * u.K, 1.1) == Debye_number(1.1, 1.1 * u.m ** -3)
 
 
@@ -714,7 +714,7 @@ def test_inertial_length():
 
     assert inertial_length(n_i, particle='p') == inertial_length(n_i, particle='p')
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         inertial_length(4, particle='p')
 
     with pytest.raises(u.UnitConversionError):
@@ -726,7 +726,7 @@ def test_inertial_length():
     with pytest.raises(ValueError):
         inertial_length(n_i, particle=-135)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         inertial_length_no_units = inertial_length(1e19, particle='p')
         assert inertial_length_no_units == inertial_length(1e19 * u.m ** -3, particle='p')
 
@@ -734,7 +734,7 @@ def test_inertial_length():
 
     assert np.isclose(inertial_length(1 * u.cm ** -3).cgs.value, 5.31e5, rtol=1e-3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         inertial_length(5)
 
     with pytest.raises(u.UnitConversionError):
@@ -743,7 +743,7 @@ def test_inertial_length():
     with pytest.raises(ValueError):
         inertial_length(-5 * u.m ** -3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert inertial_length(1e19) == inertial_length(1e19 * u.m ** -3)
 
 
@@ -762,7 +762,7 @@ def test_magnetic_pressure():
 
     assert np.isclose(magnetic_pressure(B).value, 397887.35772973835)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         magnetic_pressure(5)
 
     with pytest.raises(u.UnitConversionError):
@@ -777,7 +777,7 @@ def test_magnetic_pressure():
     with pytest.raises(ValueError):
         magnetic_pressure(B_nanarr)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert magnetic_pressure(22.2) == magnetic_pressure(22.2 * u.T)
 
 
@@ -800,7 +800,7 @@ def test_magnetic_energy_density():
 
     assert magnetic_energy_density(B_arr)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         magnetic_energy_density(5)
 
     with pytest.raises(u.UnitConversionError):
@@ -815,7 +815,7 @@ def test_magnetic_energy_density():
     with pytest.raises(ValueError):
         magnetic_energy_density(B_nanarr)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert magnetic_energy_density(22.2) == magnetic_energy_density(22.2 * u.T)
 
 
@@ -835,11 +835,11 @@ def test_upper_hybrid_frequency():
     with pytest.raises(ValueError):
         upper_hybrid_frequency(5 * u.T, n_e=-1 * u.m ** -3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert upper_hybrid_frequency(1.2, 1.3) == upper_hybrid_frequency(1.2 * u.T,
                                                                           1.3 * u.m ** -3)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert upper_hybrid_frequency(1.4 * u.T, 1.3) == upper_hybrid_frequency(1.4,
                                                                                 1.3 * u.m ** -3)
 
@@ -870,6 +870,6 @@ def test_lower_hybrid_frequency():
         lower_hybrid_frequency(
             np.nan * u.T, n_i=-5e19 * u.m ** -3, ion='asdfasd')
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         assert lower_hybrid_frequency(1.3, 1e19) == lower_hybrid_frequency(1.3 * u.T,
                                                                            1e19 * u.m ** -3)

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -47,7 +47,7 @@ def test_deBroglie_wavelength():
     with pytest.raises(RelativityError):
         deBroglie_wavelength(c * 1.000000001, 'e')
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         deBroglie_wavelength(0.79450719277, 'Be-7 1+')
 
     with pytest.raises(u.UnitConversionError):

--- a/plasmapy/physics/tests/test_relativity.py
+++ b/plasmapy/physics/tests/test_relativity.py
@@ -29,10 +29,10 @@ def test_Lorentz_factor():
     with pytest.raises(RelativityError):
         Lorentz_factor(1.0000000001*c)
 
-    with pytest.raises((ValueError, UserWarning)):
+    with pytest.raises(ValueError):
         Lorentz_factor(299792459)
 
-    with pytest.raises(UserWarning):
+    with pytest.warns(u.UnitsWarning):
         Lorentz_factor(2.2)
 
     with pytest.raises(u.UnitConversionError):

--- a/plasmapy/physics/transport/collisions.py
+++ b/plasmapy/physics/transport/collisions.py
@@ -341,8 +341,7 @@ def b_perp(T,
     # classical effects dominate.
     # !!!Note: an average ionization parameter will have to be
     # included here in the future
-    bPerp = (charges[0] * charges[1] /
-             (4 * pi * eps0 * reduced_mass * V ** 2))
+    bPerp = (charges[0] * charges[1] / (4 * pi * eps0 * reduced_mass * V ** 2))
     return bPerp.to(u.m)
 
 

--- a/plasmapy/physics/transport/collisions.py
+++ b/plasmapy/physics/transport/collisions.py
@@ -78,15 +78,19 @@ def Coulomb_logarithm(T,
     UnitConversionError
         If the units on any of the inputs are incorrect.
 
-    UserWarning
-        If the input velocity is greater than 80% of the speed of
-        light.
-
-    TypeError
         If the n_e, T, or V are not Quantities.
 
     PhysicsError
         If the result is smaller than 1.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----
@@ -303,12 +307,17 @@ def b_perp(T,
     UnitConversionError
         If the units on any of the inputs are incorrect
 
-    UserWarning
-        If the inputted velocity is greater than 80% of the speed of
-        light.
-
     TypeError
         If T, or V are not Quantities.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----
@@ -402,12 +411,17 @@ def impact_parameter(T,
     UnitConversionError
         If the units on any of the inputs are incorrect
 
-    UserWarning
-        If the inputted velocity is greater than 80% of the speed of
-        light.
-
     TypeError
         If the n_e, T, or V are not Quantities.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----
@@ -587,12 +601,17 @@ def collision_frequency(T,
     UnitConversionError
         If the units on any of the inputs are incorrect
 
-    UserWarning
-        If the inputted velocity is greater than 80% of the speed of
-        light.
-
     TypeError
         If the n_e, T, or V are not Quantities.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----
@@ -744,12 +763,17 @@ def mean_free_path(T,
     UnitConversionError
         If the units on any of the inputs are incorrect
 
-    UserWarning
-        If the inputted velocity is greater than 80% of the speed of
-        light.
-
     TypeError
         If the n_e, T, or V are not Quantities.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----
@@ -853,12 +877,17 @@ def Spitzer_resistivity(T,
     UnitConversionError
         If the units on any of the inputs are incorrect
 
-    UserWarning
-        If the inputted velocity is greater than 80% of the speed of
-        light.
-
     TypeError
         If the n_e, T, or V are not Quantities.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----
@@ -971,12 +1000,17 @@ def mobility(T,
     UnitConversionError
         If the units on any of the inputs are incorrect
 
-    UserWarning
-        If the inputted velocity is greater than 80% of the speed of
-        light.
-
     TypeError
         If the n_e, T, or V are not Quantities.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----
@@ -1087,12 +1121,17 @@ def Knudsen_number(characteristic_length,
     UnitConversionError
         If the units on any of the inputs are incorrect
 
-    UserWarning
-        If the inputted velocity is greater than 80% of the speed of
-        light.
-
     TypeError
         If the n_e, T, or V are not Quantities.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----
@@ -1196,12 +1235,17 @@ def coupling_parameter(T,
     UnitConversionError
         If the units on any of the inputs are incorrect
 
-    UserWarning
-        If the inputted velocity is greater than 80% of the speed of
-        light.
-
     TypeError
         If the n_e, T, or V are not Quantities.
+
+    Warns
+    -----
+    ~astropy.units.UnitsWarning
+        If units are not provided and SI units are assumed
+
+    ~plasmapy.utils.RelativityWarning
+        If the input velocity is greater than 80% of the speed of
+        light.
 
     Notes
     -----

--- a/plasmapy/physics/transport/collisions.py
+++ b/plasmapy/physics/transport/collisions.py
@@ -86,7 +86,7 @@ def Coulomb_logarithm(T,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of
@@ -313,7 +313,7 @@ def b_perp(T,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of
@@ -417,7 +417,7 @@ def impact_parameter(T,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of
@@ -607,7 +607,7 @@ def collision_frequency(T,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of
@@ -769,7 +769,7 @@ def mean_free_path(T,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of
@@ -883,7 +883,7 @@ def Spitzer_resistivity(T,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of
@@ -1006,7 +1006,7 @@ def mobility(T,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of
@@ -1127,7 +1127,7 @@ def Knudsen_number(characteristic_length,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of
@@ -1241,7 +1241,7 @@ def coupling_parameter(T,
     Warns
     -----
     ~astropy.units.UnitsWarning
-        If units are not provided and SI units are assumed
+        If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 80% of the speed of

--- a/plasmapy/physics/transport/collisions.py
+++ b/plasmapy/physics/transport/collisions.py
@@ -89,7 +89,7 @@ def Coulomb_logarithm(T,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes
@@ -316,7 +316,7 @@ def b_perp(T,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes
@@ -420,7 +420,7 @@ def impact_parameter(T,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes
@@ -610,7 +610,7 @@ def collision_frequency(T,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes
@@ -772,7 +772,7 @@ def mean_free_path(T,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes
@@ -886,7 +886,7 @@ def Spitzer_resistivity(T,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes
@@ -1009,7 +1009,7 @@ def mobility(T,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes
@@ -1130,7 +1130,7 @@ def Knudsen_number(characteristic_length,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes
@@ -1244,7 +1244,7 @@ def coupling_parameter(T,
         If units are not provided, SI units are assumed
 
     ~plasmapy.utils.RelativityWarning
-        If the input velocity is greater than 80% of the speed of
+        If the input velocity is greater than 5% of the speed of
         light.
 
     Notes

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -164,9 +164,9 @@ def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
 
     Warns
     -----
-    UserWarning
+    ~astropy.units.UnitsWarning
         If a `~astropy.units.Quantity` is not provided and unique units
-        are provided, a `UserWarning` will be raised and the inputted
+        are provided, a `UnitsWarning` will be raised and the inputted
         units will be assumed.
 
     Examples

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -93,20 +93,19 @@ def check_quantity(validations):
                 can_be_inf = validation_settings.get('can_be_inf', True)
                 can_be_nan = validation_settings.get('can_be_nan', False)
 
-                given_params_values[param_to_check] = _check_quantity(value_to_check,
-                                                                      param_to_check,
-                                                                      fname,
-                                                                      validation_settings['units'],
-                                                                      can_be_negative=can_be_negative,
-                                                                      can_be_complex=can_be_complex,
-                                                                      can_be_inf=can_be_inf,
-                                                                      can_be_nan=can_be_nan)
-
+                validated_value = _check_quantity(value_to_check,
+                                                  param_to_check,
+                                                  fname,
+                                                  validation_settings['units'],
+                                                  can_be_negative=can_be_negative,
+                                                  can_be_complex=can_be_complex,
+                                                  can_be_inf=can_be_inf,
+                                                  can_be_nan=can_be_nan)
+                given_params_values[param_to_check] = validated_value
 
             return f(**given_params_values)
         return wrapper
     return decorator
-
 
 
 def _check_quantity(arg, argname, funcname, units, can_be_negative=True,

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -173,6 +173,9 @@ def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
     --------
     >>> from astropy import units as u
     >>> _check_quantity(4*u.T, 'B', 'f', u.T)
+    <Quantity 4. T>
+    >>> _check_quantity(4, 'B', 'f', u.T)
+    <Quantity 4. T>
 
     """
 

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -260,7 +260,7 @@ def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
     return arg
 
 
-def check_relativistic(func=None, betafrac=0.1):
+def check_relativistic(func=None, betafrac=0.05):
     r"""
     Warns or raises an exception when the output of the decorated
     function is greater than `betafrac` times the speed of light.
@@ -272,7 +272,7 @@ def check_relativistic(func=None, betafrac=0.1):
 
     betafrac : float, optional
         The minimum fraction of the speed of light that will raise a
-        `~plasmapy.utils.RelativityWarning`. Defaults to 0.1.
+        `~plasmapy.utils.RelativityWarning`. Defaults to 5%.
 
     Returns
     -------
@@ -325,7 +325,7 @@ def check_relativistic(func=None, betafrac=0.1):
     return decorator
 
 
-def _check_relativistic(V, funcname, betafrac=0.1):
+def _check_relativistic(V, funcname, betafrac=0.05):
     r"""
     Warn or raise error for relativistic or superrelativistic
     velocities.
@@ -339,9 +339,9 @@ def _check_relativistic(V, funcname, betafrac=0.1):
         The name of the original function to be printed in the error
         messages.
 
-    betafrac : float
+    betafrac : float, optional
         The minimum fraction of the speed of light that will generate
-        a warning.
+        a warning. Defaults to 5%.
 
     Raises
     ------

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -20,7 +20,6 @@ quantity_error_examples_default = [
     (5 * u.T, [u.T, 1], TypeError),
     (5 * u.T, [1, u.m], TypeError),
     (u.T, u.J, TypeError),
-    (5.0, u.m, UserWarning),
     (3 * u.m / u.s, u.m, u.UnitConversionError),
     (5j * u.K, u.K, ValueError),
 ]
@@ -65,6 +64,10 @@ def test__check_quantity_errors_non_default(
                         can_be_complex=can_be_complex,
                         can_be_inf=can_be_inf)
 
+
+def test__check_quantity_warns_on_casting():
+    with pytest.warns(u.UnitsWarning):
+        _check_quantity(5, 'arg', 'funcname', u.m,)
 
 @pytest.mark.parametrize(
     "value, units, error", quantity_error_examples_default)


### PR DESCRIPTION
Closes #332.

Also likely closes some other older issues. I'll go through and check.

I thought I felt better with having some measure of leniency as to units, while keeping the fact that we're working with units explicit. So this is what I ended up with:

```python
>>> from plasmapy.physics import plasma_frequency
>>> from astropy import units as u
>>> plasma_frequency(10*u.m**-3)
<Quantity 178.39863647 rad / s>
>>> plasma_frequency(10)
WARNING: UnitsWarning: No units are specified for n = 10 in plasma_frequency. Assuming units of 1 / m3.
                To silence this warning, explicitly pass in an Astropy Quantity (from astropy.units)
                (see http://docs.astropy.org/en/stable/units/) [plasmapy.utils.checks]
<Quantity 178.39863647 rad / s>
>>> 
```

Notes:
* I went ahead and added UnitsWarning to Warns in a bunch of places, but I think having it documented in a single reliable place in the docs (probably in docs for Utils) and having the code link to astropy's docs (and potentially ours?)  would be enough.
* speaking of Warns, I may have messed some up. Pointing those occurences out would be appreciated!
* I'm kinda happy with this one. :3