### PR TITLE
Fix pycodestyle error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ astropy-package-template-example = packagename.example_mod:main
 # The error codes for pycodestyle include:
 #
 #  *E121: continuation line under-indented for hanging indent
-#  *E123: closing bracket does not match indentation of opening bracket’s line
+#  *E123: closing bracket does not match indentation of opening bracket's line
 #  *E126: continuation line over-indented for hanging indent
 #  *E133: closing bracket is missing indentation
 #  *E226: missing whitespace around arithmetic operator


### PR DESCRIPTION
For some odd reason, the comment section in `setup.cfg` for `pycodestyle` is causing an error in my linter. I'm guessing that it's because the apostrophe wasn't ascii, which I've now changed.

```
[Linter] Error running pycodestyle Error: Traceback (most recent call last):
  File "/Users/dstansby/miniconda3/bin/pycodestyle", line 11, in <module>
    sys.exit(_main())
  File "/Users/dstansby/miniconda3/lib/python3.6/site-packages/pycodestyle.py", line 2302, in _main
    style_guide = StyleGuide(parse_argv=True)
  File "/Users/dstansby/miniconda3/lib/python3.6/site-packages/pycodestyle.py", line 1966, in __init__
    arglist, parse_argv, config_file, parser)
  File "/Users/dstansby/miniconda3/lib/python3.6/site-packages/pycodestyle.py", line 2259, in process_options
    options = read_config(options, args, arglist, parser)
  File "/Users/dstansby/miniconda3/lib/python3.6/site-packages/pycodestyle.py", line 2173, in read_config
    if config.read(os.path.join(parent, fn) for fn in PROJECT_CONFIG):
  File "/Users/dstansby/miniconda3/lib/python3.6/configparser.py", line 697, in read
    self._read(fp, filename)
  File "/Users/dstansby/miniconda3/lib/python3.6/configparser.py", line 1015, in _read
    for lineno, line in enumerate(fp, start=1):
  File "/Users/dstansby/miniconda3/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1251: ordinal not in range(128)
    at ChildProcess.<anonymous> (/Users/dstansby/.atom/packages/linter-pycodestyle/node_modules/sb-exec/lib/index.js:56)
    at emitTwo (events.js:106)
    at ChildProcess.emit (events.js:194)
    at maybeClose (internal/child_process.js:899)
    at Socket.<anonymous> (internal/child_process.js:342)
    at emitOne (events.js:96)
    at Socket.emit (events.js:191)
    at Pipe._handle.close [as _onclose] (net.js:510)
```