### PR TITLE
Update list of PlasmaPy contributors in docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,12 @@ Here are a few things to keep in mind when making a pull request (PR).
   to be made before the PR is merged.
 * PlasmaPy follows the PEP 8 style guide: https://www.python.org/dev/peps/pep-0008
 * Please double check that a new PR will not duplicate an existing PR.
-* If this PR will solve an issue tracked by GitHub, please add a phrase like 
-  "Closes #404." to automatically close the issue once the pull request is 
-  merged.  If your PR will not completely solve the issue, please still 
+* If this PR will solve an issue tracked by GitHub, please add a phrase like
+  "Closes #404." to automatically close the issue once the pull request is
+  merged.  If your PR will not completely solve the issue, please still
   reference the issue.
+* If this is your first contribution, please add your name to the author
+  list in `docs/about/credits.rst`.
 * Feel free to chat with other developers on our Matrix channel at:
   https://riot.im/app/#/room/#plasmapy:matrix.org
+

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -19,41 +19,62 @@ PlasmaPy Contributors
    GitHub page, so it is important to check the git log as well to make
    sure we are not missing anyone.
 
-* Jasper Beckers
-* Ludovico Bessi
-* Sean Carroll
-* Apoorv Choubey
-* cclauss
-* Leah Einhorn
-* Thomas Fan
-* Graham Goudeau
-* Silvina Guidoni
-* Colby Haggerty
-* Julien Hillairet
-* Poh Zi How
-* Yi-Min Huang
-* Nabil Humphrey
-* Maria Isupova
-* Pawel Kozlowski
-* Siddharth Kulshrestha
-* Piotr Kuszaj
-* Samuel Langendorf
-* Drew Leonard
-* Ritiek Malhotra
-* Stuart Mumford
-* Joshua Munn
-* Nick Murphy
-* Nismirno
-* nrb1324
-* Tulasi Parashar
-* Neil Patel
-* Roberto Díaz Pérez
-* Raajit Raj
-* Dawa Nurbu Sherpa
-* David Stansby
-* Dominik Stańczak
-* Antoine Tavant
-* Sixue Xu
+The following people have contributed to PlasmaPy:
+
+* `Jasper Beckers <https://github.com/jasperbeckers>`__
+* `Manas Bedmutha <https://github.com/manasbedmutha98>`__
+* `Ludovico Bessi <https://github.com/ludoro>`__
+* `BH4 <https://github.com/BH4>`__
+* `Sean Carroll <https://github.com/seanwilliamcarroll>`__
+* `Sean Chambers <https://github.com/schambers>`__
+* `Apoorv Choubey <https://github.com/apooravc>`__
+* `cclauss <https://github.com/cclauss>`__
+* `Leah Einhorn <https://github.com/leahein>`__
+* `Thomas Fan <https://github.com/thomasjpfan>`__
+* `Samaiyah Farid <https://github.com/samaiyahfarid>`__
+* `Michael Fischer <https://github.com/mj-fischer>`__
+* `Graham Goudeau <https://github.com/GrahamGoudeau>`__
+* `Silvina Guidoni <https://www.american.edu/cas/faculty/guidoni.cfm>`__
+* `Colby Haggerty <https://github.com/colbych>`__
+* `Julien Hillairet <https://github.com/jhillairet>`__ (`0000-0002-1073-6383 <https://orcid.org/0000-0002-1073-6383>`__)
+* `Poh Zi How <https://github.com/pohzipohzi>`__
+* `Yi-Min Huang <https://github.com/yopology>`__ (`0000-0002-4237-2211 <https://orcid.org/0000-0002-4237-2211>`__)
+* `Nabil Humphrey <https://github.com/NabilHumphrey>`__
+* `Maria Isupova <https://github.com/misupova>`__
+* `Pawel Kozlowski <https://github.com/lemmatum>`__ (`0000-0001-6849-3612 <https://orcid.org/0000-0001-6849-3612>`__)
+* `Siddharth Kulshrestha <https://github.com/siddharth185>`__
+* `Piotr Kuszaj <https://github.com/kuszaj>`__
+* `Samuel Langendorf <https://github.com/samurai688>`__ (`0000-0002-7757-5879 <https://orcid.org/0000-0002-7757-5879>`__)
+* `Drew Leonard <https://github.com/SolarDrew>`__ (`0000-0001-5270-7487 <https://orcid.org/0000-0001-5270-7487>`__)
+* `lgoenner <https://github.com/lgoenner>`__
+* `Ritiek Malhotra <https://github.com/ritiek>`__
+* `Stuart Mumford <https://github.com/Cadair>`__ (`0000-0003-4217-4642 <https://orcid.org/0000-0003-4217-4642>`__)
+* `Joshua Munn <https://github.com/jams2>`__
+* `Nick Murphy <https://github.com/namurphy>`__ (`0000-0001-6628-8033 <https://orcid.org/0000-0001-6628-8033>`__)
+* `Nismirno <https://github.com/Nismirno>`__
+* `nrb1324 <https://github.com/nrb1324>`__
+* `Tulasi Parashar <https://github.com/tulasinandan>`__ (`0000-0003-0602-8381 <https://orcid.org/0000-0003-0602-8381>`__)
+* `Neil Patel <https://github.com/ministrike3>`__
+* `Francisco Silva Pavon <https://github.com/fsilvapavon>`__
+* `Roberto Díaz Pérez <https://github.com/RobertTnf>`__
+* `Raajit Raj <https://github.com/raajitr>`__
+* `Antonia Savcheva <https://github.com/savcheva>`__ (`0000-0002-5598-046X <https://orcid.org/0000-0002-5598-046X>`__)
+* `Chengcai Shen <https://github.com/ionizationcalc>`__ (`0000-0002-9258-4490 <https://orcid.org/0000-0002-9258-4490>`__)
+* `Dawa Nurbu Sherpa <https://github.com/nurbu5>`__
+* `Ankit Singh <https://github.com/Griffintaur>`__
+* `David Stansby <https://github.com/dstansby>`__ (`0000-0002-1365-1908 <https://orcid.org/0000-0002-1365-1908>`__)
+* `Dominik Stańczak <https://github.com/StanczakDominik>`__ (`0000-0001-6291-8843 <https://orcid.org/0000-0001-6291-8843>`__)
+* `Antoine Tavant <https://github.com/antoinelpp>`__
+* `Thomas Ulrich <https://github.com/Elfhelm>`__
+* `Sixue Xu <https://github.com/hzxusx>`__
+
+This list contains contributors to PlasmaPy's core package and vision
+statement, including a few people whose contributions do not show up `on
+GitHub  <https://github.com/PlasmaPy/PlasmaPy/graphs/contributors>`__.
+If you made a contribution that was merged and your name is missing from
+the list, your information is incorrect, or you do not wish to be
+listed, then please submit a pull request or email Nick Murphy at
+``namurphy@cfa.harvard.edu``.
 
 Other Credits
 =============

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -19,7 +19,8 @@ PlasmaPy Contributors
    GitHub page, so it is important to check the git log as well to make
    sure we are not missing anyone.
 
-The following people have contributed to PlasmaPy:
+The people in the following list have contributed to PlasmaPy.  Included
+in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 
 * `Jasper Beckers <https://github.com/jasperbeckers>`__
 * `Manas Bedmutha <https://github.com/manasbedmutha98>`__
@@ -31,7 +32,7 @@ The following people have contributed to PlasmaPy:
 * `cclauss <https://github.com/cclauss>`__
 * `Leah Einhorn <https://github.com/leahein>`__
 * `Thomas Fan <https://github.com/thomasjpfan>`__
-* `Samaiyah Farid <https://github.com/samaiyahfarid>`__
+* `Samaiyah I. Farid <https://github.com/samaiyahfarid>`__
 * `Michael Fischer <https://github.com/mj-fischer>`__
 * `Graham Goudeau <https://github.com/GrahamGoudeau>`__
 * `Silvina Guidoni <https://www.american.edu/cas/faculty/guidoni.cfm>`__
@@ -69,12 +70,12 @@ The following people have contributed to PlasmaPy:
 * `Sixue Xu <https://github.com/hzxusx>`__
 
 This list contains contributors to PlasmaPy's core package and vision
-statement, including a few people whose contributions do not show up `on
-GitHub  <https://github.com/PlasmaPy/PlasmaPy/graphs/contributors>`__.
-If you made a contribution that was merged and your name is missing from
-the list, your information is incorrect, or you do not wish to be
-listed, then please submit a pull request or email Nick Murphy at
-``namurphy@cfa.harvard.edu``.
+statement, including a few people who do not show up as `PlasmaPy
+contributors on GitHub
+<https://github.com/PlasmaPy/PlasmaPy/graphs/contributors>`__. If you
+made a contribution that was merged and your name is missing from the
+list, your information is incorrect, or you do not wish to be listed,
+then please submit a pull request or email ``namurphy@cfa.harvard.edu``.
 
 Other Credits
 =============


### PR DESCRIPTION
I went through and added our recent contributors to the list of PlasmaPy authors that we have in the docs.  I also added [ORCID](https://orcid.org/) unique author identifier numbers and linked to GitHub usernames in this list.  For people whose name I was not able to find, I included GitHub usernames directly in the list.

I'm going to add some information to the contribution guide and maybe the PR template about the credits list.  

