### PR TITLE
Rename classical_transport class to ClassicalTransport

### DIFF
--- a/plasmapy/examples/plot_braginskii.py
+++ b/plasmapy/examples/plot_braginskii.py
@@ -8,7 +8,7 @@ from Bragiński's theory.
 """
 
 from astropy import units as u
-from plasmapy.physics.transport.braginskii import classical_transport
+from plasmapy.physics.transport.braginskii import ClassicalTransport
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -24,13 +24,13 @@ ion_concentration = electron_concentration
 ion_particle = 'D+'  # a crude approximation
 
 ######################################################
-# We now make the default classical_transport object:
+# We now make the default ClassicalTransport object:
 
-braginskii = classical_transport(thermal_energy_per_electron,
-                                 electron_concentration,
-                                 thermal_energy_per_ion,
-                                 ion_concentration,
-                                 ion_particle)
+braginskii = ClassicalTransport(thermal_energy_per_electron,
+                                electron_concentration,
+                                thermal_energy_per_ion,
+                                ion_concentration,
+                                ion_particle)
 
 ######################################################
 # These variables are calculated during initialization and can be

--- a/plasmapy/physics/dielectric.py
+++ b/plasmapy/physics/dielectric.py
@@ -1,4 +1,4 @@
-"""Functions to calculate plasma dielectric paramaters"""
+"""Functions to calculate plasma dielectric parameters"""
 
 from astropy import units as u
 import plasmapy.utils as utils

--- a/plasmapy/physics/transport/__init__.py
+++ b/plasmapy/physics/transport/__init__.py
@@ -8,7 +8,7 @@ from .collisions import (Coulomb_logarithm,
                          mobility,
                          Knudsen_number,
                          coupling_parameter)
-from .braginskii import (classical_transport,
+from .braginskii import (ClassicalTransport,
                          resistivity,
                          thermoelectric_conductivity,
                          electron_thermal_conductivity,

--- a/plasmapy/physics/transport/braginskii.py
+++ b/plasmapy/physics/transport/braginskii.py
@@ -16,7 +16,7 @@ from plasmapy.physics.transport.collisions import (collision_rate_electron_ion,
 from plasmapy.constants import e, m_e, k_B
 
 
-class classical_transport:
+class ClassicalTransport:
     r"""
     Classical transport coefficients (e.g. Braginskii, 1965).
 
@@ -187,7 +187,7 @@ class classical_transport:
     Examples
     --------
     >>> from astropy import units as u
-    >>> t = classical_transport(1*u.eV, 1e20/u.m**3,
+    >>> t = ClassicalTransport(1*u.eV, 1e20/u.m**3,
     ...                         1*u.eV, 1e20/u.m**3, 'p')
     >>> t.resistivity()
     <Quantity 0.00036701 m Ohm>
@@ -283,7 +283,7 @@ class classical_transport:
                 self.m_i = atomic.particle_mass(ion_particle)
             except Exception:
                 raise ValueError(f"Unable to find mass of particle: "
-                                 f"{ion_particle} in classical_transport")
+                                 f"{ion_particle} in ClassicalTransport")
         else:
             self.m_i = m_i.to(u.kg)
         self.Z = grab_charge(ion_particle, Z)
@@ -539,10 +539,10 @@ class classical_transport:
 def resistivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None, Z=None, B=0.0 * u.T,
                 model='Braginskii', field_orientation='parallel',
                 mu=None, theta=None, coulomb_log_method="classical"):
-    ct = classical_transport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                             Z=Z, B=B, model=model,
-                             field_orientation=field_orientation,
-                             mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
+                            Z=Z, B=B, model=model,
+                            field_orientation=field_orientation,
+                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
     return ct.resistivity()
 
 
@@ -550,10 +550,10 @@ def thermoelectric_conductivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
                                 Z=None, B=0.0 * u.T, model='Braginskii',
                                 field_orientation='parallel', mu=None,
                                 theta=None, coulomb_log_method="classical"):
-    ct = classical_transport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                             Z=Z, B=B, model=model,
-                             field_orientation=field_orientation,
-                             mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
+                            Z=Z, B=B, model=model,
+                            field_orientation=field_orientation,
+                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
     return ct.thermoelectric_conductivity()
 
 
@@ -561,10 +561,10 @@ def ion_thermal_conductivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
                              Z=None, B=0.0 * u.T, model='Braginskii',
                              field_orientation='parallel', mu=None,
                              theta=None, coulomb_log_method="classical"):
-    ct = classical_transport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                             Z=Z, B=B, model=model,
-                             field_orientation=field_orientation,
-                             mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
+                            Z=Z, B=B, model=model,
+                            field_orientation=field_orientation,
+                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
     return ct.ion_thermal_conductivity()
 
 
@@ -572,10 +572,10 @@ def electron_thermal_conductivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
                                   Z=None, B=0.0 * u.T, model='Braginskii',
                                   field_orientation='parallel', mu=None,
                                   theta=None, coulomb_log_method="classical"):
-    ct = classical_transport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                             Z=Z, B=B, model=model,
-                             field_orientation=field_orientation,
-                             mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
+                            Z=Z, B=B, model=model,
+                            field_orientation=field_orientation,
+                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
     return ct.electron_thermal_conductivity()
 
 
@@ -583,10 +583,10 @@ def ion_viscosity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
                   Z=None, B=0.0 * u.T, model='Braginskii',
                   field_orientation='parallel', mu=None,
                   theta=None, coulomb_log_method="classical"):
-    ct = classical_transport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                             Z=Z, B=B, model=model,
-                             field_orientation=field_orientation,
-                             mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
+                            Z=Z, B=B, model=model,
+                            field_orientation=field_orientation,
+                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
     return ct.ion_viscosity()
 
 
@@ -594,10 +594,10 @@ def electron_viscosity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
                        Z=None, B=0.0 * u.T, model='Braginskii',
                        field_orientation='parallel', mu=None,
                        theta=None, coulomb_log_method="classical"):
-    ct = classical_transport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                             Z=Z, B=B, model=model,
-                             field_orientation=field_orientation,
-                             mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
+                            Z=Z, B=B, model=model,
+                            field_orientation=field_orientation,
+                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
     return ct.electron_viscosity()
 
 

--- a/plasmapy/physics/transport/braginskii.py
+++ b/plasmapy/physics/transport/braginskii.py
@@ -309,8 +309,8 @@ class ClassicalTransport:
         else:
             self.coulomb_log_ei = Coulomb_logarithm(T_e,
                                                     n_e,
-                                                    [self.e_particle,
-                                                     self.ion_particle],
+                                                    (self.e_particle,
+                                                     self.ion_particle),
                                                     V_ei,
                                                     method=coulomb_log_method)
         if coulomb_log_ii is not None:
@@ -322,8 +322,8 @@ class ClassicalTransport:
         else:
             self.coulomb_log_ii = Coulomb_logarithm(T_i,
                                                     n_e,  # this is not a typo!
-                                                    [self.ion_particle,
-                                                     self.ion_particle],
+                                                    (self.ion_particle,
+                                                     self.ion_particle),
                                                     V_ii,
                                                     method=coulomb_log_method)
 
@@ -536,9 +536,20 @@ class ClassicalTransport:
         return d
 
 
-def resistivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None, Z=None, B=0.0 * u.T,
-                model='Braginskii', field_orientation='parallel',
-                mu=None, theta=None, coulomb_log_method="classical"):
+def resistivity(T_e,
+                n_e,
+                T_i,
+                n_i,
+                ion_particle,
+                m_i=None,
+                Z=None,
+                B=0.0 * u.T,
+                model='Braginskii',
+                field_orientation='parallel',
+                mu=None,
+                theta=None,
+                coulomb_log_method="classical"):
+
     ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
                             Z=Z, B=B, model=model,
                             field_orientation=field_orientation,
@@ -546,58 +557,148 @@ def resistivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None, Z=None, B=0.0 * u.T,
     return ct.resistivity()
 
 
-def thermoelectric_conductivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
-                                Z=None, B=0.0 * u.T, model='Braginskii',
-                                field_orientation='parallel', mu=None,
-                                theta=None, coulomb_log_method="classical"):
-    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                            Z=Z, B=B, model=model,
+def thermoelectric_conductivity(T_e,
+                                n_e,
+                                T_i,
+                                n_i,
+                                ion_particle,
+                                m_i=None,
+                                Z=None,
+                                B=0.0 * u.T,
+                                model='Braginskii',
+                                field_orientation='parallel',
+                                mu=None,
+                                theta=None,
+                                coulomb_log_method="classical"):
+    ct = ClassicalTransport(T_e,
+                            n_e,
+                            T_i,
+                            n_i,
+                            ion_particle,
+                            m_i,
+                            Z=Z,
+                            B=B,
+                            model=model,
                             field_orientation=field_orientation,
-                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+                            mu=mu,
+                            theta=theta,
+                            coulomb_log_method=coulomb_log_method)
     return ct.thermoelectric_conductivity()
 
 
-def ion_thermal_conductivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
-                             Z=None, B=0.0 * u.T, model='Braginskii',
-                             field_orientation='parallel', mu=None,
-                             theta=None, coulomb_log_method="classical"):
-    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                            Z=Z, B=B, model=model,
+def ion_thermal_conductivity(T_e,
+                             n_e,
+                             T_i,
+                             n_i,
+                             ion_particle,
+                             m_i=None,
+                             Z=None,
+                             B=0.0 * u.T,
+                             model='Braginskii',
+                             field_orientation='parallel',
+                             mu=None,
+                             theta=None,
+                             coulomb_log_method="classical"):
+    ct = ClassicalTransport(T_e,
+                            n_e,
+                            T_i,
+                            n_i,
+                            ion_particle,
+                            m_i,
+                            Z=Z,
+                            B=B,
+                            model=model,
                             field_orientation=field_orientation,
-                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+                            mu=mu,
+                            theta=theta,
+                            coulomb_log_method=coulomb_log_method)
     return ct.ion_thermal_conductivity()
 
 
-def electron_thermal_conductivity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
-                                  Z=None, B=0.0 * u.T, model='Braginskii',
-                                  field_orientation='parallel', mu=None,
-                                  theta=None, coulomb_log_method="classical"):
-    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                            Z=Z, B=B, model=model,
+def electron_thermal_conductivity(T_e,
+                                  n_e,
+                                  T_i,
+                                  n_i,
+                                  ion_particle,
+                                  m_i=None,
+                                  Z=None,
+                                  B=0.0 * u.T,
+                                  model='Braginskii',
+                                  field_orientation='parallel',
+                                  mu=None,
+                                  theta=None,
+                                  coulomb_log_method="classical"):
+    ct = ClassicalTransport(T_e,
+                            n_e,
+                            T_i,
+                            n_i,
+                            ion_particle,
+                            m_i,
+                            Z=Z,
+                            B=B,
+                            model=model,
                             field_orientation=field_orientation,
-                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+                            mu=mu,
+                            theta=theta,
+                            coulomb_log_method=coulomb_log_method)
     return ct.electron_thermal_conductivity()
 
 
-def ion_viscosity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
-                  Z=None, B=0.0 * u.T, model='Braginskii',
-                  field_orientation='parallel', mu=None,
-                  theta=None, coulomb_log_method="classical"):
-    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                            Z=Z, B=B, model=model,
+def ion_viscosity(T_e,
+                  n_e,
+                  T_i,
+                  n_i,
+                  ion_particle,
+                  m_i=None,
+                  Z=None,
+                  B=0.0 * u.T,
+                  model='Braginskii',
+                  field_orientation='parallel',
+                  mu=None,
+                  theta=None,
+                  coulomb_log_method="classical"):
+    ct = ClassicalTransport(T_e,
+                            n_e,
+                            T_i,
+                            n_i,
+                            ion_particle,
+                            m_i,
+                            Z=Z,
+                            B=B,
+                            model=model,
                             field_orientation=field_orientation,
-                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+                            mu=mu,
+                            theta=theta,
+                            coulomb_log_method=coulomb_log_method)
     return ct.ion_viscosity()
 
 
-def electron_viscosity(T_e, n_e, T_i, n_i, ion_particle, m_i=None,
-                       Z=None, B=0.0 * u.T, model='Braginskii',
-                       field_orientation='parallel', mu=None,
-                       theta=None, coulomb_log_method="classical"):
-    ct = ClassicalTransport(T_e, n_e, T_i, n_i, ion_particle, m_i,
-                            Z=Z, B=B, model=model,
+def electron_viscosity(T_e,
+                       n_e,
+                       T_i,
+                       n_i,
+                       ion_particle,
+                       m_i=None,
+                       Z=None,
+                       B=0.0 * u.T,
+                       model='Braginskii',
+                       field_orientation='parallel',
+                       mu=None,
+                       theta=None,
+                       coulomb_log_method="classical"):
+    ct = ClassicalTransport(T_e,
+                            n_e,
+                            T_i,
+                            n_i,
+                            ion_particle,
+                            m_i,
+                            Z=Z,
+                            B=B,
+                            model=model,
                             field_orientation=field_orientation,
-                            mu=mu, theta=theta, coulomb_log_method=coulomb_log_method)
+                            mu=mu,
+                            theta=theta,
+                            coulomb_log_method=coulomb_log_method)
     return ct.electron_viscosity()
 
 
@@ -628,8 +729,7 @@ def _nondim_thermal_conductivity(hall, Z,
         if model == 'braginskii':
             kappa_hat = _nondim_tc_i_braginskii(hall, field_orientation)
         elif model == 'ji-held':
-            kappa_hat = _nondim_tc_i_ji_held(hall, Z, mu, theta,
-                                             field_orientation)
+            kappa_hat = _nondim_tc_i_ji_held(hall, Z, mu, theta, field_orientation)
         elif model == 'spitzer-harm' or model == 'spitzer':
             raise NotImplementedError("Ion thermal conductivity is not "
                                       "implemented in the Spitzer model.")
@@ -758,8 +858,7 @@ def _nondim_tc_e_spitzer(Z):
     This result is for parallel field or unmagnetized plasma only.
     """
     (gamma_E, gamma_T, delta_E, delta_T) = _get_spitzer_harm_coeffs(Z)
-    kappa = (64 / np.pi) * delta_T * \
-            (5 / 3 - (gamma_T * delta_E) / (delta_T * gamma_E))
+    kappa = (64 / np.pi) * delta_T * (5 / 3 - (gamma_T * delta_E) / (delta_T * gamma_E))
     return kappa
 
 
@@ -866,15 +965,13 @@ def _nondim_tc_i_braginskii(hall, field_orientation):
     if field_orientation == 'perpendicular' or field_orientation == 'perp':
         kappa_perp_coeff_2 = 2.0
         kappa_perp_coeff_0 = 2.645
-        kappa_perp = (kappa_perp_coeff_2 * hall ** 2 +
-                      kappa_perp_coeff_0) / Delta
+        kappa_perp = (kappa_perp_coeff_2 * hall ** 2 + kappa_perp_coeff_0) / Delta
         return kappa_perp
 
     if field_orientation == 'cross':
         kappa_cross_coeff_3 = 2.5
         kappa_cross_coeff_1 = 4.65
-        kappa_cross = (kappa_cross_coeff_3 * hall ** 3 +
-                       kappa_cross_coeff_1 * hall) / Delta
+        kappa_cross = (kappa_cross_coeff_3 * hall ** 3 + kappa_cross_coeff_1 * hall) / Delta
         return kappa_cross
 
     if field_orientation == 'all':
@@ -883,13 +980,11 @@ def _nondim_tc_i_braginskii(hall, field_orientation):
 
         kappa_perp_coeff_2 = 2.0
         kappa_perp_coeff_0 = 2.645
-        kappa_perp = (kappa_perp_coeff_2 * hall ** 2 +
-                      kappa_perp_coeff_0) / Delta
+        kappa_perp = (kappa_perp_coeff_2 * hall ** 2 + kappa_perp_coeff_0) / Delta
 
         kappa_cross_coeff_3 = 2.5
         kappa_cross_coeff_1 = 4.65
-        kappa_cross = (kappa_cross_coeff_3 * hall ** 3 +
-                       kappa_cross_coeff_1 * hall) / Delta
+        kappa_cross = (kappa_cross_coeff_3 * hall ** 3 + kappa_cross_coeff_1 * hall) / Delta
         return np.array((kappa_par, kappa_perp, kappa_cross))
 
 
@@ -922,8 +1017,7 @@ def _nondim_visc_e_braginskii(hall, Z):
 
     def f_eta_4(hall):
         Delta = hall ** 4 + delta_1 * hall ** 2 + delta_0
-        return (eta_tripleprime_2 * hall ** 3 +
-                eta_tripleprime_0 * hall) / Delta
+        return (eta_tripleprime_2 * hall ** 3 + eta_tripleprime_0 * hall) / Delta
 
     eta_4_e = f_eta_4(hall)
     eta_3_e = f_eta_4(2 * hall)
@@ -995,8 +1089,7 @@ def _nondim_resist_braginskii(hall, Z, field_orientation):
         return alpha_par
 
     if field_orientation == 'perpendicular' or field_orientation == 'perp':
-        alpha_perp = (1 - (alpha_1_prime[Z_idx] * hall ** 2 +
-                           alpha_0_prime[Z_idx]) / Delta)
+        alpha_perp = (1 - (alpha_1_prime[Z_idx] * hall ** 2 + alpha_0_prime[Z_idx]) / Delta)
         return alpha_perp
 
     if field_orientation == 'cross':
@@ -1007,8 +1100,7 @@ def _nondim_resist_braginskii(hall, Z, field_orientation):
     if field_orientation == 'all':
         alpha_par = alpha_0
 
-        alpha_perp = (1 - (alpha_1_prime[Z_idx] * hall ** 2 +
-                           alpha_0_prime[Z_idx]) / Delta)
+        alpha_perp = (1 - (alpha_1_prime[Z_idx] * hall ** 2 + alpha_0_prime[Z_idx]) / Delta)
 
         alpha_cross = (alpha_1_doubleprime[Z_idx] * hall ** 3 +
                        alpha_0_doubleprime[Z_idx] * hall) / Delta
@@ -1043,8 +1135,7 @@ def _nondim_tec_braginskii(hall, Z, field_orientation):
         return beta_par
 
     if field_orientation == 'perpendicular' or field_orientation == 'perp':
-        beta_perp = (beta_1_prime[Z_idx] * hall ** 2 +
-                     beta_0_prime[Z_idx]) / Delta
+        beta_perp = (beta_1_prime[Z_idx] * hall ** 2 + beta_0_prime[Z_idx]) / Delta
         return beta_perp
 
     if field_orientation == 'cross':
@@ -1055,8 +1146,7 @@ def _nondim_tec_braginskii(hall, Z, field_orientation):
     if field_orientation == 'all':
         beta_par = beta_0
 
-        beta_perp = (beta_1_prime[Z_idx] * hall ** 2 +
-                     beta_0_prime[Z_idx]) / Delta
+        beta_perp = (beta_1_prime[Z_idx] * hall ** 2 + beta_0_prime[Z_idx]) / Delta
 
         beta_cross = (beta_1_doubleprime[Z_idx] * hall ** 3 +
                       beta_0_doubleprime[Z_idx] * hall) / Delta
@@ -1158,8 +1248,7 @@ def _nondim_tc_e_ji_held(hall, Z, field_orientation):
         return Z * kappa_par
 
     def f_kappa_perp(Z_idx):
-        numerator = ((13 / 4 * Z + np.sqrt(2)) * r +
-                     kappa_0[Z_idx] * kappa_par_e[Z_idx])
+        numerator = ((13 / 4 * Z + np.sqrt(2)) * r + kappa_0[Z_idx] * kappa_par_e[Z_idx])
         denominator = (r ** 3 +
                        kappa_4[Z_idx] * r ** (7 / 3) +
                        kappa_3[Z_idx] * r ** 2 +
@@ -1251,8 +1340,7 @@ def _nondim_resist_ji_held(hall, Z, field_orientation):
         return alpha_par
 
     def f_alpha_perp(Z_idx):
-        numerator = (1.46 * Z ** (2 / 3) * r +
-                     alpha_0[Z_idx] * (1 - alpha_par_e[Z_idx]))
+        numerator = (1.46 * Z ** (2 / 3) * r + alpha_0[Z_idx] * (1 - alpha_par_e[Z_idx]))
         denominator = (r ** (5 / 3) +
                        alpha_2[Z_idx] * r ** (4 / 3) +
                        alpha_1[Z_idx] * r +

--- a/plasmapy/physics/transport/collisions.py
+++ b/plasmapy/physics/transport/collisions.py
@@ -21,7 +21,7 @@ from plasmapy.physics.quantum import (Wigner_Seitz_radius,
 from plasmapy.mathematics import Fermi_integral
 
 
-@utils.check_quantity({"T":   {"units": u.K, "can_be_negative": False},
+@utils.check_quantity({"T": {"units": u.K, "can_be_negative": False},
                        "n_e": {"units": u.m ** -3}
                        })
 def Coulomb_logarithm(T,
@@ -355,7 +355,7 @@ def b_perp(T,
     return bPerp.to(u.m)
 
 
-@check_quantity({"T":   {"units": u.K, "can_be_negative": False},
+@check_quantity({"T": {"units": u.K, "can_be_negative": False},
                  "n_e": {"units": u.m ** -3}
                  })
 def impact_parameter(T,
@@ -953,7 +953,7 @@ def collision_rate_ion_ion(T_i,
     return nu_i.to(1 / u.s)
 
 
-@check_quantity({"T":   {"units": u.K, "can_be_negative": False},
+@check_quantity({"T": {"units": u.K, "can_be_negative": False},
                  "n_e": {"units": u.m ** -3}
                  })
 def mean_free_path(T,
@@ -1192,7 +1192,7 @@ def Spitzer_resistivity(T,
     return spitzer.to(u.Ohm * u.m)
 
 
-@check_quantity({"T":   {"units": u.K, "can_be_negative": False},
+@check_quantity({"T": {"units": u.K, "can_be_negative": False},
                  "n_e": {"units": u.m ** -3}
                  })
 def mobility(T,
@@ -1315,7 +1315,7 @@ def mobility(T,
     return mobility_value.to(u.m ** 2 / (u.V * u.s))
 
 
-@check_quantity({"T":   {"units": u.K, "can_be_negative": False},
+@check_quantity({"T": {"units": u.K, "can_be_negative": False},
                  "n_e": {"units": u.m ** -3}
                  })
 def Knudsen_number(characteristic_length,
@@ -1430,7 +1430,7 @@ def Knudsen_number(characteristic_length,
     return knudsen_param.to(u.dimensionless_unscaled)
 
 
-@check_quantity({"T":   {"units": u.K, "can_be_negative": False},
+@check_quantity({"T": {"units": u.K, "can_be_negative": False},
                  "n_e": {"units": u.m ** -3}
                  })
 def coupling_parameter(T,

--- a/plasmapy/physics/transport/tests/test_transport.py
+++ b/plasmapy/physics/transport/tests/test_transport.py
@@ -42,7 +42,7 @@ from plasmapy.physics.transport.braginskii import (_nondim_thermal_conductivity,
                                                    ion_viscosity,
                                                    thermoelectric_conductivity,
                                                    )
-from plasmapy.physics.transport import classical_transport
+from plasmapy.physics.transport import ClassicalTransport
 
 
 def count_decimal_places(digits):
@@ -51,7 +51,7 @@ def count_decimal_places(digits):
     return len(fractional)
 
 
-# test class for classical_transport class:
+# test class for ClassicalTransport class:
 class Test_classical_transport:
     @classmethod
     def setup_class(self):
@@ -76,7 +76,7 @@ class Test_classical_transport:
         self.model = 'Braginskii'
         self.field_orientation = 'all'
         with pytest.warns(RelativityWarning):
-            self.ct = classical_transport(
+            self.ct = ClassicalTransport(
                 T_e=self.T_e,
                 n_e=self.n_e,
                 T_i=self.T_i,
@@ -95,7 +95,7 @@ class Test_classical_transport:
                 mu=self.mu,
                 theta=self.theta,
                 )
-            self.ct_wrapper = classical_transport(
+            self.ct_wrapper = ClassicalTransport(
                 T_e=self.T_e,
                 n_e=self.n_e,
                 T_i=self.T_i,
@@ -113,13 +113,13 @@ class Test_classical_transport:
     def test_spitzer_vs_formulary(self):
         """Spitzer resistivity should agree with approx. in NRL formulary"""
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model='spitzer',
-                                      field_orientation='perp')
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model='spitzer',
+                                     field_orientation='perp')
             alpha_spitzer_perp_NRL = (1.03e-4 * ct2.Z *
                                       ct2.coulomb_log_ei *
                                       (ct2.T_e.to(u.eV)).value ** (-3 / 2) *
@@ -180,77 +180,77 @@ class Test_classical_transport:
     def test_particle_mass(self):
         """should raise ValueError if particle mass not found"""
         with pytest.raises(ValueError):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle='empty moment',
-                                      Z=1)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle='empty moment',
+                                     Z=1)
 
     def test_particle_charge_state(self):
         """should raise ValueError if particle charge state not found"""
         with pytest.raises(InvalidParticleError):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle='empty moment',
-                                      m_i=m_p)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle='empty moment',
+                                     m_i=m_p)
 
     def test_Z_checks(self):
         """should raise ValueError if Z is negative"""
         with pytest.raises(ValueError):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      Z=-1)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     Z=-1)
 
     def test_coulomb_log_warnings(self):
         """should warn PhysicsWarning if coulomb log is near 1"""
         with pytest.warns(PhysicsWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      coulomb_log_ii=1.3)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     coulomb_log_ii=1.3)
 
         with pytest.warns(PhysicsWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      coulomb_log_ei=1.3)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     coulomb_log_ei=1.3)
 
     def test_coulomb_log_errors(self):
         """should raise PhysicsError if coulomb log is < 1"""
         with pytest.warns(PhysicsWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      coulomb_log_ii=0.3)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     coulomb_log_ii=0.3)
 
         with pytest.warns(PhysicsWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      coulomb_log_ei=0.3)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     coulomb_log_ei=0.3)
 
     def test_coulomb_log_calc(self):
         """if no coulomb logs are input, they should be calculated"""
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle)
             cl_ii = Coulomb_logarithm(self.T_i,
                                       self.n_e,
                                       [self.ion_particle, self.ion_particle],
@@ -271,11 +271,11 @@ class Test_classical_transport:
     def test_hall_calc(self):
         """if no hall parameters are input, they should be calculated"""
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle)
             hall_i = Hall_parameter(ct2.n_i,
                                     ct2.T_i,
                                     ct2.B,
@@ -301,31 +301,31 @@ class Test_classical_transport:
 
     def test_invalid_model(self):
         with pytest.raises(ValueError):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model="standard")
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model="standard")
 
     def test_invalid_field(self):
         with pytest.raises(ValueError):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      field_orientation='to the left')
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     field_orientation='to the left')
 
     def test_precalculated_parameters(self):
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      hall_i=0,
-                                      hall_e=0)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     hall_i=0,
+                                     hall_e=0)
             testTrue = np.isclose(ct2.resistivity(),
                                   2.8184954e-8 * u.Ohm * u.m,
                                   atol=1e-6 * u.Ohm * u.m)
@@ -343,13 +343,13 @@ class Test_classical_transport:
     def test_number_of_returns(self, model, method, field_orientation,
                                expected):
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model=model,
-                                      field_orientation=field_orientation)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model=model,
+                                     field_orientation=field_orientation)
             method_to_call = getattr(ct2, method)
             testTrue = np.size(method_to_call()) == expected
             errStr = (f"{method} in {model} model returns "
@@ -364,12 +364,12 @@ class Test_classical_transport:
         ])
     def test_resistivity_by_model(self, model, expected):
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model=model)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model=model)
             testTrue = np.isclose(ct2.resistivity(),
                                   expected,
                                   atol=1e-6 * u.Ohm * u.m)
@@ -384,12 +384,12 @@ class Test_classical_transport:
         ])
     def test_thermoelectric_conductivity_by_model(self, model, expected):
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model=model)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model=model)
             testTrue = np.isclose(ct2.thermoelectric_conductivity(),
                                   expected,
                                   atol=1e-6 * u.s / u.s)
@@ -406,12 +406,12 @@ class Test_classical_transport:
         ])
     def test_electron_viscosity_by_model(self, model, expected):
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model=model)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model=model)
             testTrue = np.allclose(ct2.electron_viscosity(),
                                    expected,
                                    atol=1e-6 * u.Pa * u.s)
@@ -427,12 +427,12 @@ class Test_classical_transport:
         ])
     def test_ion_viscosity_by_model(self, model, expected):
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model=model)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model=model)
             testTrue = np.allclose(ct2.ion_viscosity(),
                                    expected,
                                    atol=1e-6 * u.Pa * u.s)
@@ -447,12 +447,12 @@ class Test_classical_transport:
         ])
     def test_electron_thermal_conductivity_by_model(self, model, expected):
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model=model)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model=model)
             testTrue = np.allclose(ct2.electron_thermal_conductivity(),
                                    expected,
                                    atol=1e-6 * u.W / (u.K * u.m))
@@ -467,12 +467,12 @@ class Test_classical_transport:
         ])
     def test_ion_thermal_conductivity_by_model(self, model, expected):
         with pytest.warns(RelativityWarning):
-            ct2 = classical_transport(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      T_i=self.T_i,
-                                      n_i=self.n_i,
-                                      ion_particle=self.ion_particle,
-                                      model=model)
+            ct2 = ClassicalTransport(T_e=self.T_e,
+                                     n_e=self.n_e,
+                                     T_i=self.T_i,
+                                     n_i=self.n_i,
+                                     ion_particle=self.ion_particle,
+                                     model=model)
             testTrue = np.allclose(ct2.ion_thermal_conductivity(),
                                    expected,
                                    atol=1e-6 * u.W / (u.K * u.m))

--- a/plasmapy/physics/transport/tests/test_transport.py
+++ b/plasmapy/physics/transport/tests/test_transport.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests for functions that calculate transport coefficients."""
 
 import numpy as np
@@ -482,28 +481,34 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize("key, expected", {
-        'resistivity':                   [2.84304305e-08,
-                                          5.54447070e-08,
-                                          1.67853407e-12],
-        'thermoelectric conductivity':   [7.11083999e-01,
-                                          1.61011272e-09,
-                                          2.66496639e-05],
-        'electron thermal conductivity': [4.91374931e+06,
-                                          2.28808496e-03,
-                                          6.90324259e+01],
-        'electron viscosity':            [7.51661800e-02,
-                                          5.23617668e-21,
-                                          2.09447067e-20,
-                                          1.61841341e-11,
-                                          3.23682681e-11],
-        'ion thermal conductivity':      [1.41709276e+05,
-                                          4.20329493e-02,
-                                          6.90323924e+01],
-        'ion viscosity':                 [8.43463595e+00,
-                                          8.84513731e-13,
-                                          3.53805159e-12,
-                                          2.54483240e-06,
-                                          5.08966116e-06]}.items())
+        'resistivity': [
+            2.84304305e-08,
+            5.54447070e-08,
+            1.67853407e-12],
+        'thermoelectric conductivity': [
+            7.11083999e-01,
+            1.61011272e-09,
+            2.66496639e-05],
+        'electron thermal conductivity': [
+            4.91374931e+06,
+            2.28808496e-03,
+            6.90324259e+01],
+        'electron viscosity': [
+            7.51661800e-02,
+            5.23617668e-21,
+            2.09447067e-20,
+            1.61841341e-11,
+            3.23682681e-11],
+        'ion thermal conductivity': [
+            1.41709276e+05,
+            4.20329493e-02,
+            6.90323924e+01],
+        'ion viscosity': [
+            8.43463595e+00,
+            8.84513731e-13,
+            3.53805159e-12,
+            2.54483240e-06,
+            5.08966116e-06]}.items())
     def test_dictionary(self, key, expected):
         calculated = self.all_variables[key]
         testTrue = np.allclose(expected, calculated.si.value)


### PR DESCRIPTION
The naming conventions in the PEP 8 style guide say that classes should be in CamelCase.  This PR adopts that naming convention for the class that calculates classical transport coefficients.