### PR TITLE
Presevering function hints when decorated by `check_quantity` and `check_relativistic`

### DIFF
--- a/plasmapy/atomic/particle_input.py
+++ b/plasmapy/atomic/particle_input.py
@@ -233,7 +233,11 @@ def particle_input(wrapped_function: Callable = None,
     def decorator(wrapped_function: Callable):
         wrapped_signature = inspect.signature(wrapped_function)
 
-        @functools.wraps(wrapped_function)
+        # add '__signature__' to methods that are copied from
+        # wrapped_function onto wrapper
+        assigned = list(functools.WRAPPER_ASSIGNMENTS)
+        assigned.append('__signature__')
+        @functools.wraps(wrapped_function, assigned=assigned)
         def wrapper(*args, **kwargs):
             annotations = wrapped_function.__annotations__
             bound_args = wrapped_signature.bind(*args, **kwargs)
@@ -384,6 +388,11 @@ def particle_input(wrapped_function: Callable = None,
                         new_kwargs[argname] = particle
 
             return wrapped_function(**new_kwargs)
+
+        # add '__signature__' if it does not exist
+        # - this will preserve parameter hints in IDE's
+        if not hasattr(wrapper, '__signature__'):
+            wrapper.__signature__ = inspect.signature(wrapped_function)
 
         return wrapper
 

--- a/plasmapy/utils/checks.py
+++ b/plasmapy/utils/checks.py
@@ -1,6 +1,6 @@
 import functools
 import inspect
-from typing import Dict
+from typing import (Dict, Union)
 
 import numpy as np
 from astropy import units as u
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-def check_quantity(**validations: Dict[str, bool]):
+def check_quantity(**validations: Dict[str, Union[bool, u.Quantity]]):
     """
     Verify that the function's arguments have correct units.
 
@@ -125,7 +125,11 @@ def check_quantity(**validations: Dict[str, bool]):
         wrapped_sign = inspect.signature(f)
         fname = f.__name__
 
-        @functools.wraps(f)
+        # add '__signature__' to methods that are copied from
+        # f onto wrapper
+        assigned = list(functools.WRAPPER_ASSIGNMENTS)
+        assigned.append('__signature__')
+        @functools.wraps(f, assigned=assigned)
         def wrapper(*args, **kwargs):
             # combine args and kwargs into dictionary
             bound_args = wrapped_sign.bind(*args, **kwargs)
@@ -167,6 +171,12 @@ def check_quantity(**validations: Dict[str, bool]):
                 given_params_values[param_to_check] = validated_value
 
             return f(**given_params_values)
+
+        # add '__signature__' if it does not exist
+        # - this will preserve parameter hints in IDE's
+        if not hasattr(wrapper, '__signature__'):
+            wrapper.__signature__ = inspect.signature(f)
+
         return wrapper
     return decorator
 
@@ -392,11 +402,21 @@ def check_relativistic(func=None, betafrac=0.05):
 
     """
     def decorator(f):
+        # add '__signature__' to methods that are copied from
+        # f onto wrapper
+        assigned = list(functools.WRAPPER_ASSIGNMENTS)
+        assigned.append('__signature__')
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
             return_ = f(*args, **kwargs)
             _check_relativistic(return_, f.__name__, betafrac=betafrac)
             return return_
+
+        # add '__signature__' if it does not exist
+        # - this will preserve parameter hints in IDE's
+        if not hasattr(wrapper, '__signature__'):
+            wrapper.__signature__ = inspect.signature(f)
+
         return wrapper
     if func:
         return decorator(func)


### PR DESCRIPTION
Decorators in Python 3.4+ do preserve signatures of their wrapped functions, but they still loose the ability to give parameter hints in IDEs.

For example, in PyCharm, the current `master` branch would yield parameter hints for `plasmapy.physics.parameters.Alfven_speed()` as:

![Screen Shot 2019-05-07 at 7 44 17 PM](https://user-images.githubusercontent.com/29869348/57345647-7944c700-7100-11e9-84c8-b3b3bb88b98d.png)

But after defining the `__signature__` method for the wrapper function, the parameter hint now shows the arguments as:

![Screen Shot 2019-05-07 at 7 47 11 PM](https://user-images.githubusercontent.com/29869348/57345738-c5900700-7100-11e9-9d58-7f67f89fb514.png)

The `__signature__` dunder has existed since Python 3.3 and is well documented in [PEP 362](https://www.python.org/dev/peps/pep-0362/).
