### PR TITLE
Modify gyroradius function to work with numpy array Quantities

### DIFF
--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -881,6 +881,7 @@ def gyroradius(B, particle='e-', *, Vperp=np.nan * u.m / u.s, T_i=np.nan * u.K):
     # the underlying values of the astropy quantity may be numpy arrays
     if np.any(np.logical_not(np.logical_xor(isfinite_Vperp, isfinite_Ti))):
         raise ValueError("Must give Vperp or T_i, but not both, as arguments to gyroradius")
+    
 
     # check 2: get Vperp as the thermal speed if is not already a valid input
     if np.isscalar(Vperp.value) and np.isscalar(T_i.value):  # both T_i and Vperp are scalars

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -873,7 +873,7 @@ def gyroradius(B, particle='e-', *, Vperp=np.nan * u.m / u.s, T_i=np.nan * u.K):
     <Quantity 0.00142141 m>
 
     """
-    
+
     isfinite_Ti = np.isfinite(T_i)
     isfinite_Vperp = np.isfinite(Vperp)
 
@@ -881,7 +881,6 @@ def gyroradius(B, particle='e-', *, Vperp=np.nan * u.m / u.s, T_i=np.nan * u.K):
     # the underlying values of the astropy quantity may be numpy arrays
     if np.any(np.logical_not(np.logical_xor(isfinite_Vperp, isfinite_Ti))):
         raise ValueError("Must give Vperp or T_i, but not both, as arguments to gyroradius")
-    
 
     # check 2: get Vperp as the thermal speed if is not already a valid input
     if np.isscalar(Vperp.value) and np.isscalar(T_i.value):  # both T_i and Vperp are scalars

--- a/plasmapy/physics/parameters.py
+++ b/plasmapy/physics/parameters.py
@@ -888,9 +888,7 @@ def gyroradius(B, particle='e-', *, Vperp=np.nan * u.m / u.s, T_i=np.nan * u.K):
         if isfinite_Ti:
             # T_i is valid, so use it to determine Vperp
             Vperp = thermal_speed(T_i, particle=particle)
-        else:
-            # Vperp is alread valid, do nothing
-            pass
+        # else: Vperp is alread valid, do nothing
     elif np.isscalar(Vperp.value):  # only T_i is an array
         # this means either Vperp must be nan, or T_i must be array of all nan,
         # or else we couldn't have gotten through check 1
@@ -908,10 +906,8 @@ def gyroradius(B, particle='e-', *, Vperp=np.nan * u.m / u.s, T_i=np.nan * u.K):
             # T_i is valid, V_perp is an array of all nan
             # uh...
             Vperp = thermal_speed(np.repeat(T_i, len(Vperp)), particle=particle)
-        else:
-            # normal case where T_i is scalar nan and Vperp is already a valid array
-            # so, do nothing
-            pass
+        # else: normal case where T_i is scalar nan and Vperp is already a valid array
+        # so, do nothing
     else:  # both T_i and Vperp are arrays
         # we know all the elementwise combinations have one nan and one finite, due to check 1
         # use the valid Vperps, and replace the others with those calculated from T_i

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -51,6 +51,7 @@ mu = m_p.to(u.u).value
 
 V = 25.2 * u.m / u.s
 V_arr = np.array([25, 50]) * u.m / u.s
+V_nanarr = np.array([np.nan, 50]) * u.m / u.s
 
 
 class Test_mass_density:
@@ -592,6 +593,12 @@ def test_gyroradius():
     # Tests to verify that can handle Quantities with numpy array as the value:
     assert gyroradius(B_arr, Vperp=V_arr)[0] == gyroradius(B_arr[0], Vperp=V_arr[0])
     assert gyroradius(B_arr, T_i=T_arr)[0] == gyroradius(B_arr[0], T_i=T_arr[0])
+    
+    # If both Vperp or Ti are nan-less, arrays or not, should still raise ValueError:
+    with pytest.raises(ValueError):
+        gyroradius(B_arr, Vperp=V, T_i=T_arr)
+    with pytest.raises(ValueError):
+        gyroradius(B_arr, Vperp=V_arr, T_i=T_i)
 
 
 def test_plasma_frequency():

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -598,24 +598,25 @@ def test_gyroradius():
     # Tests to verify that can handle Quantities with numpy array as the value:
     assert gyroradius(B_arr, Vperp=V_arr)[0] == gyroradius(B_arr[0], Vperp=V_arr[0])
     assert gyroradius(B_arr, T_i=T_arr)[0] == gyroradius(B_arr[0], T_i=T_arr[0])
-    
+
     # If both Vperp or Ti are input as Qarrays, but only one of the two is valid
     # at each element, then that's fine, the function should work:
     assert gyroradius(B_arr, Vperp=V_nanarr, T_i=T_nanarr2)[0] == gyroradius(B_arr[0],
-        Vperp=V_nanarr[0], T_i=T_nanarr2[0])
-    
+                                                                             Vperp=V_nanarr[0],
+                                                                             T_i=T_nanarr2[0])
+
     # If both Vperp or Ti are nan-less, Qarrays or not, should raise ValueError:
     with pytest.raises(ValueError):
         gyroradius(B_arr, Vperp=V, T_i=T_arr)
     with pytest.raises(ValueError):
         gyroradius(B_arr, Vperp=V_arr, T_i=T_i)
-        
+
     # If one of (Vperp, Ti) is a valid and one is Qarray with at least one valid, ValueError:
     with pytest.raises(ValueError):
         gyroradius(B_arr, Vperp=V, T_i=T_nanarr)
     with pytest.raises(ValueError):
         gyroradius(B_arr, Vperp=V_nanarr, T_i=T_i)
-        
+
     # If either Vperp or Ti is a valid scalar and the other is a Qarray of all nans,
     # should do something valid and not raise a ValueError
     assert np.all(np.isfinite(gyroradius(B_arr, Vperp=V, T_i=T_allnanarr)))

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -39,6 +39,7 @@ T_i = 1e6 * u.K
 
 B_arr = np.array([0.001, 0.002]) * u.T
 rho_arr = np.array([5e-10, 2e-10]) * u.kg / u.m ** 3
+T_arr = np.array([1e6, 2e6]) * u.K
 
 B_nanarr = np.array([0.001, np.nan]) * u.T
 rho_infarr = np.array([np.inf, 5e19]) * u.m ** -3
@@ -49,6 +50,7 @@ T_negarr = np.array([1e6, -5151.]) * u.K
 mu = m_p.to(u.u).value
 
 V = 25.2 * u.m / u.s
+V_arr = np.array([25, 50]) * u.m / u.s
 
 
 class Test_mass_density:
@@ -586,6 +588,10 @@ def test_gyroradius():
 
     with pytest.raises(ValueError):
         gyroradius(1.1 * u.T, particle="p", Vperp=1.2 * u.m, T_i=1.1 * u.K)
+
+    # Tests to verify that can handle Quantities with numpy array as the value:
+    assert gyroradius(B_arr, Vperp=V_arr)[0] == gyroradius(B_arr[0], Vperp=V_arr[0])
+    assert gyroradius(B_arr, T_i=T_arr)[0] == gyroradius(B_arr[0], T_i=T_arr[0])
 
 
 def test_plasma_frequency():


### PR DESCRIPTION
First baby step of progress towards issue #469, this one is focused solely on the gyroradius function.

Gyroradius seemed to have trouble due to its unique feature, in which it will accept a T_i input, or a Vperp input, but not both.  I put in some conditional statements to hopefully extend this behavior to numpy array Quantities.  

The main new behavior that I have tried to test for and achieve is:
- If only Ti is input and is a no-nan-Qarray, function should work (result is a Qarray calculated with Ti)
- If only Vperp is input and is a no-nan-Qarray, function should work (result is a Qarray calculated with Vperp)
- If both Vperp and Ti are input and are both Qarray, but with nans in each array such that for each element there is exactly 1 nan, function should work (result is a Qarray calculated with the non-nans)
- if, for some reason, Vperp is a Qarray of all nan and Ti is valid, function should work. The result I went with was to return a Qarray of len(Vperp) all calculated with the valid scalar Ti, but I'm open to other returns here. Hopefully this case won't get activated much.
- same as above but vice versa with Vperp, Ti

And hopefully raise ValueError on all the various invalid combinations. Of note is
- if Ti is a valid scalar, and Vperp is a Qarray that has some nan but not all, raise ValueError
- same as above but vice versa with Vperp, Ti

This one is debateable, I think doing it this way of raising the ValueError keeps to the spirit of the original "you must provide either Ti or Vperp but not both" and is hopefully more consistent and least confusing, but I could also imagine a way in which the scalar would be used only in the cases where there are the nans in the array.

---

Actually, it looks like gyroradius and hall parameter are the only two plasma parameter functions that currently have issues when given numpy array Quantities.  So, we'd be 50% done!...  Except that hall parameter calls collision_frequency, which opens up the collisions module, which looks to be in a world of pain.

