### PR TITLE
Issue #515: ignore CouplingWarning, RelativityWarning when running tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ norecursedirs = "astropy_helpers" "docs" "build" "docs/_build" "examples" "auto_
 filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
+    ignore::plasmapy.utils.exceptions.RelativityWarning
+    ignore::plasmapy.utils.exceptions.CouplingWarning
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
Closes #515 

You can specifically ignore CouplingWarning, RelativityWarning in setup.cfg. After looking at a couple of different options, this seemed to be the easiest and best approach. This doesn't ignore all warnings as mentioned as an undesirable approach in #515 comments, it ONLY ignores the two mentioned warning types.

This brings the number of warnings when running tests down to 85. The remaining warnings are likely valid and should be investigated separately.