### PR TITLE
Metadata updates prior to version 0.2.0

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -2,41 +2,40 @@ Acknowledging and Citing PlasmaPy
 =================================
 
 If you use PlasmaPy for a project resulting in a publication, we ask
-that you cite the following reference (`BibTeX
-<https://zenodo.org/record/1238132/export/hx#.WvMkQK0cChc>`_):
+that you cite both the specific version of PlasmaPy used in your
+project and an informational reference.  Including these references
+provides credit to developers of PlasmaPy and enables greater
+scientific reproducibility.
+
+Version 0.2.0 of PlasmaPy may be cited using the following reference.
+
+* PlasmaPy Community et al. (2019). *PlasmaPy version 0.2.0*, Zenodo,
+  https://doi.org/10.5281/zenodo.3235817
+
+The current standard informational reference for PlasmaPy is
 
 * PlasmaPy Community, Nicholas A. Murphy, Andrew J. Leonard, Dominik
   Stańczak, Pawel M. Kozlowski, Samuel J. Langendorf, Colby C. Haggerty,
   Jasper P. Beckers, Stuart J. Mumford, Tulasi N. Parashar, and Yi-Min
-  Huang. (2018, April). *PlasmaPy: an open source community-developed
-  Python package for plasma physics.* Zenodo.
-  http://doi.org/10.5281/zenodo.1238132
+  Huang. (2018). *PlasmaPy: an open source community-developed
+  Python package for plasma physics*, Zenodo,
+  https://doi.org/10.5281/zenodo.1238132
 
-We provide the following standard acknowledgment that you may use
-instead of a citation in the body of a paper.
+These references may be made by adding the following line to the
+methods or acknowledgements sections of a paper.
 
-* This research made use of PlasmaPy, a community-developed open source
-  core Python package for plasma physics (PlasmaPy Community 2018).
+* This research made use of PlasmaPy version 0.2.0, a
+  community-developed open source Python package for plasma
+  physics (PlasmaPy Community et al. 2018, 2019).
 
-The source code for the most recent release of PlasmaPy (version
-0.1.1) is archived on `Zenodo
-<https://zenodo.org/communities/plasmapy>`__ and can be cited using
-the following reference (`BibTeX
-<https://zenodo.org/record/1436019/export/hx#.W6wUbxxG2Pc>`__):
+All public releases of PlasmaPy are openly archived in the `PlasmaPy
+Community <https://zenodo.org/communities/plasmapy>`__ on `Zenodo
+<https://zenodo.org>`__.
 
-* PlasmaPy Community, Nicholas A. Murphy, Dominik Stańczak,
-  Pawel M. Kozlowski, Samuel J. Langendorf, Andrew J. Leonard,
-  Jasper P. Beckers, Colby C. Haggerty, Stuart J. Mumford, Ritiek
-  Malhotra, Ludovico Bessi, Sean Carroll, Apoorv Choubey, Roberto Díaz
-  Pérez, Leah Einhorn, Thomas Fan, Graham Goudeau, Silvina Guidoni,
-  Julien Hillairet, Poh Zi How, Yi-Min Huang, Nabil Humphrey, Maria
-  Isupova, Siddharth Kulshrestha, Piotr Kuszaj, Joshua Munn, Tulasi
-  Parashar, Neil Patel, Raajit Raj, Dawa Nurbu Sherpa, David Stansby,
-  Antoine Tavant, and Sixue Xu. (2018, May 27). *PlasmaPy* (Version
-  0.1.1). Zenodo. http://doi.org/10.5281/zenodo.1436019
-
-We highly encourage researchers to acknowledge the packages that
-PlasmaPy depends on, including but not limited to 
-`Astropy <https://www.astropy.org/acknowledging.html>`__, 
+We encourage authors to acknowledge the packages that PlasmaPy
+depends on, including but not limited to
+`Astropy <https://www.astropy.org/acknowledging.html>`__,
 `NumPy <https://www.scipy.org/citing.html#numpy>`__, and
 `SciPy <https://www.scipy.org/citing.html#scipy-the-library>`__.
+
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,0 @@
-# Installation
-
-To install PlasmaPy, please refer to the [installation 
-instructions](http://docs.plasmapy.org/en/latest/install.html)
-in our online documentation.

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -4,41 +4,40 @@ Acknowledging and Citing PlasmaPy
 =================================
 
 If you use PlasmaPy for a project resulting in a publication, we ask
-that you cite the following reference (`BibTeX
-<https://zenodo.org/record/1238132/export/hx#.WvMkQK0cChc>`_):
+that you cite both the specific version of PlasmaPy used in your
+project and an informational reference.  Including these references
+provides credit to developers of PlasmaPy and enables greater
+scientific reproducibility.
+
+Version 0.2.0 of PlasmaPy may be cited using the following reference.
+
+* PlasmaPy Community et al. (2019). *PlasmaPy version 0.2.0*, Zenodo,
+  http://doi.org/10.5281/zenodo.3235817
+
+The current standard informational reference for PlasmaPy is
 
 * PlasmaPy Community, Nicholas A. Murphy, Andrew J. Leonard, Dominik
   Stańczak, Pawel M. Kozlowski, Samuel J. Langendorf, Colby C. Haggerty,
   Jasper P. Beckers, Stuart J. Mumford, Tulasi N. Parashar, and Yi-Min
-  Huang. (2018, April). *PlasmaPy: an open source community-developed
-  Python package for plasma physics.* Zenodo.
+  Huang. (2018). *PlasmaPy: an open source community-developed
+  Python package for plasma physics*, Zenodo,
   http://doi.org/10.5281/zenodo.1238132
 
-We provide the following standard acknowledgment that you may use
-instead of a citation in the body of a paper.
+These references may be made by adding the following line to the
+methods or acknowledgements sections of a paper.
 
-* This research made use of PlasmaPy, a community-developed open source
-  core Python package for plasma physics (PlasmaPy Community 2018).
+* This research made use of PlasmaPy version 0.2.0, a
+  community-developed open source Python package for plasma
+  physics (PlasmaPy Community et al. 2018, 2019).
 
-The source code for the most recent release of PlasmaPy (version
-0.1.1) is archived on `Zenodo
-<https://zenodo.org/communities/plasmapy>`__ and can be cited using
-the following reference (`BibTeX
-<https://zenodo.org/record/1436019/export/hx#.W6wUbxxG2Pc>`__):
+All public releases of PlasmaPy are openly archived in the `PlasmaPy
+Community <https://zenodo.org/communities/plasmapy>`__ on `Zenodo
+<https://zenodo.org>`__.
 
-* PlasmaPy Community, Nicholas A. Murphy, Dominik Stańczak,
-  Pawel M. Kozlowski, Samuel J. Langendorf, Andrew J. Leonard,
-  Jasper P. Beckers, Colby C. Haggerty, Stuart J. Mumford, Ritiek
-  Malhotra, Ludovico Bessi, Sean Carroll, Apoorv Choubey, Roberto Díaz
-  Pérez, Leah Einhorn, Thomas Fan, Graham Goudeau, Silvina Guidoni,
-  Julien Hillairet, Poh Zi How, Yi-Min Huang, Nabil Humphrey, Maria
-  Isupova, Siddharth Kulshrestha, Piotr Kuszaj, Joshua Munn, Tulasi
-  Parashar, Neil Patel, Raajit Raj, Dawa Nurbu Sherpa, David Stansby,
-  Antoine Tavant, and Sixue Xu. (2018, May 27). *PlasmaPy* (Version
-  0.1.1). Zenodo. http://doi.org/10.5281/zenodo.1436019
-
-We highly encourage researchers to acknowledge the packages that
-PlasmaPy depends on, including but not limited to 
-`Astropy <https://www.astropy.org/acknowledging.html>`__, 
+We encourage authors to acknowledge the packages that PlasmaPy
+depends on, including but not limited to
+`Astropy <https://www.astropy.org/acknowledging.html>`__,
 `NumPy <https://www.scipy.org/citing.html#numpy>`__, and
 `SciPy <https://www.scipy.org/citing.html#scipy-the-library>`__.
+
+

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -54,6 +54,7 @@ __name__ = "plasmapy"
 if sys.version_info < tuple((int(val) for val in "3.6".split('.'))):
     raise Exception("plasmapy does not support Python < {}".format(3.6))
 
+
 def online_help(query):
     """
     Search the online PlasmaPy documentation for the given query from plasmapy.org
@@ -77,22 +78,8 @@ def online_help(query):
 
     webbrowser.open(url)
 
-__citation__ = """@misc{plasmapy_community_2018_1238132,
-  author       = {{PlasmaPy Community} and
-                  Murphy, Nicholas A. and
-                  Leonard, Andrew J. and
-                  Sta\'nczak, Dominik and
-                  Kozlowski, Pawel M. and
-                  Langendorf, Samuel J. and
-                  Haggerty, Colby C. and
-                  Beckers, Jasper P. and
-                  Mumford, Stuart J. and
-                  Parashar, Tulasi N. and
-                  Huang, Yi-Min},
-  title        = {{PlasmaPy: an open source community-developed 
-                   Python package for plasma physics}},
-  month        = apr,
-  year         = 2018,
-  doi          = {10.5281/zenodo.1238132},
-  url          = {https://doi.org/10.5281/zenodo.1238132}
-}"""
+
+__citation__ = [
+    "https://doi.org/10.5281/zenodo.1238132",
+    "https://doi.org/10.5281/zenodo.3235817",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
 package_name = plasmapy
 description = Python package for plasma physics
-long_description = PlasmaPy is a community-developed and community-driven generalist Python package for plasma physics tools.
+long_description = PlasmaPy is a community-developed and community-driven open source Python package for plasma physics.
 author = PlasmaPy Community
-license = BSD 3-Clause
+license = BSD+Patent
 url = http://www.plasmapy.org
 edit_on_github = True
 github_project = PlasmaPy/PlasmaPy
@@ -19,7 +19,7 @@ math_requires = mpmath
 physics_requires = lmfit
 
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 0.1.1.dev
+version = 0.2.0.dev
 
 [build_sphinx]
 source-dir = docs


### PR DESCRIPTION
I updated some of the information about PlasmaPy in `setup.cfg` and the information on how to cite PlasmaPy (in particular by saying that users should cite both the specific version of PlasmaPy, as well as our standard informational reference from last year).  

I also changed `plasmapy.__citation__` to be a list of DOI links, partially because the metadata for a Zenodo upload has the potential to change, and DOIs are the most robust identifiers.  Another possibility would be to include a link to the directions in our documentation, though this approach might be prone to bit rot when releases become old in case we ever reorganize our docs.

