### PR TITLE
Turn h5py into an optional dependency

### DIFF
--- a/plasmapy/classes/sources/openpmd_hdf5.py
+++ b/plasmapy/classes/sources/openpmd_hdf5.py
@@ -1,4 +1,3 @@
-import h5py
 import numpy as np
 import astropy.units as u
 
@@ -8,6 +7,11 @@ from plasmapy.utils import DataStandardError
 import os
 from distutils.version import StrictVersion
 
+# make h5py an optional dependency
+try:
+    import h5py
+except ImportError:
+    h5py = None
 
 _OUTDATED_VERSION = "1.1.0"
 _NEWER_VERSION = "2.0.0"


### PR DESCRIPTION
Closes #522 .

This is a pretty minimal solution - I'm not sure about the best practice for this kind of thing.
I could also, I suppose, put `import h5py` into the two functions that actually use it. That way, they'd get imported at first function runtime, if I'm correct.