### PR TITLE
Raise `NotImplementedError` in `BasePlasma` and `GenericPlasma`

### DIFF
--- a/plasmapy/classes/plasma_base.py
+++ b/plasmapy/classes/plasma_base.py
@@ -34,23 +34,23 @@ class BasePlasma(ABC):
 
     @abstractproperty
     def electron_temperature(self):
-        pass
+        raise NotImplementedError
 
     @abstractproperty
     def ion_temperature(self):
-        pass
+        raise NotImplementedError
 
     @abstractproperty
     def electron_density(self):
-        pass
+        raise NotImplementedError
 
     @abstractproperty
     def ion_density(self):
-        pass
+        raise NotImplementedError
 
     @abstractproperty
     def average_ionization(self):
-        pass
+        raise NotImplementedError
 
 
 class GenericPlasma(BasePlasma):
@@ -65,16 +65,16 @@ class GenericPlasma(BasePlasma):
     # goes here.
 
     def electron_temperature(self):
-        pass
+        raise NotImplementedError
 
     def ion_temperature(self):
-        pass
+        raise NotImplementedError
 
     def electron_density(self):
-        pass
+        raise NotImplementedError
 
     def ion_density(self):
-        pass
+        raise NotImplementedError
 
     def average_ionization(self):
-        pass
+        raise NotImplementedError


### PR DESCRIPTION
I didn't realize a better idea would be to raise a `NotImplementedError` instead of just `pass` in our currently unimplemented properties in `BasePlasma` and `GenericPlasma`.

This would also help us increase code coverage since we mention to [skip such lines in coveragerc](https://github.com/PlasmaPy/PlasmaPy/blob/23b55eb569a1c7fbbf192827d889bf2d9a69b678/plasmapy/tests/coveragerc#L12).

(By the way, `coverage` at the moment still doesn't seem to read `exclude_lines` from our `coveragerc`. I made a *not-so-good* workaround in ritiek/PlasmaPy#4 to make it read them. I'll make a PR if it seems okay to you).