### PR TITLE
Second attempt at optional dependencies

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,12 +22,20 @@ installation:
 - `NumPy <http://www.numpy.org/>`_ 1.13 or newer
 - `SciPy <https://www.scipy.org/>`_ 0.19 or newer
 - `Astropy <http://www.astropy.org/>`_ 2.0 or newer
-- `matplotlib <https://matplotlib.org/>`_ 2.0 or newer
 - `Cython <http://cython.org/>`_ 0.27.2 or newer
-- `h5py <https://www.h5py.org/>`_ 2.8 or newer
-- `mpmath <http://mpmath.org/>`_ 1.0 or newer
-- `lmfit <https://lmfit.github.io/lmfit-py/>`_ 0.9.7 or newer
 - `colorama <https://pypi.org/project/colorama/>`_ 0.3 or newer
+
+PlasmaPy also uses optional dependencies which are grouped as follows
+
+- `visualization` for plotting:
+    - `matplotlib <https://matplotlib.org/>`_ 2.0 or newer
+- `openPMD` for loading `openPMD <https://www.openpmd.org/#/start>`_-compliant datasets:
+    - `h5py <https://www.h5py.org/>`_ 2.8 or newer
+- `analysis` for a few functions from the `physics` and `transport` subpackages:
+    - `mpmath <http://mpmath.org/>`_ 1.0 or newer
+    - `lmfit <https://lmfit.github.io/lmfit-py/>`_ 0.9.7 or newer
+
+The categories above also function as :ref:`extras keys for pip install<install-pip>`.
 
 .. _create-conda-env:
 
@@ -76,7 +84,17 @@ run
 
 .. code:: bash
 
-   pip install plasmapy
+   pip install plasmapy[all]
+
+To install a minimal set of dependencies (which does not guarantee that
+everything will run and may result in `ImportError`s, skip `[all]` and run
+simply
+
+.. code:: bash
+
+    pip install plasmapy
+
+For other optional options, see :ref:`install-requirements`.
 
 .. _install-conda:
 
@@ -84,6 +102,8 @@ Installation with conda
 -----------------------
 
 We’re not on conda just yet, but we’re working on it!
+
+Conda installs all dependencies by default.
 
 Building and installing from source code
 ========================================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,17 +25,15 @@ installation:
 - `Cython <http://cython.org/>`_ 0.27.2 or newer
 - `colorama <https://pypi.org/project/colorama/>`_ 0.3 or newer
 
-PlasmaPy also uses optional dependencies which are grouped as follows
+PlasmaPy also uses the following optional dependencies:
 
-- `visualization` for plotting:
-    - `matplotlib <https://matplotlib.org/>`_ 2.0 or newer
-- `openPMD` for loading `openPMD <https://www.openpmd.org/#/start>`_-compliant datasets:
-    - `h5py <https://www.h5py.org/>`_ 2.8 or newer
-- `analysis` for a few functions from the `physics` and `transport` subpackages:
-    - `mpmath <http://mpmath.org/>`_ 1.0 or newer
-    - `lmfit <https://lmfit.github.io/lmfit-py/>`_ 0.9.7 or newer
+- `matplotlib <https://matplotlib.org/>`_ 2.0 or newer
+- `h5py <https://www.h5py.org/>`_ 2.8 or newer
+- `mpmath <http://mpmath.org/>`_ 1.0 or newer
+- `lmfit <https://lmfit.github.io/lmfit-py/>`_ 0.9.7 or newer
 
-The categories above also function as :ref:`extras keys for pip install<install-pip>`.
+PlasmaPy can be installed with all of the optional dependencies via
+`pip install plasmapy[optional]`.
 
 .. _create-conda-env:
 
@@ -79,12 +77,12 @@ Installation with pip
 ---------------------
 
 To install the most recent release of PlasmaPy `on PyPI`_ with `pip
-<https://pip.pypa.io/en/stable/>`_ into an existing Python environment,
-run
+<https://pip.pypa.io/en/stable/>`_ into an existing Python environment
+alongside all optional dependencies, run
 
 .. code:: bash
 
-   pip install plasmapy[all]
+   pip install plasmapy[optional]
 
 To install a minimal set of dependencies (which does not guarantee that
 everything will run and may result in `ImportError`s, skip `[all]` and run
@@ -93,8 +91,6 @@ simply
 .. code:: bash
 
     pip install plasmapy
-
-For other optional options, see :ref:`install-requirements`.
 
 .. _install-conda:
 

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -23,16 +23,6 @@ class UnsupportedPythonError(Exception):
 if sys.version_info < tuple((int(val) for val in "3.6".split('.'))):
     raise UnsupportedPythonError("plasmapy does not support Python < {}".format(3.6))
 
-if not _ASTROPY_SETUP_:
-    # For egg_info test builds to pass, put package imports here.
-    from . import atomic
-    from . import classes
-    from . import constants
-    from . import diagnostics
-    from . import mathematics
-    from . import physics
-    from . import utils
-
 def online_help(query):
     """
     Search the online PlasmaPy documentation for the given query from plasmapy.org

--- a/plasmapy/classes/sources/openpmd_hdf5.py
+++ b/plasmapy/classes/sources/openpmd_hdf5.py
@@ -1,6 +1,10 @@
-import h5py
 import numpy as np
 import astropy.units as u
+try:
+    import h5py
+except (ImportError, ModuleNotFoundError) as e:
+    from plasmapy.optional_deps import h5py_import_error
+    raise ImportError(h5py_import_error) from e
 
 from plasmapy.classes import GenericPlasma
 from plasmapy.utils import DataStandardError

--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -6,7 +6,11 @@ from plasmapy import utils
 import plasmapy.constants as const
 import copy
 from astropy.visualization import quantity_support
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except (ImportError, ModuleNotFoundError) as e:
+    from plasmapy.optional_deps import mpl_import_error
+    raise mpl_import_error from e
 from scipy.optimize import curve_fit
 from plasmapy.atomic import Particle
 

--- a/plasmapy/mathematics/mathematics.py
+++ b/plasmapy/mathematics/mathematics.py
@@ -3,7 +3,11 @@
 import numbers
 import numpy as np
 from astropy import units as u
-from mpmath import polylog
+try:
+    from mpmath import polylog
+except (ImportError, ModuleNotFoundError) as e:
+    from plasmapy.optional_deps import mpmath_import_error
+    raise mpmath_import_error from e
 from scipy.special import wofz as Faddeeva_function
 from typing import Union
 

--- a/plasmapy/optional_deps.py
+++ b/plasmapy/optional_deps.py
@@ -1,0 +1,50 @@
+""" Useful error messages for optional dependencies that aren't found. """
+from typing import Optional
+
+def _template(pkgname: str,
+              url: str,
+              library: Optional[str] = None) -> ImportError:
+    """
+    Simple template to prevent text duplication.
+
+    Parameters
+    ----------
+    pkgname : str
+        Package name on pip or conda
+    url : str
+        Link to install page for given package
+    library : str (optional)
+        Full package name
+
+    Returns
+    -------
+    ImportError
+
+    """
+    library = pkgname if library is None else library
+    template = f"""
+    {library} could not be found. Try either
+
+        conda install {pkgname}
+        
+    on Anaconda environments or
+        
+        pip install {pkgname}
+
+    in general. In case of trouble refer to
+    {url}"""
+
+    return ImportError(template)
+
+h5py_import_error = _template("h5py",
+                              "http://docs.h5py.org/en/latest/build.html")
+
+mpl_import_error = _template("matplotlib",
+                             "https://matplotlib.org/users/installing.html")
+
+mpmath_import_error = _template("mpmath",
+                                "http://mpmath.org/doc/current/setup.html#download-and-installation")
+
+lmfit_import_error = _template("lmfit",
+                               "https://lmfit.github.io/lmfit-py/installation.html")
+

--- a/plasmapy/optional_deps.py
+++ b/plasmapy/optional_deps.py
@@ -1,9 +1,12 @@
 """ Useful error messages for optional dependencies that aren't found. """
 from typing import Optional
 
-def _template(pkgname: str,
-              url: str,
-              library: Optional[str] = None) -> ImportError:
+
+def _optional_import_error_template(pkgname: str,
+                                    url: str,
+                                    library: Optional[str] = None,
+                                    conda_channel: Optional[str] = None,
+                                    ) -> ImportError:
     """
     Simple template to prevent text duplication.
 
@@ -15,6 +18,8 @@ def _template(pkgname: str,
         Link to install page for given package
     library : str (optional)
         Full package name
+    conda_channel: str (optional)
+        set to "conda-forge" to add -c conda-forge to the conda install line
 
     Returns
     -------
@@ -22,29 +27,35 @@ def _template(pkgname: str,
 
     """
     library = pkgname if library is None else library
+    conda_channel = f"-c {conda_channel} " if conda_channel is not None else ""
+
     template = f"""
     {library} could not be found. Try either
 
-        conda install {pkgname}
+        conda install {conda_channel}{pkgname}
         
     on Anaconda environments or
         
         pip install {pkgname}
 
     in general. In case of trouble refer to
-    {url}"""
+    
+        {url} 
+    
+    (link active as of 2018.10.31 - please report dead links on GitHub!)"""
 
     return ImportError(template)
 
-h5py_import_error = _template("h5py",
+
+h5py_import_error = _optional_import_error_template("h5py",
                               "http://docs.h5py.org/en/latest/build.html")
 
-mpl_import_error = _template("matplotlib",
+mpl_import_error = _optional_import_error_template("matplotlib",
                              "https://matplotlib.org/users/installing.html")
 
-mpmath_import_error = _template("mpmath",
+mpmath_import_error = _optional_import_error_template("mpmath",
                                 "http://mpmath.org/doc/current/setup.html#download-and-installation")
 
-lmfit_import_error = _template("lmfit",
+lmfit_import_error = _optional_import_error_template("lmfit",
                                "https://lmfit.github.io/lmfit-py/installation.html")
 

--- a/plasmapy/physics/quantum.py
+++ b/plasmapy/physics/quantum.py
@@ -6,6 +6,11 @@ gases and warm dense matter.
 # python modules
 import numpy as np
 from astropy import units as u
+try:
+    from lmfit import minimize, Parameters
+except (ImportError, ModuleNotFoundError) as e:
+    from plasmapy.optional_deps import lmfit_import_error
+    raise lmfit_import_error from e
 
 # plasmapy modules
 from plasmapy import atomic, utils, mathematics
@@ -447,7 +452,6 @@ def chemical_potential(n_e: u.m ** -3, T: u.K):
     <Quantity 2.00039985e-12>
 
     """
-    from lmfit import minimize, Parameters
     # deBroglie wavelength
     lambdaDB = thermal_deBroglie_wavelength(T)
     # degeneracy parameter

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ edit_on_github = True
 github_project = PlasmaPy/PlasmaPy
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = numpy, scipy, astropy, cython, lmfit, matplotlib, colorama, mpmath, h5py
+install_requires = numpy, scipy, astropy, cython, colorama
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.1.dev
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,14 @@ github_project = PlasmaPy/PlasmaPy
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
 install_requires = numpy, scipy, astropy, cython, colorama
+
+extra_requires = classes, diagnostics, tests, math, physics
+classes_requires = h5py, matplotlib
+diagnostics_requires = matplotlib
+tests_requires = pytest, pytest_astropy
+math_requires = mpmath
+physics_requires = lmfit
+
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.1.dev
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 import glob
 import os
 import sys
+import itertools
 
 # Enforce Python version check - this is the same check as in __init__.py but
 # this one has to happen before importing ah_bootstrap.
@@ -127,14 +128,13 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 
 setup_requires = ['numpy']
 
-extras_require = {'openPMD': ["h5py"],
-                  'visualization': ["matplotlib"],
-                  'analysis': ["lmfit", "mpmath"],
-                  'tests': ["pytest", "pytest-astropy"]}
-extras_require['all'] = extras_require['openPMD'] +\
-                        extras_require['visualization'] + \
-                        extras_require['analysis'] + \
-                        extras_require['tests']
+extra_tags = [m.strip() for m in metadata.get("extra_requires", "").split(',')] 
+if extra_tags: 
+     extras_require = {tag: [m.strip() for m in metadata[f"{tag}_requires"].split(',')] 
+                       for tag in extra_tags} 
+     extras_require['all'] = list(itertools.chain.from_iterable(extras_require.values())) 
+else:
+     extras_require = None 
 
 # Make sure to have the packages needed for building PlasmaPy, but do not require them
 # when installing from an sdist as the c files are included there.

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setup(name=PACKAGENAME,
       include_package_data=True,
       entry_points=entry_points,
       python_requires='>={}'.format("3.6"),
-      tests_require=extras_require['tests'],
+      tests_require=extras_require.get("all", ""),
       extras_require=extras_require,
       **package_info
 )

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,15 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 
 setup_requires = ['numpy']
 
+extras_require = {'openPMD': ["h5py"],
+                  'visualization': ["matplotlib"],
+                  'analysis': ["lmfit", "mpmath"],
+                  'tests': ["pytest", "pytest-astropy"]}
+extras_require['all'] = extras_require['openPMD'] +\
+                        extras_require['visualization'] + \
+                        extras_require['analysis'] + \
+                        extras_require['tests']
+
 # Make sure to have the packages needed for building PlasmaPy, but do not require them
 # when installing from an sdist as the c files are included there.
 if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
@@ -172,6 +181,7 @@ setup(name=PACKAGENAME,
       include_package_data=True,
       entry_points=entry_points,
       python_requires='>={}'.format("3.6"),
-      tests_require=["pytest", "pytest-astropy"],
+      tests_require=extras_require['tests'],
+      extras_require=extras_require,
       **package_info
 )

--- a/setup.py
+++ b/setup.py
@@ -129,10 +129,14 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 setup_requires = ['numpy']
 
 extra_tags = [m.strip() for m in metadata.get("extra_requires", "").split(',')] 
-if extra_tags: 
+if extra_tags:
+     # TODO: the line below will prove useful once #576 is in play
      extras_require = {tag: [m.strip() for m in metadata[f"{tag}_requires"].split(',')] 
-                       for tag in extra_tags} 
-     extras_require['all'] = list(itertools.chain.from_iterable(extras_require.values())) 
+                       for tag in extra_tags}
+
+    # but for now we'll limit ourselves to pip install plasmapy[optional]
+     optionals_require = list(itertools.chain.from_iterable(extras_require.values()))
+     extras_require = dict(optional=optionals_require)
 else:
      extras_require = None 
 
@@ -181,7 +185,7 @@ setup(name=PACKAGENAME,
       include_package_data=True,
       entry_points=entry_points,
       python_requires='>={}'.format("3.6"),
-      tests_require=extras_require.get("all", ""),
+      tests_require=extras_require.get("optional", ""),
       extras_require=extras_require,
       **package_info
 )


### PR DESCRIPTION
Closes #522 later.

This implements what I started writing in PLEP8 (`pip install plasmapy[all]`) and solves the issue of what @dstansby [was referring to over here](https://github.com/PlasmaPy/PlasmaPy/pull/533#discussion_r220880549). This is going to be a breaking change (I'm not yet 100% sure I've got the implementation right), but I believe it's one we need to make (will explain later).

Checklist:
* [x] extras_require
* [x] remove main namespace imports
* [x] update documentation