### PR TITLE
Undefined name 'quantum_theta' in test_dimensionless.py

### DIFF
--- a/plasmapy/physics/tests/test_dimensionless.py
+++ b/plasmapy/physics/tests/test_dimensionless.py
@@ -13,7 +13,7 @@ def test_beta_dimensionless():
     float(beta(T, n, B))
 
 
-def quantum_theta_dimensionless():
+def test_quantum_theta_dimensionless():
     # Check that quantum theta is dimensionless
     float(quantum_theta(T, n))
 

--- a/plasmapy/physics/tests/test_dimensionless.py
+++ b/plasmapy/physics/tests/test_dimensionless.py
@@ -1,4 +1,4 @@
-from plasmapy.physics.dimensionless import (beta)
+from plasmapy.physics.dimensionless import (beta, quantum_theta)
 
 import astropy.units as u
 import numpy as np


### PR DESCRIPTION
__quantum_theta__ is used on line 18 of test_dimensionless.py but it is never defined or imported.

[flake8](http://flake8.pycqa.org) testing of https://github.com/PlasmaPy/PlasmaPy on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./plasmapy/physics/tests/test_dimensionless.py:18:11: F821 undefined name 'quantum_theta'
    float(quantum_theta(T, n))
          ^
1     F821 undefined name 'quantum_theta'
1
```

Hello, thanks for contributing to PlasmaPy!

If you're contributing changes to solve an issue tracked by GitHub, please add a phrase like:

    Closes #404.

Where 404 is the number of the issue you're attempting to solve!

This makes all our lives easier by automatically closing the issue once your pull request is merged.

If you don't think your Pull Request is enough to completely solve the issue, please still refer
to the issue in text.

https://help.github.com/articles/closing-issues-using-keywords
