### PR TITLE
Use `Optional[Particle]` as an annotation

### DIFF
--- a/plasmapy/atomic/particle_input.py
+++ b/plasmapy/atomic/particle_input.py
@@ -22,6 +22,7 @@ __all__ = [
     "particle_input",
 ]
 
+
 def _particle_errmsg(argname: str,
                      argval: str,
                      Z: int = None,
@@ -275,7 +276,9 @@ def particle_input(wrapped_function: Callable = None,
                     annotated_argnames = (annotations[argname],)
 
                 for annotated_argname in annotated_argnames:
-                    if (annotated_argname is Particle or annotated_argname is Optional[Particle]) and argname != 'return':
+                    is_particle = annotated_argname is Particle or \
+                                  annotated_argname is Optional[Particle]
+                    if is_particle and argname != 'return':
                         args_to_become_particles.append(argname)
 
             if not args_to_become_particles:
@@ -346,13 +349,12 @@ def particle_input(wrapped_function: Callable = None,
                     # Occasionally there will be functions where it will be
                     # useful to allow None as an argument.
 
-
                     # In case annotations[argname] is a collection (which looks
                     # like (Particle, Optional[Particle], ...) or [Particle])
                     if isinstance(annotations[argname], tuple):
                         optional_particle = annotations[argname][pos] is Optional[Particle]
                     elif isinstance(annotations[argname], list):
-                        optional_particle = annotations[argname] == [Optional[Particle],]
+                        optional_particle = annotations[argname] == [Optional[Particle], ]
                     else:
                         # Otherwise annotations[argname] must be a Particle itself
                         optional_particle = annotations[argname] is Optional[Particle]
@@ -454,7 +456,6 @@ def particle_input(wrapped_function: Callable = None,
                 _category_errmsg(particle, require, exclude, any_of, funcname))
 
         return particle
-
 
     # The following code allows the decorator to be used either with or
     # without arguments.  This allows us to invoke the decorator either

--- a/plasmapy/atomic/tests/test_particle_input.py
+++ b/plasmapy/atomic/tests/test_particle_input.py
@@ -390,29 +390,121 @@ def test_decorator_categories(decorator_kwargs, particle, expected_exception):
 
 
 def test_none_shall_pass():
-    """Tests the `none_shall_pass` keyword argument in is_particle.  If
-    `none_shall_pass=True`, then an annotated argument should allow
-    `None` to be passed through to the decorated function.  If
-    `none_shall_pass=False`, then particle_input should raise a
-    `~plasmapy.utils.AtomicError` if an annotated argument is assigned
-    the value of `None`.
-    """
+    """Tests the `none_shall_pass` keyword argument in is_particle.
+    If `none_shall_pass=True`, then an annotated argument should allow
+    `None` to be passed through to the decorated function."""
+
     @particle_input(none_shall_pass=True)
     def func_none_shall_pass(particle: Particle) -> Optional[Particle]:
         return particle
 
-    @particle_input(none_shall_pass=False)
-    def func_none_shall_not_pass(particle: Particle) -> Particle:
-        return particle
+    @particle_input(none_shall_pass=True)
+    def func_none_shall_pass_with_tuple(particles: (Particle, Particle)) -> (Optional[Particle], Optional[Particle]):
+        return particles
+
+    @particle_input(none_shall_pass=True)
+    def func_none_shall_pass_with_list(particles: [Particle]) -> [Optional[Particle]]:
+        return particles
 
     assert func_none_shall_pass(None) is None, \
         ("The none_shall_pass keyword in the particle_input decorator is set "
          "to True, but is not passing through None.")
 
+    assert func_none_shall_pass_with_tuple((None, None)) == (None, None), \
+        ("The none_shall_pass keyword in the particle_input decorator is set "
+         "to True, but is not passing through None.")
+
+    assert func_none_shall_pass_with_list((None, None)) == (None, None), \
+        ("The none_shall_pass keyword in the particle_input decorator is set "
+         "to True, but is not passing through None.")
+
+
+def test_none_shall_not_pass():
+    """Tests the `none_shall_pass` keyword argument in is_particle.
+    If `none_shall_pass=False`, then particle_input should raise a
+    `TypeError` if an annotated argument is assigned the value of
+    `None`."""
+
+    @particle_input(none_shall_pass=False)
+    def func_none_shall_not_pass(particle: Particle) -> Particle:
+        return particle
+
+    @particle_input(none_shall_pass=False)
+    def func_none_shall_not_pass_with_tuple(particles: (Particle, Particle)) -> (Particle, Particle):
+        return particles
+
+    @particle_input(none_shall_pass=False)
+    def func_none_shall_not_pass_with_list(particles: [Particle]) -> [Particle]:
+        return particles
+
     with pytest.raises(TypeError, message=(
             "The none_shall_pass keyword in the particle_input decorator is "
             "set to False, but is not raising a TypeError.")):
         func_none_shall_not_pass(None)
+
+    with pytest.raises(TypeError, message=(
+            "The none_shall_pass keyword in the particle_input decorator is "
+            "set to False, but is not raising a TypeError.")):
+        func_none_shall_not_pass_with_tuple(('He', None))
+
+    with pytest.raises(TypeError, message=(
+            "The none_shall_pass keyword in the particle_input decorator is "
+            "set to False, but is not raising a TypeError.")):
+        func_none_shall_not_pass(('He', None))
+
+
+def test_optional_particle_annotation_argname():
+    """Tests the `Optional[Particle]` annotation argument in a function
+    decorated by `@particle_input` such that the annotated argument allows
+    `None` to be passed through to the decorated function."""
+
+    @particle_input
+    def func_optional_particle(particle: Optional[Particle]) -> Optional[Particle]:
+        return particle
+
+    @particle_input
+    def func_optional_particle_with_tuple(particles: (Particle, Optional[Particle])) -> (Particle, Optional[Particle]):
+        return particles
+
+    @particle_input
+    def func_optional_particle_with_list(particles: [Optional[Particle]]) -> [Optional[Particle]]:
+        return particles
+
+    assert func_optional_particle(None) is None, \
+        ("The particle keyword in the particle_input decorator is set "
+         "to accept Optional[Particle], but is not passing through None.")
+
+    assert func_optional_particle_with_tuple(('He', None)) == (Particle('He'), None), \
+        ("The particles keyword in the particle_input decorator is set "
+         "to accept Optional[Particle], but is not passing through None.")
+
+    assert func_optional_particle_with_list(('He', None)) == (Particle('He'), None), \
+        ("The particles keyword in the particle_input decorator is set "
+         "to accept Optional[Particle], but is not passing through None.")
+
+
+def test_not_optional_particle_annotation_argname():
+    """Tests the `Optional[Particle]` annotation argument in a function
+    decorated by `@particle_input` such that the annotated argument does
+    not allows `None` to be passed through to the decorated function."""
+
+    @particle_input
+    def func_not_optional_particle_with_tuple(particles: (Particle, Optional[Particle])) -> (Particle, Optional[Particle]):
+        return particles
+
+    @particle_input
+    def func_not_optional_particle_with_list(particles: [Particle]) -> [Particle]:
+        return particles
+
+    with pytest.raises(TypeError, message=(
+            "The particle keyword in the particle_input decorator received a "
+            "None instead of a Particle, but is not raising a TypeError.")):
+        func_not_optional_particle_with_tuple((None, 'He'))
+
+    with pytest.raises(TypeError, message=(
+            "The particle keyword in the particle_input decorator received a "
+            "None instead of a Particle, but is not raising a TypeError.")):
+        func_not_optional_particle_with_list(('He', None))
 
 
 # TODO: The following tests might be able to be cleaned up and/or

--- a/plasmapy/atomic/tests/test_particle_input.py
+++ b/plasmapy/atomic/tests/test_particle_input.py
@@ -399,7 +399,8 @@ def test_none_shall_pass():
         return particle
 
     @particle_input(none_shall_pass=True)
-    def func_none_shall_pass_with_tuple(particles: (Particle, Particle)) -> (Optional[Particle], Optional[Particle]):
+    def func_none_shall_pass_with_tuple(particles: (Particle, Particle)) -> \
+                                       (Optional[Particle], Optional[Particle]):
         return particles
 
     @particle_input(none_shall_pass=True)
@@ -430,7 +431,8 @@ def test_none_shall_not_pass():
         return particle
 
     @particle_input(none_shall_pass=False)
-    def func_none_shall_not_pass_with_tuple(particles: (Particle, Particle)) -> (Particle, Particle):
+    def func_none_shall_not_pass_with_tuple(particles: (Particle, Particle)) -> \
+                                           (Particle, Particle):
         return particles
 
     @particle_input(none_shall_pass=False)
@@ -463,7 +465,8 @@ def test_optional_particle_annotation_argname():
         return particle
 
     @particle_input
-    def func_optional_particle_with_tuple(particles: (Particle, Optional[Particle])) -> (Particle, Optional[Particle]):
+    def func_optional_particle_with_tuple(particles: (Particle, Optional[Particle])) -> \
+                                         (Particle, Optional[Particle]):
         return particles
 
     @particle_input
@@ -489,7 +492,8 @@ def test_not_optional_particle_annotation_argname():
     not allows `None` to be passed through to the decorated function."""
 
     @particle_input
-    def func_not_optional_particle_with_tuple(particles: (Particle, Optional[Particle])) -> (Particle, Optional[Particle]):
+    def func_not_optional_particle_with_tuple(particles: (Particle, Optional[Particle])) -> \
+                                             (Particle, Optional[Particle]):
         return particles
 
     @particle_input


### PR DESCRIPTION
Addresses #530.

This PR adds the ability to use `Optional[Particle]` as an annotation which allows passing `None` as a Particle when a function is decorated by `@particle_input`.

```python
>>> from plasmapy.atomic import Particle, particle_input
>>> from typing import Optional

>>> @particle_input
... def take_optional_particle(particle: Optional[Particle]):
...     return particle

>>> take_optional_particle(None)
None
```

It also works with collections!

```python
>>> @particle_input
... def take_optional_particles(particles: (Optional[Particle], Particle)):
...     return particles

>>> take_optional_particles((None, 'He'))
(None, Particle("He"))