### PR TITLE
Add Python 3.8 to Travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - env: PYTHON_VERSION=3.7 SETUP_CMD='test --coverage'
           stage: Generic tests
           
-        - env: PYTHON_VERSION=3.8 CONDA_ALL_DEPENDENCIES='Cython scipy h5py matplotlib mpmath pytest -c conda-forge/label/pre-3.8 python'
+        - env: PYTHON_VERSION=3.8
           stage: Generic tests
 
         - env: ASTROPY_VERSION='dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - env: PYTHON_VERSION=3.7 SETUP_CMD='test --coverage'
           stage: Generic tests
           
-        - env: PYTHON_VERSION=3.8
+        - env: PYTHON_VERSION=3.8 CONDA_ALL_DEPENDENCIES='Cython scipy h5py matplotlib mpmath pytest -c conda-forge/label/pre-3.8 python'
           stage: Generic tests
 
         - env: ASTROPY_VERSION='dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,13 @@ matrix:
 
     include:
 
-        - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.6 
           stage: Generic tests
 
-        - env: PYTHON_VERSION=3.7
+        - env: PYTHON_VERSION=3.7 SETUP_CMD='test --coverage'
+          stage: Generic tests
+          
+        - env: PYTHON_VERSION=3.8
           stage: Generic tests
 
         - env: ASTROPY_VERSION='dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - env: PYTHON_VERSION=3.7 SETUP_CMD='test --coverage'
           stage: Generic tests
           
-        - env: PYTHON_VERSION=3.8
+        - env: PYTHON_VERSION=3.8 CONDA_CHANNELS=conda-forge
           stage: Generic tests
 
         - env: ASTROPY_VERSION='dev'

--- a/requirements/automated-documentation-tests.txt
+++ b/requirements/automated-documentation-tests.txt
@@ -6,3 +6,4 @@ sphinx
 sphinx-automodapi
 sphinx-gallery
 sphinx_rtd_theme
+sphinx-astropy

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -23,3 +23,4 @@ dependencies:
     - sphinx-gallery
     - sphinx-automodapi
     - sphinx_rtd_theme
+    - sphinx-astropy


### PR DESCRIPTION
Closes #635 

also switch coverage tests to the illustrious Python 3.7, as it's been out long enough by now