### PR TITLE
Allow NaNs through collisional_frequency without any warnings

### DIFF
--- a/plasmapy/transport/collisions.py
+++ b/plasmapy/transport/collisions.py
@@ -280,12 +280,14 @@ def Coulomb_logarithm(T,
         raise ValueError("Unknown method! Choose from 'classical' and 'GMS-N', N from 1 to 6.")
     # applying dimensionless units
     ln_Lambda = ln_Lambda.to(u.dimensionless_unscaled).value
-    if np.any(ln_Lambda < 2) and method in ["classical", "GMS-1", "GMS-2"]:
-        warnings.warn(f"Coulomb logarithm is {ln_Lambda} and {method} relies on weak coupling.",
-                      utils.CouplingWarning)
-    elif np.any(ln_Lambda < 4):
-        warnings.warn(f"Coulomb logarithm is {ln_Lambda}, you might have strong coupling effects",
-                      utils.CouplingWarning)
+    # Allow NaNs through the < checks without warning
+    with np.errstate(invalid='ignore'):
+        if np.any(ln_Lambda < 2) and method in ["classical", "GMS-1", "GMS-2"]:
+            warnings.warn(f"Coulomb logarithm is {ln_Lambda} and {method} relies on "
+                          "weak coupling.", utils.CouplingWarning)
+        elif np.any(ln_Lambda < 4):
+            warnings.warn(f"Coulomb logarithm is {ln_Lambda}, you might have strong "
+                          "coupling effects", utils.CouplingWarning)
     return ln_Lambda
 
 

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -326,8 +326,12 @@ def _check_quantity(arg, argname, funcname, units, can_be_negative=True,
         raise ValueError(f"{valueerror_message} NaNs.")
     elif np.any(np.iscomplex(arg.value)) and not can_be_complex:
         raise ValueError(f"{valueerror_message} complex numbers.")
-    elif not can_be_negative and np.any(arg.value < 0):
-        raise ValueError(f"{valueerror_message} negative numbers.")
+    elif not can_be_negative:
+        # Allow NaNs through without raising a warning
+        with np.errstate(invalid='ignore'):
+            isneg = np.any(arg.value < 0)
+        if isneg:
+            raise ValueError(f"{valueerror_message} negative numbers.")
     elif not can_be_inf and np.any(np.isinf(arg.value)):
         raise ValueError(f"{valueerror_message} infs.")
 


### PR DESCRIPTION
Follow up to #607. This makes sure that `NaN`s don't raise warnings when they go through `<` or `>` comparisons.