### PR TITLE
Add file with metadata for Zenodo upload

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,177 @@
+{
+  "creators": [
+    {
+      "name": "PlasmaPy Community"
+    },
+    {
+      "name": "Murphy, Nicholas A.",
+      "affiliation": "Center for Astrophysics | Harvard & Smithsonian",
+      "orcid": "0000-0001-6628-8033"
+    },
+    {
+      "name": "Stańczak, Dominik",
+      "affiliation": "University of Warsaw",
+      "orcid": "0000-0001-6291-8843"
+    },
+    {
+      "name": "Kozlowski, Pawel M.",
+      "affiliation": "Los Alamos National Laboratory",
+      "orcid": "0000-0001-6849-3612"
+    },
+    {
+      "name": "Malhotra, Ritiek",
+      "affiliation": "Chandigarh University"
+    },
+    {
+      "name": "Langendorf, Samuel J.",
+      "affiliation": "Los Alamos National Laboratory",
+      "orcid": "0000-0002-7757-5879"
+    },
+    {
+      "name": "Leonard, Andrew J.",
+      "affiliation": "Aperio Software",
+      "orcid": "0000-0001-5270-7487"
+    },
+    {
+      "name": "Stansby, David",
+      "affiliation": "Imperial College London",
+      "orcid": "0000-0002-1365-1908"
+    },
+    {
+      "name": "Haggerty, Colby C.",
+      "affiliation": "University of Chicago"
+    },
+    {
+      "name": "Mumford, Stuart J.",
+      "affiliation": "University of Sheffield",
+      "orcid": "0000-0003-4217-4642"
+    },
+    {
+      "name": "Beckers, Jasper P.",
+      "affiliation": "ASML"
+    },
+    {
+      "name": "Bedmutha, Manas Satish"
+    },
+    {
+      "name": "Bergeron, Justin"
+    },
+    {
+      "name": "Bessi, Ludovico"
+    },
+    {
+      "name": "Carroll, Sean"
+    },
+    {
+      "name": "Chambers, Sean"
+    },
+    {
+      "name": "Choubey, Apoorv"
+    },
+    {
+      "name": "Deal, Jacob"
+    },
+    {
+      "name": "Díaz Pérez, Roberto"
+    },
+    {
+      "name": "Einhorn, Leah"
+    },
+    {
+      "name": "Everson, Eric",
+      "affiliation": "UCLA"
+    },
+    {
+      "name": "Fan, Thomas"
+    },
+    {
+      "name": "Farid, Samaiyah I.",
+      "affiliation": "Center for Astrophysics | Harvard & Smithsonian"
+    },
+    {
+      "name": "Goudeau, Graham"
+    },
+    {
+      "name": "Guidoni, Silvina",
+      "affiliation": "American University"
+    },
+    {
+      "name": "Hillairet, Julien",
+      "orcid": "0000-0002-1073-6383"
+    },
+    {
+      "name": "How, Poh Zi"
+    },
+    {
+      "name": "Huang, Yi-Min",
+      "affiliation": "Princeton University",
+      "orcid": "0000-0002-4237-2211"
+    },
+    {
+      "name": "Humphrey, Nabil"
+    },
+    {
+      "name": "Isupova, Maria"
+    },
+    {
+      "name": "Kulshrestha, Siddharth"
+    },
+    {
+      "name": "Kuszaj, Piotr"
+    },
+    {
+      "name": "Munn, Joshua"
+    },
+    {
+      "name": "Parashar, Tulasi",
+      "affiliation": "University of Delaware",
+      "orcid": "0000-0003-0602-8381"
+    },
+    {
+      "name": "Patel, Neil"
+    },
+    {
+      "name": "Raj, Raajit"
+    },
+    {
+      "name": "Savcheva, Antonia",
+      "affiliation": "Center for Astrophysics | Harvard & Smithsonian",
+      "orcid": "0000-0002-5598-046X"
+    },
+    {
+      "name": "Shen, Chengcai",
+      "affiliation": "Center for Astrophysics | Harvard & Smithsonian"
+    },
+    {
+      "name": "Sherpa, Dawa Nurbu"
+    },
+    {
+      "name": "Silva, Frank"
+    },
+    {
+      "name": "Singh, Ankit"
+    },
+    {
+      "name": "Sipőcz, Brigitta",
+      "orcid": "0000-0002-3713-6337"
+    },
+    {
+      "name": "Tavant, Antoine",
+      "affiliation": "Laboratoire de Physique des Plasmas, Ecole Polytechnique",
+      "orcid": "0000-0003-0010-8073"
+    },
+    {
+      "name": "Xu, Sixue"
+    },
+    {
+      "name": "Zhang, Carol"
+    }
+  ],
+  "keywords": [
+    "plasma physics",
+    "Python",
+    "open source"
+  ],
+  "license": "BSD+Patent",
+  "upload_type": "software"
+}


### PR DESCRIPTION
The purpose of the `.zenodo.json` file is to store the metadata needed by Zenodo for when we upload releases.  The metadata fields for a Zenodo upload should be automatically populated with the metadata spelled out in this file.  

Unfortunately, if we create a codemeta file (#622), a lot of the information will probably be duplicated so we may end up having inconsistencies.