### PR TITLE
Maxwellian 3D speed fixes

### DIFF
--- a/plasmapy/examples/plot_distribution.py
+++ b/plasmapy/examples/plot_distribution.py
@@ -29,8 +29,10 @@ quantity_support()
 # plasma at a temperature of 30 000 K:
 
 
-p_dens = Maxwellian_1D(v=1 * u.m / u.s, T=30000 * u.K,
-                       particle='e', V_drift=0 * u.m / u.s)
+p_dens = Maxwellian_1D(v=1 * u.m / u.s,
+                       T=30000 * u.K,
+                       particle='e',
+                       v_drift=0 * u.m / u.s)
 print(p_dens)
 
 ############################################################
@@ -58,8 +60,8 @@ plt.legend()
 # temperature:
 
 
-std = np.sqrt((Maxwellian_1D(v, T=T, particle='e') * v**2 * dv).sum())
-T_theo = (std**2 / k_B * m_e).to(u.K)
+std = np.sqrt((Maxwellian_1D(v, T=T, particle='e') * v ** 2 * dv).sum())
+T_theo = (std ** 2 / k_B * m_e).to(u.K)
 
 print('T from standard deviation:', T_theo)
 print('Initial T:', T)

--- a/plasmapy/physics/__init__.py
+++ b/plasmapy/physics/__init__.py
@@ -17,6 +17,7 @@ from .dielectric import (cold_plasma_permittivity_LRP,
                          cold_plasma_permittivity_SDP)
 
 from .distribution import (Maxwellian_1D,
+                           Maxwellian_velocity_2D,
                            Maxwellian_velocity_3D,
                            Maxwellian_speed_1D,
                            Maxwellian_speed_3D,

--- a/plasmapy/physics/__init__.py
+++ b/plasmapy/physics/__init__.py
@@ -20,6 +20,7 @@ from .distribution import (Maxwellian_1D,
                            Maxwellian_velocity_2D,
                            Maxwellian_velocity_3D,
                            Maxwellian_speed_1D,
+                           Maxwellian_speed_2D,
                            Maxwellian_speed_3D,
                            kappa_velocity_3D,
                            kappa_velocity_1D)

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -9,14 +9,14 @@ from plasmapy.physics import parameters
 import numpy as np
 from scipy.special import gamma
 
-__all__ = [
-    "Maxwellian_1D",
-    "Maxwellian_velocity_3D",
-    "Maxwellian_speed_1D",
-    "Maxwellian_speed_3D",
-    "kappa_velocity_1D",
-    "kappa_velocity_3D",
-]
+__all__ = ["Maxwellian_1D",
+           "Maxwellian_velocity_2D",
+           "Maxwellian_velocity_3D",
+           "Maxwellian_speed_1D",
+           "Maxwellian_speed_2D",
+           "Maxwellian_speed_3D",
+           "kappa_velocity_1D",
+           "kappa_velocity_3D"]
 
 def _v_drift_units(v_drift):
     # Helper method to assign units to  v_drift if it takes a default value
@@ -30,7 +30,7 @@ def _v_drift_units(v_drift):
 def Maxwellian_1D(v,
                   T,
                   particle="e",
-                  V_drift=0,
+                  v_drift=0,
                   vTh=np.nan,
                   units="units"):
     r"""
@@ -53,7 +53,7 @@ def Maxwellian_1D(v,
         ``'D+'`` for deuterium, or ``'He-4 +1'`` for :math:`He_4^{+1}`
         (singly ionized helium-4)), which defaults to electrons.
 
-    V_drift: ~astropy.units.Quantity, optional
+    v_drift: ~astropy.units.Quantity, optional
         The drift velocity in units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
@@ -103,7 +103,7 @@ def Maxwellian_1D(v,
     >>> from plasmapy.physics import Maxwellian_1D
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
-    >>> Maxwellian_1D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
+    >>> Maxwellian_1D(v=v, T= 30000*u.K, particle='e',v_drift=0*u.m/u.s)
     <Quantity 5.91632969e-07 s / m>
     """
 
@@ -113,7 +113,7 @@ def Maxwellian_1D(v,
         v = v.to(u.m / u.s)
         # Catching case where drift velocities have default values, they
         # need to be assigned units
-        V_drift = _v_drift_units(V_drift)
+        v_drift = _v_drift_units(v_drift)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -132,7 +132,7 @@ def Maxwellian_1D(v,
     # Get thermal velocity squared
     vThSq = vTh ** 2
     # Get square of relative particle velocity
-    vSq = (v - V_drift) ** 2
+    vSq = (v - v_drift) ** 2
     # calculating distribution function
     coeff = (vThSq * np.pi) ** (-1 / 2)
     expTerm = np.exp(-vSq / vThSq)
@@ -147,8 +147,8 @@ def Maxwellian_velocity_2D(vx,
                            vy,
                            T,
                            particle="e",
-                           Vx_drift=0,
-                           Vy_drift=0,
+                           vx_drift=0,
+                           vy_drift=0,
                            vTh=np.nan,
                            units="units"):
     r"""
@@ -175,10 +175,10 @@ def Maxwellian_velocity_2D(vx,
         ``'D+'`` for deuterium, or ``'He-4 +1'`` for :math:`He_4^{+1}`
         (singly ionized helium-4)), which defaults to electrons.
 
-    Vx_drift: ~astropy.units.Quantity, optional
+    vx_drift: ~astropy.units.Quantity, optional
         The drift velocity in x-direction units convertible to m/s.
 
-    Vy_drift: ~astropy.units.Quantity, optional
+    vy_drift: ~astropy.units.Quantity, optional
         The drift velocity in y-direction units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
@@ -237,8 +237,8 @@ def Maxwellian_velocity_2D(vx,
     ... vy=v,
     ... T=30000*u.K,
     ... particle='e',
-    ... Vx_drift=0*u.m/u.s,
-    ... Vy_drift=0*u.m/u.s)
+    ... vx_drift=0*u.m/u.s,
+    ... vy_drift=0*u.m/u.s)
     <Quantity 3.5002957e-13 s2 / m2>
 
 
@@ -250,8 +250,8 @@ def Maxwellian_velocity_2D(vx,
         vy = vy.to(u.m / u.s)
         # catching case where drift velocities have default values, they
         # need to be assigned units
-        Vx_drift = _v_drift_units(Vx_drift)
-        Vy_drift = _v_drift_units(Vy_drift)
+        vx_drift = _v_drift_units(vx_drift)
+        vy_drift = _v_drift_units(vy_drift)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -270,7 +270,7 @@ def Maxwellian_velocity_2D(vx,
     # accounting for thermal velocity in 3D
     vThSq = vTh ** 2
     # Get square of relative particle velocity
-    vSq = ((vx - Vx_drift) ** 2 + (vy - Vy_drift) ** 2)
+    vSq = ((vx - vx_drift) ** 2 + (vy - vy_drift) ** 2)
     # calculating distribution function
     coeff = (vThSq * np.pi) ** (-1)
     expTerm = np.exp(-vSq / vThSq)
@@ -286,9 +286,9 @@ def Maxwellian_velocity_3D(vx,
                            vz,
                            T,
                            particle="e",
-                           Vx_drift=0,
-                           Vy_drift=0,
-                           Vz_drift=0,
+                           vx_drift=0,
+                           vy_drift=0,
+                           vz_drift=0,
                            vTh=np.nan,
                            units="units"):
     r"""
@@ -318,13 +318,13 @@ def Maxwellian_velocity_3D(vx,
         ``'D+'`` for deuterium, or ``'He-4 +1'`` for :math:`He_4^{+1}`
         (singly ionized helium-4)), which defaults to electrons.
 
-    Vx_drift: ~astropy.units.Quantity, optional
+    vx_drift: ~astropy.units.Quantity, optional
         The drift velocity in x-direction units convertible to m/s.
 
-    Vy_drift: ~astropy.units.Quantity, optional
+    vy_drift: ~astropy.units.Quantity, optional
         The drift velocity in y-direction units convertible to m/s.
 
-    Vz_drift: ~astropy.units.Quantity, optional
+    vz_drift: ~astropy.units.Quantity, optional
         The drift velocity in z-direction units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
@@ -384,9 +384,9 @@ def Maxwellian_velocity_3D(vx,
     ... vz=v,
     ... T=30000*u.K,
     ... particle='e',
-    ... Vx_drift=0*u.m/u.s,
-    ... Vy_drift=0*u.m/u.s,
-    ... Vz_drift=0*u.m/u.s)
+    ... vx_drift=0*u.m/u.s,
+    ... vy_drift=0*u.m/u.s,
+    ... vz_drift=0*u.m/u.s)
     <Quantity 2.07089033e-19 s3 / m3>
 
 
@@ -399,9 +399,9 @@ def Maxwellian_velocity_3D(vx,
         vz = vz.to(u.m / u.s)
         # catching case where drift velocities have default values, they
         # need to be assigned units
-        Vx_drift = _v_drift_units(Vx_drift)
-        Vy_drift = _v_drift_units(Vy_drift)
-        Vz_drift = _v_drift_units(Vz_drift)
+        vx_drift = _v_drift_units(vx_drift)
+        vy_drift = _v_drift_units(vy_drift)
+        vz_drift = _v_drift_units(vz_drift)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -420,7 +420,7 @@ def Maxwellian_velocity_3D(vx,
     # accounting for thermal velocity in 3D
     vThSq = vTh ** 2
     # Get square of relative particle velocity
-    vSq = ((vx - Vx_drift) ** 2 + (vy - Vy_drift) ** 2 + (vz - Vz_drift) ** 2)
+    vSq = ((vx - vx_drift) ** 2 + (vy - vy_drift) ** 2 + (vz - vz_drift) ** 2)
     # calculating distribution function
     coeff = (vThSq * np.pi) ** (-3 / 2)
     expTerm = np.exp(-vSq / vThSq)
@@ -434,7 +434,7 @@ def Maxwellian_velocity_3D(vx,
 def Maxwellian_speed_1D(v,
                         T,
                         particle="e",
-                        V_drift=0,
+                        v_drift=0,
                         vTh=np.nan,
                         units="units"):
     r"""
@@ -457,7 +457,7 @@ def Maxwellian_speed_1D(v,
         for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4)), which defaults to electrons.
 
-    V_drift: ~astropy.units.Quantity
+    v_drift: ~astropy.units.Quantity
         The drift speed in units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
@@ -507,7 +507,7 @@ def Maxwellian_speed_1D(v,
     >>> from plasmapy.physics import Maxwellian_speed_1D
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
-    >>> Maxwellian_speed_1D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
+    >>> Maxwellian_speed_1D(v=v, T= 30000*u.K, particle='e',v_drift=0*u.m/u.s)
     <Quantity 1.18326594e-06 s / m>
 
     """
@@ -517,7 +517,7 @@ def Maxwellian_speed_1D(v,
         v = v.to(u.m / u.s)
         # Catching case where drift velocities have default values, they
         # need to be assigned units
-        V_drift = _v_drift_units(V_drift)
+        v_drift = _v_drift_units(v_drift)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -536,7 +536,7 @@ def Maxwellian_speed_1D(v,
     # Get thermal velocity squared
     vThSq = vTh ** 2
     # Get square of relative particle velocity
-    vSq = (v - V_drift) ** 2
+    vSq = (v - v_drift) ** 2
     # calculating distribution function
     coeff = 2 * (vThSq * np.pi) ** (-1 / 2)
     expTerm = np.exp(-vSq / vThSq)
@@ -550,7 +550,7 @@ def Maxwellian_speed_1D(v,
 def Maxwellian_speed_2D(v,
                         T,
                         particle="e",
-                        V_drift=0,
+                        v_drift=0,
                         vTh=np.nan,
                         units="units"):
     r"""
@@ -574,7 +574,7 @@ def Maxwellian_speed_2D(v,
         for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4)), which defaults to electrons.
 
-    V_drift: ~astropy.units.Quantity
+    v_drift: ~astropy.units.Quantity
         The drift speed in units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
@@ -629,7 +629,7 @@ def Maxwellian_speed_2D(v,
     >>> from plasmapy.physics import Maxwellian_speed_2D
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
-    >>> Maxwellian_speed_2D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
+    >>> Maxwellian_speed_2D(v=v, T= 30000*u.K, particle='e',v_drift=0*u.m/u.s)
     <Quantity 2.19930065e-12 s / m>
 
     """
@@ -639,7 +639,7 @@ def Maxwellian_speed_2D(v,
         v = v.to(u.m / u.s)
         # Catching case where drift velocity has default value, and
         # needs to be assigned units
-        V_drift = _v_drift_units(V_drift)
+        v_drift = _v_drift_units(v_drift)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -658,10 +658,10 @@ def Maxwellian_speed_2D(v,
     # getting square of thermal speed
     vThSq = vTh ** 2
     # get square of relative particle speed
-    vSq = (v - V_drift) ** 2
+    vSq = (v - v_drift) ** 2
     # calculating distribution function
     coeff1 = (np.pi * vThSq) ** (-1)
-    coeff2 = 2 * np.pi * (v - V_drift)
+    coeff2 = 2 * np.pi * (v - v_drift)
     expTerm = np.exp(-vSq / vThSq)
     distFunc = coeff1 * coeff2 * expTerm
     if units == "units":
@@ -673,7 +673,7 @@ def Maxwellian_speed_2D(v,
 def Maxwellian_speed_3D(v,
                         T,
                         particle="e",
-                        V_drift=0,
+                        v_drift=0,
                         vTh=np.nan,
                         units="units"):
     r"""
@@ -697,7 +697,7 @@ def Maxwellian_speed_3D(v,
         for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4)), which defaults to electrons.
 
-    V_drift: ~astropy.units.Quantity
+    v_drift: ~astropy.units.Quantity
         The drift speed in units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
@@ -752,7 +752,7 @@ def Maxwellian_speed_3D(v,
     >>> from plasmapy.physics import Maxwellian_speed_3D
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
-    >>> Maxwellian_speed_3D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
+    >>> Maxwellian_speed_3D(v=v, T= 30000*u.K, particle='e',v_drift=0*u.m/u.s)
     <Quantity 2.60235754e-18 s / m>
 
     """
@@ -762,7 +762,7 @@ def Maxwellian_speed_3D(v,
         v = v.to(u.m / u.s)
         # Catching case where drift velocity has default value, and
         # needs to be assigned units
-        V_drift = _v_drift_units(V_drift)
+        v_drift = _v_drift_units(v_drift)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -781,7 +781,7 @@ def Maxwellian_speed_3D(v,
     # getting square of thermal speed
     vThSq = vTh ** 2
     # get square of relative particle speed
-    vSq = (v - V_drift) ** 2
+    vSq = (v - v_drift) ** 2
     # calculating distribution function
     coeff1 = (np.pi * vThSq) ** (-3 / 2)
     coeff2 = 4 * np.pi * vSq
@@ -797,7 +797,7 @@ def kappa_velocity_1D(v,
                       T,
                       kappa,
                       particle="e",
-                      V_drift=0,
+                      v_drift=0,
                       vTh=np.nan,
                       units="units"):
     r"""
@@ -826,7 +826,7 @@ def kappa_velocity_1D(v,
         for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4)), which defaults to electrons.
 
-    V_drift: ~astropy.units.Quantity, optional
+    v_drift: ~astropy.units.Quantity, optional
         The drift velocity in units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
@@ -884,7 +884,7 @@ def kappa_velocity_1D(v,
     >>> from plasmapy.physics import kappa_velocity_1D
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
-    >>> kappa_velocity_1D(v=v, T=30000*u.K, kappa=4, particle='e',V_drift=0*u.m/u.s)
+    >>> kappa_velocity_1D(v=v, T=30000*u.K, kappa=4, particle='e',v_drift=0*u.m/u.s)
     <Quantity 6.75549854e-07 s / m>
 
     See Also
@@ -901,11 +901,11 @@ def kappa_velocity_1D(v,
         v = v.to(u.m / u.s)
         # catching case where drift velocities have default values, they
         # need to be assigned units
-        if V_drift == 0:
-            if not isinstance(V_drift, astropy.units.quantity.Quantity):
-                V_drift = V_drift * u.m / u.s
+        if v_drift == 0:
+            if not isinstance(v_drift, astropy.units.quantity.Quantity):
+                v_drift = v_drift * u.m / u.s
         # checking units of drift velocities
-        V_drift = V_drift.to(u.m / u.s)
+        v_drift = v_drift.to(u.m / u.s)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -924,7 +924,7 @@ def kappa_velocity_1D(v,
     # Get thermal velocity squared and accounting for 1D instead of 3D
     vThSq = vTh ** 2
     # Get square of relative particle velocity
-    vSq = (v - V_drift) ** 2
+    vSq = (v - v_drift) ** 2
     # calculating distribution function
     expTerm = (1 + vSq / (kappa * vThSq)) ** (-kappa)
     coeff1 = 1 / (np.sqrt(np.pi) * kappa ** (3 / 2) * vTh)
@@ -942,9 +942,9 @@ def kappa_velocity_3D(vx,
                       T,
                       kappa,
                       particle="e",
-                      Vx_drift=0,
-                      Vy_drift=0,
-                      Vz_drift=0,
+                      vx_drift=0,
+                      vy_drift=0,
+                      vz_drift=0,
                       vTh=np.nan,
                       units="units"):
     r"""
@@ -978,13 +978,13 @@ def kappa_velocity_3D(vx,
         for deuterium, or 'He-4 +1' for :math:`He_4^{+1}` : singly ionized
         helium-4)), which defaults to electrons.
 
-    Vx_drift: ~astropy.units.Quantity, optional
+    vx_drift: ~astropy.units.Quantity, optional
         The drift velocity in x-direction units convertible to m/s.
 
-    Vy_drift: ~astropy.units.Quantity, optional
+    vy_drift: ~astropy.units.Quantity, optional
         The drift velocity in y-direction units convertible to m/s.
 
-    Vz_drift: ~astropy.units.Quantity, optional
+    vz_drift: ~astropy.units.Quantity, optional
         The drift velocity in z-direction units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
@@ -1052,9 +1052,9 @@ def kappa_velocity_3D(vx,
     ... T=30000*u.K,
     ... kappa=4,
     ... particle='e',
-    ... Vx_drift=0*u.m/u.s,
-    ... Vy_drift=0*u.m/u.s,
-    ... Vz_drift=0*u.m/u.s)
+    ... vx_drift=0*u.m/u.s,
+    ... vy_drift=0*u.m/u.s,
+    ... vz_drift=0*u.m/u.s)
     <Quantity 3.7833988e-19 s3 / m3>
     """
     # must have kappa > 3/2 for distribution function to be valid
@@ -1068,9 +1068,9 @@ def kappa_velocity_3D(vx,
         vz = vz.to(u.m / u.s)
         # Catching case where drift velocities have default values, they
         # need to be assigned units
-        Vx_drift = _v_drift_units(Vx_drift)
-        Vy_drift = _v_drift_units(Vy_drift)
-        Vz_drift = _v_drift_units(Vz_drift)
+        vx_drift = _v_drift_units(vx_drift)
+        vy_drift = _v_drift_units(vy_drift)
+        vz_drift = _v_drift_units(vz_drift)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -1089,7 +1089,7 @@ def kappa_velocity_3D(vx,
     # getting square of thermal velocity
     vThSq = vTh ** 2
     # Get square of relative particle velocity
-    vSq = ((vx - Vx_drift) ** 2 + (vy - Vy_drift) ** 2 + (vz - Vz_drift) ** 2)
+    vSq = ((vx - vx_drift) ** 2 + (vy - vy_drift) ** 2 + (vz - vz_drift) ** 2)
     # calculating distribution function
     expTerm = (1 + vSq / (kappa * vThSq)) ** (-(kappa + 1))
     coeff1 = 1 / (2 * np.pi * (kappa * vThSq) ** (3 / 2))

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -35,7 +35,7 @@ def Maxwellian_1D(v,
                   units="units"):
     r"""
     Probability distribution function of velocity for a Maxwellian 
-    distribution.
+    distribution in 1D.
 
     Returns the probability density function at the velocity `v` in m/s
     to find a particle `particle` in a plasma of temperature `T`
@@ -153,8 +153,8 @@ def Maxwellian_velocity_2D(vx,
                            vTh=np.nan,
                            units="units"):
     r"""
-    Probability distribution function of velocity for a 2D Maxwellian 
-    distribution.
+    Probability distribution function of velocity for a Maxwellian 
+    distribution in 2D.
 
     Return the probability density function for finding a particle with 
     velocity components `vx` and `vy` in m/s in an equilibrium plasma of 
@@ -294,8 +294,8 @@ def Maxwellian_velocity_3D(vx,
                            vTh=np.nan,
                            units="units"):
     r"""
-    Probability distribution function of velocity for a 3D Maxwellian 
-    distribution.
+    Probability distribution function of velocity for a Maxwellian 
+    distribution in 3D.
 
     Return the probability density function for finding a particle with 
     velocity components `vx`, `vy`, and `vz` in m/s in an equilibrium 
@@ -441,7 +441,8 @@ def Maxwellian_speed_1D(v,
                         vTh=np.nan,
                         units="units"):
     r"""
-    Probability distribution function of speed for a Maxwellian distribution.
+    Probability distribution function of speed for a Maxwellian distribution
+    in 1D.
 
     Return the probability density function for finding a particle with 
     speed `v` in m/s in an equilibrium plasma of temperature `T` which 
@@ -557,8 +558,8 @@ def Maxwellian_speed_2D(v,
                         vTh=np.nan,
                         units="units"):
     r"""
-    Probability distribution function of speed for a 2D Maxwellian
-    distribution.
+    Probability distribution function of speed for a Maxwellian distribution
+    in 2D.
 
     Return the probability density function of finding a particle with speed components
     `vx` and `vy` in m/s in an equilibrium plasma of temperature
@@ -681,8 +682,8 @@ def Maxwellian_speed_3D(v,
                         vTh=np.nan,
                         units="units"):
     r"""
-    Probability distribution function of speed for a 3D Maxwellian
-    distribution.
+    Probability distribution function of speed for a Maxwellian
+    distribution in 3D.
 
     Return the probability density function for finding a particle with 
     speed components `vx`, `vy`, and `vz` in m/s in an equilibrium 
@@ -806,9 +807,9 @@ def kappa_velocity_1D(v,
                       vTh=np.nan,
                       units="units"):
     r"""
-    Return the probability at the velocity `v` in m/s
+    Return the probability density at the velocity `v` in m/s
     to find a particle `particle` in a plasma of temperature `T`
-    following the Kappa distribution function. The slope of the
+    following the Kappa distribution function in 1D. The slope of the
     tail of the Kappa distribution function is set by 'kappa', which
     must be greater than :math:`1/2`.
 

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -249,7 +249,7 @@ def Maxwellian_velocity_3D(vx,
     ... Vx_drift=0*u.m/u.s,
     ... Vy_drift=0*u.m/u.s,
     ... Vz_drift=0*u.m/u.s)
-    <Quantity 3.98543031e-20 s3 / m3>
+    <Quantity 2.07089033e-19 s3 / m3>
 
 
     """
@@ -280,7 +280,7 @@ def Maxwellian_velocity_3D(vx,
                                        particle=particle,
                                        method="most_probable").si.value
     # accounting for thermal velocity in 3D
-    vThSq = 3 * vTh ** 2
+    vThSq = vTh ** 2
     # Get square of relative particle velocity
     vSq = ((vx - Vx_drift) ** 2 + (vy - Vy_drift) ** 2 + (vz - Vz_drift) ** 2)
     # calculating distribution function
@@ -370,7 +370,7 @@ def Maxwellian_speed_1D(v,
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
     >>> Maxwellian_speed_1D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
-    <Quantity 2.60235754e-18 s / m>
+    <Quantity 1.18326594e-06 s / m>
 
     """
     if units == "units":

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -34,7 +34,8 @@ def Maxwellian_1D(v,
                   vTh=np.nan,
                   units="units"):
     r"""
-    pdf of velocity for a Maxwellian distribution.
+    Probability distribution function of velocity for a Maxwellian 
+    distribution.
 
     Returns the probability at the velocity `v` in m/s
     to find a particle `particle` in a plasma of temperature `T`
@@ -152,7 +153,8 @@ def Maxwellian_velocity_2D(vx,
                            vTh=np.nan,
                            units="units"):
     r"""
-    pdf of velocity for a 2D Maxwellian distribution.
+    Probability distribution function of velocity for a 2D Maxwellian 
+    distribution.
 
     Return the probability of finding a particle with velocity components
     `vx` and `vy` in m/s in an equilibrium plasma of temperature
@@ -292,7 +294,8 @@ def Maxwellian_velocity_3D(vx,
                            vTh=np.nan,
                            units="units"):
     r"""
-    pdf of velocity for a 3D Maxwellian distribution.
+    Probability distribution function of velocity for a 3D Maxwellian 
+    distribution.
 
     Return the probability of finding a particle with velocity components
     `vx`, `vy`, and `vz` in m/s in an equilibrium plasma of temperature
@@ -438,7 +441,7 @@ def Maxwellian_speed_1D(v,
                         vTh=np.nan,
                         units="units"):
     r"""
-    pdf of speed for a Maxwellian distribution.
+    Probability distribution function of speed for a Maxwellian distribution.
 
     Return the probability of finding a particle with speed `v` in m/s
     in an equilibrium plasma of temperature `T` which follows the
@@ -554,7 +557,8 @@ def Maxwellian_speed_2D(v,
                         vTh=np.nan,
                         units="units"):
     r"""
-    pdf of speed for a 2D Maxwellian distribution.
+    Probability distribution function of speed for a 2D Maxwellian
+    distribution.
 
     Return the probability of finding a particle with speed components
     `vx` and `vy` in m/s in an equilibrium plasma of temperature
@@ -677,7 +681,8 @@ def Maxwellian_speed_3D(v,
                         vTh=np.nan,
                         units="units"):
     r"""
-    pdf of speed for a 3D Maxwellian distribution.
+    Probability distribution function of speed for a 3D Maxwellian
+    distribution.
 
     Return the probability of finding a particle with speed components
     `vx`, `vy`, and `vz` in m/s in an equilibrium plasma of temperature

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -156,10 +156,10 @@ def Maxwellian_velocity_2D(vx,
     Probability distribution function of velocity for a 2D Maxwellian 
     distribution.
 
-    Return the probability of finding a particle with velocity components
-    `vx` and `vy` in m/s in an equilibrium plasma of temperature
-    `T` which follows the 2D Maxwellian distribution function. This
-    function assumes Cartesian coordinates.
+    Return the probability density function for finding a particle with 
+    velocity components `vx` and `vy` in m/s in an equilibrium plasma of 
+    temperature `T` which follows the 2D Maxwellian distribution function. 
+    This function assumes Cartesian coordinates.
 
     Parameters
     ----------
@@ -297,10 +297,10 @@ def Maxwellian_velocity_3D(vx,
     Probability distribution function of velocity for a 3D Maxwellian 
     distribution.
 
-    Return the probability of finding a particle with velocity components
-    `vx`, `vy`, and `vz` in m/s in an equilibrium plasma of temperature
-    `T` which follows the 3D Maxwellian distribution function. This
-    function assumes Cartesian coordinates.
+    Return the probability density function for finding a particle with 
+    velocity components `vx`, `vy`, and `vz` in m/s in an equilibrium 
+    plasma of temperature `T` which follows the 3D Maxwellian distribution 
+    function. This function assumes Cartesian coordinates.
 
     Parameters
     ----------
@@ -443,9 +443,9 @@ def Maxwellian_speed_1D(v,
     r"""
     Probability distribution function of speed for a Maxwellian distribution.
 
-    Return the probability of finding a particle with speed `v` in m/s
-    in an equilibrium plasma of temperature `T` which follows the
-    Maxwellian distribution function.
+    Return the probability density function for finding a particle with 
+    speed `v` in m/s in an equilibrium plasma of temperature `T` which 
+    follows the Maxwellian distribution function.
 
     Parameters
     ----------
@@ -560,7 +560,7 @@ def Maxwellian_speed_2D(v,
     Probability distribution function of speed for a 2D Maxwellian
     distribution.
 
-    Return the probability of finding a particle with speed components
+    Return the probability density function of finding a particle with speed components
     `vx` and `vy` in m/s in an equilibrium plasma of temperature
     `T` which follows the 2D Maxwellian distribution function. This
     function assumes Cartesian coordinates.
@@ -684,10 +684,10 @@ def Maxwellian_speed_3D(v,
     Probability distribution function of speed for a 3D Maxwellian
     distribution.
 
-    Return the probability of finding a particle with speed components
-    `vx`, `vy`, and `vz` in m/s in an equilibrium plasma of temperature
-    `T` which follows the 3D Maxwellian distribution function. This
-    function assumes Cartesian coordinates.
+    Return the probability density function for finding a particle with 
+    speed components `vx`, `vy`, and `vz` in m/s in an equilibrium 
+    plasma of temperature `T` which follows the 3D Maxwellian 
+    distribution function. This function assumes Cartesian coordinates.
 
     Parameters
     ----------
@@ -953,10 +953,11 @@ def kappa_velocity_3D(vx,
                       vTh=np.nan,
                       units="units"):
     r"""
-    Return the probability of finding a particle with velocity components
-    `v_x`, `v_y`, and `v_z`in m/s in a suprathermal plasma of temperature
-    `T` and parameter 'kappa' which follows the 3D Kappa distribution function.
-    This function assumes Cartesian coordinates.
+    Return the probability density function for finding a particle with 
+    velocity components `v_x`, `v_y`, and `v_z`in m/s in a suprathermal 
+    plasma of temperature `T` and parameter 'kappa' which follows the 
+    3D Kappa distribution function. This function assumes Cartesian 
+    coordinates.
 
     Parameters
     ----------

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -37,7 +37,7 @@ def Maxwellian_1D(v,
     Probability distribution function of velocity for a Maxwellian 
     distribution.
 
-    Returns the probability at the velocity `v` in m/s
+    Returns the probability density function at the velocity `v` in m/s
     to find a particle `particle` in a plasma of temperature `T`
     following the Maxwellian distribution function.
 
@@ -71,7 +71,7 @@ def Maxwellian_1D(v,
     Returns
     -------
     f : ~astropy.units.Quantity
-        Probability in units of Velocity^-1, normalized so that
+        Probability density in units of Velocity^-1, normalized so that
         :math:`\int_{-\infty}^{+\infty} f(v) dv = 1`.
 
     Raises
@@ -197,7 +197,7 @@ def Maxwellian_velocity_2D(vx,
     Returns
     -------
     f : ~astropy.units.Quantity
-        Probability in Velocity^-1, normalized so that
+        Probability density in Velocity^-1, normalized so that
         :math:`\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1`.
 
     Raises
@@ -269,7 +269,7 @@ def Maxwellian_velocity_2D(vx,
         vTh = parameters.thermal_speed(T * u.K,
                                        particle=particle,
                                        method="most_probable").si.value
-    # accounting for thermal velocity in 3D
+    # accounting for thermal velocity in 2D
     vThSq = vTh ** 2
     # Get square of relative particle velocity
     vSq = ((vx - vx_drift) ** 2 + (vy - vy_drift) ** 2)
@@ -344,7 +344,7 @@ def Maxwellian_velocity_3D(vx,
     Returns
     -------
     f : ~astropy.units.Quantity
-        Probability in Velocity^-1, normalized so that
+        Probability density in Velocity^-1, normalized so that
         :math:`\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1`.
 
     Raises
@@ -477,7 +477,7 @@ def Maxwellian_speed_1D(v,
     Returns
     -------
     f : ~astropy.units.Quantity
-        Probability in speed^-1, normalized so that
+        Probability density in speed^-1, normalized so that
         :math:`\int_{0}^{\infty} f(v) dv = 1`.
 
     Raises
@@ -595,7 +595,7 @@ def Maxwellian_speed_2D(v,
     Returns
     -------
     f : ~astropy.units.Quantity
-        Probability in speed^-1, normalized so that:
+        Probability density in speed^-1, normalized so that:
         :math:`\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1`.
 
     Raises
@@ -719,7 +719,7 @@ def Maxwellian_speed_3D(v,
     Returns
     -------
     f : ~astropy.units.Quantity
-        Probability in speed^-1, normalized so that:
+        Probability density in speed^-1, normalized so that:
         :math:`\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1`.
 
     Raises
@@ -848,7 +848,7 @@ def kappa_velocity_1D(v,
     Returns
     -------
     f : ~astropy.units.Quantity
-        probability in Velocity^-1, normalized so that
+        Probability density in Velocity^-1, normalized so that
         :math:`\int_{-\infty}^{+\infty} f(v) dv = 1`.
 
     Raises
@@ -1007,7 +1007,7 @@ def kappa_velocity_3D(vx,
     Returns
     -------
     f : ~astropy.units.Quantity
-        probability in Velocity^-1, normalized so that:
+        Probability density in Velocity^-1, normalized so that:
         :math:`\iiint_{0}^{\infty} f(\vec{v}) d\vec{v} = 1`
 
     Raises

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -103,7 +103,7 @@ def Maxwellian_1D(v,
     >>> from plasmapy.physics import Maxwellian_1D
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
-    >>> Maxwellian_1D(v=v, T= 30000*u.K, particle='e',v_drift=0*u.m/u.s)
+    >>> Maxwellian_1D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
     <Quantity 5.91632969e-07 s / m>
     """
 
@@ -232,13 +232,13 @@ def Maxwellian_velocity_2D(vx,
     -------
     >>> from plasmapy.physics import Maxwellian_velocity_2D
     >>> from astropy import units as u
-    >>> v=1*u.m/u.s
+    >>> v=1 * u.m / u.s
     >>> Maxwellian_velocity_2D(vx=v,
     ... vy=v,
     ... T=30000*u.K,
     ... particle='e',
-    ... vx_drift=0*u.m/u.s,
-    ... vy_drift=0*u.m/u.s)
+    ... vx_drift=0 * u.m / u.s,
+    ... vy_drift=0 * u.m / u.s)
     <Quantity 3.5002957e-13 s2 / m2>
 
 
@@ -378,15 +378,15 @@ def Maxwellian_velocity_3D(vx,
     -------
     >>> from plasmapy.physics import Maxwellian_velocity_3D
     >>> from astropy import units as u
-    >>> v=1*u.m/u.s
+    >>> v=1 * u.m / u.s
     >>> Maxwellian_velocity_3D(vx=v,
     ... vy=v,
     ... vz=v,
-    ... T=30000*u.K,
+    ... T=30000 * u.K,
     ... particle='e',
-    ... vx_drift=0*u.m/u.s,
-    ... vy_drift=0*u.m/u.s,
-    ... vz_drift=0*u.m/u.s)
+    ... vx_drift=0 * u.m / u.s,
+    ... vy_drift=0 * u.m / u.s,
+    ... vz_drift=0 * u.m / u.s)
     <Quantity 2.07089033e-19 s3 / m3>
 
 
@@ -506,8 +506,8 @@ def Maxwellian_speed_1D(v,
     -------
     >>> from plasmapy.physics import Maxwellian_speed_1D
     >>> from astropy import units as u
-    >>> v=1*u.m/u.s
-    >>> Maxwellian_speed_1D(v=v, T= 30000*u.K, particle='e',v_drift=0*u.m/u.s)
+    >>> v=1 * u.m / u.s
+    >>> Maxwellian_speed_1D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
     <Quantity 1.18326594e-06 s / m>
 
     """
@@ -628,8 +628,8 @@ def Maxwellian_speed_2D(v,
     -------
     >>> from plasmapy.physics import Maxwellian_speed_2D
     >>> from astropy import units as u
-    >>> v=1*u.m/u.s
-    >>> Maxwellian_speed_2D(v=v, T= 30000*u.K, particle='e',v_drift=0*u.m/u.s)
+    >>> v=1 * u.m / u.s
+    >>> Maxwellian_speed_2D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
     <Quantity 2.19930065e-12 s / m>
 
     """
@@ -751,8 +751,8 @@ def Maxwellian_speed_3D(v,
     -------
     >>> from plasmapy.physics import Maxwellian_speed_3D
     >>> from astropy import units as u
-    >>> v=1*u.m/u.s
-    >>> Maxwellian_speed_3D(v=v, T= 30000*u.K, particle='e',v_drift=0*u.m/u.s)
+    >>> v=1 * u.m / u.s
+    >>> Maxwellian_speed_3D(v=v, T=30000*u.K, particle='e', v_drift=0 * u.m / u.s)
     <Quantity 2.60235754e-18 s / m>
 
     """
@@ -883,8 +883,8 @@ def kappa_velocity_1D(v,
     --------
     >>> from plasmapy.physics import kappa_velocity_1D
     >>> from astropy import units as u
-    >>> v=1*u.m/u.s
-    >>> kappa_velocity_1D(v=v, T=30000*u.K, kappa=4, particle='e',v_drift=0*u.m/u.s)
+    >>> v=1 * u.m / u.s
+    >>> kappa_velocity_1D(v=v, T=30000*u.K, kappa=4, particle='e', v_drift=0 * u.m / u.s)
     <Quantity 6.75549854e-07 s / m>
 
     See Also
@@ -1045,16 +1045,16 @@ def kappa_velocity_3D(vx,
     -------
     >>> from plasmapy.physics import kappa_velocity_3D
     >>> from astropy import units as u
-    >>> v=1*u.m/u.s
+    >>> v=1 * u.m / u.s
     >>> kappa_velocity_3D(vx=v,
     ... vy=v,
     ... vz=v,
-    ... T=30000*u.K,
+    ... T=30000 * u.K,
     ... kappa=4,
     ... particle='e',
-    ... vx_drift=0*u.m/u.s,
-    ... vy_drift=0*u.m/u.s,
-    ... vz_drift=0*u.m/u.s)
+    ... vx_drift=0 * u.m / u.s,
+    ... vy_drift=0 * u.m / u.s,
+    ... vz_drift=0 * u.m / u.s)
     <Quantity 3.7833988e-19 s3 / m3>
     """
     # must have kappa > 3/2 for distribution function to be valid

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -373,51 +373,13 @@ def Maxwellian_speed_1D(v,
     <Quantity 2.60235754e-18 s / m>
 
     """
-    if units == "units":
-        # unit checks and conversions
-        # checking velocity units
-        v = v.to(u.m / u.s)
-        # Catching case where drift velocity has default value, and
-        # needs to be assigned units
-        V_drift = _v_drift_units(V_drift)
-        # convert temperature to Kelvins
-        T = T.to(u.K, equivalencies=u.temperature_energy())
-        if np.isnan(vTh):
-            # get thermal velocity and thermal velocity squared
-            vTh = (parameters.thermal_speed(T,
-                                            particle=particle,
-                                            method="most_probable"))
-        elif not np.isnan(vTh):
-            # check units of thermal velocity
-            vTh = vTh.to(u.m / u.s)
-    elif np.isnan(vTh) and units == "unitless":
-        # assuming unitless temperature is in Kelvins
-        vTh = (parameters.thermal_speed(T * u.K,
-                                        particle=particle,
-                                        method="most_probable")).si.value
-    # getting square of thermal speed
-    vThSq = vTh ** 2
-    # get square of relative particle speed
-    vSq = (v - V_drift) ** 2
-    # calculating distribution function
-    coeff1 = (np.pi * vThSq) ** (-3 / 2)
-    coeff2 = 4 * np.pi * vSq
-    expTerm = np.exp(-vSq / vThSq)
-    distFunc = coeff1 * coeff2 * expTerm
-    if units == "units":
-        return distFunc.to(u.s / u.m)
-    elif units == "unitless":
-        return distFunc
+    return
 
 
-def Maxwellian_speed_3D(vx,
-                        vy,
-                        vz,
+def Maxwellian_speed_3D(v,
                         T,
                         particle="e",
-                        Vx_drift=0,
-                        Vy_drift=0,
-                        Vz_drift=0,
+                        V_drift=0,
                         vTh=np.nan,
                         units="units"):
     r"""
@@ -430,31 +392,19 @@ def Maxwellian_speed_3D(vx,
 
     Parameters
     ----------
-    vx: ~astropy.units.Quantity
-        The speed in x-direction units convertible to m/s.
-
-    vy: ~astropy.units.Quantity
-        The speed in y-direction units convertible to m/s.
-
-    vz: ~astropy.units.Quantity
-        The speed in z-direction units convertible to m/s.
+    v: ~astropy.units.Quantity
+        The speed in units convertible to m/s.
 
     T: ~astropy.units.Quantity
         The temperature, preferably in Kelvin.
 
     particle: str, optional
-        Representation of the particle species(e.g., 'p' for protons, 'D+'
-        for deuterium, or 'He-4 +1' for :math:`He_4^{+1}`
+        Representation of the particle species(e.g., `'p'` for protons, `'D+'`
+        for deuterium, or `'He-4 +1'` for :math:`He_4^{+1}`
         (singly ionized helium-4)), which defaults to electrons.
 
-    Vx_drift: ~astropy.units.Quantity
-        The drift speed in x-direction units convertible to m/s.
-
-    Vy_drift: ~astropy.units.Quantity
-        The drift speed in y-direction units convertible to m/s.
-
-    Vz_drift: ~astropy.units.Quantity
-        The drift speed in z-direction units convertible to m/s.
+    V_drift: ~astropy.units.Quantity
+        The drift speed in units convertible to m/s.
 
     vTh: ~astropy.units.Quantity, optional
         Thermal velocity (most probable) in m/s. This is used for
@@ -508,28 +458,17 @@ def Maxwellian_speed_3D(vx,
     >>> from plasmapy.physics import Maxwellian_speed_3D
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
-    >>> Maxwellian_speed_3D(vx=v,
-    ... vy=v,
-    ... vz=v,
-    ... T=30000*u.K,
-    ... particle='e',
-    ... Vx_drift=0*u.m/u.s,
-    ... Vy_drift=0*u.m/u.s,
-    ... Vz_drift=0*u.m/u.s)
-    <Quantity 1.76238544e-53 s3 / m3>
+    >>> Maxwellian_speed_3D(v=v, T= 30000*u.K, particle='e',V_drift=0*u.m/u.s)
+    <Quantity 2.60235754e-18 s / m>
 
     """
     if units == "units":
         # unit checks and conversions
         # checking velocity units
-        vx = vx.to(u.m / u.s)
-        vy = vy.to(u.m / u.s)
-        vz = vz.to(u.m / u.s)
-        # Catching case where drift velocities have default values, they
-        # need to be assigned units
-        Vx_drift = _v_drift_units(Vx_drift)
-        Vy_drift = _v_drift_units(Vy_drift)
-        Vz_drift = _v_drift_units(Vz_drift)
+        v = v.to(u.m / u.s)
+        # Catching case where drift velocity has default value, and
+        # needs to be assigned units
+        V_drift = _v_drift_units(V_drift)
         # convert temperature to Kelvins
         T = T.to(u.K, equivalencies=u.temperature_energy())
         if np.isnan(vTh):
@@ -545,29 +484,17 @@ def Maxwellian_speed_3D(vx,
         vTh = (parameters.thermal_speed(T * u.K,
                                         particle=particle,
                                         method="most_probable")).si.value
-    # getting distribution functions along each axis
-    fx = Maxwellian_speed_1D(vx,
-                             T,
-                             particle=particle,
-                             V_drift=Vx_drift,
-                             vTh=vTh,
-                             units=units)
-    fy = Maxwellian_speed_1D(vy,
-                             T,
-                             particle=particle,
-                             V_drift=Vy_drift,
-                             vTh=vTh,
-                             units=units)
-    fz = Maxwellian_speed_1D(vz,
-                             T,
-                             particle=particle,
-                             V_drift=Vz_drift,
-                             vTh=vTh,
-                             units=units)
-    # multiplying probabilities in each axis to get 3D probability
-    distFunc = fx * fy * fz
+    # getting square of thermal speed
+    vThSq = vTh ** 2
+    # get square of relative particle speed
+    vSq = (v - V_drift) ** 2
+    # calculating distribution function
+    coeff1 = (np.pi * vThSq) ** (-3 / 2)
+    coeff2 = 4 * np.pi * vSq
+    expTerm = np.exp(-vSq / vThSq)
+    distFunc = coeff1 * coeff2 * expTerm
     if units == "units":
-        return distFunc.to((u.s / u.m)**3)
+        return distFunc.to(u.s / u.m)
     elif units == "unitless":
         return distFunc
 

--- a/plasmapy/physics/distribution.py
+++ b/plasmapy/physics/distribution.py
@@ -638,6 +638,8 @@ def Maxwellian_speed_2D(v,
     <Quantity 2.19930065e-12 s / m>
 
     """
+    if v_drift != 0:
+        raise NotImplementedError("Non-zero drift speed is work in progress.")
     if units == "units":
         # unit checks and conversions
         # checking velocity units
@@ -762,6 +764,8 @@ def Maxwellian_speed_3D(v,
     <Quantity 2.60235754e-18 s / m>
 
     """
+    if v_drift != 0:
+        raise NotImplementedError("Non-zero drift speed is work in progress.")
     if units == "units":
         # unit checks and conversions
         # checking velocity units

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -208,135 +208,136 @@ class Test_Maxwellian_1D(object):
 
 
 # test class for Maxwellian_speed_1D function
-#class Test_Maxwellian_speed_1D(object):
-#    @classmethod
-#    def setup_class(self):
-#        """initializing parameters for tests """
-#        self.T = 1.0 * u.eV
-#        self.particle = 'H+'
-#        # get thermal velocity and thermal velocity squared
-#        self.vTh = thermal_speed(self.T,
-#                                 particle=self.particle,
-#                                 method="most_probable")
-#        self.v = 1e5 * u.m / u.s
-#        self.V_drift = 0 * u.m / u.s
-#        self.V_drift2 = 1e5 * u.m / u.s
-#        self.distFuncTrue = 1.8057567503860518e-25
-#
-#    def test_norm(self):
-#        """
-#        Tests whether distribution function is normalized, and integrates to 1.
-#        """
-#        # setting up integration from 0 to 10*vTh
-#        xData1D = np.arange(0, 10.01, 0.01) * self.vTh
-#        yData1D = Maxwellian_speed_1D(v=xData1D,
-#                                      T=self.T,
-#                                      particle=self.particle)
-#        # integrating, this should be close to 1
-#        integ = spint.trapz(y=yData1D, x=xData1D)
-#        exceptStr = "Integral of distribution function should be 1."
-#        assert np.isclose(integ.value, 1), exceptStr
-#
-#    def test_units_no_vTh(self):
-#        """
-#        Tests distribution function with units, but not passing vTh.
-#        """
-#        distFunc = Maxwellian_speed_1D(v=self.v,
-#                                       T=self.T,
-#                                       particle=self.particle,
-#                                       units="units")
-#        errStr = (f"Distribution function should be {self.distFuncTrue} "
-#                  f"and not {distFunc}.")
-#        assert np.isclose(distFunc.value,
-#                          self.distFuncTrue,
-#                          rtol=1e-8,
-#                          atol=0.0), errStr
-#
-#    def test_units_vTh(self):
-#        """
-#        Tests distribution function with units and passing vTh.
-#        """
-#        distFunc = Maxwellian_speed_1D(v=self.v,
-#                                       T=self.T,
-#                                       vTh=self.vTh,
-#                                       particle=self.particle,
-#                                       units="units")
-#        errStr = (f"Distribution function should be {self.distFuncTrue} "
-#                  f"and not {distFunc}.")
-#        assert np.isclose(distFunc.value,
-#                          self.distFuncTrue,
-#                          rtol=1e-8,
-#                          atol=0.0), errStr
-#
-#    def test_unitless_no_vTh(self):
-#        """
-#        Tests distribution function without units, and not passing vTh.
-#        """
-#        # converting T to SI then stripping units
-#        T = self.T.to(u.K, equivalencies=u.temperature_energy())
-#        T = T.si.value
-#        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
-#                                       T=T,
-#                                       particle=self.particle,
-#                                       units="unitless")
-#        errStr = (f"Distribution function should be {self.distFuncTrue} "
-#                  f"and not {distFunc}.")
-#        assert np.isclose(distFunc,
-#                          self.distFuncTrue,
-#                          rtol=1e-8,
-#                          atol=0.0), errStr
-#
-#    def test_unitless_vTh(self):
-#        """
-#        Tests distribution function without units, and with passing vTh.
-#        """
-#        # converting T to SI then stripping units
-#        T = self.T.to(u.K, equivalencies=u.temperature_energy())
-#        T = T.si.value
-#        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
-#                                       T=T,
-#                                       vTh=self.vTh.si.value,
-#                                       particle=self.particle,
-#                                       units="unitless")
-#        errStr = (f"Distribution function should be {self.distFuncTrue} "
-#                  f"and not {distFunc}.")
-#        assert np.isclose(distFunc,
-#                          self.distFuncTrue,
-#                          rtol=1e-8,
-#                          atol=0.0), errStr
-#
-#    def test_zero_drift_units(self):
-#        """
-#        Testing inputting drift equal to 0 with units. These should just
-#        get passed and not have extra units applied to them.
-#        """
-#        distFunc = Maxwellian_speed_1D(v=self.v,
-#                                       T=self.T,
-#                                       particle=self.particle,
-#                                       V_drift=self.V_drift,
-#                                       units="units")
-#        errStr = (f"Distribution function should be {self.distFuncTrue} "
-#                  f"and not {distFunc}.")
-#        assert np.isclose(distFunc.value,
-#                          self.distFuncTrue,
-#                          rtol=1e-8,
-#                          atol=0.0), errStr
-#
-#    def test_value_drift_units(self):
-#        """
-#        Testing vdrifts with values
-#        """
-#        distFunc = Maxwellian_speed_1D(v=self.v,
-#                                       T=self.T,
-#                                       particle=self.particle,
-#                                       V_drift=self.V_drift2,
-#                                       units="units")
-#        errStr = (f"Distribution function should be 0.0 "
-#                  f"and not {distFunc}.")
-#        assert np.isclose(distFunc.value,
-#                          0.0,
-#                          rtol=1e-8,
-#                          atol=0.0), errStr
+class Test_Maxwellian_speed_1D(object):
+    @classmethod
+    def setup_class(self):
+        """initializing parameters for tests """
+        self.T = 1.0 * u.eV
+        self.particle = 'H+'
+        # get thermal velocity and thermal velocity squared
+        self.vTh = thermal_speed(self.T,
+                                 particle=self.particle,
+                                 method="most_probable")
+        self.v = 1e5 * u.m / u.s
+        self.V_drift = 0 * u.m / u.s
+        self.V_drift2 = 1e5 * u.m / u.s
+        self.distFuncTrue = 1.72940389716217e-27
+        self.distFuncDrift = 2 * (self.vTh ** 2 * np.pi) ** (-1 / 2)
+
+    def test_norm(self):
+        """
+        Tests whether distribution function is normalized, and integrates to 1.
+        """
+        # setting up integration from 0 to 10*vTh
+        xData1D = np.arange(0, 10.01, 0.01) * self.vTh
+        yData1D = Maxwellian_speed_1D(v=xData1D,
+                                      T=self.T,
+                                      particle=self.particle)
+        # integrating, this should be close to 1
+        integ = spint.trapz(y=yData1D, x=xData1D)
+        exceptStr = "Integral of distribution function should be 1."
+        assert np.isclose(integ.value, 1), exceptStr
+
+    def test_units_no_vTh(self):
+        """
+        Tests distribution function with units, but not passing vTh.
+        """
+        distFunc = Maxwellian_speed_1D(v=self.v,
+                                       T=self.T,
+                                       particle=self.particle,
+                                       units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value,
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+
+    def test_units_vTh(self):
+        """
+        Tests distribution function with units and passing vTh.
+        """
+        distFunc = Maxwellian_speed_1D(v=self.v,
+                                       T=self.T,
+                                       vTh=self.vTh,
+                                       particle=self.particle,
+                                       units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value,
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+
+    def test_unitless_no_vTh(self):
+        """
+        Tests distribution function without units, and not passing vTh.
+        """
+        # converting T to SI then stripping units
+        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+        T = T.si.value
+        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
+                                       T=T,
+                                       particle=self.particle,
+                                       units="unitless")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc,
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+
+    def test_unitless_vTh(self):
+        """
+        Tests distribution function without units, and with passing vTh.
+        """
+        # converting T to SI then stripping units
+        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+        T = T.si.value
+        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
+                                       T=T,
+                                       vTh=self.vTh.si.value,
+                                       particle=self.particle,
+                                       units="unitless")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc,
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+
+    def test_zero_drift_units(self):
+        """
+        Testing inputting drift equal to 0 with units. These should just
+        get passed and not have extra units applied to them.
+        """
+        distFunc = Maxwellian_speed_1D(v=self.v,
+                                       T=self.T,
+                                       particle=self.particle,
+                                       V_drift=self.V_drift,
+                                       units="units")
+        errStr = (f"Distribution function should be {self.distFuncTrue} "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value,
+                          self.distFuncTrue,
+                          rtol=1e-8,
+                          atol=0.0), errStr
+
+    def test_value_drift_units(self):
+        """
+        Testing vdrifts with values
+        """
+        distFunc = Maxwellian_speed_1D(v=self.v,
+                                       T=self.T,
+                                       particle=self.particle,
+                                       V_drift=self.V_drift2,
+                                       units="units")
+        errStr = (f"Distribution function should be 0.0 "
+                  f"and not {distFunc}.")
+        assert np.isclose(distFunc.value,
+                          self.distFuncDrift.value,
+                          rtol=1e-8,
+                          atol=0.0), errStr
 
 
 # test class for Maxwellian_velocity_3D function

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -624,17 +624,18 @@ class Test_Maxwellian_speed_2D(object):
         """
         Testing vdrifts with values
         """
-        distFunc = Maxwellian_speed_2D(v=self.v,
-                                       T=self.T,
-                                       particle=self.particle,
-                                       v_drift=self.v_drift2,
-                                       units="units")
-        errStr = (f"Distribution function should be 0.0 "
-                  f"and not {distFunc}.")
-        assert np.isclose(distFunc.value,
-                          0.0,
-                          rtol=1e-8,
-                          atol=0.0), errStr
+        with pytest.raises(NotImplementedError):
+            distFunc = Maxwellian_speed_2D(v=self.v,
+                                           T=self.T,
+                                           particle=self.particle,
+                                           v_drift=self.v_drift2,
+                                           units="units")
+#        errStr = (f"Distribution function should be 0.0 "
+#                  f"and not {distFunc}.")
+#        assert np.isclose(distFunc.value,
+#                          0.0,
+#                          rtol=1e-8,
+#                          atol=0.0), errStr
 
 
 # test class for Maxwellian_velocity_3D function
@@ -933,17 +934,18 @@ class Test_Maxwellian_speed_3D(object):
         """
         Testing vdrifts with values
         """
-        distFunc = Maxwellian_speed_3D(v=self.v,
-                                       T=self.T,
-                                       particle=self.particle,
-                                       v_drift=self.v_drift2,
-                                       units="units")
-        errStr = (f"Distribution function should be 0.0 "
-                  f"and not {distFunc}.")
-        assert np.isclose(distFunc.value,
-                          0.0,
-                          rtol=1e-8,
-                          atol=0.0), errStr
+        with pytest.raises(NotImplementedError):
+            distFunc = Maxwellian_speed_3D(v=self.v,
+                                           T=self.T,
+                                           particle=self.particle,
+                                           v_drift=self.v_drift2,
+                                           units="units")
+#        errStr = (f"Distribution function should be 0.0 "
+#                  f"and not {distFunc}.")
+#        assert np.isclose(distFunc.value,
+#                          0.0,
+#                          rtol=1e-8,
+#                          atol=0.0), errStr
 
 
 # kappa

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -208,135 +208,135 @@ class Test_Maxwellian_1D(object):
 
 
 # test class for Maxwellian_speed_1D function
-class Test_Maxwellian_speed_1D(object):
-    @classmethod
-    def setup_class(self):
-        """initializing parameters for tests """
-        self.T = 1.0 * u.eV
-        self.particle = 'H+'
-        # get thermal velocity and thermal velocity squared
-        self.vTh = thermal_speed(self.T,
-                                 particle=self.particle,
-                                 method="most_probable")
-        self.v = 1e5 * u.m / u.s
-        self.V_drift = 0 * u.m / u.s
-        self.V_drift2 = 1e5 * u.m / u.s
-        self.distFuncTrue = 1.8057567503860518e-25
-
-    def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
-        # setting up integration from 0 to 10*vTh
-        xData1D = np.arange(0, 10.01, 0.01) * self.vTh
-        yData1D = Maxwellian_speed_1D(v=xData1D,
-                                      T=self.T,
-                                      particle=self.particle)
-        # integrating, this should be close to 1
-        integ = spint.trapz(y=yData1D, x=xData1D)
-        exceptStr = "Integral of distribution function should be 1."
-        assert np.isclose(integ.value, 1), exceptStr
-
-    def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
-        distFunc = Maxwellian_speed_1D(v=self.v,
-                                       T=self.T,
-                                       particle=self.particle,
-                                       units="units")
-        errStr = (f"Distribution function should be {self.distFuncTrue} "
-                  f"and not {distFunc}.")
-        assert np.isclose(distFunc.value,
-                          self.distFuncTrue,
-                          rtol=1e-8,
-                          atol=0.0), errStr
-
-    def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
-        distFunc = Maxwellian_speed_1D(v=self.v,
-                                       T=self.T,
-                                       vTh=self.vTh,
-                                       particle=self.particle,
-                                       units="units")
-        errStr = (f"Distribution function should be {self.distFuncTrue} "
-                  f"and not {distFunc}.")
-        assert np.isclose(distFunc.value,
-                          self.distFuncTrue,
-                          rtol=1e-8,
-                          atol=0.0), errStr
-
-    def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
-        # converting T to SI then stripping units
-        T = self.T.to(u.K, equivalencies=u.temperature_energy())
-        T = T.si.value
-        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
-                                       T=T,
-                                       particle=self.particle,
-                                       units="unitless")
-        errStr = (f"Distribution function should be {self.distFuncTrue} "
-                  f"and not {distFunc}.")
-        assert np.isclose(distFunc,
-                          self.distFuncTrue,
-                          rtol=1e-8,
-                          atol=0.0), errStr
-
-    def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
-        # converting T to SI then stripping units
-        T = self.T.to(u.K, equivalencies=u.temperature_energy())
-        T = T.si.value
-        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
-                                       T=T,
-                                       vTh=self.vTh.si.value,
-                                       particle=self.particle,
-                                       units="unitless")
-        errStr = (f"Distribution function should be {self.distFuncTrue} "
-                  f"and not {distFunc}.")
-        assert np.isclose(distFunc,
-                          self.distFuncTrue,
-                          rtol=1e-8,
-                          atol=0.0), errStr
-
-    def test_zero_drift_units(self):
-        """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
-        """
-        distFunc = Maxwellian_speed_1D(v=self.v,
-                                       T=self.T,
-                                       particle=self.particle,
-                                       V_drift=self.V_drift,
-                                       units="units")
-        errStr = (f"Distribution function should be {self.distFuncTrue} "
-                  f"and not {distFunc}.")
-        assert np.isclose(distFunc.value,
-                          self.distFuncTrue,
-                          rtol=1e-8,
-                          atol=0.0), errStr
-
-    def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
-        distFunc = Maxwellian_speed_1D(v=self.v,
-                                       T=self.T,
-                                       particle=self.particle,
-                                       V_drift=self.V_drift2,
-                                       units="units")
-        errStr = (f"Distribution function should be 0.0 "
-                  f"and not {distFunc}.")
-        assert np.isclose(distFunc.value,
-                          0.0,
-                          rtol=1e-8,
-                          atol=0.0), errStr
+#class Test_Maxwellian_speed_1D(object):
+#    @classmethod
+#    def setup_class(self):
+#        """initializing parameters for tests """
+#        self.T = 1.0 * u.eV
+#        self.particle = 'H+'
+#        # get thermal velocity and thermal velocity squared
+#        self.vTh = thermal_speed(self.T,
+#                                 particle=self.particle,
+#                                 method="most_probable")
+#        self.v = 1e5 * u.m / u.s
+#        self.V_drift = 0 * u.m / u.s
+#        self.V_drift2 = 1e5 * u.m / u.s
+#        self.distFuncTrue = 1.8057567503860518e-25
+#
+#    def test_norm(self):
+#        """
+#        Tests whether distribution function is normalized, and integrates to 1.
+#        """
+#        # setting up integration from 0 to 10*vTh
+#        xData1D = np.arange(0, 10.01, 0.01) * self.vTh
+#        yData1D = Maxwellian_speed_1D(v=xData1D,
+#                                      T=self.T,
+#                                      particle=self.particle)
+#        # integrating, this should be close to 1
+#        integ = spint.trapz(y=yData1D, x=xData1D)
+#        exceptStr = "Integral of distribution function should be 1."
+#        assert np.isclose(integ.value, 1), exceptStr
+#
+#    def test_units_no_vTh(self):
+#        """
+#        Tests distribution function with units, but not passing vTh.
+#        """
+#        distFunc = Maxwellian_speed_1D(v=self.v,
+#                                       T=self.T,
+#                                       particle=self.particle,
+#                                       units="units")
+#        errStr = (f"Distribution function should be {self.distFuncTrue} "
+#                  f"and not {distFunc}.")
+#        assert np.isclose(distFunc.value,
+#                          self.distFuncTrue,
+#                          rtol=1e-8,
+#                          atol=0.0), errStr
+#
+#    def test_units_vTh(self):
+#        """
+#        Tests distribution function with units and passing vTh.
+#        """
+#        distFunc = Maxwellian_speed_1D(v=self.v,
+#                                       T=self.T,
+#                                       vTh=self.vTh,
+#                                       particle=self.particle,
+#                                       units="units")
+#        errStr = (f"Distribution function should be {self.distFuncTrue} "
+#                  f"and not {distFunc}.")
+#        assert np.isclose(distFunc.value,
+#                          self.distFuncTrue,
+#                          rtol=1e-8,
+#                          atol=0.0), errStr
+#
+#    def test_unitless_no_vTh(self):
+#        """
+#        Tests distribution function without units, and not passing vTh.
+#        """
+#        # converting T to SI then stripping units
+#        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+#        T = T.si.value
+#        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
+#                                       T=T,
+#                                       particle=self.particle,
+#                                       units="unitless")
+#        errStr = (f"Distribution function should be {self.distFuncTrue} "
+#                  f"and not {distFunc}.")
+#        assert np.isclose(distFunc,
+#                          self.distFuncTrue,
+#                          rtol=1e-8,
+#                          atol=0.0), errStr
+#
+#    def test_unitless_vTh(self):
+#        """
+#        Tests distribution function without units, and with passing vTh.
+#        """
+#        # converting T to SI then stripping units
+#        T = self.T.to(u.K, equivalencies=u.temperature_energy())
+#        T = T.si.value
+#        distFunc = Maxwellian_speed_1D(v=self.v.si.value,
+#                                       T=T,
+#                                       vTh=self.vTh.si.value,
+#                                       particle=self.particle,
+#                                       units="unitless")
+#        errStr = (f"Distribution function should be {self.distFuncTrue} "
+#                  f"and not {distFunc}.")
+#        assert np.isclose(distFunc,
+#                          self.distFuncTrue,
+#                          rtol=1e-8,
+#                          atol=0.0), errStr
+#
+#    def test_zero_drift_units(self):
+#        """
+#        Testing inputting drift equal to 0 with units. These should just
+#        get passed and not have extra units applied to them.
+#        """
+#        distFunc = Maxwellian_speed_1D(v=self.v,
+#                                       T=self.T,
+#                                       particle=self.particle,
+#                                       V_drift=self.V_drift,
+#                                       units="units")
+#        errStr = (f"Distribution function should be {self.distFuncTrue} "
+#                  f"and not {distFunc}.")
+#        assert np.isclose(distFunc.value,
+#                          self.distFuncTrue,
+#                          rtol=1e-8,
+#                          atol=0.0), errStr
+#
+#    def test_value_drift_units(self):
+#        """
+#        Testing vdrifts with values
+#        """
+#        distFunc = Maxwellian_speed_1D(v=self.v,
+#                                       T=self.T,
+#                                       particle=self.particle,
+#                                       V_drift=self.V_drift2,
+#                                       units="units")
+#        errStr = (f"Distribution function should be 0.0 "
+#                  f"and not {distFunc}.")
+#        assert np.isclose(distFunc.value,
+#                          0.0,
+#                          rtol=1e-8,
+#                          atol=0.0), errStr
 
 
 # test class for Maxwellian_velocity_3D function
@@ -527,60 +527,30 @@ class Test_Maxwellian_speed_3D(object):
         self.vTh = thermal_speed(self.T,
                                  particle=self.particle,
                                  method="most_probable")
-        self.vx = 1e5 * u.m / u.s
-        self.vy = 1e5 * u.m / u.s
-        self.vz = 1e5 * u.m / u.s
-        self.Vx_drift = 0 * u.m / u.s
-        self.Vy_drift = 0 * u.m / u.s
-        self.Vz_drift = 0 * u.m / u.s
-        self.Vx_drift2 = 1e5 * u.m / u.s
-        self.Vy_drift2 = 1e5 * u.m / u.s
-        self.Vz_drift2 = 1e5 * u.m / u.s
-        self.distFuncTrue = 5.888134761477178e-75
+        self.v = 1e5 * u.m / u.s
+        self.V_drift = 0 * u.m / u.s
+        self.V_drift2 = 1e5 * u.m / u.s
+        self.distFuncTrue = 1.8057567503860518e-25
 
     def test_norm(self):
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
-        # converting vTh to unitless
-        vTh = self.vTh.si.value
-        # setting up integration from 0 to 10*vTh, which is close to Inf
-        infApprox = (10 * vTh)
-        # integral should be close to 1
-        integ = spint.tplquad(Maxwellian_speed_3D,
-                              0,
-                              infApprox,
-                              lambda z: 0,
-                              lambda z: infApprox,
-                              lambda z, y: 0,
-                              lambda z, y: infApprox,
-                              args=(self.T,
-                                    self.particle,
-                                    0,
-                                    0,
-                                    0,
-                                    vTh,
-                                    "unitless"),
-                              epsabs=1e0,
-                              epsrel=1e0,
-                              )
-        # value returned from tplquad is (integral, error), we just need
-        # the 1st
-        integVal = integ[0]
-        exceptStr = ("Integral of distribution function should be 1 "
-                     f"and not {integVal}")
-        assert np.isclose(integVal,
-                          1,
-                          rtol=1e-3,
-                          atol=0.0), exceptStr
+        # setting up integration from 0 to 10*vTh
+        xData1D = np.arange(0, 10.01, 0.01) * self.vTh
+        yData1D = Maxwellian_speed_3D(v=xData1D,
+                                      T=self.T,
+                                      particle=self.particle)
+        # integrating, this should be close to 1
+        integ = spint.trapz(y=yData1D, x=xData1D)
+        exceptStr = "Integral of distribution function should be 1."
+        assert np.isclose(integ.value, 1), exceptStr
 
     def test_units_no_vTh(self):
         """
         Tests distribution function with units, but not passing vTh.
         """
-        distFunc = Maxwellian_speed_3D(vx=self.vx,
-                                       vy=self.vy,
-                                       vz=self.vz,
+        distFunc = Maxwellian_speed_3D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
                                        units="units")
@@ -595,9 +565,7 @@ class Test_Maxwellian_speed_3D(object):
         """
         Tests distribution function with units and passing vTh.
         """
-        distFunc = Maxwellian_speed_3D(vx=self.vx,
-                                       vy=self.vy,
-                                       vz=self.vz,
+        distFunc = Maxwellian_speed_3D(v=self.v,
                                        T=self.T,
                                        vTh=self.vTh,
                                        particle=self.particle,
@@ -616,9 +584,7 @@ class Test_Maxwellian_speed_3D(object):
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
-        distFunc = Maxwellian_speed_3D(vx=self.vx.si.value,
-                                       vy=self.vy.si.value,
-                                       vz=self.vz.si.value,
+        distFunc = Maxwellian_speed_3D(v=self.v.si.value,
                                        T=T,
                                        particle=self.particle,
                                        units="unitless")
@@ -636,9 +602,7 @@ class Test_Maxwellian_speed_3D(object):
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
-        distFunc = Maxwellian_speed_3D(vx=self.vx.si.value,
-                                       vy=self.vy.si.value,
-                                       vz=self.vz.si.value,
+        distFunc = Maxwellian_speed_3D(v=self.v.si.value,
                                        T=T,
                                        vTh=self.vTh.si.value,
                                        particle=self.particle,
@@ -655,14 +619,10 @@ class Test_Maxwellian_speed_3D(object):
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
         """
-        distFunc = Maxwellian_speed_3D(vx=self.vx,
-                                       vy=self.vy,
-                                       vz=self.vz,
+        distFunc = Maxwellian_speed_3D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
-                                       Vx_drift=self.Vx_drift,
-                                       Vy_drift=self.Vy_drift,
-                                       Vz_drift=self.Vz_drift,
+                                       V_drift=self.V_drift,
                                        units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -675,14 +635,10 @@ class Test_Maxwellian_speed_3D(object):
         """
         Testing vdrifts with values
         """
-        distFunc = Maxwellian_speed_3D(vx=self.vx,
-                                       vy=self.vy,
-                                       vz=self.vz,
+        distFunc = Maxwellian_speed_3D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
-                                       Vx_drift=self.Vx_drift2,
-                                       Vy_drift=self.Vy_drift2,
-                                       Vz_drift=self.Vz_drift2,
+                                       V_drift=self.V_drift2,
                                        units="units")
         errStr = (f"Distribution function should be 0.0 "
                   f"and not {distFunc}.")

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -26,9 +26,9 @@ class Test_Maxwellian_1D(object):
         """initializing parameters for tests """
         self.T_e = 30000 * u.K
         self.v = 1e5 * u.m / u.s
-        self.V_drift = 1000000 * u.m / u.s
-        self.V_drift2 = 0 * u.m / u.s
-        self.V_drift3 = 1e5 * u.m / u.s
+        self.v_drift = 1000000 * u.m / u.s
+        self.v_drift2 = 0 * u.m / u.s
+        self.v_drift3 = 1e5 * u.m / u.s
         self.start = -5000
         self.stop = - self.start
         self.dv = 10000 * u.m / u.s
@@ -49,7 +49,7 @@ class Test_Maxwellian_1D(object):
         max_index = Maxwellian_1D(self.v_vect,
                                   T=self.T_e,
                                   particle=self.particle,
-                                  V_drift=0 * u.m / u.s
+                                  v_drift=0 * u.m / u.s
                                   ).argmax()
         assert np.isclose(self.v_vect[max_index].value, 0.0)
 
@@ -61,9 +61,9 @@ class Test_Maxwellian_1D(object):
         max_index = Maxwellian_1D(self.v_vect,
                                   T=self.T_e,
                                   particle=self.particle,
-                                  V_drift=self.V_drift
+                                  v_drift=self.v_drift
                                   ).argmax()
-        assert np.isclose(self.v_vect[max_index].value, self.V_drift.value)
+        assert np.isclose(self.v_vect[max_index].value, self.v_drift.value)
 
     def test_norm(self):
         """
@@ -182,7 +182,7 @@ class Test_Maxwellian_1D(object):
         distFunc = Maxwellian_1D(v=self.v,
                                  T=self.T_e,
                                  particle=self.particle,
-                                 V_drift=self.V_drift2,
+                                 v_drift=self.v_drift2,
                                  units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -199,7 +199,7 @@ class Test_Maxwellian_1D(object):
         distFunc = Maxwellian_1D(v=self.v,
                                  T=self.T_e,
                                  particle=self.particle,
-                                 V_drift=self.V_drift3,
+                                 v_drift=self.v_drift3,
                                  units="units")
         errStr = (f"Distribution function should be {testVal} "
                   f"and not {distFunc}.")
@@ -221,8 +221,8 @@ class Test_Maxwellian_speed_1D(object):
                                  particle=self.particle,
                                  method="most_probable")
         self.v = 1e5 * u.m / u.s
-        self.V_drift = 0 * u.m / u.s
-        self.V_drift2 = 1e5 * u.m / u.s
+        self.v_drift = 0 * u.m / u.s
+        self.v_drift2 = 1e5 * u.m / u.s
         self.distFuncTrue = 1.72940389716217e-27
         self.distFuncDrift = 2 * (self.vTh ** 2 * np.pi) ** (-1 / 2)
 
@@ -316,7 +316,7 @@ class Test_Maxwellian_speed_1D(object):
         distFunc = Maxwellian_speed_1D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
-                                       V_drift=self.V_drift,
+                                       v_drift=self.v_drift,
                                        units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -332,7 +332,7 @@ class Test_Maxwellian_speed_1D(object):
         distFunc = Maxwellian_speed_1D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
-                                       V_drift=self.V_drift2,
+                                       v_drift=self.v_drift2,
                                        units="units")
         errStr = (f"Distribution function should be 0.0 "
                   f"and not {distFunc}.")
@@ -355,10 +355,10 @@ class Test_Maxwellian_velocity_2D(object):
                                  method="most_probable")
         self.vx = 1e5 * u.m / u.s
         self.vy = 1e5 * u.m / u.s
-        self.Vx_drift = 0 * u.m / u.s
-        self.Vy_drift = 0 * u.m / u.s
-        self.Vx_drift2 = 1e5 * u.m / u.s
-        self.Vy_drift2 = 1e5 * u.m / u.s
+        self.vx_drift = 0 * u.m / u.s
+        self.vy_drift = 0 * u.m / u.s
+        self.vx_drift2 = 1e5 * u.m / u.s
+        self.vy_drift2 = 1e5 * u.m / u.s
         self.distFuncTrue = 7.477094598799251e-55
 
     def test_norm(self):
@@ -475,8 +475,8 @@ class Test_Maxwellian_velocity_2D(object):
                                           vy=self.vy,
                                           T=self.T,
                                           particle=self.particle,
-                                          Vx_drift=self.Vx_drift,
-                                          Vy_drift=self.Vy_drift,
+                                          vx_drift=self.vx_drift,
+                                          vy_drift=self.vy_drift,
                                           units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -494,8 +494,8 @@ class Test_Maxwellian_velocity_2D(object):
                                           vy=self.vy,
                                           T=self.T,
                                           particle=self.particle,
-                                          Vx_drift=self.Vx_drift2,
-                                          Vy_drift=self.Vy_drift2,
+                                          vx_drift=self.vx_drift2,
+                                          vy_drift=self.vy_drift2,
                                           units="units")
         errStr = (f"Distribution function should be {testVal} "
                   f"and not {distFunc}.")
@@ -517,8 +517,8 @@ class Test_Maxwellian_speed_2D(object):
                                  particle=self.particle,
                                  method="most_probable")
         self.v = 1e5 * u.m / u.s
-        self.V_drift = 0 * u.m / u.s
-        self.V_drift2 = 1e5 * u.m / u.s
+        self.v_drift = 0 * u.m / u.s
+        self.v_drift2 = 1e5 * u.m / u.s
         self.distFuncTrue = 2.2148166449365907e-26
 
     def test_norm(self):
@@ -611,7 +611,7 @@ class Test_Maxwellian_speed_2D(object):
         distFunc = Maxwellian_speed_2D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
-                                       V_drift=self.V_drift,
+                                       v_drift=self.v_drift,
                                        units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -627,7 +627,7 @@ class Test_Maxwellian_speed_2D(object):
         distFunc = Maxwellian_speed_2D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
-                                       V_drift=self.V_drift2,
+                                       v_drift=self.v_drift2,
                                        units="units")
         errStr = (f"Distribution function should be 0.0 "
                   f"and not {distFunc}.")
@@ -651,12 +651,12 @@ class Test_Maxwellian_velocity_3D(object):
         self.vx = 1e5 * u.m / u.s
         self.vy = 1e5 * u.m / u.s
         self.vz = 1e5 * u.m / u.s
-        self.Vx_drift = 0 * u.m / u.s
-        self.Vy_drift = 0 * u.m / u.s
-        self.Vz_drift = 0 * u.m / u.s
-        self.Vx_drift2 = 1e5 * u.m / u.s
-        self.Vy_drift2 = 1e5 * u.m / u.s
-        self.Vz_drift2 = 1e5 * u.m / u.s
+        self.vx_drift = 0 * u.m / u.s
+        self.vy_drift = 0 * u.m / u.s
+        self.vz_drift = 0 * u.m / u.s
+        self.vx_drift2 = 1e5 * u.m / u.s
+        self.vy_drift2 = 1e5 * u.m / u.s
+        self.vz_drift2 = 1e5 * u.m / u.s
         self.distFuncTrue = 6.465458269306909e-82
 
     def test_norm(self):
@@ -781,9 +781,9 @@ class Test_Maxwellian_velocity_3D(object):
                                           vz=self.vz,
                                           T=self.T,
                                           particle=self.particle,
-                                          Vx_drift=self.Vx_drift,
-                                          Vy_drift=self.Vy_drift,
-                                          Vz_drift=self.Vz_drift,
+                                          vx_drift=self.vx_drift,
+                                          vy_drift=self.vy_drift,
+                                          vz_drift=self.vz_drift,
                                           units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -802,9 +802,9 @@ class Test_Maxwellian_velocity_3D(object):
                                           vz=self.vz,
                                           T=self.T,
                                           particle=self.particle,
-                                          Vx_drift=self.Vx_drift2,
-                                          Vy_drift=self.Vy_drift2,
-                                          Vz_drift=self.Vz_drift2,
+                                          vx_drift=self.vx_drift2,
+                                          vy_drift=self.vy_drift2,
+                                          vz_drift=self.vz_drift2,
                                           units="units")
         errStr = (f"Distribution function should be {testVal} "
                   f"and not {distFunc}.")
@@ -826,8 +826,8 @@ class Test_Maxwellian_speed_3D(object):
                                  particle=self.particle,
                                  method="most_probable")
         self.v = 1e5 * u.m / u.s
-        self.V_drift = 0 * u.m / u.s
-        self.V_drift2 = 1e5 * u.m / u.s
+        self.v_drift = 0 * u.m / u.s
+        self.v_drift2 = 1e5 * u.m / u.s
         self.distFuncTrue = 1.8057567503860518e-25
 
     def test_norm(self):
@@ -920,7 +920,7 @@ class Test_Maxwellian_speed_3D(object):
         distFunc = Maxwellian_speed_3D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
-                                       V_drift=self.V_drift,
+                                       v_drift=self.v_drift,
                                        units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -936,7 +936,7 @@ class Test_Maxwellian_speed_3D(object):
         distFunc = Maxwellian_speed_3D(v=self.v,
                                        T=self.T,
                                        particle=self.particle,
-                                       V_drift=self.V_drift2,
+                                       v_drift=self.v_drift2,
                                        units="units")
         errStr = (f"Distribution function should be 0.0 "
                   f"and not {distFunc}.")
@@ -957,9 +957,9 @@ class Test_kappa_velocity_1D(object):
         self.kappa = 4
         self.kappaInvalid = 3 / 2
         self.v = 1e5 * u.m / u.s
-        self.V_drift = 1000000 * u.m / u.s
-        self.V_drift2 = 0 * u.m / u.s
-        self.V_drift3 = 1e5 * u.m / u.s
+        self.v_drift = 1000000 * u.m / u.s
+        self.v_drift2 = 0 * u.m / u.s
+        self.v_drift3 = 1e5 * u.m / u.s
         self.start = -5000
         self.stop = -self.start
         self.dv = 10000 * u.m / u.s
@@ -993,7 +993,7 @@ class Test_kappa_velocity_1D(object):
                                       T=self.T_e,
                                       kappa=self.kappa,
                                       particle=self.particle,
-                                      V_drift=0 * u.m / u.s).argmax()
+                                      v_drift=0 * u.m / u.s).argmax()
         assert np.isclose(self.v_vect[max_index].value, 0.0)
 
     def test_max_drift(self):
@@ -1005,8 +1005,8 @@ class Test_kappa_velocity_1D(object):
                                       T=self.T_e,
                                       kappa=self.kappa,
                                       particle=self.particle,
-                                      V_drift=self.V_drift).argmax()
-        assert np.isclose(self.v_vect[max_index].value, self.V_drift.value)
+                                      v_drift=self.v_drift).argmax()
+        assert np.isclose(self.v_vect[max_index].value, self.v_drift.value)
 
     def test_maxwellian_limit(self):
         """
@@ -1138,7 +1138,7 @@ class Test_kappa_velocity_1D(object):
                                      T=self.T_e,
                                      kappa=self.kappa,
                                      particle=self.particle,
-                                     V_drift=self.V_drift2,
+                                     v_drift=self.v_drift2,
                                      units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -1156,7 +1156,7 @@ class Test_kappa_velocity_1D(object):
                                      T=self.T_e,
                                      kappa=self.kappa,
                                      particle=self.particle,
-                                     V_drift=self.V_drift3,
+                                     v_drift=self.v_drift3,
                                      units="units")
         errStr = (f"Distribution function should be {testVal} "
                   f"and not {distFunc}.")
@@ -1182,12 +1182,12 @@ class Test_kappa_velocity_3D(object):
         self.vx = 1e5 * u.m / u.s
         self.vy = 1e5 * u.m / u.s
         self.vz = 1e5 * u.m / u.s
-        self.Vx_drift = 0 * u.m / u.s
-        self.Vy_drift = 0 * u.m / u.s
-        self.Vz_drift = 0 * u.m / u.s
-        self.Vx_drift2 = 1e5 * u.m / u.s
-        self.Vy_drift2 = 1e5 * u.m / u.s
-        self.Vz_drift2 = 1e5 * u.m / u.s
+        self.vx_drift = 0 * u.m / u.s
+        self.vy_drift = 0 * u.m / u.s
+        self.vz_drift = 0 * u.m / u.s
+        self.vx_drift2 = 1e5 * u.m / u.s
+        self.vy_drift2 = 1e5 * u.m / u.s
+        self.vz_drift2 = 1e5 * u.m / u.s
         self.distFuncTrue = 1.1847914288918793e-22
 
     def test_invalid_kappa(self):
@@ -1216,9 +1216,9 @@ class Test_kappa_velocity_3D(object):
 #                                          T=self.T,
 #                                          kappa=kappaLarge,
 #                                          particle=self.particle,
-#                                          Vx_drift=self.Vx_drift2,
-#                                          Vy_drift=self.Vy_drift2,
-#                                          Vz_drift=self.Vz_drift2,
+#                                          vx_drift=self.vx_drift2,
+#                                          vy_drift=self.vy_drift2,
+#                                          vz_drift=self.vz_drift2,
 #                                          units="units")
 #        Teff =  self.T
 #        maxwellDistFunc = Maxwellian_velocity_3D(vx=self.vx,
@@ -1226,9 +1226,9 @@ class Test_kappa_velocity_3D(object):
 #                                                 vz=self.vz,
 #                                                 T=Teff,
 #                                                 particle=self.particle,
-#                                                 Vx_drift=self.Vx_drift2,
-#                                                 Vy_drift=self.Vy_drift2,
-#                                                 Vz_drift=self.Vz_drift2,
+#                                                 vx_drift=self.vx_drift2,
+#                                                 vy_drift=self.vy_drift2,
+#                                                 vz_drift=self.vz_drift2,
 #                                                 units="units")
 #        errStr = (f"Distribution function should be {maxwellDistFunc} "
 #                  f"and not {kappaDistFunc}.")
@@ -1367,9 +1367,9 @@ class Test_kappa_velocity_3D(object):
                                      T=self.T,
                                      kappa=self.kappa,
                                      particle=self.particle,
-                                     Vx_drift=self.Vx_drift,
-                                     Vy_drift=self.Vy_drift,
-                                     Vz_drift=self.Vz_drift,
+                                     vx_drift=self.vx_drift,
+                                     vy_drift=self.vy_drift,
+                                     vz_drift=self.vz_drift,
                                      units="units")
         errStr = (f"Distribution function should be {self.distFuncTrue} "
                   f"and not {distFunc}.")
@@ -1389,9 +1389,9 @@ class Test_kappa_velocity_3D(object):
                                      T=self.T,
                                      kappa=self.kappa,
                                      particle=self.particle,
-                                     Vx_drift=self.Vx_drift2,
-                                     Vy_drift=self.Vy_drift2,
-                                     Vz_drift=self.Vz_drift2,
+                                     vx_drift=self.vx_drift2,
+                                     vy_drift=self.vy_drift2,
+                                     vz_drift=self.vz_drift2,
                                      units="units")
         errStr = (f"Distribution function should be {testVal} "
                   f"and not {distFunc}.")

--- a/plasmapy/physics/tests/test_distribution.py
+++ b/plasmapy/physics/tests/test_distribution.py
@@ -360,7 +360,7 @@ class Test_Maxwellian_velocity_3D(object):
         self.Vx_drift2 = 1e5 * u.m / u.s
         self.Vy_drift2 = 1e5 * u.m / u.s
         self.Vz_drift2 = 1e5 * u.m / u.s
-        self.distFuncTrue = 2.7654607627522045e-37
+        self.distFuncTrue = 6.465458269306909e-82
 
     def test_norm(self):
         """
@@ -499,7 +499,7 @@ class Test_Maxwellian_velocity_3D(object):
         """
         Testing vdrifts with values
         """
-        testVal = ((3 * self.vTh**2 * np.pi) ** (-3 / 2)).si.value
+        testVal = ((self.vTh**2 * np.pi) ** (-3 / 2)).si.value
         distFunc = Maxwellian_velocity_3D(vx=self.vx,
                                           vy=self.vy,
                                           vz=self.vz,


### PR DESCRIPTION
Supersedes #451 
Closes #392 

Our speed distributions are all wrong. The 1D Maxwellian speed distribution is actually the 3D distribution, so that is being renamed. I'm also adding the correct form for the 1D distribution and adding 2D distributions.