### PR TITLE
Make Particle(particle) == Particle(Particle(particle))

### DIFF
--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -261,10 +261,18 @@ class Particle:
         attributes.
         """
 
-        if not isinstance(argument, (int, str)):
+        if not isinstance(argument, (int, np.integer, str, Particle)):
             raise TypeError(
                 "The first positional argument when creating a Particle "
-                "object must be either an integer or string.")
+                "object must be either an integer, string, or another"
+                "Particle object.")
+
+        # If argument is a Particle instance, then we will construct a
+        # new Particle instance for the same Particle (essentially a
+        # copy).
+
+        if isinstance(argument, Particle):
+            argument = argument.particle
 
         if mass_numb is not None and not isinstance(mass_numb, int):
             raise TypeError("mass_numb is not an integer")

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -113,9 +113,10 @@ class Particle:
 
     Parameters
     ----------
-    argument : `str` or `int`
-        A string representing a particle, element, isotope, or ion; or
-        an integer representing the atomic number of an element.
+    argument : `str`, `int`, or `~plasmapy.atomic.Particle`
+        A string representing a particle, element, isotope, or ion; an
+        integer representing the atomic number of an element; or a
+        `Particle` instance.
 
     mass_numb : `int`, optional
         The mass number of an isotope or nuclide.
@@ -238,6 +239,25 @@ class Particle:
     >>> ~positron
     Particle("e-")
 
+    A `~plasmapy.atomic.Particle` instance may be used as the first
+    argument to `~plasmapy.atomic.Particle`.
+
+    >>> iron = Particle('Fe')
+    >>> iron == Particle(iron)
+    True
+    >>> Particle(iron, mass_numb=56, Z=6)
+    Particle("Fe-56 6+")
+
+    If the previously constructed `~plasmapy.atomic.Particle` instance
+    represents an element, then the `Z` and `mass_numb` arguments may be
+    used to specify an ion or isotope.
+
+    >>> iron = Particle('Fe')
+    >>> Particle(iron, Z=1)
+    Particle("Fe 1+")
+    >>> Particle(iron, mass_numb=56)
+    Particle("Fe-56")
+
     The `~plasmapy.atomic.particle_class.Particle.categories` attribute
     and `~plasmapy.atomic.particle_class.Particle.is_category` method
     may be used to find and test particle membership in categories.
@@ -257,7 +277,7 @@ class Particle:
 
     def __init__(self, argument: Union[str, int], mass_numb: int = None, Z: int = None):
         """
-        Initialize a `~plasmapy.atomic.Particle` object and set private
+        Instantiate a `~plasmapy.atomic.Particle` object and set private
         attributes.
         """
 

--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -377,6 +377,17 @@ test_Particle_table = [
       'is_category("boson", exclude="boson")': AtomicError,
       'is_category(any_of="boson", exclude="boson")': AtomicError,
       }),
+
+    (Particle('C'), {},
+     {'particle': 'C',
+      }),
+
+    (Particle('C'), {'Z': 3, 'mass_numb': 14},
+     {'particle': 'C-14 3+',
+      'element': 'C',
+      'isotope': 'C-14',
+      'ionic_symbol': 'C-14 3+',
+     }),
 ]
 
 
@@ -478,6 +489,8 @@ test_Particle_error_table = [
     ('Fe', {}, '.spin', MissingAtomicDataError),
     ('nu_e', {}, '.mass', MissingAtomicDataError),
     ('Og', {}, '.standard_atomic_weight', MissingAtomicDataError),
+    (Particle('C-14'), {'mass_numb': 13}, "", InvalidParticleError),
+    (Particle('Au 1+'), {'Z': 2}, "", InvalidParticleError),
     ([], {}, "", TypeError),
 ]
 

--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -707,3 +707,25 @@ class Test_antiparticle_properties_inversion:
             (f"{repr(particle)}.antiparticle returned "
              f"{particle.antiparticle}, whereas ~{repr(particle)} "
              f"returned {~particle}.")
+
+
+@pytest.mark.parametrize('arg', ['e-', 'D+', 'Fe 25+', 'H-', 'mu+'])
+def test_particleing_a_particle(arg):
+    """
+    Test that Particle(arg) is equal to Particle(Particle(arg)), but is
+    not the same object in memory.
+    """
+    particle = Particle(arg)
+
+    assert particle == Particle(particle), (
+        f"Particle({repr(arg)}) does not equal "
+        f"Particle(Particle({repr(arg)}).")
+
+    assert particle == Particle(Particle(Particle(particle))), (
+        f"Particle({repr(arg)}) does not equal "
+        f"Particle(Particle(Particle({repr(arg)})).")
+
+    assert particle is not Particle(particle), (
+        f"Particle({repr(arg)}) is the same object in memory as "
+        f"Particle(Particle({repr(arg)})), when it is intended to "
+        f"create a new object in memory (e.g., a copy).")


### PR DESCRIPTION
This makes `Particle(particle) == Particle(Particle(particle))` while making sure that `Particle(particle) is not Particle(Particle(particle))`. 

Closes #486, using the suggestion made by @colbych.  See #486 and the commit log for details.

