### PR TITLE
Allow nans by default when checking unit input

### DIFF
--- a/plasmapy/physics/tests/test_dimensionless.py
+++ b/plasmapy/physics/tests/test_dimensionless.py
@@ -24,4 +24,5 @@ def test_beta_nan():
     n = np.array([1, 1]) * u.cm**-3
     T = np.array([1, 1]) * u.K
     out = beta(T, n, B)
-    assert out[1] == np.nan * u.dimensionless_unscaled
+    assert np.isnan(out[1])
+    assert out[1].unit == u.dimensionless_unscaled

--- a/plasmapy/physics/tests/test_dimensionless.py
+++ b/plasmapy/physics/tests/test_dimensionless.py
@@ -1,12 +1,27 @@
 from plasmapy.physics.dimensionless import (beta)
 
 import astropy.units as u
+import numpy as np
 
 B = 1.0 * u.T
-n_i = 5e19 * u.m ** -3
-T_e = 1e6 * u.K
+n = 5e19 * u.m ** -3
+T = 1e6 * u.K
 
 
-def test_beta():
+def test_beta_dimensionless():
     # Check that beta is dimensionless
-    float(beta(T_e, n_i, B))
+    float(beta(T, n, B))
+
+
+def quantum_theta_dimensionless():
+    # Check that quantum theta is dimensionless
+    float(quantum_theta(T, n))
+
+
+def test_beta_nan():
+    # Check that nans are passed through properly
+    B = np.array([1, np.nan]) * u.T
+    n = np.array([1, 1]) * u.cm**-3
+    T = np.array([1, 1]) * u.K
+    out = beta(T, n, B)
+    assert out[1] == np.nan * u.dimensionless_unscaled

--- a/plasmapy/physics/tests/test_parameters.py
+++ b/plasmapy/physics/tests/test_parameters.py
@@ -464,8 +464,7 @@ def test_gyrofrequency():
     with pytest.raises(u.UnitConversionError):
         gyrofrequency(u.m * 1)
 
-    with pytest.raises(ValueError):
-        gyrofrequency(B_nanarr)
+    assert np.isnan(gyrofrequency(B_nanarr)[-1])
 
     # The following is a test to check that equivalencies from astropy
     # are working.
@@ -548,8 +547,7 @@ def test_gyroradius():
     with pytest.raises(ValueError):
         gyroradius(np.array([5, 6]) * u.T, Vperp=np.array([5, 6, 7]) * u.m / u.s)
 
-    with pytest.raises(ValueError):
-        gyroradius(np.nan * u.T, Vperp=1 * u.m / u.s)
+    assert np.isnan(gyroradius(np.nan * u.T, Vperp=1 * u.m / u.s))
 
     with pytest.raises(ValueError):
         gyroradius(3.14159 * u.T, T_i=-1 * u.K)
@@ -680,8 +678,7 @@ def test_plasma_frequency():
     with pytest.raises(u.UnitConversionError):
         plasma_frequency(5 * u.m ** -2)
 
-    with pytest.raises(ValueError):
-        plasma_frequency(np.nan * u.m ** -3)
+    assert np.isnan(plasma_frequency(np.nan * u.m ** -3))
 
     with pytest.warns(u.UnitsWarning):
         assert plasma_frequency(1e19) == plasma_frequency(1e19 * u.m ** -3)
@@ -859,14 +856,12 @@ def test_magnetic_pressure():
     with pytest.raises(u.UnitConversionError):
         magnetic_pressure(5 * u.m)
 
-    with pytest.raises(ValueError):
-        magnetic_pressure(np.nan * u.T)
+    assert np.isnan(magnetic_pressure(np.nan * u.T))
 
     with pytest.raises(ValueError):
         magnetic_pressure(5j * u.T)
 
-    with pytest.raises(ValueError):
-        magnetic_pressure(B_nanarr)
+    assert np.isnan(magnetic_pressure(B_nanarr)[-1])
 
     with pytest.warns(u.UnitsWarning):
         assert magnetic_pressure(22.2) == magnetic_pressure(22.2 * u.T)
@@ -897,14 +892,12 @@ def test_magnetic_energy_density():
     with pytest.raises(u.UnitConversionError):
         magnetic_energy_density(5 * u.m)
 
-    with pytest.raises(ValueError):
-        magnetic_energy_density(np.nan * u.T)
+    assert np.isnan(magnetic_energy_density(np.nan * u.T))
 
     with pytest.raises(ValueError):
         magnetic_energy_density(5j * u.T)
 
-    with pytest.raises(ValueError):
-        magnetic_energy_density(B_nanarr)
+    assert np.isnan(magnetic_energy_density(B_nanarr)[-1])
 
     with pytest.warns(u.UnitsWarning):
         assert magnetic_energy_density(22.2) == magnetic_energy_density(22.2 * u.T)

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -143,7 +143,7 @@ def check_quantity(**validations):
                 can_be_negative = validation_settings.get('can_be_negative', True)
                 can_be_complex = validation_settings.get('can_be_complex', False)
                 can_be_inf = validation_settings.get('can_be_inf', True)
-                can_be_nan = validation_settings.get('can_be_nan', False)
+                can_be_nan = validation_settings.get('can_be_nan', True)
                 none_shall_pass = validation_settings.get('none_shall_pass', False)
 
                 validated_value = _check_quantity(value_to_check,
@@ -163,7 +163,7 @@ def check_quantity(**validations):
 
 
 def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
-                    can_be_complex=False, can_be_inf=True, can_be_nan=False,
+                    can_be_complex=False, can_be_inf=True, can_be_nan=True,
                     none_shall_pass=False):
     """
     Raise an exception if an object is not a `~astropy.units.Quantity`


### PR DESCRIPTION
I think this was the intended default (the documentation says the default should be `True`), and I also think in general most functions should be able to handle nans. Also added a test to check that `beta` passes through nans fine.