### PR TITLE
Follow up to astropy 3.1.1 unit bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
         - NUMPY_VERSION='stable'
         - ASTROPY_VERSION='stable'
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='Cython astropy scipy h5py matplotlib mpmath pytest'
-        - CONDA_ALL_DEPENDENCIES='Cython astropy scipy h5py matplotlib mpmath pytest'
+        - CONDA_DEPENDENCIES='Cython scipy h5py matplotlib mpmath pytest'
+        - CONDA_ALL_DEPENDENCIES='Cython scipy h5py matplotlib mpmath pytest'
         - PIP_DEPENDENCIES='roman lmfit colorama codecov'
 
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,16 +37,13 @@ matrix:
           stage: Generic tests
 
         - env: ASTROPY_VERSION='dev'
-          stage: Generic tests
-#          stage: Cron tests
+          stage: Cron tests
 
         - env: NUMPY_VERSION='dev'
-          stage: Generic tests
-#          stage: Cron tests
+          stage: Cron tests
 
         - env: NUMPY_VERSION='dev' ASTROPY_VERSION='dev'
-          stage: Generic tests
-#          stage: Cron tests
+          stage: Cron tests
 
 install:
         - git clone git://github.com/astropy/ci-helpers.git --depth 1

--- a/plasmapy/mathematics/tests/test_Fermi_integral.py
+++ b/plasmapy/mathematics/tests/test_Fermi_integral.py
@@ -48,14 +48,6 @@ class Test_Fermi_integral:
                   f"not be equal to {fail1}.")
         assert testTrue, errStr
 
-    def test_polog_fail(self):
-        """
-        Test whether Fermi_integral fails due to `~mpmath.polylog`
-        not having an implementation for larger argument values.
-        """
-        with pytest.raises(NotImplementedError):
-            Fermi_integral(self.argFail1, self.order1)
-
     def test_array(self):
         """Test Fermi_integral where argument is an array of inputs."""
         methodVals = Fermi_integral(self.args, self.order1)

--- a/plasmapy/physics/tests/test_quantum.py
+++ b/plasmapy/physics/tests/test_quantum.py
@@ -181,14 +181,6 @@ class Test_chemical_potential:
                   f"should not be equal to {fail1}.")
         assert testTrue, errStr
 
-    def test_polog_fail(self):
-        """
-        Tests whether Fermi_integral() fails due to polylog from mpmath
-        not having an implementation for larger argument values.
-        """
-        with pytest.raises(NotImplementedError):
-            chemical_potential(self.n_e_fail, self.T)
-
 
 class Test__chemical_potential_interp:
     @classmethod

--- a/plasmapy/utils/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers.py
@@ -25,6 +25,22 @@ _func_color = f"{_cyan}{_bold}"
 _result_color = f"{_blue}{_bold}"
 _message_color = f"{_red}{_bold}"
 
+__all__ = [
+    "RunTestError",
+    "UnexpectedResultError",
+    "InconsistentTypeError",
+    "MissingExceptionError",
+    "UnexpectedResultError",
+    "MissingExceptionError",
+    "MissingWarningError",
+    "IncorrectResultError",
+    "InvalidTestError",
+    "call_string",
+    "run_test",
+    "run_test_equivalent_calls",
+    "assert_can_handle_nparray",
+]
+
 
 class RunTestError(Exception):
     """Base exception for test failures. Derived from `Exception`."""


### PR DESCRIPTION
I guess f8fac842ea1e074aba60d93f91fbdecf153987bf was broken in that it provided two mentions of astropy and this is causing conflicts.

Closes #589 and closes #587 too.