### PR TITLE
tried "try .to" approach in _check_relativistic to avoid .si

### DIFF
--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -410,14 +410,14 @@ def _check_relativistic(V, funcname, betafrac=0.05):
         raise TypeError(errmsg)
 
     try:
-        V = V.to(u.m / u.s)
+        V_over_c = (V / c).to_value(u.dimensionless_unscaled)
     except Exception:
         raise u.UnitConversionError(errmsg)
 
     if np.any(np.isnan(V.value)):
         raise ValueError(f"V includes NaNs in {funcname}")
 
-    beta = np.max(np.abs((V / c).value))
+    beta = np.max(np.abs((V_over_c)))
 
     if beta == np.inf:
         raise RelativityError(f"{funcname} is yielding an infinite velocity.")

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -409,13 +409,15 @@ def _check_relativistic(V, funcname, betafrac=0.05):
     if not isinstance(V, u.Quantity):
         raise TypeError(errmsg)
 
-    if V.si.unit != u.m / u.s:
+    try:
+        V = V.to(u.m / u.s)
+    except Exception:
         raise u.UnitConversionError(errmsg)
 
     if np.any(np.isnan(V.value)):
         raise ValueError(f"V includes NaNs in {funcname}")
 
-    beta = np.max(np.abs((V.si / c).value))
+    beta = np.max(np.abs((V / c).value))
 
     if beta == np.inf:
         raise RelativityError(f"{funcname} is yielding an infinite velocity.")


### PR DESCRIPTION
Can we get away with this?  It seemed to work much faster, cut the run time of my whole script by a factor of 3.

Hmm, using timeit shows a speedup from 4.019467848003842 to 1.8043721090070903 .... which I guess is kind of close to a factor of 3.

Closes #465