### PR TITLE
Update development roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,19 +51,19 @@ ABC.
 
 ### Experimental support
 
-
 ### Plasma simulation capabilities
 
+### Turbulence analysis tools
 
-### Plasma parameters
+### Dispersion relation solver
 
-- Dimensionless numbers functionality
+### Plasma parameters and transport coefficients
 
-- Code and documentation infrastructure
-- Plasma parameter calculations
-- Transport coefficient functions
-   - Braginskii theory
-- Base PlasmaBlob class
+PlasmaPy currently has numerous functions and classes that compute
+plasma parameters and transport coefficients.  Plasma physics is a
+very broad discipline, so there remain many plasma parameter functions
+that have not yet been implemented.  We will continue to expand and
+refactor this functionality.
 
 
 ### Features to be included in Version 0.2 release
@@ -87,8 +87,3 @@ ABC.
 - Analytical plasma physics tools (with SymPy)
 
 
-### Future events
-
-- Code development meeting
-- Software Carpentry workshops at plasma physics conferences
-- Python in Plasma Physics conference?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,24 +1,72 @@
 # PlasmaPy Development Roadmap
 
-This document summarizes the overall development plans for PlasmaPy.
-This roadmap is very fluid and is subject to change due to community
-priorities.  For the most up-to-date information, see PlasmaPy's
-[issues](https://github.com/PlasmaPy/plasmapy/issues), [pull
-requests](https://github.com/PlasmaPy/plasmapy/pulls), and
-[projects](https://github.com/PlasmaPy/PlasmaPy/projects).
+This document summarizes the long-term development plans for PlasmaPy.
+This roadmap is very fluid and will continue to be updated and changed
+throughout the development process based on community input.  
 
-## Features to be included in Version 0.1 release
+If you have feature requests, we highly encourage you to [raise an
+issue](https://github.com/PlasmaPy/PlasmaPy/issues/new) in [PlasmaPy's
+GitHub repository](https://github.com/PlasmaPy/PlasmaPy).  More
+in-depth development plans are contained within the repository for
+[PlasmaPy Enhancement Proposals
+(PLEPs)](https://github.com/PlasmaPy/PlasmaPy-PLEPs) for some topics.
+Additional resources (including grant proposals) may found on the
+[PlasmaPy Community on
+Zenodo](https://zenodo.org/communities/plasmapy).
 
-This is to be a preview/prototype release.
+## Objective
+
+The goal of PlasmaPy is to foster a fully open source software
+ecosystem for plasma research and education.  Functionality needed by
+most plasma physicists will go in the PlasmaPy core package, whereas
+more specialized functionality will go into PlasmaPy's affiliated
+packages.
+
+## Code development priorities
+
+### High level data structures
+
+One of the most fundamental design decisions for PlasmaPy is how to
+represent different plasmas.  This decision is challenging given that
+plasma data comes from many different sources, in many different
+formats, and with many different conventions for storing and
+representing metadata.  Creating a single base class will become
+monolithic very quickly, whereas creating numerous different classes
+has the potential problems of requiring users to remember many
+different classes with diverging application programming interfaces
+(APIs).  PlasmaPy is taking a hybrid approach (described in [PLEP
+6](http://doi.org/10.5281/zenodo.1460977)) that involves creating an
+[abstract base class
+(ABC)](https://docs.python.org/3/library/abc.html) that contains
+abstract methods that have to be defined for each of the subclasses
+for different plasma representations (thus ensuring a more consistent
+API).  Users can then invoke the `Plasma` class factory to select and
+instantiate the appropriate subclass based on inputs provided by the
+user.  The framework for base data structures was implemented by
+Google Summer of Code student Ritiek Malhotra in 2018, along with the
+[OpenPMD](https://github.com/openPMD/openPMD-standard) subclass.  The
+next major development tasks are to create subclasses for different
+plasma representations and to expand/refine the API defined by the
+ABC.  
+
+### Experimental support
+
+
+### Plasma simulation capabilities
+
+
+### Plasma parameters
+
+- Dimensionless numbers functionality
 
 - Code and documentation infrastructure
 - Plasma parameter calculations
 - Transport coefficient functions
    - Braginskii theory
 - Base PlasmaBlob class
-- Dimensionless numbers functionality
 
-## Features to be included in Version 0.2 release
+
+### Features to be included in Version 0.2 release
 
 - MHD simulation capability (finite difference & spectral)
 - PIC simulation capability (only 1D for v0.1?)
@@ -27,7 +75,7 @@ This is to be a preview/prototype release.
     [TurbPlasma](https://github.com/tulasinandan/TurbPlasma) (to be
     speeded up via Numba/Cython)
     
-## Features to be included in Version 0.3 release or at an indefinite time in future
+### Features to be included in Version 0.3 release or at an indefinite time in future
 - Magnetic topology analysis tools (data cube)
 - Grad-Shafranov solver
 - Dispersion solver
@@ -37,9 +85,9 @@ This is to be a preview/prototype release.
 - Spacecraft data analysis
 - Experimental analysis tools
 - Analytical plasma physics tools (with SymPy)
-- Capability to read in CDF files (separate package?)
 
-## Future events
+
+### Future events
 
 - Code development meeting
 - Software Carpentry workshops at plasma physics conferences


### PR DESCRIPTION
This PR is to update `ROADMAP.md` (which hadn't been updated in over a year) in advance of our version 0.2.0 release.  I think it'll be best to avoid specifying which changes are slated to go into each release since that changes a lot and can be tracked better with the projects and milestone features on GitHub.  Plus, given how frequently we update the roadmap, we don't want to make changes that'll go out of date more obviously.  So far, I'm using some of what I wrote for our recent [NSF CSSI proposal for PlasmaPy](https://zenodo.org/record/2633287).

One possibility for the future would be to make a separate document for our roadmap that we can archive on Zenodo as a versioned document.  This would make the history of our roadmap more transparent.  Our roadmap would also be citable, which would mean that we could refer to it directly in things like grant proposals.

Closes #426.