### PR TITLE
Implement ionize and recombine methods in Particle class

### DIFF
--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -1248,17 +1248,17 @@ class Particle:
         """
 
         def become_set(arg: Union[str, Set, Tuple, List]) -> Set[str]:
-                """Change the argument into a `set`."""
-                if len(arg) == 0:
-                    return set()
-                if isinstance(arg, set):
-                    return arg
-                if isinstance(arg, str):
-                    return {arg}
-                if isinstance(arg[0], (tuple, list, set)):
-                    return set(arg[0])
-                else:
-                    return set(arg)
+            """Change the argument into a `set`."""
+            if len(arg) == 0:
+                return set()
+            if isinstance(arg, set):
+                return arg
+            if isinstance(arg, str):
+                return {arg}
+            if isinstance(arg[0], (tuple, list, set)):
+                return set(arg[0])
+            else:
+                return set(arg)
 
         if category_tuple != () and require != set():  # coveralls: ignore
             raise AtomicError(
@@ -1330,23 +1330,37 @@ class Particle:
         """
         return self.is_category('ion')
 
-    def ionize(self, n: numbers.Integral = 1):
+    def ionize(self, n: numbers.Integral = 1, inplace: bool = False):
         """
-        Remove an electron from a `~plasmapy.atomic.Particle` object. If
-        a positive integer `n` is specified, then remove `n` electrons
-        instead.
+        Create a new `~plasmapy.atomic.Particle` instance corresponding
+        to the current `~plasmapy.atomic.Particle` after being ionized
+        `n` times.
+
+        If `inplace` is `False` (default), then return the ionized
+        `~plasmapy.atomic.Particle`.
+
+        If `inplace` is `True`, then replace the current
+        `~plasmapy.atomic.Particle` with the newly ionized
+        `~plasmapy.atomic.Particle`.
 
         Parameters
         ----------
         n : positive integer
-            The number of electrons to remove from the
-            `~plasmapy.atomic.Particle` object.
+            The number of bound electrons to remove from the
+            `~plasmapy.atomic.Particle` object.  Defaults to `1`.
+
+        inplace : bool, optional
+            If `True`, then replace the current
+            `~plasmapy.atomic.Particle` instance with the newly ionized
+            `~plasmapy.atomic.Particle`.
 
         Returns
         -------
-        self : ~plasmapy.atomic.Particle
-            The new `~plasmapy.atomic.Particle` object after being
-            ionized.
+        particle : ~plasmapy.atomic.Particle
+            A new `~plasmapy.atomic.Particle` object that has been
+            ionized `n` times relative to the original
+            `~plasmapy.atomic.Particle`.  If `inplace` is `False`,
+            instead return `None`.
 
         Raises
         ------
@@ -1365,11 +1379,12 @@ class Particle:
 
         Examples
         --------
-        >>> atom = Particle("Fe 6+")
-        >>> atom.ionize()
+        >>> Particle("Fe 6+").ionize()
         Particle("Fe 7+")
-        >>> atom.ionize(2)
-        Particle("Fe 9+")
+        >>> helium_particle = Particle("He-4 0+")
+        >>> helium_particle.ionize(n=2, inplace=True)
+        >>> helium_particle
+        Particle("He-4 2+")
 
         """
         if not self.element:
@@ -1392,18 +1407,23 @@ class Particle:
         base_particle = self.isotope if self.isotope else self.element
         new_integer_charge = self.integer_charge + n
 
-        self.__init__(base_particle, Z=new_integer_charge)
+        if inplace:
+            self.__init__(base_particle, Z=new_integer_charge)
+        else:
+            return Particle(base_particle, Z=new_integer_charge)
 
-        # Returning self here allows comparisons like
-        # Particle("Fe 5+").ionize() == Particle("Fe 6+")
-
-        return self
-
-    def recombine(self, n: numbers.Integral = 1):
+    def recombine(self, n: numbers.Integral = 1, inplace=False):
         """
-        Add an electron into a `~plasmapy.atomic.Particle` object
-        through recombination.  If a positive integer `n` is specified,
-        then remove `n` electrons instead.
+        Create a new `~plasmapy.atomic.Particle` instance corresponding
+        to the current `~plasmapy.atomic.Particle` after undergoing
+        recombination `n` times.
+
+        If `inplace` is `False` (default), then return the
+        `~plasmapy.atomic.Particle` that just underwent recombination.
+
+        If `inplace` is `True`, then replace the current
+        `~plasmapy.atomic.Particle` with the `~plasmapy.atomic.Particle`
+        that just underwent recombination.
 
         Parameters
         ----------
@@ -1411,11 +1431,19 @@ class Particle:
             The number of electrons to recombine into the
             `~plasmapy.atomic.Particle` object.
 
+        inplace : bool, optional
+            If `True`, then replace the current
+            `~plasmapy.atomic.Particle` instance with the
+            `~plasmapy.atomic.Particle` that just underwent
+            recombination.
+
         Returns
         -------
-        self : ~plasmapy.atomic.Particle
-            The new `~plasmapy.atomic.Particle` object after
-            recombination.
+        particle : ~plasmapy.atomic.Particle
+            A new `~plasmapy.atomic.Particle` object that has undergone
+            recombination `n` times relative to the original
+            `~plasmapy.atomic.Particle`.  If `inplace` is `False`,
+            instead return `None`.
 
         Raises
         ------
@@ -1431,12 +1459,12 @@ class Particle:
 
         Examples
         --------
-        >>> atom = Particle("alpha")
-        >>> atom.recombine()
-        Particle("He-4 1+")
-        >>> iron_ion = Particle("Fe 26+")
-        >>> iron_ion.recombine(8)
-        Particle("Fe 18+")
+        >>> Particle("Fe 6+").recombine()
+        Particle("Fe 5+")
+        >>> helium_particle = Particle("He-4 2+")
+        >>> helium_particle.recombine(n=2, inplace=True)
+        >>> helium_particle
+        Particle("He-4 0+")
 
         """
 
@@ -1456,9 +1484,7 @@ class Particle:
         base_particle = self.isotope if self.isotope else self.element
         new_integer_charge = self.integer_charge - n
 
-        self.__init__(base_particle, Z=new_integer_charge)
-
-        # Returning self here allows comparisons like
-        # Particle("Fe 5+").recombine() == Particle("Fe 4+")
-
-        return self
+        if inplace:
+            self.__init__(base_particle, Z=new_integer_charge)
+        else:
+            return Particle(base_particle, Z=new_integer_charge)

--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -504,6 +504,8 @@ test_Particle_error_table = [
     ('Fe 25+', {}, ".recombine(0)", ValueError),
     ('Fe 6+', {}, ".ionize(4.6)", TypeError),
     ('Fe 25+', {}, ".recombine(8.2)", TypeError),
+    ('e-', {}, ".ionize()", InvalidElementError),
+    ('e+', {}, ".recombine()", InvalidElementError),
 ]
 
 

--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -14,6 +14,7 @@ from ...utils import (
     InvalidParticleError,
     InvalidElementError,
     InvalidIsotopeError,
+    InvalidIonError,
     ChargeError,
     call_string,
     run_test_equivalent_calls,
@@ -80,6 +81,7 @@ test_Particle_table = [
       'periodic_table.period': 1,
       'periodic_table.category': 'nonmetal',
       'binding_energy': 0 * u.J,
+      'recombine()': 'H-1 0+',
       }),
 
     ('p-', {},
@@ -298,6 +300,7 @@ test_Particle_table = [
       'baryon_number': 4,
       'lepton_number': 0,
       'half_life': np.inf * u.s,
+      'recombine()': Particle('He-4 1+')
       }),
 
     ('Li', {'mass_numb': 7},
@@ -456,6 +459,8 @@ equivalent_particles_table = [
     ['n', 'n-1', 'neutron', 'NEUTRON'],
     ['muon', 'mu-', 'muon-'],
     ['tau', 'tau-'],
+    [Particle('Fe 5+'), Particle('Fe 4+').ionize()],
+    [Particle('He-4 0+'), Particle('alpha').recombine(2)]
 ]
 
 
@@ -492,6 +497,13 @@ test_Particle_error_table = [
     (Particle('C-14'), {'mass_numb': 13}, "", InvalidParticleError),
     (Particle('Au 1+'), {'Z': 2}, "", InvalidParticleError),
     ([], {}, "", TypeError),
+    ('Fe', {}, ".ionize()", ChargeError),
+    ('D', {}, ".recombine()", ChargeError),
+    ('Fe 26+', {}, ".ionize()", InvalidIonError),
+    ('Fe 6+', {}, ".ionize(-1)", ValueError),
+    ('Fe 25+', {}, ".recombine(0)", ValueError),
+    ('Fe 6+', {}, ".ionize(4.6)", TypeError),
+    ('Fe 25+', {}, ".recombine(8.2)", TypeError),
 ]
 
 


### PR DESCRIPTION
These methods take a `Particle` object and run `__init__` again for the same element/isotope but for a different charge.  The `Particle.ionize` method will raise an `InvalidIonError` if a bare nucleus is attempted to be ionized.  The `recombine` method will issue a warning if the charge becomes negative; however, no exception will be raised in that case.

One behavior that I'm not certain about is both running `__init__` again and returning the new Particle instance.  We may wish to have just one behavior or the other.  If we have just the in-place re-initialization, then a disadvantage is that we would not be able to do comparisons like:
```Python
Particle("Fe 5+").recombine() == Particle("Fe 4+")
```
which require the new `Particle` instance to be returned.  I would appreciate more opinions on whether we should do both `__init__` and returning `self`, or just one of them.  Or, if there is even a better approach than I am taking here.  

I'd also like to check to make sure that there are no side effects from `__init__` again (e.g., if I have a list and add items to it such that every item in the list shows up twice).

Closes #287.