### PR TITLE
Handle `Quantity` objects in `call_string()`

### DIFF
--- a/plasmapy/classes/plasma.py
+++ b/plasmapy/classes/plasma.py
@@ -155,10 +155,10 @@ class PlasmaBlob():
         >>> PlasmaBlob(1e4*u.K, 1e20/u.m**3, particle='p')
         PlasmaBlob(T_e=10000.0 K, n_e=1e+20 1 / m3, particle=p, Z=1)
         """
-        argument_dict = { 'T_e'      : self.T_e,
-                          'n_e'      : self.n_e,
-                          'particle' : self.particle,
-                          'Z'        : self.Z }
+        argument_dict = {'T_e': self.T_e,
+                         'n_e': self.n_e,
+                         'particle': self.particle,
+                         'Z': self.Z}
 
         return call_string(PlasmaBlob, (), argument_dict)
 

--- a/plasmapy/classes/plasma.py
+++ b/plasmapy/classes/plasma.py
@@ -23,6 +23,8 @@ from plasmapy.atomic import (particle_mass,
                              integer_charge,
                              )
 
+from plasmapy.utils import call_string
+
 class Plasma3D():
     """
     Core class for describing and calculating plasma parameters with
@@ -153,7 +155,12 @@ class PlasmaBlob():
         >>> PlasmaBlob(1e4*u.K, 1e20/u.m**3, particle='p')
         PlasmaBlob(T_e=10000.0 K, n_e=1e+20 1 / m3, particle=p, Z=1)
         """
-        return f"PlasmaBlob(T_e={self.T_e}, n_e={self.n_e}, particle={self.particle}, Z={self.Z})"
+        argument_dict = { 'T_e'      : self.T_e,
+                          'n_e'      : self.n_e,
+                          'particle' : self.particle,
+                          'Z'        : self.Z }
+
+        return call_string(PlasmaBlob, (), argument_dict)
 
     @property
     def electron_temperature(self):

--- a/plasmapy/classes/plasma.py
+++ b/plasmapy/classes/plasma.py
@@ -135,7 +135,7 @@ class PlasmaBlob():
         Examples
         --------
         >>> print(PlasmaBlob(1e4*u.K, 1e20/u.m**3, particle='p'))
-        PlasmaBlob(T_e=10000.0 K, n_e=1e+20 1 / m3, particle=p, Z=1)
+        PlasmaBlob(T_e=10000.0*u.K, n_e=1e+20*u.m**-3, particle='p', Z=1)
         Intermediate coupling regime: Gamma = 0.012502837623108332.
         Thermal kinetic energy dominant: Theta = 109690.53176225389
 
@@ -153,7 +153,7 @@ class PlasmaBlob():
         --------
         >>> from astropy import units as u
         >>> PlasmaBlob(1e4*u.K, 1e20/u.m**3, particle='p')
-        PlasmaBlob(T_e=10000.0 K, n_e=1e+20 1 / m3, particle=p, Z=1)
+        PlasmaBlob(T_e=10000.0*u.K, n_e=1e+20*u.m**-3, particle='p', Z=1)
         """
         argument_dict = {'T_e': self.T_e,
                          'n_e': self.n_e,

--- a/plasmapy/utils/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers.py
@@ -87,11 +87,22 @@ def call_string(f: Callable,
                 ) -> str:
     """Return a string with the equivalent call of a function."""
 
+    def format_quantity(arg):
+        formatted = f'{arg.value}'
+        for base, power in zip(arg.unit.bases, arg.unit.powers):
+            if power == -1:
+                formatted += f"/u.{base}"
+            elif power == 1:
+                formatted += f"*u.{base}"
+            else:
+                formatted += f"*u.{base}**{power}"
+        return formatted
+
     def format_arg(arg):
         if hasattr(arg, '__name__'):
             return arg.__name__
         elif isinstance(arg, u.quantity.Quantity):
-            return f"{arg.value} * u.{arg.unit}"
+            return format_quantity(arg)
         else:
             return repr(arg)
 

--- a/plasmapy/utils/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers.py
@@ -88,7 +88,12 @@ def call_string(f: Callable,
     """Return a string with the equivalent call of a function."""
 
     def format_arg(arg):
-        return arg.__name__ if hasattr(arg, '__name__') else repr(arg)
+        if hasattr(arg, '__name__'):
+            return arg.__name__
+        elif isinstance(arg, u.quantity.Quantity):
+            return f"{arg.value} * u.{arg.unit}"
+        else:
+            return repr(arg)
 
     def format_kw(keyword):
         if isinstance(keyword, str):


### PR DESCRIPTION
Closes #337 and #331.

For example, now passing a `Quantity` object to `call_string` results in following output:
```python
>>> from plasmapy.utils import call_string
>>> import astropy.units as u
>>> def f(x, y, z):
...        pass
>>> call_string(f, 5 * u.m, {'y': 8*u.m, 'z': 5*u.kg})
'f(5.0 * u.m, y=8.0 * u.m, z=5.0 * u.kg)'
```

However, I personally find this a bit more readable :smile::
```python
'f(5.0*u.m, y=8.0*u.m, z=5.0*u.kg)'
```

What do you guys think?