### PR TITLE
Add DOI and citation for source code

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -2,22 +2,41 @@ Acknowledging and Citing PlasmaPy
 =================================
 
 If you use PlasmaPy for a project resulting in a publication, we ask
-that you cite the following reference
-(`BibTeX <https://zenodo.org/record/1238132/export/hx#.WvMkQK0cChc>`_):
+that you cite the following reference (`BibTeX
+<https://zenodo.org/record/1238132/export/hx#.WvMkQK0cChc>`_):
 
 * PlasmaPy Community, Nicholas A. Murphy, Andrew J. Leonard, Dominik
   Stańczak, Pawel M. Kozlowski, Samuel J. Langendorf, Colby C. Haggerty,
   Jasper P. Beckers, Stuart J. Mumford, Tulasi N. Parashar, and Yi-Min
-  Huang. (2018, April). PlasmaPy: an open source community-developed
-  Python package for plasma physics. Zenodo.
+  Huang. (2018, April). *PlasmaPy: an open source community-developed
+  Python package for plasma physics.* Zenodo.
   http://doi.org/10.5281/zenodo.1238132
 
-We provide the following standard acknowledgment with this citation that
-you may use instead of a citation in the body of a paper.
+We provide the following standard acknowledgment that you may use
+instead of a citation in the body of a paper.
 
 * This research made use of PlasmaPy, a community-developed open source
   core Python package for plasma physics (PlasmaPy Community 2018).
 
+The source code for the most recent release of PlasmaPy (version
+0.1.1) is archived on `Zenodo
+<https://zenodo.org/communities/plasmapy>`__ and can be cited using
+the following reference (`BibTeX
+<https://zenodo.org/record/1436019/export/hx#.W6wUbxxG2Pc>`__):
+
+* PlasmaPy Community, Nicholas A. Murphy, Dominik Stańczak,
+  Pawel M. Kozlowski, Samuel J. Langendorf, Andrew J. Leonard,
+  Jasper P. Beckers, Colby C. Haggerty, Stuart J. Mumford, Ritiek
+  Malhotra, Ludovico Bessi, Sean Carroll, Apoorv Choubey, Roberto Díaz
+  Pérez, Leah Einhorn, Thomas Fan, Graham Goudeau, Silvina Guidoni,
+  Julien Hillairet, Poh Zi How, Yi-Min Huang, Nabil Humphrey, Maria
+  Isupova, Siddharth Kulshrestha, Piotr Kuszaj, Joshua Munn, Tulasi
+  Parashar, Neil Patel, Raajit Raj, Dawa Nurbu Sherpa, David Stansby,
+  Antoine Tavant, and Sixue Xu. (2018, May 27). *PlasmaPy* (Version
+  0.1.1). Zenodo. http://doi.org/10.5281/zenodo.1436019
+
 We highly encourage researchers to acknowledge the packages that
-PlasmaPy depends on, including but not limited to Astropy, NumPy, and
-SciPy.
+PlasmaPy depends on, including but not limited to 
+`Astropy <https://www.astropy.org/acknowledging.html>`__, 
+`NumPy <https://www.scipy.org/citing.html#numpy>`__, and
+`SciPy <https://www.scipy.org/citing.html#scipy-the-library>`__.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 [![PyPI version](https://badge.fury.io/py/plasmapy.svg)](https://badge.fury.io/py/plasmapy)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](./LICENSE.md)
-[![astropy](http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat)](http://www.astropy.org/)
-[![Matrix](https://matrix.to/img/matrix-badge.svg)](https://riot.im/app/#/room/#plasmapy:matrix.org)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PlasmaPy/Lobby)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1436019.svg)](https://doi.org/10.5281/zenodo.1436019)
 
 [![Build Status](https://travis-ci.org/PlasmaPy/PlasmaPy.svg?branch=master)](https://travis-ci.org/PlasmaPy/PlasmaPy)
 [![Build status](https://ci.appveyor.com/api/projects/status/hbduy62sqrvy8rn7?svg=true)](https://ci.appveyor.com/project/namurphy/plasmapy)
 [![codecov](https://codecov.io/gh/PlasmaPy/PlasmaPy/branch/master/graph/badge.svg)](https://codecov.io/gh/PlasmaPy/PlasmaPy)
 [![Documentation Status](https://readthedocs.org/projects/plasmapy/badge/?version=latest)](http://plasmapy.readthedocs.io/en/latest/?badge=latest)
+
+[![Matrix](https://matrix.to/img/matrix-badge.svg)](https://riot.im/app/#/room/#plasmapy:matrix.org)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PlasmaPy/Lobby)
+[![astropy](http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat)](http://www.astropy.org/)
 
 PlasmaPy is an open source community developed Python 3.6+ package for
 plasma physics in the early stages of development.  PlasmaPy intends to

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/plasmapy.svg)](https://badge.fury.io/py/plasmapy)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](./LICENSE.md)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1436019.svg)](https://doi.org/10.5281/zenodo.1436019)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1436011.svg)](https://doi.org/10.5281/zenodo.1436011)
 
 [![Build Status](https://travis-ci.org/PlasmaPy/PlasmaPy.svg?branch=master)](https://travis-ci.org/PlasmaPy/PlasmaPy)
 [![Build status](https://ci.appveyor.com/api/projects/status/hbduy62sqrvy8rn7?svg=true)](https://ci.appveyor.com/project/namurphy/plasmapy)

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -4,22 +4,41 @@ Acknowledging and Citing PlasmaPy
 =================================
 
 If you use PlasmaPy for a project resulting in a publication, we ask
-that you cite the following reference
-(`BibTeX <https://zenodo.org/record/1238132/export/hx#.WvMkQK0cChc>`_):
+that you cite the following reference (`BibTeX
+<https://zenodo.org/record/1238132/export/hx#.WvMkQK0cChc>`_):
 
 * PlasmaPy Community, Nicholas A. Murphy, Andrew J. Leonard, Dominik
   Stańczak, Pawel M. Kozlowski, Samuel J. Langendorf, Colby C. Haggerty,
   Jasper P. Beckers, Stuart J. Mumford, Tulasi N. Parashar, and Yi-Min
-  Huang. (2018, April). PlasmaPy: an open source community-developed
-  Python package for plasma physics. Zenodo.
+  Huang. (2018, April). *PlasmaPy: an open source community-developed
+  Python package for plasma physics.* Zenodo.
   http://doi.org/10.5281/zenodo.1238132
 
-We provide the following standard acknowledgment with this citation that
-you may use instead of a citation in the body of a paper.
+We provide the following standard acknowledgment that you may use
+instead of a citation in the body of a paper.
 
 * This research made use of PlasmaPy, a community-developed open source
   core Python package for plasma physics (PlasmaPy Community 2018).
 
+The source code for the most recent release of PlasmaPy (version
+0.1.1) is archived on `Zenodo
+<https://zenodo.org/communities/plasmapy>`__ and can be cited using
+the following reference (`BibTeX
+<https://zenodo.org/record/1436019/export/hx#.W6wUbxxG2Pc>`__):
+
+* PlasmaPy Community, Nicholas A. Murphy, Dominik Stańczak,
+  Pawel M. Kozlowski, Samuel J. Langendorf, Andrew J. Leonard,
+  Jasper P. Beckers, Colby C. Haggerty, Stuart J. Mumford, Ritiek
+  Malhotra, Ludovico Bessi, Sean Carroll, Apoorv Choubey, Roberto Díaz
+  Pérez, Leah Einhorn, Thomas Fan, Graham Goudeau, Silvina Guidoni,
+  Julien Hillairet, Poh Zi How, Yi-Min Huang, Nabil Humphrey, Maria
+  Isupova, Siddharth Kulshrestha, Piotr Kuszaj, Joshua Munn, Tulasi
+  Parashar, Neil Patel, Raajit Raj, Dawa Nurbu Sherpa, David Stansby,
+  Antoine Tavant, and Sixue Xu. (2018, May 27). *PlasmaPy* (Version
+  0.1.1). Zenodo. http://doi.org/10.5281/zenodo.1436019
+
 We highly encourage researchers to acknowledge the packages that
-PlasmaPy depends on, including but not limited to Astropy, NumPy, and
-SciPy.
+PlasmaPy depends on, including but not limited to 
+`Astropy <https://www.astropy.org/acknowledging.html>`__, 
+`NumPy <https://www.scipy.org/citing.html#numpy>`__, and
+`SciPy <https://www.scipy.org/citing.html#scipy-the-library>`__.

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -57,7 +57,7 @@ def online_help(query):
     webbrowser.open(url)
 
 __citation__ = """@misc{plasmapy_community_2018_1238132,
-  author       = {PlasmaPy Community and
+  author       = {{PlasmaPy Community} and
                   Murphy, Nicholas A. and
                   Leonard, Andrew J. and
                   Sta\'nczak, Dominik and


### PR DESCRIPTION
This PR updates the citation information to reflect that we now have DOIs for our source code!  The DOI that points to our latest release that has been archived on Zenodo is:

[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1436011.svg)](https://doi.org/10.5281/zenodo.1436011)

I uploaded versions 0.1.0 and 0.1.1 and right now the about link points to 0.1.1.  

Closes #144.  Cross-references: #432 and #450