### PR TITLE
Remove message keyword argument in pytest.raises and pytest.warns

### DIFF
--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -634,12 +634,12 @@ def test_half_life_u_220():
 
     with pytest.raises(MissingAtomicDataError):
         half_life(isotope_without_half_life_data)
-        pytest.fail((
+        pytest.fail(
             f"This test assumes that {isotope_without_half_life_data} does "
             f"not have half-life data.  If half-life data is added for this "
             f"isotope, then a different isotope that does not have half-life "
             f"data should be chosen for this test."
-        ))
+        )
 
 
 def test_known_common_stable_isotopes_cases():

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -632,13 +632,14 @@ def test_half_life_u_220():
 
     isotope_without_half_life_data = "No-248"
 
-    with pytest.raises(MissingAtomicDataError, message=(
+    with pytest.raises(MissingAtomicDataError):
+        half_life(isotope_without_half_life_data)
+        pytest.fail((
             f"This test assumes that {isotope_without_half_life_data} does "
             f"not have half-life data.  If half-life data is added for this "
             f"isotope, then a different isotope that does not have half-life "
-            f"data should be chosen for this test.")):
-
-        half_life(isotope_without_half_life_data)
+            f"data should be chosen for this test."
+        ))
 
 
 def test_known_common_stable_isotopes_cases():
@@ -692,9 +693,9 @@ def test_known_common_stable_isotopes_error(func):
     """Test that `known_isotopes`, `common_isotopes`, and
     `stable_isotopes` raise an `~plasmapy.utils.InvalidElementError` for
     neutrons."""
-    with pytest.raises(InvalidElementError, message=(
-            f"{func} is not raising a ElementError for neutrons.")):
+    with pytest.raises(InvalidElementError):
         func('n')
+        pytest.fail(f"{func} is not raising a ElementError for neutrons.")
 
 
 def test_isotopic_abundance():
@@ -708,9 +709,9 @@ def test_isotopic_abundance():
     with pytest.warns(AtomicWarning):
         isotopic_abundance('Og', 294)
 
-    with pytest.raises(InvalidIsotopeError, message="No exception raised for "
-                                                    "neutrons"):
+    with pytest.raises(InvalidIsotopeError):
         isotopic_abundance('neutron')
+        pytest.fail("No exception raised for neutrons.")
 
     with pytest.raises(InvalidParticleError):
         isotopic_abundance('Og-2')

--- a/plasmapy/atomic/tests/test_ionization_state.py
+++ b/plasmapy/atomic/tests/test_ionization_state.py
@@ -532,11 +532,11 @@ class Test_IonizationStateNumberDensitiesSetter:
             "number_densities was set.")
 
     def test_that_negative_density_raises_error(self):
-        with pytest.raises(AtomicError, message="cannot be negative"):
+        with pytest.raises(AtomicError, match="cannot be negative"):
             self.instance.number_densities = u.Quantity([-0.1, 0.2], unit=u.m**-3)
 
     def test_incorrect_number_of_charge_states_error(self):
-        with pytest.raises(AtomicError, message="Incorrect number of charge states"):
+        with pytest.raises(AtomicError, match="Incorrect number of charge states"):
             self.instance.number_densities = u.Quantity([0.1, 0.2, 0.3], unit=u.m**-3)
 
     def test_incorrect_units_error(self):

--- a/plasmapy/atomic/tests/test_ionization_states.py
+++ b/plasmapy/atomic/tests/test_ionization_states.py
@@ -476,8 +476,9 @@ class TestIonizationStatesAttributes:
         command = f"self.instance.{attribute} = {invalid_value}"
         errmsg = f"No {expected_exception} was raised for command\n\n: {command}"
 
-        with pytest.raises(expected_exception, message=errmsg):
+        with pytest.raises(expected_exception):
             exec(command)
+            pytest.fail(errmsg)
 
     def test_setting_ionic_fractions_for_single_element(self):
         """
@@ -512,8 +513,9 @@ class TestIonizationStatesAttributes:
         errmsg = (
             f"No {expected_exception} is raised when trying to assign "
             f"{invalid_fracs} to {key} in an IonizationStates instance.")
-        with pytest.raises(expected_exception, message=errmsg):
+        with pytest.raises(expected_exception):
             self.instance[key] = invalid_fracs
+            pytest.fail(errmsg)
 
     def test_setting_incomplete_abundances(self):
         new_abundances = {'H': 1, 'He': 0.1, 'Fe': 1e-5, 'Au': 1e-8}  # missing lithium

--- a/plasmapy/atomic/tests/test_parsing.py
+++ b/plasmapy/atomic/tests/test_parsing.py
@@ -256,10 +256,10 @@ def test_parse_InvalidParticleErrors(arg, kwargs):
     to a real particle."""
     with pytest.raises(InvalidParticleError):
         _parse_and_check_atomic_input(arg, **kwargs)
-        pytest.fail((
+        pytest.fail(
             "An InvalidParticleError was expected to be raised by "
             f"{_call_string(arg, kwargs)}, but no exception was raised."
-        ))
+        )
 
 @pytest.mark.parametrize('arg', ParticleZoo.everything - {'p+'})
 def test_parse_InvalidElementErrors(arg):
@@ -268,10 +268,10 @@ def test_parse_InvalidElementErrors(arg):
     particle but not a valid element, isotope, or ion."""
     with pytest.raises(InvalidElementError):
         _parse_and_check_atomic_input(arg)
-        pytest.fail((
+        pytest.fail(
             "An InvalidElementError was expected to be raised by "
             f"{_call_string(arg)}, but no exception was raised."
-        ))
+        )
 
 
 # (arg, kwargs, num_warnings)
@@ -289,14 +289,14 @@ def test_parse_AtomicWarnings(arg, kwargs, num_warnings):
     r"""Tests that _parse_and_check_atomic_input issues an AtomicWarning
     under the required conditions.  """
 
-    try:
-        with pytest.warns(AtomicWarning) as record:
-            _parse_and_check_atomic_input(arg, **kwargs)
-    except pytest.fail.Exception:
-        pytest.fail((
-            f"No AtomicWarning was issued by {_call_string(arg, kwargs)} but "
-            f"the expected number of warnings was {num_warnings}"
-        ))
+    with pytest.warns(AtomicWarning) as record:
+        _parse_and_check_atomic_input(arg, **kwargs)
+        if record:
+            pytest.fail(
+                f"No AtomicWarning was issued by "
+                f"{_call_string(arg, kwargs)} but the expected number "
+                f"of warnings was {num_warnings}"
+            )
 
     assert len(record) == num_warnings, (
         f"The number of AtomicWarnings issued by {_call_string(arg, kwargs)} "

--- a/plasmapy/atomic/tests/test_parsing.py
+++ b/plasmapy/atomic/tests/test_parsing.py
@@ -254,21 +254,24 @@ def test_parse_InvalidParticleErrors(arg, kwargs):
     r"""Tests that _parse_and_check_atomic_input raises an
     InvalidParticleError when the input does not correspond
     to a real particle."""
-    with pytest.raises(InvalidParticleError, message=(
-            "An InvalidParticleError was expected to be raised by "
-            f"{_call_string(arg, kwargs)}, but no exception was raised.")):
+    with pytest.raises(InvalidParticleError):
         _parse_and_check_atomic_input(arg, **kwargs)
-
+        pytest.fail((
+            "An InvalidParticleError was expected to be raised by "
+            f"{_call_string(arg, kwargs)}, but no exception was raised."
+        ))
 
 @pytest.mark.parametrize('arg', ParticleZoo.everything - {'p+'})
 def test_parse_InvalidElementErrors(arg):
     r"""Tests that _parse_and_check_atomic_input raises an
     InvalidElementError when the input corresponds to a valid
     particle but not a valid element, isotope, or ion."""
-    with pytest.raises(InvalidElementError, message=(
-            "An InvalidElementError was expected to be raised by "
-            f"{_call_string(arg)}, but no exception was raised.")):
+    with pytest.raises(InvalidElementError):
         _parse_and_check_atomic_input(arg)
+        pytest.fail((
+            "An InvalidElementError was expected to be raised by "
+            f"{_call_string(arg)}, but no exception was raised."
+        ))
 
 
 # (arg, kwargs, num_warnings)
@@ -285,10 +288,16 @@ atomic_warnings_table = [
 def test_parse_AtomicWarnings(arg, kwargs, num_warnings):
     r"""Tests that _parse_and_check_atomic_input issues an AtomicWarning
     under the required conditions.  """
-    with pytest.warns(AtomicWarning, message=(
+
+    try:
+        with pytest.warns(AtomicWarning) as record:
+            _parse_and_check_atomic_input(arg, **kwargs)
+    except pytest.fail.Exception:
+        pytest.fail((
             f"No AtomicWarning was issued by {_call_string(arg, kwargs)} but "
-            f"the expected number of warnings was {num_warnings}")) as record:
-        _parse_and_check_atomic_input(arg, **kwargs)
+            f"the expected number of warnings was {num_warnings}"
+        ))
+
     assert len(record) == num_warnings, (
         f"The number of AtomicWarnings issued by {_call_string(arg, kwargs)} "
         f"was {len(record)}, which differs from the expected number "

--- a/plasmapy/atomic/tests/test_parsing.py
+++ b/plasmapy/atomic/tests/test_parsing.py
@@ -258,8 +258,7 @@ def test_parse_InvalidParticleErrors(arg, kwargs):
         _parse_and_check_atomic_input(arg, **kwargs)
         pytest.fail(
             "An InvalidParticleError was expected to be raised by "
-            f"{_call_string(arg, kwargs)}, but no exception was raised."
-        )
+            f"{_call_string(arg, kwargs)}, but no exception was raised.")
 
 @pytest.mark.parametrize('arg', ParticleZoo.everything - {'p+'})
 def test_parse_InvalidElementErrors(arg):
@@ -270,8 +269,7 @@ def test_parse_InvalidElementErrors(arg):
         _parse_and_check_atomic_input(arg)
         pytest.fail(
             "An InvalidElementError was expected to be raised by "
-            f"{_call_string(arg)}, but no exception was raised."
-        )
+            f"{_call_string(arg)}, but no exception was raised.")
 
 
 # (arg, kwargs, num_warnings)
@@ -291,12 +289,11 @@ def test_parse_AtomicWarnings(arg, kwargs, num_warnings):
 
     with pytest.warns(AtomicWarning) as record:
         _parse_and_check_atomic_input(arg, **kwargs)
-        if record:
+        if not record:
             pytest.fail(
                 f"No AtomicWarning was issued by "
                 f"{_call_string(arg, kwargs)} but the expected number "
-                f"of warnings was {num_warnings}"
-            )
+                f"of warnings was {num_warnings}")
 
     assert len(record) == num_warnings, (
         f"The number of AtomicWarnings issued by {_call_string(arg, kwargs)} "

--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -529,12 +529,12 @@ def test_Particle_errors(arg, kwargs, attribute, exception):
     Test that the appropriate exceptions are raised during the creation
     and use of a `~plasmapy.atomic.Particle` object.
     """
-    with pytest.raises(exception, message=(
+    with pytest.raises(exception):
+        exec(f'Particle(arg, **kwargs){attribute}')
+        pytest.fail(
             f"The following command: "
             f"\n\n  {call_string(Particle, arg, kwargs)}{attribute}\n\n"
-            f"did not raise a {exception.__name__} as expected")):
-        exec(f'Particle(arg, **kwargs){attribute}')
-
+            f"did not raise a {exception.__name__} as expected")
 
 # arg, kwargs, attribute, exception
 test_Particle_warning_table = [
@@ -551,12 +551,12 @@ def test_Particle_warnings(arg, kwargs, attribute, warning):
     Test that the appropriate warnings are issued during the creation
     and use of a `~plasmapy.atomic.Particle` object.
     """
-    with pytest.warns(warning, message=(
+    with pytest.warns(warning):
+        exec(f'Particle(arg, **kwargs){attribute}')
+        pytest.fail(
             f"The following command: "
             f"\n\n >>> {call_string(Particle, arg, kwargs)}{attribute}\n\n"
-            f"did not issue a {warning.__name__} as expected")):
-        exec(f'Particle(arg, **kwargs){attribute}')
-
+            f"did not issue a {warning.__name__} as expected")
 
 def test_Particle_cmp():
     """Test ``__eq__`` and ``__ne__`` in the Particle class."""

--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -551,12 +551,13 @@ def test_Particle_warnings(arg, kwargs, attribute, warning):
     Test that the appropriate warnings are issued during the creation
     and use of a `~plasmapy.atomic.Particle` object.
     """
-    with pytest.warns(warning):
+    with pytest.warns(warning) as record:
         exec(f'Particle(arg, **kwargs){attribute}')
-        pytest.fail(
-            f"The following command: "
-            f"\n\n >>> {call_string(Particle, arg, kwargs)}{attribute}\n\n"
-            f"did not issue a {warning.__name__} as expected")
+        if not record:
+            pytest.fail(
+                f"The following command: "
+                f"\n\n >>> {call_string(Particle, arg, kwargs)}{attribute}\n\n"
+                f"did not issue a {warning.__name__} as expected")
 
 def test_Particle_cmp():
     """Test ``__eq__`` and ``__ne__`` in the Particle class."""

--- a/plasmapy/atomic/tests/test_particle_input.py
+++ b/plasmapy/atomic/tests/test_particle_input.py
@@ -100,9 +100,9 @@ def test_particle_input_errors(func, kwargs, expected_error):
     Test that functions decorated with particle_input raise the
     expected errors.
     """
-    with pytest.raises(expected_error, message=(
-            f"{func} did not raise {expected_error} with kwargs = {kwargs}")):
+    with pytest.raises(expected_error):
         func(**kwargs)
+        pytest.fail(f"{func} did not raise {expected_error} with kwargs = {kwargs}")
 
 
 class Test_particle_input:
@@ -439,20 +439,23 @@ def test_none_shall_not_pass():
     def func_none_shall_not_pass_with_list(particles: [Particle]) -> [Particle]:
         return particles
 
-    with pytest.raises(TypeError, message=(
-            "The none_shall_pass keyword in the particle_input decorator is "
-            "set to False, but is not raising a TypeError.")):
+    with pytest.raises(TypeError):
         func_none_shall_not_pass(None)
+        pytest.fail(
+            "The none_shall_pass keyword in the particle_input "
+            "decorator is set to False, but is not raising a TypeError.")
 
-    with pytest.raises(TypeError, message=(
-            "The none_shall_pass keyword in the particle_input decorator is "
-            "set to False, but is not raising a TypeError.")):
+    with pytest.raises(TypeError):
         func_none_shall_not_pass_with_tuple(('He', None))
+        pytest.fail(
+            "The none_shall_pass keyword in the particle_input "
+            "decorator is set to False, but is not raising a TypeError.")
 
-    with pytest.raises(TypeError, message=(
-            "The none_shall_pass keyword in the particle_input decorator is "
-            "set to False, but is not raising a TypeError.")):
+    with pytest.raises(TypeError):
         func_none_shall_not_pass(('He', None))
+        pytest.fail(
+            "The none_shall_pass keyword in the particle_input "
+            "decorator is set to False, but is not raising a TypeError.")
 
 
 def test_optional_particle_annotation_argname():
@@ -500,15 +503,20 @@ def test_not_optional_particle_annotation_argname():
     def func_not_optional_particle_with_list(particles: [Particle]) -> [Particle]:
         return particles
 
-    with pytest.raises(TypeError, message=(
-            "The particle keyword in the particle_input decorator received a "
-            "None instead of a Particle, but is not raising a TypeError.")):
+    with pytest.raises(TypeError):
         func_not_optional_particle_with_tuple((None, 'He'))
+        pytest.fail(
+            "The particle keyword in the particle_input decorator "
+            "received None instead of a Particle, but is not raising a "
+            "TypeError.")
 
-    with pytest.raises(TypeError, message=(
-            "The particle keyword in the particle_input decorator received a "
-            "None instead of a Particle, but is not raising a TypeError.")):
+    with pytest.raises(TypeError):
+
         func_not_optional_particle_with_list(('He', None))
+        pytest.fail(
+            "The particle keyword in the particle_input decorator "
+            "received None instead of a Particle, but is not raising a "
+            "TypeError.")
 
 
 # TODO: The following tests might be able to be cleaned up and/or
@@ -575,11 +583,12 @@ def test_not_element(particle):
     `~plasmapy.atomic.Particle` is named 'element', but the annotated
     argument ends up not being an element, isotope, or ion.
     """
-    with pytest.raises(InvalidElementError, message=(
-            "@particle_input is not raising an InvalidElementError for "
-            f"{repr(particle)} even though the annotated argument is named "
-            "'element'.")):
+    with pytest.raises(InvalidElementError):
         function_with_element_argument(particle)
+        pytest.fail(
+            "@particle_input is not raising an InvalidElementError for "
+            f"{repr(particle)} even though the annotated argument is "
+            f"named 'element'.")
 
 
 @pytest.mark.parametrize('isotope', is_isotope)

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -50,7 +50,7 @@ def check_quantity(**validations: Dict[str, bool]):
     astropy.units.core.UnitConversionError: The argument x to func should be a Quantity with the following units: m
 
     >>> import pytest    # to show the UnitsWarning
-    >>> with pytest.warns(u.UnitsWarning, message="Assuming units of m."):
+    >>> with pytest.warns(u.UnitsWarning, match="Assuming units of m."):
     ...     func(1)
     <Quantity 1. m>
 
@@ -106,7 +106,7 @@ def check_quantity(**validations: Dict[str, bool]):
 
     Notes
     -----
-    This functionality may end up becoming deprecated due to 
+    This functionality may end up becoming deprecated due to
     noncompliance with the `IEEE 754 standard
     <https://en.wikipedia.org/wiki/IEEE_754#Exception_handling>`_
     and in favor of `~astropy.units.quantity_input`.


### PR DESCRIPTION
The message keyword argument is being deprecated from pytest.raises and may be removed instead of renamed.  This PR removes the use of message in our tests and checks.  Closes #601.