### PR TITLE
Create subpackage stability table in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,6 +117,8 @@ Project Details
 .. toctree::
    :maxdepth: 2
 
+   stability
+
 * `Vision Statement
   <https://github.com/PlasmaPy/PlasmaPy/blob/master/VISION.md>`_
 

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -91,7 +91,7 @@ PlasmaPy's planned and existing subpackages are:
             <td>
                 plasmapy.atomic
             </td>
-            <td align='dev'>
+            <td align='center'>
                 <span class="dev"></span>
             </td>
             <td>
@@ -103,7 +103,7 @@ PlasmaPy's planned and existing subpackages are:
             <td>
                 plasmapy.classes
             </td>
-            <td align='planned'>
+            <td align='center'>
                 <span class="dev"></span>
             </td>
             <td>
@@ -116,7 +116,7 @@ PlasmaPy's planned and existing subpackages are:
             <td>
                 plasmapy.constants
             </td>
-            <td align='mature'>
+            <td align='center'>
                 <span class="stable"></span>
             </td>
             <td>
@@ -131,8 +131,8 @@ PlasmaPy's planned and existing subpackages are:
             <td>
                 plasmapy.diagnostics
             </td>
-            <td align='dev'>
-                <span class="planned"></span>
+            <td align='center'>
+                <span class="dev"></span>
             </td>
             <td>
                 This subpackage is in the early stages of development.
@@ -142,7 +142,7 @@ PlasmaPy's planned and existing subpackages are:
             <td>
                 plasmapy.mathematics
             </td>
-            <td align='dev'>
+            <td align='center'>
                 <span class="dev"></span>
             </td>
             <td>
@@ -155,7 +155,7 @@ PlasmaPy's planned and existing subpackages are:
             <td>
                 plasmapy.parameters
             </td>
-            <td align='dev'>
+            <td align='center'>
                 <span class="dev"></span>
             </td>
             <td>
@@ -170,7 +170,7 @@ PlasmaPy's planned and existing subpackages are:
             <td>
                 plasmapy.parameters.transport
             </td>
-            <td align='dev'>
+            <td align='center'>
                 <span class="dev"></span>
             </td>
             <td>
@@ -184,7 +184,7 @@ PlasmaPy's planned and existing subpackages are:
             <td>
                 plasmapy.utils
             </td>
-            <td align='dev'>
+            <td align='center'>
                 <span class="dev"></span>
             </td>
             <td>

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -1,0 +1,197 @@
+*****************************
+Current status of subpackages
+*****************************
+
+.. This document is derived from docs/stability.rst in Astropy.  See
+   licenses/Astropy_LICENSE.rst in PlasmaPy's directory.
+
+This document summarizes the stability of PlasmaPy's subpackages so that
+users understand where they might expect changes in the future, and
+which subpackages they can safely use for production code.  Please note
+that backward compatibility is not guaranteed for the `0.*.*` series of
+development releases.  Starting with version `1.0.0`, the major version
+number will be incremented when a release contains backward incompatible
+changes.
+
+The classification is as follows:
+
+.. raw:: html
+
+    <style>
+         .planned:before {
+              color: #cbcbcb;
+              content: "⬤";
+         }
+         .dev:before {
+              color: #ffad00;
+              content: "⬤";
+         }
+         .stable:before {
+              color: #4e72c3;
+              content: "⬤";
+         }
+         .mature:before {
+              color: #03a913;
+              content: "⬤";
+         }
+         .pendingdep:before {
+              color: #a84b03;
+              content: "⬤";
+         }
+         .deprecated:before {
+              color: #ff0000;
+              content: "⬤";
+         }
+    </style>
+
+    <table align='center'>
+      <tr>
+        <td align='center'><span class="planned"></span></td>
+        <td>Planned</td>
+      </tr>
+      <tr>
+        <td align='center'><span class="dev"></span></td>
+        <td>Actively developed, be prepared for possible significant changes.</td>
+      </tr>
+      <tr>
+        <td align='center'><span class="stable"></span></td>
+        <td>Reasonably stable, any significant changes/additions will generally include backwards-compatiblity.</td>
+      </tr>
+      <tr>
+        <td align='center'><span class="mature"></span></td>
+        <td>Mature.  Additions/improvements possible, but no major changes planned. </td>
+      </tr>
+      <tr>
+        <td align='center'><span class="pendingdep"></span></td>
+        <td>Pending deprecation.  Might be deprecated in a future version.</td>
+      </tr>
+      <tr>
+        <td align='center'><span class="deprecated"></span></td>
+        <td>Deprecated.  Might be removed in a future version.</td>
+      </tr>
+    </table>
+
+PlasmaPy's planned and existing subpackages are:
+
+.. raw:: html
+
+    <table border="1" class="docutils stability" align='center'>
+        <tr>
+            <th class="head">
+                Subpackage
+            </th>
+            <th class="head">
+                &nbsp;
+            </th>
+            <th class="head">
+                Comments
+            </th>
+        </tr>
+        <tr>
+            <td>
+                plasmapy.atomic
+            </td>
+            <td align='dev'>
+                <span class="dev"></span>
+            </td>
+            <td>
+                This package is being actively developed and expanded,
+                and there may be backward incompatible changes to the API.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                plasmapy.classes
+            </td>
+            <td align='planned'>
+                <span class="dev"></span>
+            </td>
+            <td>
+                The plan for PlasmaPy's base classes is being planned in
+                PLEP 7, which is in the process of being written.  The
+                existing functionality is unstable.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                plasmapy.constants
+            </td>
+            <td align='mature'>
+                <span class="stable"></span>
+            </td>
+            <td>
+                We do not anticipate that there will be any major backward
+                incompatible changes within the
+                <tt class="docutils literal"><span class="pre">constants</span></tt>
+                subpackage.  However, the values for constants may be updated
+                when improved values become available.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                plasmapy.diagnostics
+            </td>
+            <td align='dev'>
+                <span class="planned"></span>
+            </td>
+            <td>
+                This subpackage is in the early stages of development.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                plasmapy.mathematics
+            </td>
+            <td align='dev'>
+                <span class="dev"></span>
+            </td>
+            <td>
+                The
+                <tt class="docutils literal"><span class="pre">mathematics</span></tt>
+                subpackage is in the early stages of development.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                plasmapy.parameters
+            </td>
+            <td align='dev'>
+                <span class="dev"></span>
+            </td>
+            <td>
+                The
+                <tt class="docutils literal"><span class="pre">parameters</span></tt>
+                subpackage may undergo significant reorganization with potentially
+                major changes to the API.  We anticipate that there will be major
+                additions to this package.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                plasmapy.parameters.transport
+            </td>
+            <td align='dev'>
+                <span class="dev"></span>
+            </td>
+            <td>
+                The
+                <tt class="docutils literal"><span class="pre">transport</span></tt>
+                subpackage will likely undergo significant reorganization
+                and expansion with major changes to the API.
+            </td>
+        </tr>
+        <tr>
+            <td>
+                plasmapy.utils
+            </td>
+            <td align='dev'>
+                <span class="dev"></span>
+            </td>
+            <td>
+                The
+                <tt class="docutils literal"><span class="pre">utils</span></tt>
+                subpackage may undergo significant reorganization with potentially
+                major changes to the API.
+            </td>
+        </tr>
+    </table>

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -51,11 +51,11 @@ The classification is as follows:
       </tr>
       <tr>
         <td align='center'><span class="dev"></span></td>
-        <td>Actively developed, be prepared for possible significant changes.</td>
+        <td>Actively being developed. Be prepared for possible significant changes.</td>
       </tr>
       <tr>
         <td align='center'><span class="stable"></span></td>
-        <td>Reasonably stable, any significant changes/additions will generally include backwards-compatiblity.</td>
+        <td>Reasonably stable. Any significant changes/additions will generally include backwards-compatiblity.</td>
       </tr>
       <tr>
         <td align='center'><span class="mature"></span></td>
@@ -153,14 +153,14 @@ PlasmaPy's planned and existing subpackages are:
         </tr>
         <tr>
             <td>
-                plasmapy.parameters
+                plasmapy.physics
             </td>
             <td align='center'>
                 <span class="dev"></span>
             </td>
             <td>
                 The
-                <tt class="docutils literal"><span class="pre">parameters</span></tt>
+                <tt class="docutils literal"><span class="pre">physics</span></tt>
                 subpackage may undergo significant reorganization with potentially
                 major changes to the API.  We anticipate that there will be major
                 additions to this package.
@@ -168,7 +168,7 @@ PlasmaPy's planned and existing subpackages are:
         </tr>
         <tr>
             <td>
-                plasmapy.parameters.transport
+                plasmapy.physics.transport
             </td>
             <td align='center'>
                 <span class="dev"></span>


### PR DESCRIPTION
Astropy's docs have a wonderfully useful page describing the [current status of subpackages](http://docs.astropy.org/en/stable/stability.html).  This page contains information on how stable Astropy's different subpackages are (e.g., if they're stable or undergoing active development).  It would be extremely useful for us to post that information for PlasmaPy's subpackages as well.  

Please let me know if you think we should change any of the subpackage statuses that I tentatively put in, since I wasn't quite sure what to put for `classes` since we'll be making major changes as will be described in PLEP 7 and for `diagnostics` since we're just now beginning to develop it and it's mostly in the planning stage.  I was thinking that we should err on the side of saying that a subpackage is less stable rather than suggesting that it is more stable than it actually is.

I imagine it's going to be a nice feeling in the coming years when we get to change subpackages from "planned" to "dev" to "mature" and finally to "stable".  :smile_cat: 