### PR TITLE
Change `# coveralls: ignore` to `# coverage: ignore`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,5 @@ omit =
 exclude_lines =
     coveralls: ignore
     def __repr__
-    NotImplementedError
     ImportError
     ModuleNotFoundError
-    SyntaxError

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,7 @@ omit =
     plasmapy/setup_package.py
     plasmapy/version.py
 exclude_lines =
-    coveralls: ignore
+    coverage: ignore
     def __repr__
     ImportError
     ModuleNotFoundError

--- a/plasmapy/atomic/parsing.py
+++ b/plasmapy/atomic/parsing.py
@@ -343,7 +343,7 @@ def _parse_and_check_atomic_input(argument: Union[str, numbers.Integral], mass_n
 
         return ion
 
-    if not isinstance(argument, (str, numbers.Integral)):  # coveralls: ignore
+    if not isinstance(argument, (str, numbers.Integral)):  # coverage: ignore
         raise TypeError(f"The argument {argument} is not an integer or string.")
 
     arg = _dealias_particle_aliases(argument)

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -487,7 +487,7 @@ class Particle:
         no_particle_attr = 'particle' not in dir(self) or 'particle' not in dir(other)
         no_attributes_attr = '_attributes' not in dir(self) or '_attributes' not in dir(other)
 
-        if no_particle_attr or no_attributes_attr:  # coveralls: ignore
+        if no_particle_attr or no_attributes_attr:  # coverage: ignore
             raise TypeError(f"The equality of {self} with {other} is undefined.")
 
         same_particle = self.particle == other.particle
@@ -508,7 +508,7 @@ class Particle:
 
         same_attributes = self._attributes == other._attributes
 
-        if same_particle and not same_attributes:  # coveralls: ignore
+        if same_particle and not same_attributes:  # coverage: ignore
             raise AtomicError(
                 f"{self} and {other} should be the same Particle, but "
                 f"have differing attributes.\n\n"
@@ -789,7 +789,7 @@ class Particle:
         """
         if self.isotope or self.is_ion or not self.element:
             raise InvalidElementError(_category_errmsg(self, 'element'))
-        if self._attributes['standard atomic weight'] is None:  # coveralls: ignore
+        if self._attributes['standard atomic weight'] is None:  # coverage: ignore
             raise MissingAtomicDataError(
                 f"The standard atomic weight of {self} is unavailable.")
         return self._attributes['standard atomic weight'].to(u.kg)
@@ -827,7 +827,7 @@ class Particle:
 
         base_mass = self._attributes['isotope mass']
 
-        if base_mass is None:  # coveralls: ignore
+        if base_mass is None:  # coverage: ignore
             raise MissingAtomicDataError(f"The mass of a {self.isotope} nuclide is not available.")
 
         _nuclide_mass = self._attributes['isotope mass'] - self.atomic_number * const.m_e
@@ -970,7 +970,7 @@ class Particle:
             return 1
         elif self.isotope:
             return self.mass_number - self.atomic_number
-        else:  # coveralls: ignore
+        else:  # coverage: ignore
             raise InvalidIsotopeError(_category_errmsg(self, 'isotope'))
 
     @property
@@ -996,7 +996,7 @@ class Particle:
             return 1
         elif self.ionic_symbol:
             return self.atomic_number - self.integer_charge
-        else:  # coveralls: ignore
+        else:  # coverage: ignore
             raise InvalidIonError(_category_errmsg(self, 'ion'))
 
     @property
@@ -1018,7 +1018,7 @@ class Particle:
         """
         from .atomic import common_isotopes
 
-        if not self.isotope or self.is_ion:  # coveralls: ignore
+        if not self.isotope or self.is_ion:  # coverage: ignore
             raise InvalidIsotopeError(_category_errmsg(self.particle, 'isotope'))
 
         abundance = self._attributes.get('isotopic abundance', 0.0)
@@ -1050,7 +1050,7 @@ class Particle:
         4
 
         """
-        if self._attributes['baryon number'] is None:  # coveralls: ignore
+        if self._attributes['baryon number'] is None:  # coverage: ignore
             raise MissingAtomicDataError(
                 f"The baryon number for '{self.particle}' is not available.")
         return self._attributes['baryon number']
@@ -1077,7 +1077,7 @@ class Particle:
         0
 
         """
-        if self._attributes['lepton number'] is None:  # coveralls: ignore
+        if self._attributes['lepton number'] is None:  # coverage: ignore
             raise MissingAtomicDataError(
                 f"The lepton number for {self.particle} is not available.")
         return self._attributes['lepton number']
@@ -1195,7 +1195,7 @@ class Particle:
         """
         if self.element:
             return self._attributes['periodic table']
-        else:  # coveralls: ignore
+        else:  # coverage: ignore
             raise InvalidElementError(_category_errmsg(self.particle, 'element'))
 
     @property
@@ -1265,7 +1265,7 @@ class Particle:
             else:
                 return set(arg)
 
-        if category_tuple != () and require != set():  # coveralls: ignore
+        if category_tuple != () and require != set():  # coverage: ignore
             raise AtomicError(
                 "No positional arguments are allowed if the `require` keyword "
                 "is set in is_category.")

--- a/plasmapy/atomic/special_particles.py
+++ b/plasmapy/atomic/special_particles.py
@@ -166,7 +166,7 @@ def _create_Particles_dict() -> Dict[str, dict]:
     for fermion in ParticleZoo.fermions:
         Particles[fermion]['spin'] = 0.5
 
-    for boson in ParticleZoo.bosons:  # coveralls: ignore
+    for boson in ParticleZoo.bosons:  # coverage: ignore
         Particles[boson]['spin'] = 0
 
     for lepton in ParticleZoo.leptons:
@@ -299,7 +299,7 @@ _antiparticles = {
     'anti_nu_tau': 'nu_tau',
 }
 
-if __name__ == "__main__":  # coveralls: ignore
+if __name__ == "__main__":  # coverage: ignore
     from pprint import pprint
     print("Particles:")
     pprint(_Particles)

--- a/plasmapy/classes/species.py
+++ b/plasmapy/classes/species.py
@@ -63,7 +63,7 @@ class Species:
     def __init__(self, plasma, particle_type='p', n_particles=1, scaling=1,
                  dt=np.inf * u.s, nt=np.inf):
 
-        if np.isinf(dt) and np.isinf(nt):  # coveralls: ignore
+        if np.isinf(dt) and np.isinf(nt):  # coverage: ignore
             raise ValueError("Both dt and nt are infinite.")
 
         self.q = atomic.integer_charge(particle_type) * constants.e.si
@@ -191,13 +191,13 @@ class Species:
         return f"Species(q={self.q:.4e},m={self.m:.4e},N={self.N}," \
                f"name=\"{self.name}\",NT={self.NT})"
 
-    def __str__(self):  # coveralls: ignore
+    def __str__(self):  # coverage: ignore
         return f"{self.N} {self.scaling:.2e}-{self.name} with " \
                f"q = {self.q:.2e}, m = {self.m:.2e}, " \
                f"{self.saved_iterations} saved history " \
                f"steps over {self.NT} iterations"
 
-    def plot_trajectories(self):  # coveralls: ignore
+    def plot_trajectories(self):  # coverage: ignore
         r"""Draws trajectory history."""
         from astropy.visualization import quantity_support
         import matplotlib.pyplot as plt
@@ -216,7 +216,7 @@ class Species:
         ax.set_zlabel("$z$ position")
         plt.show()
 
-    def plot_time_trajectories(self, plot="xyz"):  # coveralls: ignore
+    def plot_time_trajectories(self, plot="xyz"):  # coverage: ignore
         r"""
         Draws position history versus time.
 

--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -163,7 +163,7 @@ class Characteristic:
                               can_be_negative=True, can_be_complex=False,
                               can_be_inf=False, can_be_nan=True)
 
-    def get_padded_limit(self, padding, log=False):  # coveralls: ignore
+    def get_padded_limit(self, padding, log=False):  # coverage: ignore
         r"""Return the limits of the current range for plotting, taking into
         account padding. Matplotlib lacks this functionality.
 
@@ -190,7 +190,7 @@ class Characteristic:
             return [ymin - padding * (ymax - ymin),
                     ymax + padding * (ymax - ymin)] * u.A
 
-    def plot(self):  # coveralls: ignore
+    def plot(self):  # coverage: ignore
         r"""Plot the characteristic in matplotlib."""
 
         with quantity_support():
@@ -340,7 +340,7 @@ def swept_probe_analysis(probe_characteristic, probe_area, gas,
     n_e = get_electron_density_LM(I_es, reduce_bimaxwellian_temperature(T_e,
                                   hot_fraction), probe_area)
 
-    if visualize:  # coveralls: ignore
+    if visualize:  # coverage: ignore
         with quantity_support():
             fig, (ax1, ax2) = plt.subplots(2, 1)
             ax1.plot(probe_characteristic.bias,
@@ -378,7 +378,7 @@ def swept_probe_analysis(probe_characteristic, probe_area, gas,
 
     # Obtain and show the EEDF. This is only useful if the characteristic data
     # has been preprocessed to be sufficiently smooth and noiseless.
-    if plot_EEDF:  # coveralls: ignore
+    if plot_EEDF:  # coverage: ignore
         get_EEDF(probe_characteristic, visualize=True)
 
     # Compile the results dictionary
@@ -862,7 +862,7 @@ def get_electron_temperature(exponential_section, bimaxwellian=False,
         # If bi-Maxwellian, return main temperature first
         T_e = np.array([T0, T0 + Delta_T]) * u.eV
 
-    if visualize:  # coveralls: ignore
+    if visualize:  # coverage: ignore
         with quantity_support():
             plt.figure()
 
@@ -950,7 +950,7 @@ def extrapolate_electron_current(probe_characteristic, fit,
     electron_characteristic = Characteristic(probe_characteristic.bias,
                                              electron_current)
 
-    if visualize:  # coveralls: ignore
+    if visualize:  # coverage: ignore
         with quantity_support():
             plt.figure()
             plt.scatter(probe_characteristic.bias,
@@ -1075,7 +1075,7 @@ def get_ion_density_OML(probe_characteristic, probe_area, gas,
     n_i_OML = np.sqrt(-slope * u.mA ** 2 / u.V * np.pi ** 2 * gas /
                       (probe_area ** 2 * const.e ** 3 * 2))
 
-    if visualize:  # coveralls: ignore
+    if visualize:  # coverage: ignore
         with quantity_support():
             plt.figure()
             plt.scatter(ion_section.bias.to(u.V), ion_section.current.to(
@@ -1133,7 +1133,7 @@ def extrapolate_ion_current_OML(probe_characteristic, fit,
 
     ion_characteristic = Characteristic(probe_characteristic.bias, ion_current)
 
-    if visualize:  # coveralls: ignore
+    if visualize:  # coverage: ignore
         with quantity_support():
             plt.figure()
             plt.scatter(probe_characteristic.bias,
@@ -1217,7 +1217,7 @@ def get_EEDF(probe_characteristic, visualize=False):
     integral = np.abs(np.trapz(probability, x=energy.to(u.eV).value))
     probability = probability / integral
 
-    if visualize:  # coveralls: ignore
+    if visualize:  # coverage: ignore
         with quantity_support():
             plt.figure()
             plt.semilogy(energy, probability, c='k')

--- a/plasmapy/import_helpers.py
+++ b/plasmapy/import_helpers.py
@@ -56,13 +56,13 @@ def check_versions(minimum_versions=None):
             raise ImportError(
                 f"Unable to import PlasmaPy because the required "
                 f"package {module_name} cannot be imported.") from None
-        except AttributeError:  # coveralls: ignore
+        except AttributeError:  # coverage: ignore
             warnings.warn(
                 f"{module_name} version {minimum_version.vstring} "
                 "is required for PlasmaPy.  However, the version of "
                 f"{module_name} could not be determined to check if "
                 "this requirement is met.", UserWarning)
-        else:  # coveralls: ignore
+        else:  # coverage: ignore
             if minimum_version > module_version:
                 raise ImportError(
                     f"PlasmaPy requires {module_name} {minimum_version}"

--- a/plasmapy/transport/collisions.py
+++ b/plasmapy/transport/collisions.py
@@ -1786,7 +1786,7 @@ def coupling_parameter(T,
         kineticEnergy = 2 * k_B * T / denom
         if np.all(np.imag(kineticEnergy) == 0):
             kineticEnergy = np.real(kineticEnergy)
-        else:  # coveralls: ignore
+        else:  # coverage: ignore
             raise ValueError("Kinetic energy should not be imaginary."
                              "Something went horribly wrong.")
     coupling = coulombEnergy / kineticEnergy

--- a/plasmapy/utils/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers.py
@@ -488,7 +488,7 @@ def run_test(
     try:
         if result == expected['result']:
             return None
-    except Exception as exc_equality:  # coveralls: ignore
+    except Exception as exc_equality:  # coverage: ignore
         raise TypeError(
             f"The equality of {_represent_result(result)} and "
             f"{_represent_result(expected['result'])} "
@@ -697,7 +697,7 @@ def run_test_equivalent_calls(*test_inputs, require_same_type: bool = True):
 
     try:
         equals_first_result = [result == results[0] for result in results]
-    except Exception as exc:  # coveralls: ignore
+    except Exception as exc:  # coverage: ignore
         raise UnexpectedExceptionError(
             f"Unable to determine equality properties of results."
         ) from exc


### PR DESCRIPTION
This PR renames the comment that we use to specify that a line of code should not be counted in coverage reports (e.g., these lines will not be marked as tested or untested).  We now use Codecov instead of Coveralls, and this commit makes it more general that we ignore these lines for coverage tests rather than one of the above specific platforms.

Additionally, lines with `NotImplementedError` & `SyntaxError` are now no longer automatically ignored in coverage reports.