### PR TITLE
Style and naming fixes in atomic subpackage

### DIFF
--- a/plasmapy/atomic/atomic.py
+++ b/plasmapy/atomic/atomic.py
@@ -47,6 +47,7 @@ __all__ = [
     "periodic_table_category"
 ]
 
+
 @particle_input
 def atomic_number(element: Particle) -> numbers.Integral:
     """
@@ -204,7 +205,11 @@ def standard_atomic_weight(element: Particle) -> u.Quantity:
 
 
 @particle_input(exclude={'neutrino', 'antineutrino'})
-def particle_mass(particle: Particle, *, Z: numbers.Integral = None, mass_numb: numbers.Integral = None) -> u.Quantity:
+def particle_mass(
+        particle: Particle,
+        *,
+        Z: numbers.Integral = None,
+        mass_numb: numbers.Integral = None) -> u.Quantity:
     """
     Return the mass of a particle.
 
@@ -617,7 +622,9 @@ def known_isotopes(argument: Union[str, numbers.Integral] = None) -> List[str]:
     return isotopes_list
 
 
-def common_isotopes(argument: Union[str, numbers.Integral] = None, most_common_only: bool = False) -> List[str]:
+def common_isotopes(
+        argument: Union[str, numbers.Integral] = None,
+        most_common_only: bool = False) -> List[str]:
     """
     Return a list of isotopes of an element with an isotopic abundances
     greater than zero, or if no input is provided, a list of all such

--- a/plasmapy/atomic/nuclear.py
+++ b/plasmapy/atomic/nuclear.py
@@ -7,8 +7,6 @@ import re
 from ..utils import (
     AtomicError,
     InvalidParticleError,
-    InvalidIsotopeError,
-    ChargeError,
 )
 
 from .particle_class import Particle
@@ -18,6 +16,7 @@ __all__ = [
     "nuclear_binding_energy",
     "nuclear_reaction_energy",
 ]
+
 
 @particle_input(any_of={'isotope', 'baryon'})
 def nuclear_binding_energy(particle: Particle, mass_numb: int = None) -> u.Quantity:

--- a/plasmapy/atomic/parsing.py
+++ b/plasmapy/atomic/parsing.py
@@ -121,7 +121,10 @@ def _invalid_particle_errmsg(argument, mass_numb=None, Z=None):
     return errmsg
 
 
-def _parse_and_check_atomic_input(argument: Union[str, numbers.Integral], mass_numb: numbers.Integral = None, Z: numbers.Integral = None):
+def _parse_and_check_atomic_input(
+        argument: Union[str, numbers.Integral],
+        mass_numb: numbers.Integral = None,
+        Z: numbers.Integral = None):
     """
     Parse information about a particle into a dictionary of standard
     symbols, and check the validity of the particle.

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -278,7 +278,11 @@ class Particle:
 
 """
 
-    def __init__(self, argument: Union[str, numbers.Integral], mass_numb: numbers.Integral = None, Z: numbers.Integral = None):
+    def __init__(
+            self,
+            argument: Union[str, numbers.Integral],
+            mass_numb: numbers.Integral = None,
+            Z: numbers.Integral = None):
         """
         Instantiate a `~plasmapy.atomic.Particle` object and set private
         attributes.

--- a/plasmapy/atomic/symbols.py
+++ b/plasmapy/atomic/symbols.py
@@ -24,6 +24,7 @@ __all__ = [
     "element_name",
 ]
 
+
 @particle_input
 def atomic_symbol(element: Particle) -> str:
     """
@@ -152,7 +153,10 @@ def isotope_symbol(isotope: Particle, mass_numb: numbers.Integral = None) -> str
 
 
 @particle_input(require="element", any_of=('charged', 'uncharged'))
-def ionic_symbol(particle: Particle, mass_numb: numbers.Integral = None, Z: numbers.Integral = None) -> str:
+def ionic_symbol(
+        particle: Particle,
+        mass_numb: numbers.Integral = None,
+        Z: numbers.Integral = None) -> str:
     """
     Return the ionic symbol of an ion or neutral atom.
 
@@ -216,9 +220,11 @@ def ionic_symbol(particle: Particle, mass_numb: numbers.Integral = None, Z: numb
     return particle.ionic_symbol
 
 
-
 @particle_input
-def particle_symbol(particle: Particle, mass_numb: numbers.Integral = None, Z: numbers.Integral = None) -> str:
+def particle_symbol(
+        particle: Particle,
+        mass_numb: numbers.Integral = None,
+        Z: numbers.Integral = None) -> str:
     """
     Return the symbol of a particle.
 

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -419,6 +419,7 @@ class TestInvalidPeriodicElement:
 # the correct function to each list containing args, kwargs, and the
 # expected outcome prior to being passed through to run_test.
 
+
 tables_and_functions = [
     (atomic_symbol, atomic_symbol_table),
     (isotope_symbol, isotope_symbol_table),
@@ -637,7 +638,6 @@ def test_half_life_u_220():
             f"data should be chosen for this test.")):
 
         half_life(isotope_without_half_life_data)
-
 
 
 def test_known_common_stable_isotopes_cases():

--- a/plasmapy/atomic/tests/test_nuclear.py
+++ b/plasmapy/atomic/tests/test_nuclear.py
@@ -39,12 +39,12 @@ def test_nuclear(test_inputs):
     run_test(*test_inputs, rtol=1e-3)
 
 
-test_nuclear_equivalent_calls = [
+test_nuclear_equivalent_calls_table = [
     [nuclear_binding_energy, ['He-4', {}], ['alpha', {}], ['He', {'mass_numb': 4}]],
-
 ]
 
-@pytest.mark.parametrize('test_inputs', test_nuclear_equivalent_calls)
+
+@pytest.mark.parametrize('test_inputs', test_nuclear_equivalent_calls_table)
 def test_nuclear_equivalent_calls(test_inputs):
     run_test_equivalent_calls(test_inputs)
 
@@ -123,4 +123,3 @@ def test_nuclear_reaction_energy_kwargs(reactants, products, expectedMeV, tol):
     energy = nuclear_reaction_energy(reactants=reactants, products=products).si
     expected = (expectedMeV * u.MeV).si
     assert np.isclose(expected.value, energy.value, atol=tol)
-

--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -390,7 +390,7 @@ test_Particle_table = [
       'element': 'C',
       'isotope': 'C-14',
       'ionic_symbol': 'C-14 3+',
-     }),
+      }),
 ]
 
 


### PR DESCRIPTION
These are mostly PEP 8 fixes, with one variable in tests of nuclear.py being renamed since it was the same as a function name that was declared immediate after (discovered in mypy test results in #548).
