### PR TITLE
[WIP] Cleaner warning display in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,3 @@
-deps-run: &deps-install
-  name: Install Python dependencies and PlasmaPy
-  command: |
-    pip install --user -r requirements/automated-documentation-tests.txt | cat
-    pip install --user . | cat
-
-html-run: &doc-html
-  name: Build HTML documentation
-  command: python setup.py build_docs -w
-
-latex-run: &doc-latex
-  name: Build LaTeX documentation
-  command: python setup.py build_docs -b latex -w
-
 version: 2
 jobs:
   test-html:
@@ -19,14 +5,30 @@ jobs:
       - image: plasmapy/documentation-builder:latest
     steps:
       - checkout
-      - run: *deps-install
-      - run: *doc-html
+      - run: 
+          name: Install Python dependencies and PlasmaPy
+          command: |
+            pip install --user -r requirements/automated-documentation-tests.txt | cat
+            pip install --user . | cat
+      - run:
+          name: Build HTML documentation
+          shell: /bin/bash
+          command: |
+            python setup.py build_docs -W 2> >(tee /tmp/stderr) 1> >(tee /tmp/stdout) || true; echo $? | tee /tmp/EXITCODE
       - store_artifacts:
           path: docs/_build/html
       - run:
           name: "Built documentation is available at:"
           command: DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/_build/html/index.html"; echo $DOCS_URL
-      - run: *doc-latex
+      - run:
+          name: "Output from html documentation build is:"
+          command: cat /tmp/stdout
+      - run:
+          name: "Error from html documentation build is:"
+          command: cat /tmp/stderr && [ $(cat /tmp/EXITCODE) -eq 0 ]
+      - run: 
+          name: Build LaTeX documentation
+          command: python setup.py build_docs -b latex -w
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,13 @@ jobs:
       - run:
           name: Build HTML documentation
           shell: /bin/bash
+          # command needed to not fail the build step on non-zero exit code from sphinx
+          # (now is not the time for build fail)
+          # (that comes later)
           command: |
+            # build docs, sending standard output and error to separate files in /tmp
+            # || true ignores the error code as stated above
+            # echo | tee prints out sphinx's error code and saves it to /tmp
             python setup.py build_docs -W 2> >(tee /tmp/stderr) 1> >(tee /tmp/stdout) || true; echo $? | tee /tmp/EXITCODE
       - store_artifacts:
           path: docs/_build/html
@@ -25,6 +31,8 @@ jobs:
           command: cat /tmp/stdout
       - run:
           name: "Error from html documentation build is:"
+          # display stderr from build AND assert the build went successfully
+          # build errors should fail at this stage
           command: cat /tmp/stderr && [ $(cat /tmp/EXITCODE) -eq 0 ]
       - run: 
           name: Build LaTeX documentation


### PR DESCRIPTION
I have applied BASH MAGIC to the doc builder, it'll save stdout and stderr to files - now I can:
* [x] hopefully display them separately as needed
* [x] check if warnings are empty, if they are, return 1 and fail the build