### PR TITLE
Revert "Explicitly show DeprecationWarning in tests"

### DIFF
--- a/plasmapy/classes/tests/test_Plasma.py
+++ b/plasmapy/classes/tests/test_Plasma.py
@@ -98,7 +98,8 @@ def test_Plasma3D_derived_vars():
 
 
 class Test_PlasmaBlob():
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T_e = 5 * 11e3 * u.K
         self.n_e = 1e23 * u.cm ** -3

--- a/plasmapy/mathematics/tests/test_Fermi_integral.py
+++ b/plasmapy/mathematics/tests/test_Fermi_integral.py
@@ -9,7 +9,8 @@ from .. mathematics import Fermi_integral
 
 
 class Test_Fermi_integral:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """Initialize parameters for tests."""
         self.arg1 = 3.889780
         self.True1 = (6.272518847136373 - 8.673617379884035e-19j)

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -19,7 +19,8 @@ from ..parameters import (thermal_speed,
 
 
 class Test_Maxwellian_1D(object):
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T_e = 30000 * u.K
         self.v = 1e5 * u.m / u.s
@@ -218,7 +219,8 @@ class Test_Maxwellian_1D(object):
 
 # test class for Maxwellian_speed_1D function
 class Test_Maxwellian_speed_1D(object):
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 1.0 * u.eV
         self.particle = 'H'
@@ -349,7 +351,8 @@ class Test_Maxwellian_speed_1D(object):
 
 # test class for Maxwellian_velocity_3D function
 class Test_Maxwellian_velocity_3D(object):
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 1.0 * u.eV
         self.particle = 'H'
@@ -525,7 +528,8 @@ class Test_Maxwellian_velocity_3D(object):
 
 # test class for Maxwellian_speed_3D function
 class Test_Maxwellian_speed_3D(object):
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 1.0 * u.eV
         self.particle = 'H'
@@ -702,7 +706,8 @@ class Test_Maxwellian_speed_3D(object):
 
 # test class for kappa_velocity_1D function:
 class Test_kappa_velocity_1D(object):
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T_e = 30000 * u.K
         self.kappa = 4
@@ -930,7 +935,8 @@ class Test_kappa_velocity_1D(object):
 
 # test class for kappa_velocity_3D function
 class Test_kappa_velocity_3D(object):
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 1.0 * u.eV
         self.kappa = 4

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -326,7 +326,8 @@ def test_thermal_speed():
 
 
 class Test_kappa_thermal_speed(object):
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T_e = 5 * u.eV
         self.kappaInvalid = 3 / 2

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pytest
 from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
 from warnings import simplefilter
 
 from plasmapy.utils.exceptions import RelativityWarning, RelativityError
@@ -786,15 +787,15 @@ def test_magnetic_energy_density():
 
     assert magnetic_energy_density(B_arr).unit.is_equivalent(u.J / u.m ** 3)
 
-    assert str(magnetic_energy_density(B).unit) == 'J / m3'
+    assert magnetic_energy_density(B).unit.is_equivalent('J / m3')
 
     assert magnetic_energy_density(B).value == magnetic_pressure(B).value
 
-    assert magnetic_energy_density(2 * B) == 4 * magnetic_energy_density(B)
+    assert_quantity_allclose(magnetic_energy_density(2 * B), 4 * magnetic_energy_density(B))
 
-    assert np.isclose(magnetic_energy_density(B).value, 397887.35772973835)
+    assert_quantity_allclose(magnetic_energy_density(B).value, 397887.35772973835)
 
-    assert magnetic_energy_density(B) == magnetic_energy_density(B.to(u.G))
+    assert_quantity_allclose(magnetic_energy_density(B), magnetic_energy_density(B.to(u.G)))
 
     # TODO Add an array test!
 

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -85,10 +85,11 @@ def test_Alfven_speed():
     assert Alfven_speed(2 * B, rho) == 2 * Alfven_speed(B, rho)
 
     # Case when Z=1 is assumed
-    assert np.isclose(Alfven_speed(5 * u.T, 5e19 * u.m ** -3, ion='H+'),
-                      Alfven_speed(5 * u.T, 5e19 * u.m ** -3, ion='p'),
-                      atol=0 * u.m / u.s,
-                      rtol=1e-3)
+    with pytest.warns(RelativityWarning):
+        assert np.isclose(Alfven_speed(5 * u.T, 5e19 * u.m ** -3, ion='H+'),
+                          Alfven_speed(5 * u.T, 5e19 * u.m ** -3, ion='p'),
+                          atol=0 * u.m / u.s,
+                          rtol=1e-3)
 
     # Case where magnetic field and density are Quantity arrays
     V_A_arr = Alfven_speed(B_arr, rho_arr)

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -145,7 +145,8 @@ def test_Wigner_Seitz_radius():
 
 
 class Test_chemical_potential:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.n_e = 1e20 * u.cm ** -3
         self.n_e_fail = 1e23 * u.cm ** -3
@@ -190,7 +191,8 @@ class Test_chemical_potential:
 
 
 class Test_chemical_potential_interp:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.n_e = 1e23 * u.cm ** -3
         self.T = 11604 * u.K

--- a/plasmapy/physics/tests/test_relativity.py
+++ b/plasmapy/physics/tests/test_relativity.py
@@ -29,8 +29,8 @@ def test_Lorentz_factor():
     with pytest.raises(RelativityError):
         Lorentz_factor(1.0000000001*c)
 
-    with pytest.raises(ValueError):
-        Lorentz_factor(299792459)
+    with pytest.raises(ValueError), pytest.warns(u.UnitsWarning):
+            Lorentz_factor(299792459)
 
     with pytest.warns(u.UnitsWarning):
         Lorentz_factor(2.2)

--- a/plasmapy/physics/transport/tests/test_collisions.py
+++ b/plasmapy/physics/transport/tests/test_collisions.py
@@ -16,7 +16,8 @@ from plasmapy.constants import m_p, m_e, c
 
 
 class Test_Coulomb_logarithm:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.temperature1 = 10 * 11604 * u.K
         self.density1 = 1e20 * u.cm ** -3
@@ -473,7 +474,8 @@ class Test_Coulomb_logarithm:
 
 
 class Test_b_perp:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 11604 * u.K
         self.particles = ('e', 'p')
@@ -520,7 +522,8 @@ class Test_b_perp:
 
 
 class Test_impact_parameter:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 11604 * u.K
         self.n_e = 1e17 * u.cm ** -3
@@ -583,7 +586,8 @@ class Test_impact_parameter:
 
 
 class Test_collision_frequency:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 11604 * u.K
         self.n = 1e17 * u.cm ** -3
@@ -696,7 +700,8 @@ class Test_collision_frequency:
 
 
 class Test_mean_free_path:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 11604 * u.K
         self.n_e = 1e17 * u.cm ** -3
@@ -747,7 +752,8 @@ class Test_mean_free_path:
 
 
 class Test_Spitzer_resistivity:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 11604 * u.K
         self.n = 1e12 * u.cm ** -3
@@ -813,7 +819,8 @@ class Test_Spitzer_resistivity:
 
 
 class Test_mobility:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 11604 * u.K
         self.n_e = 1e17 * u.cm ** -3
@@ -882,7 +889,8 @@ class Test_mobility:
 
 
 class Test_Knudsen_number:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.length = 1 * u.nm
         self.T = 11604 * u.K
@@ -936,7 +944,8 @@ class Test_Knudsen_number:
 
 
 class Test_coupling_parameter:
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """initializing parameters for tests """
         self.T = 11604 * u.K
         self.n_e = 1e21 * u.cm ** -3

--- a/plasmapy/physics/transport/tests/test_collisions.py
+++ b/plasmapy/physics/transport/tests/test_collisions.py
@@ -11,7 +11,7 @@ from plasmapy.physics.transport import (Coulomb_logarithm,
                                         Knudsen_number,
                                         coupling_parameter)
 from plasmapy.physics.transport.collisions import Spitzer_resistivity
-from plasmapy.utils import RelativityWarning, RelativityError
+from plasmapy.utils import RelativityWarning, RelativityError, PhysicsWarning
 from plasmapy.constants import m_p, m_e, c
 
 
@@ -139,7 +139,8 @@ class Test_Coulomb_logarithm:
         # velocity. Chen uses v**2 = k * T / m  whereas we use
         # v ** 2 = 2 * k * T / m
         lnLambdaChen = 6.8 + np.log(2)
-        lnLambda = Coulomb_logarithm(T, n, ('e', 'p'))
+        with pytest.warns(RelativityWarning):
+            lnLambda = Coulomb_logarithm(T, n, ('e', 'p'))
         testTrue = np.isclose(lnLambda,
                               lnLambdaChen,
                               rtol=1e-1,
@@ -153,12 +154,13 @@ class Test_Coulomb_logarithm:
         Test for first version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        methodVal = Coulomb_logarithm(self.temperature1,
-                                      self.density1,
-                                      self.particles,
-                                      z_mean=np.nan * u.dimensionless_unscaled,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-1")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature1,
+                                          self.density1,
+                                          self.particles,
+                                          z_mean=np.nan * u.dimensionless_unscaled,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-1")
         testTrue = np.isclose(methodVal,
                               self.gms1,
                               rtol=1e-15,
@@ -173,12 +175,13 @@ class Test_Coulomb_logarithm:
         Murillo, and Schlanges PRE (2002). This checks for when
         a negative (invalid) Coulomb logarithm is returned.
         """
-        methodVal = Coulomb_logarithm(self.temperature2,
-                                      self.density2,
-                                      self.particles,
-                                      z_mean=np.nan * u.dimensionless_unscaled,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-1")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature2,
+                                          self.density2,
+                                          self.particles,
+                                          z_mean=np.nan * u.dimensionless_unscaled,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-1")
         testTrue = np.isclose(methodVal,
                               self.gms1_negative,
                               rtol=1e-15,
@@ -192,12 +195,13 @@ class Test_Coulomb_logarithm:
         Test for second version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        methodVal = Coulomb_logarithm(self.temperature1,
-                                      self.density1,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-2")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature1,
+                                          self.density1,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-2")
         testTrue = np.isclose(methodVal,
                               self.gms2,
                               rtol=1e-15,
@@ -212,12 +216,13 @@ class Test_Coulomb_logarithm:
         Murillo, and Schlanges PRE (2002). This checks for when
         a negative (invalid) Coulomb logarithm is returned.
         """
-        methodVal = Coulomb_logarithm(self.temperature2,
-                                      self.density2,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-2")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature2,
+                                          self.density2,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-2")
         testTrue = np.isclose(methodVal,
                               self.gms2_negative,
                               rtol=1e-15,
@@ -231,12 +236,13 @@ class Test_Coulomb_logarithm:
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        methodVal = Coulomb_logarithm(self.temperature1,
-                                      self.density1,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-3")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature1,
+                                          self.density1,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-3")
         testTrue = np.isclose(methodVal,
                               self.gms3,
                               rtol=1e-15,
@@ -252,12 +258,13 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        methodVal = Coulomb_logarithm(self.temperature2,
-                                      self.density2,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-3")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature2,
+                                          self.density2,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-3")
         testTrue = np.isclose(methodVal,
                               self.gms3_negative,
                               rtol=1e-15,
@@ -271,12 +278,13 @@ class Test_Coulomb_logarithm:
         Test for fourth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        methodVal = Coulomb_logarithm(self.temperature1,
-                                      self.density1,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-4")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature1,
+                                          self.density1,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-4")
         testTrue = np.isclose(methodVal,
                               self.gms4,
                               rtol=1e-15,
@@ -292,12 +300,13 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        methodVal = Coulomb_logarithm(self.temperature2,
-                                      self.density2,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-4")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature2,
+                                          self.density2,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-4")
         testTrue = np.isclose(methodVal,
                               self.gms4_negative,
                               rtol=1e-15,
@@ -311,12 +320,13 @@ class Test_Coulomb_logarithm:
         Test for fifth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        methodVal = Coulomb_logarithm(self.temperature1,
-                                      self.density1,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-5")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature1,
+                                          self.density1,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-5")
         testTrue = np.isclose(methodVal,
                               self.gms5,
                               rtol=1e-15,
@@ -332,12 +342,13 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        methodVal = Coulomb_logarithm(self.temperature2,
-                                      self.density2,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-5")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature2,
+                                          self.density2,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-5")
         testTrue = np.isclose(methodVal,
                               self.gms5_negative,
                               rtol=1e-15,
@@ -351,12 +362,13 @@ class Test_Coulomb_logarithm:
         Test for sixth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        methodVal = Coulomb_logarithm(self.temperature1,
-                                      self.density1,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-6")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature1,
+                                          self.density1,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-6")
         testTrue = np.isclose(methodVal,
                               self.gms6,
                               rtol=1e-15,
@@ -372,12 +384,13 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        methodVal = Coulomb_logarithm(self.temperature2,
-                                      self.density2,
-                                      self.particles,
-                                      z_mean=self.z_mean,
-                                      V=np.nan * u.m / u.s,
-                                      method="GMS-6")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(self.temperature2,
+                                          self.density2,
+                                          self.particles,
+                                          z_mean=self.z_mean,
+                                          V=np.nan * u.m / u.s,
+                                          method="GMS-6")
         testTrue = np.isclose(methodVal,
                               self.gms6_negative,
                               rtol=1e-15,
@@ -588,12 +601,13 @@ class Test_collision_frequency:
         """
         Test for known value.
         """
-        methodVal = collision_frequency(self.T,
-                                        self.n,
-                                        self.particles,
-                                        z_mean=np.nan * u.dimensionless_unscaled,
-                                        V=np.nan * u.m / u.s,
-                                        method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = collision_frequency(self.T,
+                                            self.n,
+                                            self.particles,
+                                            z_mean=np.nan * u.dimensionless_unscaled,
+                                            V=np.nan * u.m / u.s,
+                                            method="classical")
         testTrue = np.isclose(self.True1,
                               methodVal.si.value,
                               rtol=1e-1,
@@ -608,12 +622,13 @@ class Test_collision_frequency:
         value comparison by some quantity close to numerical error.
         """
         fail1 = self.True1 * (1 + 1e-15)
-        methodVal = collision_frequency(self.T,
-                                        self.n,
-                                        self.particles,
-                                        z_mean=np.nan * u.dimensionless_unscaled,
-                                        V=np.nan * u.m / u.s,
-                                        method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = collision_frequency(self.T,
+                                            self.n,
+                                            self.particles,
+                                            z_mean=np.nan * u.dimensionless_unscaled,
+                                            V=np.nan * u.m / u.s,
+                                            method="classical")
         testTrue = not np.isclose(methodVal.si.value,
                                   fail1,
                                   rtol=1e-16,
@@ -626,12 +641,13 @@ class Test_collision_frequency:
         """
         Testing collision frequency between electrons.
         """
-        methodVal = collision_frequency(self.T,
-                                        self.n,
-                                        self.electrons,
-                                        z_mean=np.nan * u.dimensionless_unscaled,
-                                        V=np.nan * u.m / u.s,
-                                        method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = collision_frequency(self.T,
+                                            self.n,
+                                            self.electrons,
+                                            z_mean=np.nan * u.dimensionless_unscaled,
+                                            V=np.nan * u.m / u.s,
+                                            method="classical")
         testTrue = np.isclose(self.True_electrons,
                               methodVal.si.value,
                               rtol=1e-1,
@@ -644,12 +660,13 @@ class Test_collision_frequency:
         """
         Testing collision frequency between protons (ions).
         """
-        methodVal = collision_frequency(self.T,
-                                        self.n,
-                                        self.protons,
-                                        z_mean=np.nan * u.dimensionless_unscaled,
-                                        V=np.nan * u.m / u.s,
-                                        method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = collision_frequency(self.T,
+                                            self.n,
+                                            self.protons,
+                                            z_mean=np.nan * u.dimensionless_unscaled,
+                                            V=np.nan * u.m / u.s,
+                                            method="classical")
         testTrue = np.isclose(self.True_protons,
                               methodVal.si.value,
                               rtol=1e-1,
@@ -662,12 +679,13 @@ class Test_collision_frequency:
         """
         Test collisional frequency function when given arbitrary z_mean.
         """
-        methodVal = collision_frequency(self.T,
-                                        self.n,
-                                        self.particles,
-                                        z_mean=self.z_mean,
-                                        V=np.nan * u.m / u.s,
-                                        method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = collision_frequency(self.T,
+                                            self.n,
+                                            self.particles,
+                                            z_mean=self.z_mean,
+                                            V=np.nan * u.m / u.s,
+                                            method="classical")
         testTrue = np.isclose(self.True_zmean,
                               methodVal.si.value,
                               rtol=1e-1,
@@ -691,12 +709,13 @@ class Test_mean_free_path:
         """
         Test for known value.
         """
-        methodVal = mean_free_path(self.T,
-                                   self.n_e,
-                                   self.particles,
-                                   z_mean=np.nan * u.dimensionless_unscaled,
-                                   V=np.nan * u.m / u.s,
-                                   method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = mean_free_path(self.T,
+                                       self.n_e,
+                                       self.particles,
+                                       z_mean=np.nan * u.dimensionless_unscaled,
+                                       V=np.nan * u.m / u.s,
+                                       method="classical")
         testTrue = np.isclose(self.True1,
                               methodVal.si.value,
                               rtol=1e-1,
@@ -711,12 +730,13 @@ class Test_mean_free_path:
         value comparison by some quantity close to numerical error.
         """
         fail1 = self.True1 * (1 + 1e-15)
-        methodVal = mean_free_path(self.T,
-                                   self.n_e,
-                                   self.particles,
-                                   z_mean=np.nan * u.dimensionless_unscaled,
-                                   V=np.nan * u.m / u.s,
-                                   method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = mean_free_path(self.T,
+                                       self.n_e,
+                                       self.particles,
+                                       z_mean=np.nan * u.dimensionless_unscaled,
+                                       V=np.nan * u.m / u.s,
+                                       method="classical")
         testTrue = not np.isclose(methodVal.si.value,
                                   fail1,
                                   rtol=1e-16,
@@ -807,12 +827,13 @@ class Test_mobility:
         """
         Test for known value.
         """
-        methodVal = mobility(self.T,
-                             self.n_e,
-                             self.particles,
-                             z_mean=np.nan * u.dimensionless_unscaled,
-                             V=np.nan * u.m / u.s,
-                             method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = mobility(self.T,
+                                 self.n_e,
+                                 self.particles,
+                                 z_mean=np.nan * u.dimensionless_unscaled,
+                                 V=np.nan * u.m / u.s,
+                                 method="classical")
         testTrue = np.isclose(self.True1,
                               methodVal.si.value,
                               rtol=1e-1,
@@ -827,12 +848,13 @@ class Test_mobility:
         value comparison by some quantity close to numerical error.
         """
         fail1 = self.True1 * (1 + 1e-15)
-        methodVal = mobility(self.T,
-                             self.n_e,
-                             self.particles,
-                             z_mean=np.nan * u.dimensionless_unscaled,
-                             V=np.nan * u.m / u.s,
-                             method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = mobility(self.T,
+                                 self.n_e,
+                                 self.particles,
+                                 z_mean=np.nan * u.dimensionless_unscaled,
+                                 V=np.nan * u.m / u.s,
+                                 method="classical")
         testTrue = not np.isclose(methodVal.si.value,
                                   fail1,
                                   rtol=1e-16,
@@ -843,12 +865,13 @@ class Test_mobility:
 
     def test_zmean(self):
         """Testing mobility when z_mean is passed."""
-        methodVal = mobility(self.T,
-                             self.n_e,
-                             self.particles,
-                             z_mean=self.z_mean,
-                             V=np.nan * u.m / u.s,
-                             method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = mobility(self.T,
+                                 self.n_e,
+                                 self.particles,
+                                 z_mean=self.z_mean,
+                                 V=np.nan * u.m / u.s,
+                                 method="classical")
         testTrue = np.isclose(self.True_zmean,
                               methodVal.si.value,
                               rtol=1e-1,
@@ -873,13 +896,14 @@ class Test_Knudsen_number:
         """
         Test for known value.
         """
-        methodVal = Knudsen_number(self.length,
-                                   self.T,
-                                   self.n_e,
-                                   self.particles,
-                                   z_mean=np.nan * u.dimensionless_unscaled,
-                                   V=np.nan * u.m / u.s,
-                                   method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Knudsen_number(self.length,
+                                       self.T,
+                                       self.n_e,
+                                       self.particles,
+                                       z_mean=np.nan * u.dimensionless_unscaled,
+                                       V=np.nan * u.m / u.s,
+                                       method="classical")
         testTrue = np.isclose(self.True1,
                               methodVal,
                               rtol=1e-1,
@@ -894,13 +918,14 @@ class Test_Knudsen_number:
         value comparison by some quantity close to numerical error.
         """
         fail1 = self.True1 * (1 + 1e-15)
-        methodVal = Knudsen_number(self.length,
-                                   self.T,
-                                   self.n_e,
-                                   self.particles,
-                                   z_mean=np.nan * u.dimensionless_unscaled,
-                                   V=np.nan * u.m / u.s,
-                                   method="classical")
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
+            methodVal = Knudsen_number(self.length,
+                                       self.T,
+                                       self.n_e,
+                                       self.particles,
+                                       z_mean=np.nan * u.dimensionless_unscaled,
+                                       V=np.nan * u.m / u.s,
+                                       method="classical")
         testTrue = not np.isclose(methodVal,
                                   fail1,
                                   rtol=0.0,

--- a/plasmapy/physics/transport/tests/test_transport.py
+++ b/plasmapy/physics/transport/tests/test_transport.py
@@ -119,16 +119,16 @@ class Test_classical_transport:
                                       ion_particle=self.ion_particle,
                                       model='spitzer',
                                       field_orientation='perp')
-        alpha_spitzer_perp_NRL = (1.03e-4 * ct2.Z *
-                                  ct2.coulomb_log_ei *
-                                  (ct2.T_e.to(u.eV)).value ** (-3 / 2) *
-                                  u.Ohm * u.m)
-        testTrue = np.isclose(ct2.resistivity().value,
-                              alpha_spitzer_perp_NRL.value,
-                              rtol=2e-2)
-        errStr = (f"Resistivity should be close to "
-                  f"{alpha_spitzer_perp_NRL.value} "
-                  f"and not {ct2.resistivity().value}.")
+            alpha_spitzer_perp_NRL = (1.03e-4 * ct2.Z *
+                                      ct2.coulomb_log_ei *
+                                      (ct2.T_e.to(u.eV)).value ** (-3 / 2) *
+                                      u.Ohm * u.m)
+            testTrue = np.isclose(ct2.resistivity().value,
+                                  alpha_spitzer_perp_NRL.value,
+                                  rtol=2e-2)
+            errStr = (f"Resistivity should be close to "
+                      f"{alpha_spitzer_perp_NRL.value} "
+                      f"and not {ct2.resistivity().value}.")
         assert testTrue, errStr
 
     def test_resistivity_units(self):

--- a/plasmapy/physics/transport/tests/test_transport.py
+++ b/plasmapy/physics/transport/tests/test_transport.py
@@ -53,8 +53,8 @@ def count_decimal_places(digits):
 
 # test class for classical_transport class:
 class Test_classical_transport:
-
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """set up some initial values for tests"""
         u.set_enabled_equivalencies(u.temperature_energy())
         self.T_e = 1000 * u.eV
@@ -75,39 +75,40 @@ class Test_classical_transport:
         self.theta = self.T_e / self.T_i
         self.model = 'Braginskii'
         self.field_orientation = 'all'
-        self.ct = classical_transport(
-            T_e=self.T_e,
-            n_e=self.n_e,
-            T_i=self.T_i,
-            n_i=self.n_i,
-            ion_particle=self.ion_particle,
-            Z=self.Z,
-            B=self.B,
-            model=self.model,
-            field_orientation=self.field_orientation,
-            coulomb_log_ei=self.coulomb_log_val_ei,
-            coulomb_log_ii=self.coulomb_log_val_ii,
-            V_ei=self.V_ei,
-            V_ii=self.V_ii,
-            hall_e=self.hall_e,
-            hall_i=self.hall_i,
-            mu=self.mu,
-            theta=self.theta,
-            )
-        self.ct_wrapper = classical_transport(
-            T_e=self.T_e,
-            n_e=self.n_e,
-            T_i=self.T_i,
-            n_i=self.n_i,
-            ion_particle=self.ion_particle,
-            Z=self.Z,
-            B=self.B,
-            model=self.model,
-            field_orientation=self.field_orientation,
-            mu=self.mu,
-            theta=self.theta,
-            )
-        self.all_variables = self.ct.all_variables()
+        with pytest.warns(RelativityWarning):
+            self.ct = classical_transport(
+                T_e=self.T_e,
+                n_e=self.n_e,
+                T_i=self.T_i,
+                n_i=self.n_i,
+                ion_particle=self.ion_particle,
+                Z=self.Z,
+                B=self.B,
+                model=self.model,
+                field_orientation=self.field_orientation,
+                coulomb_log_ei=self.coulomb_log_val_ei,
+                coulomb_log_ii=self.coulomb_log_val_ii,
+                V_ei=self.V_ei,
+                V_ii=self.V_ii,
+                hall_e=self.hall_e,
+                hall_i=self.hall_i,
+                mu=self.mu,
+                theta=self.theta,
+                )
+            self.ct_wrapper = classical_transport(
+                T_e=self.T_e,
+                n_e=self.n_e,
+                T_i=self.T_i,
+                n_i=self.n_i,
+                ion_particle=self.ion_particle,
+                Z=self.Z,
+                B=self.B,
+                model=self.model,
+                field_orientation=self.field_orientation,
+                mu=self.mu,
+                theta=self.theta,
+                )
+            self.all_variables = self.ct.all_variables()
 
     def test_spitzer_vs_formulary(self):
         """Spitzer resistivity should agree with approx. in NRL formulary"""
@@ -636,8 +637,8 @@ def test_nondim_viscosity_unrecognized_model(particle):
 
 # test class for _nondim_tc_e_braginskii function:
 class Test__nondim_tc_e_braginskii:
-
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """set up some initial values for tests"""
         self.big_hall = 1000
         self.small_hall = 0
@@ -699,8 +700,8 @@ class Test__nondim_tc_e_braginskii:
 
 # test class for _nondim_tc_i_braginskii function:
 class Test__nondim_tc_i_braginskii:
-
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """set up some initial values for tests"""
         self.big_hall = 1000
         self.small_hall = 0
@@ -737,8 +738,8 @@ class Test__nondim_tc_i_braginskii:
 
 # test class for _nondim_tec_braginskii function:
 class Test__nondim_tec_braginskii:
-
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """set up some initial values for tests"""
         self.big_hall = 1000
         self.small_hall = 0
@@ -775,8 +776,8 @@ class Test__nondim_tec_braginskii:
 
 # test class for _nondim_resist_braginskii function:
 class Test__nondim_resist_braginskii:
-
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """set up some initial values for tests"""
         self.big_hall = 1000
         self.small_hall = 0
@@ -813,8 +814,8 @@ class Test__nondim_resist_braginskii:
 
 # test class for _nondim_visc_i_braginskii function:
 class Test__nondim_visc_i_braginskii:
-
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """set up some initial values for tests"""
         self.big_hall = 1000
         self.small_hall = 0
@@ -840,8 +841,8 @@ class Test__nondim_visc_i_braginskii:
 
 # test class for _nondim_visc_e_braginskii function:
 class Test__nondim_visc_e_braginskii:
-
-    def setup_method(self):
+    @classmethod
+    def setup_class(self):
         """set up some initial values for tests"""
         self.big_hall = 1000
         self.small_hall = 0

--- a/plasmapy/physics/transport/tests/test_transport.py
+++ b/plasmapy/physics/transport/tests/test_transport.py
@@ -546,37 +546,35 @@ class Test_classical_transport:
 
     def test_ion_thermal_conductivity_wrapper(self):
         with pytest.warns(RelativityWarning):
-            assert_quantity_allclose(ion_thermal_conductivity(T_e=self.T_e,
-                                                              n_e=self.n_e,
-                                                              T_i=self.T_i,
-                                                              n_i=self.n_i,
-                                                              ion_particle=self.ion_particle,
-                                                              Z=self.Z,
-                                                              B=self.B,
-                                                              model=self.model,
-                                                              field_orientation=self.field_orientation,
-                                                              mu=self.mu,
-                                                              theta=self.theta,
-                                                              ),
-                                     self.ct_wrapper.ion_thermal_conductivity())
-
+            wrapped = ion_thermal_conductivity(T_e=self.T_e,
+                                               n_e=self.n_e,
+                                               T_i=self.T_i,
+                                               n_i=self.n_i,
+                                               ion_particle=self.ion_particle,
+                                               Z=self.Z,
+                                               B=self.B,
+                                               model=self.model,
+                                               field_orientation=self.field_orientation,
+                                               mu=self.mu,
+                                               theta=self.theta,
+                                               )
+            assert_quantity_allclose(wrapped, self.ct_wrapper.ion_thermal_conductivity())
 
     def test_electron_thermal_conductivity_wrapper(self):
         with pytest.warns(RelativityWarning):
-            assert_quantity_allclose(electron_thermal_conductivity(T_e=self.T_e,
-                                                                   n_e=self.n_e,
-                                                                   T_i=self.T_i,
-                                                                   n_i=self.n_i,
-                                                                   ion_particle=self.ion_particle,
-                                                                   Z=self.Z,
-                                                                   B=self.B,
-                                                                   model=self.model,
-                                                                   field_orientation=self.field_orientation,
-                                                                   mu=self.mu,
-                                                                   theta=self.theta,
-                                                                   ),
-                                     self.ct_wrapper.electron_thermal_conductivity())
-
+            wrapped = electron_thermal_conductivity(T_e=self.T_e,
+                                                    n_e=self.n_e,
+                                                    T_i=self.T_i,
+                                                    n_i=self.n_i,
+                                                    ion_particle=self.ion_particle,
+                                                    Z=self.Z,
+                                                    B=self.B,
+                                                    model=self.model,
+                                                    field_orientation=self.field_orientation,
+                                                    mu=self.mu,
+                                                    theta=self.theta,
+                                                    )
+            assert_quantity_allclose(wrapped, self.ct_wrapper.electron_thermal_conductivity())
 
     def test_ion_viscosity_wrapper(self):
         with pytest.warns(RelativityWarning):

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -171,10 +171,11 @@ def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
     Examples
     --------
     >>> from astropy import units as u
+    >>> import pytest
     >>> _check_quantity(4*u.T, 'B', 'f', u.T)
     <Quantity 4. T>
-    >>> _check_quantity(4, 'B', 'f', u.T)
-    <Quantity 4. T>
+    >>> with pytest.warns(u.UnitsWarning, match="No units are specified"):
+    ...     assert _check_quantity(4, 'B', 'f', u.T) == 4 * u.T
 
     """
 

--- a/plasmapy/utils/tests/test_checks.py
+++ b/plasmapy/utils/tests/test_checks.py
@@ -222,8 +222,8 @@ def test_check_quantity_decorator_two_args_one_kwargs_not_default():
 # (speed, betafrac)
 non_relativistic_speed_examples = [
     (0 * u.m / u.s, 0.1),
-    (0.099999 * c, 0.1),
-    (-0.09 * c, 0.1),
+    (0.0099999 * c, 0.1),
+    (-0.009 * c, 0.1),
     (5 * u.AA / u.Gyr, 0.1)
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,9 +30,6 @@ show-response = 1
 [tool:pytest]
 addopts = --doctest-modules
 norecursedirs = "astropy_helpers" "docs" "build" "docs/_build" "examples"
-filterwarnings =
-    once::DeprecationWarning
-    once::PendingDeprecationWarning
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
It seemed like a good idea at the time, but it turns out everyone takes exception to a ton of `DeprecationWarning`s showing up in Pytest output. Who knew.

I still think it's a good idea somewhat, just that the implementation with pytest was not the right one. 

I'll merge this once tests pass and we're not getting anything too silly in Travis.