### PR TITLE
[WIP] Basic plasma factory implementation

### DIFF
--- a/docs/plasma/index.rst
+++ b/docs/plasma/index.rst
@@ -1,8 +1,8 @@
 .. _plasma:
 
-****************************************
-Plasma class (`plasmapy.classes.plasma`)
-****************************************
+***********************************************
+Plasma sub-classes (`plasmapy.classes.sources`)
+***********************************************
 
 Introduction
 ============
@@ -28,5 +28,5 @@ This feature is currently under heavy development.
 Reference/API
 =============
 
-.. automodapi:: plasmapy.classes.plasma
+.. automodapi:: plasmapy.classes.sources
    :no-heading:

--- a/docs/plasma/index.rst
+++ b/docs/plasma/index.rst
@@ -1,32 +1,123 @@
-.. _plasma:
+.. _classes:
 
-***********************************************
-Plasma sub-classes (`plasmapy.classes.sources`)
-***********************************************
+===============
+PlasmaPy Plasma
+===============
 
-Introduction
-============
+.. module:: plasmapy.classes
+.. currentmodule:: plasmapy.classes
 
-The :class:`Plasma3D` class is a basic structure to contain spatial
-information about a plasma.  To initialize a Plasma3D system, first
-create an instance of the :class:`Plasma3D` class and then set the
-:attr:`Plasma3D.density`, :attr:`Plasma3D.momentum`,
-:attr:`Plasma3D.pressure` and the :attr:`Plasma3D.magnetic_field`.
+Overview
+--------
+One of core classes in PlasmaPy is a `Plasma`. In order to make it easy to work
+with different plasma data in PlasmaPy, the Plasma object provides a number of
+methods for commonly existing plasmas in nature.
 
-This feature is currently under development.
+All Plasma objects are created using the Plasma factory `~plasmapy.classes.Plasma`.
 
-The :class:`PlasmaBlob` class is a basic structure to contain just
-plasma parameter information about a plasma with no associated
-spatial or temporal scales.  To initialize a PlasmaBlob system, call
-it with arguments: electron temperature :attr:`PlasmaBlob.T_e`, 
-and electron density :attr:`PlasmaBlob.n_e`. You may also optionally
-define the ionization, :attr:`PlasmaBlob.Z`, and relevant plasma 
-particle, :attr:`PlasmaBlob.particle`.
+A number of plasma data structures are supported by subclassing this base object. See
+:ref:`plasma-sources` to see a list of all of them.
 
-This feature is currently under heavy development.
 
-Reference/API
-=============
+Creating Plasma Objects
+-----------------------
+Plasma objects are constructed using the special factory
+class `~plasmapy.classes.Plasma`: ::
 
-.. automodapi:: plasmapy.classes.sources
-   :no-heading:
+    >>> x = plasmapy.classes.Plasma(T_e=T_e,
+                                    n_e=n_e,
+                                    Z=Z,
+                                    particle=particle)  # doctest: +SKIP
+
+The result of a call to `~plasmapy.classes.Plasma` will be either a
+`~plasmapy.classes.GenericPlasma` object, or a subclass of `~plasmapy.classes.GenericPlasma`
+which deals with a specific type of data,
+e.g. `~plasmapy.classes.sources.PlasmaBlob` or `~plasmapy.classes.sources.Plasma3D`
+(see :ref:`plasma-sources` to see a list of all of them).
+
+
+.. autoclass:: plasmapy.classes.plasma_factory.PlasmaFactory
+
+
+Using Plasma Objects
+--------------------
+
+Once a Plasma object has been created using `~plasmapy.classes.Plasma` it will be a instance
+or a subclass of the `~plasmapy.classes.GenericPlasma` class. The documentation of
+`~plasmapy.classes.GenericPlasma` lists the attributes and methods that are available
+on all Plasma objects.
+
+.. _plasma-classes:
+
+Plasma Classes
+--------------
+Defined in `plasmapy.classes.sources` are a set of `~plasmapy.classes.GenericPlasma` subclasses
+which convert the keyword arguments data to the standard `~plasmapy.classes.GenericPlasma` interface.
+These subclasses also provide a method, which describes to the `Plasma <plasmapy.classes.plasma_factory.PlasmaFactory>` factory
+which the data match its plasma data structure.
+
+.. automodapi:: plasmapy.classes
+    :no-main-docstr:
+    :no-heading:
+
+.. _plasma-sources:
+
+Plasma Subclasses
+-----------------
+
+.. toctree::
+    sources
+
+
+Writing a new Plasma subclass
+--------------------------------
+
+Any subclass of `~plasmapy.classes.GenericPlasma` which defines a method named
+`~plasmapy.classes.GenericPlasma.is_datasource_for` will automatically be registered with
+the `Plasma <plasmapy.classes.plasma_factory.PlasmaFactory>` factory.
+The ``is_datasource_for`` method describes the form of the data for which the
+`~plasmapy.classes.GenericPlasma` subclass is valid. For
+example it might check the number and types of keyword arguments.
+This makes it straightforward to define your own
+`~plasmapy.classes.GenericPlasma` subclass for a new data structure or a custom data source
+like simulated data. These classes only have to be imported for this to work, as
+demonstrated by the following example.
+
+.. code-block:: python
+
+    import plasmapy.classes
+    import astropy.units as u
+
+    class FuturePlasma(plasmapy.classes.GenericPlasma):
+        def __init__(self, **kwargs):
+
+            super(FuturePlasma, self).__init__(**kwargs)
+
+        # Specify a classmethod that determines if the input data matches
+        # this new subclass
+        @classmethod
+        def is_datasource_for(cls, **kwargs):
+            """
+            Determines if any of keyword arguments have a dimensionless value.
+            """
+            for _, value in kwargs.items():
+                try:
+                    if value.unit == u.dimensionless_unscaled:
+                        return True
+                except AttributeError:
+                    pass
+
+            return False
+
+
+This class will now be available through the `Plasma <plasmapy.classes.plasma_factory.PlasmaFactory>` factory as long as this
+class has been defined, i.e. imported into the current session.
+
+If you do not want to create a method named ``is_datasource_for`` you can
+manually register your class and matching method using the following method
+
+.. code-block:: python
+
+    import plasmapy.classes
+
+    plasmapy.classes.Plasma.register(FuturePlasma, FuturePlasma.some_matching_method)

--- a/docs/plasma/sources.rst
+++ b/docs/plasma/sources.rst
@@ -1,0 +1,32 @@
+.. _plasma:
+
+**********************************************
+Plasma Subclasses (`plasmapy.classes.sources`)
+**********************************************
+
+Introduction
+============
+
+The :class:`Plasma3D` class is a basic structure to contain spatial
+information about a plasma.  To initialize a Plasma3D system, first
+create an instance of the :class:`Plasma3D` class and then set the
+:attr:`Plasma3D.density`, :attr:`Plasma3D.momentum`,
+:attr:`Plasma3D.pressure` and the :attr:`Plasma3D.magnetic_field`.
+
+This feature is currently under development.
+
+The :class:`PlasmaBlob` class is a basic structure to contain just
+plasma parameter information about a plasma with no associated
+spatial or temporal scales.  To initialize a PlasmaBlob system, call
+it with arguments: electron temperature :attr:`PlasmaBlob.T_e`, 
+and electron density :attr:`PlasmaBlob.n_e`. You may also optionally
+define the ionization, :attr:`PlasmaBlob.Z`, and relevant plasma 
+particle, :attr:`PlasmaBlob.particle`.
+
+This feature is currently under heavy development.
+
+Reference/API
+=============
+
+.. automodapi:: plasmapy.classes.sources
+   :no-heading:

--- a/plasmapy/classes/__init__.py
+++ b/plasmapy/classes/__init__.py
@@ -1,2 +1,4 @@
-from .plasma import Plasma3D, PlasmaBlob
+from .plasma_base import GenericPlasma
+from . import sources
+from .plasma_factory import Plasma
 from .species import Species

--- a/plasmapy/classes/__init__.py
+++ b/plasmapy/classes/__init__.py
@@ -1,4 +1,4 @@
-from .plasma_base import GenericPlasma
+from .plasma_base import BasePlasma, GenericPlasma
 from . import sources
 from .plasma_factory import Plasma
 from .species import Species

--- a/plasmapy/classes/plasma_base.py
+++ b/plasmapy/classes/plasma_base.py
@@ -1,8 +1,5 @@
-from collections import OrderedDict
 from abc import ABC
 
-# GenericPlasma subclass registry
-PLASMA_CLASSES = OrderedDict()
 
 class GenericPlasmaRegistrar(ABC):
     """
@@ -12,7 +9,8 @@ class GenericPlasmaRegistrar(ABC):
     when a subclass of `GenericPlasma` is defined. If it exists it will add that
     class to the registry.
     """
-    _registry = PLASMA_CLASSES
+    # GenericPlasma subclass registry
+    _registry = dict()
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -22,5 +20,4 @@ class GenericPlasmaRegistrar(ABC):
 
 class GenericPlasma(GenericPlasmaRegistrar):
     def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        pass

--- a/plasmapy/classes/plasma_base.py
+++ b/plasmapy/classes/plasma_base.py
@@ -1,9 +1,10 @@
-from abc import ABC
+from abc import ABC, abstractmethod, abstractproperty
 
 
-class GenericPlasmaRegistrar(ABC):
+class BasePlasma(ABC):
     """
-    Registration class for `~plasmapy.classes.GenericPlasma`.
+    Registration class for `~plasmapy.classes.GenericPlasma` and declares
+    some abstract methods for data common in different kinds of plasmas.
 
     This class checks for the existance of a method named ``is_datasource_for``
     when a subclass of `GenericPlasma` is defined. If it exists it will add that
@@ -17,7 +18,55 @@ class GenericPlasmaRegistrar(ABC):
         if hasattr(cls, 'is_datasource_for'):
             cls._registry[cls] = cls.is_datasource_for
 
+    # This class is supposed to declare abstract methods (@abstractmethod or
+    # @abstractproperty as appropriate) that are common in most plasmas
+    # (like `electronTemperature`, `ionTemperature`,
+    # `electronDensitry`, `ionDensity`, `averageIonization`, etc.)
+    # where as `GenericPlasma` class will hold the definitions for these
+    # abstract methods.
 
-class GenericPlasma(GenericPlasmaRegistrar):
+    # For reference, see
+    # https://github.com/sunpy/ndcube/blob/master/ndcube/ndcube.py#L26
+
+    @abstractproperty
+    def electron_temperature(self):
+        pass
+
+    @abstractproperty
+    def ion_temperature(self):
+        pass
+
+    @abstractproperty
+    def electron_density(self):
+        pass
+
+    @abstractproperty
+    def ion_density(self):
+        pass
+
+    @abstractproperty
+    def average_ionization(self):
+        pass
+
+
+class GenericPlasma(BasePlasma):
     def __init__(self, **kwargs):
+        pass
+
+    # The definitions for the abstract methods declared in `BasePlasma`
+    # goes here.
+
+    def electron_temperature(self):
+        pass
+
+    def ion_temperature(self):
+        pass
+
+    def electron_density(self):
+        pass
+
+    def ion_density(self):
+        pass
+
+    def average_ionization(self):
         pass

--- a/plasmapy/classes/plasma_base.py
+++ b/plasmapy/classes/plasma_base.py
@@ -1,0 +1,26 @@
+from collections import OrderedDict
+from abc import ABC
+
+# GenericPlasma subclass registry
+PLASMA_CLASSES = OrderedDict()
+
+class GenericPlasmaRegistrar(ABC):
+    """
+    Registration class for `~plasmapy.classes.GenericPlasma`.
+
+    This class checks for the existance of a method named ``is_datasource_for``
+    when a subclass of `GenericPlasma` is defined. If it exists it will add that
+    class to the registry.
+    """
+    _registry = PLASMA_CLASSES
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if hasattr(cls, 'is_datasource_for'):
+            cls._registry[cls] = cls.is_datasource_for
+
+
+class GenericPlasma(GenericPlasmaRegistrar):
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)

--- a/plasmapy/classes/plasma_base.py
+++ b/plasmapy/classes/plasma_base.py
@@ -50,6 +50,10 @@ class BasePlasma(ABC):
 
 
 class GenericPlasma(BasePlasma):
+    """
+    A Generic Plasma class. This class contains definitions for abstract
+    methods declared in the `~plasmapy.classes.plasma_base.BaseClass`.
+    """
     def __init__(self, **kwargs):
         pass
 

--- a/plasmapy/classes/plasma_base.py
+++ b/plasmapy/classes/plasma_base.py
@@ -1,5 +1,9 @@
 from abc import ABC, abstractmethod, abstractproperty
 
+__all__ = [
+    "BasePlasma",
+    "GenericPlasma",
+]
 
 class BasePlasma(ABC):
     """

--- a/plasmapy/classes/plasma_factory.py
+++ b/plasmapy/classes/plasma_factory.py
@@ -1,4 +1,4 @@
-from plasmapy.classes.plasma_base import GenericPlasma, PLASMA_CLASSES
+from plasmapy.classes.plasma_base import GenericPlasma
 
 from plasmapy.utils.datatype_factory_base import BasicRegistrationFactory
 from plasmapy.utils.datatype_factory_base import NoMatchError
@@ -15,5 +15,5 @@ class PlasmaFactory(BasicRegistrationFactory):
 
 
 Plasma = PlasmaFactory(default_widget_type=GenericPlasma,
+                       registry=GenericPlasma._registry,
                        additional_validation_functions=['is_datasource_for'])
-Plasma.registry = PLASMA_CLASSES

--- a/plasmapy/classes/plasma_factory.py
+++ b/plasmapy/classes/plasma_factory.py
@@ -8,8 +8,9 @@ from plasmapy.utils.datatype_factory_base import ValidationFunctionError
 
 class PlasmaFactory(BasicRegistrationFactory):
     """
-    Plasma factory class. Used to create a variety of Map objects. Valid plasma
-    structures are specified by registering them with the factory.
+    Plasma factory class. Used to create a variety of Plasma objects.
+    Valid plasma structures are specified by registering them with the
+    factory.
     """
     pass
 

--- a/plasmapy/classes/plasma_factory.py
+++ b/plasmapy/classes/plasma_factory.py
@@ -5,6 +5,10 @@ from plasmapy.utils.datatype_factory_base import NoMatchError
 from plasmapy.utils.datatype_factory_base import MultipleMatchError
 from plasmapy.utils.datatype_factory_base import ValidationFunctionError
 
+__all__ = [
+    "PlasmaFactory",
+    "Plasma",
+]
 
 class PlasmaFactory(BasicRegistrationFactory):
     """

--- a/plasmapy/classes/plasma_factory.py
+++ b/plasmapy/classes/plasma_factory.py
@@ -1,0 +1,19 @@
+from plasmapy.classes.plasma_base import GenericPlasma, PLASMA_CLASSES
+
+from plasmapy.utils.datatype_factory_base import BasicRegistrationFactory
+from plasmapy.utils.datatype_factory_base import NoMatchError
+from plasmapy.utils.datatype_factory_base import MultipleMatchError
+from plasmapy.utils.datatype_factory_base import ValidationFunctionError
+
+
+class PlasmaFactory(BasicRegistrationFactory):
+    """
+    Plasma factory class. Used to create a variety of Map objects. Valid plasma
+    structures are specified by registering them with the factory.
+    """
+    pass
+
+
+Plasma = PlasmaFactory(default_widget_type=GenericPlasma,
+                       additional_validation_functions=['is_datasource_for'])
+Plasma.registry = PLASMA_CLASSES

--- a/plasmapy/classes/sources/__init__.py
+++ b/plasmapy/classes/sources/__init__.py
@@ -1,0 +1,2 @@
+from .plasma3d import Plasma3D
+from .plasmablob import PlasmaBlob

--- a/plasmapy/classes/sources/plasma3d.py
+++ b/plasmapy/classes/sources/plasma3d.py
@@ -70,8 +70,6 @@ class Plasma3D(GenericPlasma):
     """
     @u.quantity_input(domain_x=u.m, domain_y=u.m, domain_z=u.m)
     def __init__(self, domain_x, domain_y, domain_z):
-        #GenericPlasma.__init__(self, data, header, **kwargs)
-
         # Define domain sizes
         self.x = domain_x
         self.y = domain_y

--- a/plasmapy/classes/sources/plasma3d.py
+++ b/plasmapy/classes/sources/plasma3d.py
@@ -1,0 +1,119 @@
+"""
+Defines the core Plasma class used by PlasmaPy to represent plasma properties.
+"""
+import warnings
+
+import numpy as np
+import astropy.units as u
+
+from plasmapy.constants import (m_p,
+                                m_e,
+                                c,
+                                mu0,
+                                k_B,
+                                e,
+                                eps0,
+                                pi,
+                                )
+
+from plasmapy.classes import GenericPlasma
+
+__all__ = [
+    "Plasma3D"
+]
+
+
+class Plasma3D(GenericPlasma):
+    """
+    Core class for describing and calculating plasma parameters with
+    spatial dimensions.
+
+    Attributes
+    ----------
+    x : `astropy.units.Quantity`
+        x-coordinates within the plasma domain. Equal to the
+        `domain_x` input parameter.
+    y : `astropy.units.Quantity`
+        y-coordinates within the plasma domain. Equal to the
+        `domain_y` input parameter.
+    z : `astropy.units.Quantity`
+        z-coordinates within the plasma domain. Equal to the
+        `domain_z` input parameter.
+    grid : `astropy.units.Quantity`
+        (3, x, y, z) array containing the values of each coordinate at
+        every point in the domain.
+    domain_shape : tuple
+        Shape of the plasma domain.
+    density : `astropy.units.Quantity`
+        (x, y, z) array of mass density at every point in the domain.
+    momentum : `astropy.units.Quantity`
+        (3, x, y, z) array of the momentum vector at every point in
+        the domain.
+    pressure : `astropy.units.Quantity`
+        (x, y, z) array of pressure at every point in the domain.
+    magnetic_field : `astropy.units.Quantity`
+        (3, x, y, z) array of the magnetic field vector at every point
+        in the domain.
+
+    Parameters
+    ----------
+    domain_x : `astropy.units.Quantity`
+        1D array of x-coordinates for the plasma domain. Must have
+        units convertable to length.
+    domain_y : `astropy.units.Quantity`
+        1D array of y-coordinates for the plasma domain. Must have
+        units convertable to length.
+    domain_z : `astropy.units.Quantity`
+        1D array of z-coordinates for the plasma domain. Must have
+        units convertable to length.
+
+    """
+    @u.quantity_input(domain_x=u.m, domain_y=u.m, domain_z=u.m)
+    def __init__(self, domain_x, domain_y, domain_z):
+        #GenericPlasma.__init__(self, data, header, **kwargs)
+
+        # Define domain sizes
+        self.x = domain_x
+        self.y = domain_y
+        self.z = domain_z
+
+        self.grid = np.array(np.meshgrid(self.x, self.y, self.z,
+                                         indexing='ij'))
+        self.domain_shape = (len(self.x), len(self.y), len(self.z))
+
+        # Initiate core plasma variables
+        self.density = np.zeros(self.domain_shape) * u.kg / u.m**3
+        self.momentum = np.zeros((3, *self.domain_shape)) * u.kg / (u.m ** 2 * u.s)
+        self.pressure = np.zeros(self.domain_shape) * u.Pa
+        self.magnetic_field = np.zeros((3, *self.domain_shape)) * u.T
+        self.electric_field = np.zeros((3, *self.domain_shape)) * u.V / u.m
+
+    @property
+    def velocity(self):
+        return self.momentum / self.density
+
+    @property
+    def magnetic_field_strength(self):
+        B = self.magnetic_field
+        return np.sqrt(np.sum(B * B, axis=0))
+
+    @property
+    def electric_field_strength(self):
+        E = self.electric_field
+        return np.sqrt(np.sum(E * E, axis=0))
+
+    @property
+    def alfven_speed(self):
+        B = self.magnetic_field
+        rho = self.density
+        return np.sqrt(np.sum(B * B, axis=0) / (mu0 * rho))
+
+    @classmethod
+    def is_datasource_for(cls, **kwargs):
+        if len(kwargs) == 3:
+            match = kwargs.get('domain_x') and \
+                    kwargs.get('domain_y') and \
+                    kwargs.get('domain_z')
+        else:
+            match = False
+        return match

--- a/plasmapy/classes/sources/plasmablob.py
+++ b/plasmapy/classes/sources/plasmablob.py
@@ -24,97 +24,13 @@ from plasmapy.atomic import particle_mass
 
 from plasmapy.utils import call_string, CouplingWarning
 
+from plasmapy.classes import GenericPlasma
+
 __all__ = [
-    "Plasma3D",
     "PlasmaBlob"
 ]
 
-
-class Plasma3D:
-    """
-    Core class for describing and calculating plasma parameters with
-    spatial dimensions.
-
-    Attributes
-    ----------
-    x : `astropy.units.Quantity`
-        x-coordinates within the plasma domain. Equal to the
-        `domain_x` input parameter.
-    y : `astropy.units.Quantity`
-        y-coordinates within the plasma domain. Equal to the
-        `domain_y` input parameter.
-    z : `astropy.units.Quantity`
-        z-coordinates within the plasma domain. Equal to the
-        `domain_z` input parameter.
-    grid : `astropy.units.Quantity`
-        (3, x, y, z) array containing the values of each coordinate at
-        every point in the domain.
-    domain_shape : tuple
-        Shape of the plasma domain.
-    density : `astropy.units.Quantity`
-        (x, y, z) array of mass density at every point in the domain.
-    momentum : `astropy.units.Quantity`
-        (3, x, y, z) array of the momentum vector at every point in
-        the domain.
-    pressure : `astropy.units.Quantity`
-        (x, y, z) array of pressure at every point in the domain.
-    magnetic_field : `astropy.units.Quantity`
-        (3, x, y, z) array of the magnetic field vector at every point
-        in the domain.
-
-    Parameters
-    ----------
-    domain_x : `astropy.units.Quantity`
-        1D array of x-coordinates for the plasma domain. Must have
-        units convertable to length.
-    domain_y : `astropy.units.Quantity`
-        1D array of y-coordinates for the plasma domain. Must have
-        units convertable to length.
-    domain_z : `astropy.units.Quantity`
-        1D array of z-coordinates for the plasma domain. Must have
-        units convertable to length.
-
-    """
-    @u.quantity_input(domain_x=u.m, domain_y=u.m, domain_z=u.m)
-    def __init__(self, domain_x, domain_y, domain_z):
-        # Define domain sizes
-        self.x = domain_x
-        self.y = domain_y
-        self.z = domain_z
-
-        self.grid = np.array(np.meshgrid(self.x, self.y, self.z,
-                                         indexing='ij'))
-        self.domain_shape = (len(self.x), len(self.y), len(self.z))
-
-        # Initiate core plasma variables
-        self.density = np.zeros(self.domain_shape) * u.kg / u.m**3
-        self.momentum = np.zeros((3, *self.domain_shape)) * u.kg / (u.m ** 2 * u.s)
-        self.pressure = np.zeros(self.domain_shape) * u.Pa
-        self.magnetic_field = np.zeros((3, *self.domain_shape)) * u.T
-        self.electric_field = np.zeros((3, *self.domain_shape)) * u.V / u.m
-
-    @property
-    def velocity(self):
-        return self.momentum / self.density
-
-    @property
-    def magnetic_field_strength(self):
-        B = self.magnetic_field
-        return np.sqrt(np.sum(B * B, axis=0))
-
-    @property
-    def electric_field_strength(self):
-        E = self.electric_field
-        return np.sqrt(np.sum(E * E, axis=0))
-
-    @property
-    def alfven_speed(self):
-        B = self.magnetic_field
-        rho = self.density
-        return np.sqrt(np.sum(B * B, axis=0) / (mu0 * rho))
-
-
-class PlasmaBlob:
+class PlasmaBlob(GenericPlasma):
     """
     Class for describing and calculating plasma parameters without
     spatial/temporal description.
@@ -245,3 +161,8 @@ class PlasmaBlob:
         """
         theta = quantum_theta(self.T_e, self.n_e)
         return theta
+
+    @classmethod
+    def is_datasource_for(cls, **kwargs):
+        match = kwargs.get('T_e') and kwargs.get('n_e')
+        return match

--- a/plasmapy/classes/sources/plasmablob.py
+++ b/plasmapy/classes/sources/plasmablob.py
@@ -30,6 +30,7 @@ __all__ = [
     "PlasmaBlob"
 ]
 
+
 class PlasmaBlob(GenericPlasma):
     """
     Class for describing and calculating plasma parameters without

--- a/plasmapy/classes/tests/test_Plasma.py
+++ b/plasmapy/classes/tests/test_Plasma.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import astropy.units as u
 
-from plasmapy.classes import plasma
+from plasmapy.classes.sources import plasma3d, plasmablob
 from plasmapy.utils.exceptions import InvalidParticleError
 
 @pytest.mark.parametrize('grid_dimensions, expected_size', [
@@ -33,9 +33,9 @@ def test_Plasma3D_setup(grid_dimensions, expected_size):
     >>> test_Plasma3D_setup((100, 10, 1), 1000)
     """
     x, y, z = grid_dimensions
-    test_plasma = plasma.Plasma3D(domain_x=np.linspace(0, 1, x) * u.m,
-                                  domain_y=np.linspace(0, 1, y) * u.m,
-                                  domain_z=np.linspace(0, 1, z) * u.m)
+    test_plasma = plasma3d.Plasma3D(domain_x=np.linspace(0, 1, x) * u.m,
+                                    domain_y=np.linspace(0, 1, y) * u.m,
+                                    domain_z=np.linspace(0, 1, z) * u.m)
 
     # Basic grid setup
     assert test_plasma.x.size == x
@@ -68,9 +68,9 @@ def test_Plasma3D_derived_vars():
     variables.  The core variables are set with arbitrary uniform
     values.
     """
-    test_plasma = plasma.Plasma3D(domain_x=np.linspace(0, 1, 64) * u.m,
-                                  domain_y=np.linspace(0, 1, 64) * u.m,
-                                  domain_z=np.linspace(0, 1, 1) * u.m)
+    test_plasma = plasma3d.Plasma3D(domain_x=np.linspace(0, 1, 64) * u.m,
+                                    domain_y=np.linspace(0, 1, 64) * u.m,
+                                    domain_z=np.linspace(0, 1, 1) * u.m)
 
     # Set an arbitrary uniform values throughout the plasma
     test_plasma.density[...] = 2.0 * u.kg / u.m ** 3
@@ -113,10 +113,10 @@ class Test_PlasmaBlobRegimes:
         n_e = 1e26 * u.cm ** -3
         Z = 2.0
         particle = 'p'
-        blob = plasma.PlasmaBlob(T_e=T_e,
-                                 n_e=n_e,
-                                 Z=Z,
-                                 particle=particle)
+        blob = plasmablob.PlasmaBlob(T_e=T_e,
+                                     n_e=n_e,
+                                     Z=Z,
+                                     particle=particle)
 
         expect_regime = 'Intermediate coupling regime: Gamma = 10.585076050938532.'
         regime, _ = blob.regimes()
@@ -140,10 +140,10 @@ class Test_PlasmaBlobRegimes:
         n_e = 1e26 * u.cm ** -3
         Z = 3.0
         particle = 'p'
-        blob = plasma.PlasmaBlob(T_e=T_e,
-                                 n_e=n_e,
-                                 Z=Z,
-                                 particle=particle)
+        blob = plasmablob.PlasmaBlob(T_e=T_e,
+                                     n_e=n_e,
+                                     Z=Z,
+                                     particle=particle)
 
         expect_regime = 'Strongly coupled regime: Gamma = 104.02780112828943.'
 
@@ -168,10 +168,10 @@ class Test_PlasmaBlobRegimes:
         n_e = 1e15 * u.cm ** -3
         Z = 2.5
         particle = 'p'
-        blob = plasma.PlasmaBlob(T_e=T_e,
-                                 n_e=n_e,
-                                 Z=Z,
-                                 particle=particle)
+        blob = plasmablob.PlasmaBlob(T_e=T_e,
+                                     n_e=n_e,
+                                     Z=Z,
+                                     particle=particle)
 
         expect_regime = 'Weakly coupled regime: Gamma = 0.0075178096952688445.'
 
@@ -196,10 +196,10 @@ class Test_PlasmaBlobRegimes:
         n_e = 1e20 * u.cm ** -3
         Z = 2.5
         particle = 'p'
-        blob = plasma.PlasmaBlob(T_e=T_e,
-                                 n_e=n_e,
-                                 Z=Z,
-                                 particle=particle)
+        blob = plasmablob.PlasmaBlob(T_e=T_e,
+                                     n_e=n_e,
+                                     Z=Z,
+                                     particle=particle)
 
         expect_regime = 'Thermal kinetic energy dominant: Theta = 120.65958493847927'
 
@@ -224,10 +224,10 @@ class Test_PlasmaBlobRegimes:
         n_e = 1e26 * u.cm ** -3
         Z = 3.0
         particle = 'p'
-        blob = plasma.PlasmaBlob(T_e=T_e,
-                                 n_e=n_e,
-                                 Z=Z,
-                                 particle=particle)
+        blob = plasmablob.PlasmaBlob(T_e=T_e,
+                                     n_e=n_e,
+                                     Z=Z,
+                                     particle=particle)
 
         expect_regime = 'Fermi quantum energy dominant: Theta = 0.009872147858602853'
 
@@ -252,10 +252,10 @@ class Test_PlasmaBlobRegimes:
         n_e = 1e25 * u.cm ** -3
         Z = 2.0
         particle = 'p'
-        blob = plasma.PlasmaBlob(T_e=T_e,
-                                 n_e=n_e,
-                                 Z=Z,
-                                 particle=particle)
+        blob = plasmablob.PlasmaBlob(T_e=T_e,
+                                     n_e=n_e,
+                                     Z=Z,
+                                     particle=particle)
 
         expect_regime = 'Both Fermi and thermal energy important: Theta = 0.03818537605355442'
 
@@ -274,10 +274,10 @@ class Test_PlasmaBlob:
         self.n_e = 1e23 * u.cm ** -3
         self.Z = 2.5
         self.particle = 'p'
-        self.blob = plasma.PlasmaBlob(T_e=self.T_e,
-                                      n_e=self.n_e,
-                                      Z=self.Z,
-                                      particle=self.particle)
+        self.blob = plasmablob.PlasmaBlob(T_e=self.T_e,
+                                          n_e=self.n_e,
+                                          Z=self.Z,
+                                          particle=self.particle)
         self.couplingVal = 10.468374460435724
         self.thetaVal = 0.6032979246923964
 
@@ -286,10 +286,10 @@ class Test_PlasmaBlob:
         Checks if function raises error for invalid particle.
         """
         with pytest.raises(InvalidParticleError):
-            plasma.PlasmaBlob(T_e=self.T_e,
-                              n_e=self.n_e,
-                              Z=self.Z,
-                              particle="cupcakes")
+            plasmablob.PlasmaBlob(T_e=self.T_e,
+                                  n_e=self.n_e,
+                                  Z=self.Z,
+                                  particle="cupcakes")
 
     def test_electron_temperature(self):
         """Testing if we get the same electron temperature we put in """

--- a/plasmapy/classes/tests/test_Species.py
+++ b/plasmapy/classes/tests/test_Species.py
@@ -5,7 +5,7 @@ from astropy.modeling import models, fitting
 from scipy.optimize import curve_fit
 
 from plasmapy.classes import Species
-from plasmapy.classes.sources.plasma3d import Plasma3D
+from plasmapy.classes.sources import Plasma3D
 
 
 @pytest.fixture()

--- a/plasmapy/classes/tests/test_Species.py
+++ b/plasmapy/classes/tests/test_Species.py
@@ -4,7 +4,8 @@ from astropy import units as u
 from astropy.modeling import models, fitting
 from scipy.optimize import curve_fit
 
-from plasmapy.classes import Plasma3D, Species
+from plasmapy.classes import Species
+from plasmapy.classes.sources.plasma3d import Plasma3D
 
 
 @pytest.fixture()

--- a/plasmapy/classes/tests/test_plasma_base.py
+++ b/plasmapy/classes/tests/test_plasma_base.py
@@ -1,17 +1,15 @@
-from plasmapy.classes.plasma_base import (
-                        GenericPlasmaRegistrar,
-                        GenericPlasma,
-                        )
+from plasmapy.classes import BasePlasma, GenericPlasma
 
-class NoDataSource(GenericPlasmaRegistrar):
+
+class NoDataSource(BasePlasma):
     pass
 
-class IsDataSource(GenericPlasmaRegistrar):
+class IsDataSource(BasePlasma):
     @classmethod
     def is_datasource_for(cls, **kwargs):
         return True
 
-class IsNotDataSource(GenericPlasmaRegistrar):
+class IsNotDataSource(BasePlasma):
     @classmethod
     def is_datasource_for(cls, **kwargs):
         return False
@@ -23,28 +21,28 @@ class TestRegistrar:
         NoDataSource class should not be registered since it has
         no method named ``is_datasource_for``.
         """
-        assert not GenericPlasmaRegistrar._registry.get(NoDataSource)
+        assert not BasePlasma._registry.get(NoDataSource)
 
     def test_is_data_source(self):
         """
         IsDataSource class should be registered since it has a
         method named ``is_datasource_for`` and must return True.
         """
-        assert GenericPlasmaRegistrar._registry.get(IsDataSource)
-        assert GenericPlasmaRegistrar._registry[IsDataSource]()
+        assert BasePlasma._registry.get(IsDataSource)
+        assert BasePlasma._registry[IsDataSource]()
         # Delete the class from _registry once test is done
         # to not interfere with plasma factory tests
-        del GenericPlasmaRegistrar._registry[IsDataSource]
+        del BasePlasma._registry[IsDataSource]
 
     def test_is_not_data_source(self):
         """
         IsNotDataSource class should be registered since it has a
         method named ``is_datasource_for`` but must return False.
         """
-        assert GenericPlasmaRegistrar._registry.get(IsNotDataSource)
-        assert not GenericPlasmaRegistrar._registry[IsNotDataSource]()
-        del GenericPlasmaRegistrar._registry[IsNotDataSource]
+        assert BasePlasma._registry.get(IsNotDataSource)
+        assert not BasePlasma._registry[IsNotDataSource]()
+        del BasePlasma._registry[IsNotDataSource]
 
 
 def test_subclasses():
-    assert issubclass(GenericPlasma, GenericPlasmaRegistrar)
+    assert issubclass(GenericPlasma, BasePlasma)

--- a/plasmapy/classes/tests/test_plasma_base.py
+++ b/plasmapy/classes/tests/test_plasma_base.py
@@ -1,4 +1,6 @@
 from plasmapy.classes import BasePlasma, GenericPlasma
+# Get rid of any previously registered classes.
+BasePlasma._registry = {}
 
 
 class NoDataSource(BasePlasma):

--- a/plasmapy/classes/tests/test_plasma_base.py
+++ b/plasmapy/classes/tests/test_plasma_base.py
@@ -1,0 +1,51 @@
+from plasmapy.classes.plasma_base import (
+                        GenericPlasmaRegistrar,
+                        GenericPlasma,
+                        PLASMA_CLASSES
+                        )
+
+class NoDataSource(GenericPlasmaRegistrar):
+    pass
+
+class IsDataSource(GenericPlasmaRegistrar):
+    @classmethod
+    def is_datasource_for(cls, **kwargs):
+        return True
+
+class IsNotDataSource(GenericPlasmaRegistrar):
+    @classmethod
+    def is_datasource_for(cls, **kwargs):
+        return False
+
+
+class TestRegistrar:
+    def test_no_data_source(self):
+        """
+        NoDataSource class should not be registered since it has
+        no method named ``is_datasource_for``.
+        """
+        assert not PLASMA_CLASSES.get(NoDataSource)
+
+    def test_is_data_source(self):
+        """
+        IsDataSource class should be registered since it has a
+        method named ``is_datasource_for`` and must return True.
+        """
+        assert PLASMA_CLASSES.get(IsDataSource)
+        assert PLASMA_CLASSES[IsDataSource]()
+        # Delete the class from registry once test is done
+        # to not interfere with plasma factory tests
+        del PLASMA_CLASSES[IsDataSource]
+
+    def test_is_not_data_source(self):
+        """
+        IsNotDataSource class should be registered since it has a
+        method named ``is_datasource_for`` but must return False.
+        """
+        assert PLASMA_CLASSES.get(IsNotDataSource)
+        assert not PLASMA_CLASSES[IsNotDataSource]()
+        del PLASMA_CLASSES[IsNotDataSource]
+
+
+def test_subclasses():
+    assert issubclass(GenericPlasma, GenericPlasmaRegistrar)

--- a/plasmapy/classes/tests/test_plasma_base.py
+++ b/plasmapy/classes/tests/test_plasma_base.py
@@ -6,10 +6,12 @@ BasePlasma._registry = {}
 class NoDataSource(BasePlasma):
     pass
 
+
 class IsDataSource(BasePlasma):
     @classmethod
     def is_datasource_for(cls, **kwargs):
         return True
+
 
 class IsNotDataSource(BasePlasma):
     @classmethod

--- a/plasmapy/classes/tests/test_plasma_base.py
+++ b/plasmapy/classes/tests/test_plasma_base.py
@@ -1,7 +1,6 @@
 from plasmapy.classes.plasma_base import (
                         GenericPlasmaRegistrar,
                         GenericPlasma,
-                        PLASMA_CLASSES
                         )
 
 class NoDataSource(GenericPlasmaRegistrar):
@@ -24,27 +23,27 @@ class TestRegistrar:
         NoDataSource class should not be registered since it has
         no method named ``is_datasource_for``.
         """
-        assert not PLASMA_CLASSES.get(NoDataSource)
+        assert not GenericPlasmaRegistrar._registry.get(NoDataSource)
 
     def test_is_data_source(self):
         """
         IsDataSource class should be registered since it has a
         method named ``is_datasource_for`` and must return True.
         """
-        assert PLASMA_CLASSES.get(IsDataSource)
-        assert PLASMA_CLASSES[IsDataSource]()
-        # Delete the class from registry once test is done
+        assert GenericPlasmaRegistrar._registry.get(IsDataSource)
+        assert GenericPlasmaRegistrar._registry[IsDataSource]()
+        # Delete the class from _registry once test is done
         # to not interfere with plasma factory tests
-        del PLASMA_CLASSES[IsDataSource]
+        del GenericPlasmaRegistrar._registry[IsDataSource]
 
     def test_is_not_data_source(self):
         """
         IsNotDataSource class should be registered since it has a
         method named ``is_datasource_for`` but must return False.
         """
-        assert PLASMA_CLASSES.get(IsNotDataSource)
-        assert not PLASMA_CLASSES[IsNotDataSource]()
-        del PLASMA_CLASSES[IsNotDataSource]
+        assert GenericPlasmaRegistrar._registry.get(IsNotDataSource)
+        assert not GenericPlasmaRegistrar._registry[IsNotDataSource]()
+        del GenericPlasmaRegistrar._registry[IsNotDataSource]
 
 
 def test_subclasses():

--- a/plasmapy/classes/tests/test_plasma_factory.py
+++ b/plasmapy/classes/tests/test_plasma_factory.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import plasmapy.classes
 
+
 class TestPlasma(object):
     def test_patters(self):
         # Input data whose specific subclass cannot be known

--- a/plasmapy/classes/tests/test_plasma_factory.py
+++ b/plasmapy/classes/tests/test_plasma_factory.py
@@ -1,0 +1,29 @@
+import astropy.units as u
+import numpy as np
+
+import plasmapy.classes
+
+class TestPlasma(object):
+    def test_patters(self):
+        # Input data whose specific subclass cannot be known
+        generic = plasmapy.classes.Plasma(blablobleh='spam')
+        assert isinstance(generic, plasmapy.classes.GenericPlasma)
+
+    def test_Plasma3D(self):
+        # Input data for Plasma3D
+        three_dimensional = plasmapy.classes.Plasma(domain_x=np.linspace(0, 1, 3) * u.m,
+                                                    domain_y=np.linspace(0, 1, 3) * u.m,
+                                                    domain_z=np.linspace(0, 1, 3) * u.m)
+        assert isinstance(three_dimensional, plasmapy.classes.sources.Plasma3D)
+
+    def test_PlasmaBlob(self):
+        # Input data for PlasmaBlob
+        T_e = 25 * 15e3 * u.K
+        n_e = 1e26 * u.cm ** -3
+        Z = 2.0
+        particle = 'p'
+        blob = plasmapy.classes.Plasma(T_e=T_e,
+                                       n_e=n_e,
+                                       Z=Z,
+                                       particle=particle)
+        assert isinstance(blob, plasmapy.classes.sources.PlasmaBlob)

--- a/plasmapy/classes/tests/test_plasma_factory.py
+++ b/plasmapy/classes/tests/test_plasma_factory.py
@@ -15,6 +15,7 @@ class TestPlasma(object):
                                                     domain_y=np.linspace(0, 1, 3) * u.m,
                                                     domain_z=np.linspace(0, 1, 3) * u.m)
         assert isinstance(three_dimensional, plasmapy.classes.sources.Plasma3D)
+        assert isinstance(three_dimensional, plasmapy.classes.BasePlasma)
 
     def test_PlasmaBlob(self):
         # Input data for PlasmaBlob
@@ -27,3 +28,4 @@ class TestPlasma(object):
                                        Z=Z,
                                        particle=particle)
         assert isinstance(blob, plasmapy.classes.sources.PlasmaBlob)
+        assert isinstance(blob, plasmapy.classes.BasePlasma)

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -33,7 +33,7 @@
 
 import inspect
 
-class BasicRegistrationFactory(object):
+class BasicRegistrationFactory:
     """
     Generalized registerable factory type.
 

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -33,6 +33,7 @@
 
 import inspect
 
+
 class BasicRegistrationFactory:
     """
     Generalized registerable factory type.

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -1,0 +1,191 @@
+# SunPy is released under a BSD-style open source licence:
+
+# Copyright (c) 2013-2018 The SunPy developers
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Project     : https://github.com/sunpy/sunpy
+# File        : sunpy/util/datatype_factory_base.py
+# Commit hash : f6330eea602ea796b5b004dee283b8877b24da23
+
+
+import inspect
+
+class BasicRegistrationFactory(object):
+    """
+    Generalized registerable factory type.
+
+    Widgets (classes) can be registered with an instance of this class.
+    Arguments to the factory's `__call__` method are then passed to a function
+    specified by the registered factory, which validates the input and returns
+    a instance of the class that best matches the inputs.
+
+    Attributes
+    ----------
+
+    registry : dict
+        Dictionary mapping classes (key) to function (value) which validates
+        input.
+
+    default_widget_type : type
+        Class of the default widget.  Defaults to None.
+
+    validation_functions : list of strings
+        List of function names that are valid validation functions.
+
+    Parameters
+    ----------
+
+    default_widget_type : type, optional
+
+    additional_validation_functions : list of strings, optional
+        List of strings corresponding to additional validation function names.
+
+    Notes
+    -----
+
+    * A valid validation function must be a classmethod of the registered widget
+      and it must return True or False.
+
+    """
+
+    def __init__(self, default_widget_type=None,
+                 additional_validation_functions=[], registry=None):
+
+        if registry is None:
+            self.registry = dict()
+        else:
+            self.registry = registry
+
+        self.default_widget_type = default_widget_type
+
+        self.validation_functions = (['_factory_validation_function'] +
+                                     additional_validation_functions)
+
+    def __call__(self, *args, **kwargs):
+        """ Method for running the factory.
+
+        Arguments args and kwargs are passed through to the validation
+        function and to the constructor for the final type.
+        """
+
+        # Any preprocessing and massaging of inputs can happen here
+
+        return self._check_registered_widget(*args, **kwargs)
+
+    def _check_registered_widget(self, *args, **kwargs):
+
+        candidate_widget_types = list()
+
+        for key in self.registry:
+
+            # Call the registered validation function for each registered class
+            if self.registry[key](*args, **kwargs):
+                candidate_widget_types.append(key)
+
+        n_matches = len(candidate_widget_types)
+
+        if n_matches == 0:
+            if self.default_widget_type is None:
+                raise NoMatchError("No types match specified arguments and no default is set.")
+            else:
+                candidate_widget_types = [self.default_widget_type]
+        elif n_matches > 1:
+            print(candidate_widget_types)
+            raise MultipleMatchError("Too many candidate types identified ({0})."
+                                     "Specify enough keywords to guarantee unique type "
+                                     "identification.".format(n_matches))
+
+        # Only one is found
+        WidgetType = candidate_widget_types[0]
+
+        return WidgetType(*args, **kwargs)
+
+    def register(self, WidgetType, validation_function=None, is_default=False):
+        """ Register a widget with the factory.
+
+        If `validation_function` is not specified, tests `WidgetType` for
+        existence of any function in in the list `self.validation_functions`,
+        which is a list of strings which must be callable class attribute
+
+        Parameters
+        ----------
+
+        WidgetType : type
+            Widget to register.
+
+        validation_function : function, optional
+            Function to validate against.  Defaults to None, which indicates
+            that a classmethod in validation_functions is used.
+
+        is_default : bool, optional
+            Sets WidgetType to be the default widget.
+
+        """
+        if is_default:
+            self.default_widget_type = WidgetType
+
+        elif validation_function is not None:
+            if not callable(validation_function):
+                raise AttributeError("Keyword argument 'validation_function' must be callable.")
+
+            self.registry[WidgetType] = validation_function
+
+        else:
+            found = False
+            for vfunc_str in self.validation_functions:
+                if hasattr(WidgetType, vfunc_str):
+                    vfunc = getattr(WidgetType, vfunc_str)
+
+                    # check if classmethod: stackoverflow #19227724
+                    _classmethod = inspect.ismethod(vfunc) and vfunc.__self__ is WidgetType
+
+                    if _classmethod:
+                        self.registry[WidgetType] = vfunc
+                        found = True
+                        break
+                    else:
+                        raise ValidationFunctionError("{0}.{1} must be a classmethod."
+                                                      .format(WidgetType.__name__, vfunc_str))
+
+            if not found:
+                raise ValidationFunctionError("No proper validation function for class {0} "
+                                              "found.".format(WidgetType.__name__))
+
+    def unregister(self, WidgetType):
+        """ Remove a widget from the factory's registry."""
+        self.registry.pop(WidgetType)
+
+
+class NoMatchError(Exception):
+    """Exception for when no candidate class is found."""
+
+
+class MultipleMatchError(Exception):
+    """Exception for when too many candidate classes are found."""
+
+
+class ValidationFunctionError(AttributeError):
+    """Exception for when no candidate class is found."""

--- a/plasmapy/utils/tests/test_datatype_factory_base.py
+++ b/plasmapy/utils/tests/test_datatype_factory_base.py
@@ -181,4 +181,3 @@ class TestBasicRegistrationFactory(object):
 
         with pytest.raises(ValidationFunctionError):
             ExtraValidationFactory.register(MissingClassMethodDifferentValidationWidget)
-

--- a/plasmapy/utils/tests/test_datatype_factory_base.py
+++ b/plasmapy/utils/tests/test_datatype_factory_base.py
@@ -1,0 +1,184 @@
+import pytest
+
+from plasmapy.utils.datatype_factory_base import BasicRegistrationFactory
+from plasmapy.utils.datatype_factory_base import NoMatchError
+from plasmapy.utils.datatype_factory_base import MultipleMatchError
+from plasmapy.utils.datatype_factory_base import ValidationFunctionError
+
+# SunPy is released under a BSD-style open source licence:
+
+# Copyright (c) 2013-2018 The SunPy developers
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Project     : https://github.com/sunpy/sunpy
+# File        : sunpy/util/tests/test_datatype_factory_base.py
+# Commit hash : f6330eea602ea796b5b004dee283b8877b24da23
+
+
+class BaseWidget(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class DefaultWidget(BaseWidget):
+    pass
+
+
+class StandardWidget(BaseWidget):
+    @classmethod
+    def _factory_validation_function(cls, *args, **kwargs):
+        return kwargs.get('style') == 'standard'
+
+
+class DuplicateStandardWidget(BaseWidget):
+    @classmethod
+    def _factory_validation_function(cls, *args, **kwargs):
+        return kwargs.get('style') == 'standard'
+
+
+class FancyWidget(BaseWidget):
+    @classmethod
+    def _factory_validation_function(cls, *args, **kwargs):
+        return kwargs.get('style') == 'fancy' and 'feature' in kwargs
+
+
+class ExternallyValidatedWidget(BaseWidget):
+    pass
+
+
+def external_validation_function(*args, **kwargs):
+    return kwargs.get('style') == 'external'
+
+
+class UnvalidatedWidget(BaseWidget):
+    pass
+
+
+class MissingClassMethodWidget(BaseWidget):
+    def _factory_validation_function(cls, *args, **kwargs):
+        return kwargs.get('style') == 'missing'
+
+
+class DifferentValidationWidget(BaseWidget):
+    @classmethod
+    def different_validation_function(cls, *args, **kwargs):
+        return kwargs.get('style') == 'different'
+
+
+class MissingClassMethodDifferentValidationWidget(BaseWidget):
+    def different_validation_function(cls, *args, **kwargs):
+        return kwargs.get('style') == 'missing-different'
+
+
+class TestBasicRegistrationFactory(object):
+
+    def test_default_factory(self):
+
+        DefaultFactory = BasicRegistrationFactory()
+
+        DefaultFactory.register(DefaultWidget, is_default=True)
+        assert DefaultFactory.default_widget_type == DefaultWidget
+
+        DefaultFactory.register(StandardWidget)
+        DefaultFactory.register(FancyWidget)
+        DefaultFactory.register(ExternallyValidatedWidget,
+                                validation_function=external_validation_function)
+
+        assert type(DefaultFactory()) is DefaultWidget
+        assert type(DefaultFactory(style='standard')) is StandardWidget
+        assert type(DefaultFactory(style='fancy')) is DefaultWidget
+        assert type(DefaultFactory(style='fancy', feature="present")) is FancyWidget
+        assert type(DefaultFactory(style='external')) is ExternallyValidatedWidget
+
+        with pytest.raises(ValidationFunctionError):
+            DefaultFactory.register(UnvalidatedWidget)
+
+        with pytest.raises(ValidationFunctionError):
+            DefaultFactory.register(MissingClassMethodWidget)
+
+        DefaultFactory.unregister(StandardWidget)
+        assert type(DefaultFactory(style='standard')) is not StandardWidget
+
+    def test_validation_fun_not_callable(self):
+        TestFactory = BasicRegistrationFactory()
+
+        with pytest.raises(AttributeError):
+            TestFactory.register(StandardWidget, validation_function='not_callable')
+
+    def test_no_default_factory(self):
+
+        NoDefaultFactory = BasicRegistrationFactory()
+
+        NoDefaultFactory.register(StandardWidget)
+        NoDefaultFactory.register(FancyWidget)
+
+        with pytest.raises(NoMatchError):
+            NoDefaultFactory()
+
+        # Raises because all requirements are not met for FancyWidget and no
+        # default is present.
+        with pytest.raises(NoMatchError):
+            NoDefaultFactory(style='fancy')
+
+        assert type(NoDefaultFactory(style='standard')) is StandardWidget
+        assert type(NoDefaultFactory(style='fancy', feature='present')) is FancyWidget
+
+    def test_with_external_registry(self):
+        external_registry = {}
+
+        FactoryWithExternalRegistry = \
+            BasicRegistrationFactory(registry=external_registry)
+
+        assert len(external_registry) == 0
+
+        FactoryWithExternalRegistry.register(StandardWidget)
+        assert type(FactoryWithExternalRegistry(style='standard')) is StandardWidget
+
+        # Ensure the 'external_registry' is being populated see #1988
+        assert len(external_registry) == 1
+
+    def test_multiple_match_factory(self):
+
+        MultipleMatchFactory = BasicRegistrationFactory()
+
+        MultipleMatchFactory.register(StandardWidget)
+        MultipleMatchFactory.register(DuplicateStandardWidget)
+
+        with pytest.raises(MultipleMatchError):
+            MultipleMatchFactory(style='standard')
+
+    def test_extra_validation_factory(self):
+        ExtraValidationFactory = \
+            BasicRegistrationFactory(
+                additional_validation_functions=['different_validation_function'])
+
+        ExtraValidationFactory.register(DifferentValidationWidget)
+
+        assert type(ExtraValidationFactory(style='different')) is DifferentValidationWidget
+
+        with pytest.raises(ValidationFunctionError):
+            ExtraValidationFactory.register(MissingClassMethodDifferentValidationWidget)
+


### PR DESCRIPTION
We can now instantiate the expected plasma subclass based on input keyword arguments.

```python
>>> import astropy.units as u
>>> import numpy as np
>>> import plasmapy.classes

>>> T_e = 25 * 15e3 * u.K
>>> n_e = 1e26 * u.cm ** -3
>>> Z = 2.0
>>> particle = 'p'
>>> blob = plasmapy.classes.Plasma(T_e=T_e,
...                                n_e=n_e,
...                                Z=Z,
...                                particle=particle)

>>> type(blob)
plasmapy.classes.sources.plasmablob.PlasmaBlob

>>> three_dims = plasmapy.classes.Plasma(domain_x=np.linspace(0, 1, 3) * u.m,
...                                      domain_y=np.linspace(0, 1, 3) * u.m,
...                                      domain_z=np.linspace(0, 1, 3) * u.m)

>>> type(three_dims)
plasmapy.classes.sources.plasma3d.Plasma3D
```

I am not sure if relying solely on keyword arguments is good enough to assume the plasma subclass but I don't have a better idea either (SunPy uses different parameters for `data` and `header`, I don't know how well will it work in our case).

We also need to add common plasma data to `GenericPlasma` and as of now `PlasmaFactory` does nothing but just inherits from `BasicRegistrationFactory`.