### PR TITLE
Adding information on acknowledging PlasmaPy in docs

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -1,9 +1,0 @@
-If you use PlasmaPy for work or research resulting in a publication, please use the following acknowledgement:
-  
-* This project made use of PlasmaPy, a community-developed core Python package for plasma physics.
-
-The earliest citation for PlasmaPy is:
-
-* Murphy, Nicholas A, Huang, Yi-Min, & PlasmaPy Community. (2016, October). PlasmaPy: beginning a community developed Python package for plasma physics. Zenodo. http://doi.org/10.5281/zenodo.163752
-    
-We highly encourage researchers to acknowledge the packages that PlasmaPy depends on, including but not limited to Astropy, NumPy, and SciPy.

--- a/docs/about/acknowledging.rst
+++ b/docs/about/acknowledging.rst
@@ -1,0 +1,26 @@
+.. _acknowledging:
+
+Acknowledging or Citing PlasmaPy
+================================
+
+If you use PlasmaPy for a project resulting in a publication, we ask
+that you cite the following reference
+(`BibTeX <https://zenodo.org/record/1238132/export/hx#.WvMkQK0cChc>`_):
+
+* PlasmaPy Community, Nicholas A. Murphy, Andrew J. Leonard, Dominik
+  Stańczak, Pawel M. Kozlowski, Samuel J. Langendorf, Colby C. Haggerty,
+  Jasper P. Beckers, Stuart J. Mumford, Tulasi N. Parashar, and Yi-Min
+  Huang. (2018, April). PlasmaPy: an open source community-developed
+  Python package for plasma physics. Zenodo.
+  http://doi.org/10.5281/zenodo.1238132
+
+We provide the following standard acknowledgment with this citation that
+you may use instead of a citation in the body of a paper.
+
+* This research made use of PlasmaPy, a community-developed open source
+  core Python package for plasma physics (PlasmaPy Community et al.,
+  2018).
+
+We highly encourage researchers to acknowledge the packages that
+PlasmaPy depends on, including but not limited to Astropy, NumPy, and
+SciPy.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Getting Started
 * `PlasmaPy website
   <http://www.plasmapy.org/>`_
 * `Using astropy.units <http://docs.astropy.org/en/stable/units/>`_
+* :ref:`acknowledging`
 
 .. _toplevel-user-documentation:
 


### PR DESCRIPTION
This PR adds information on how to acknowledge and cite PlasmaPy, in particular the [PlasmaPy Community et al. (2018)](https://doi.org/10.5281/zenodo.1238131) reference on Zenodo.  I am adding a page to our documentation, putting a link to it in `README.md`, and adding a private attribute currently called `_citation_bibtex` to `__init__.py`.

This fulfils most of #432, but we should add information on acknowledging PlasmaPy to our website, and we should include a link to the persistent identifier that we get when we archive PlasmaPy on Zenodo.