### PR TITLE
Revert "Add binder links to gallery notebooks"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,15 +180,4 @@ sphinx_gallery_conf = {
     # path where to save gallery generated examples
     'backreferences_dir': 'gen_modules/backreferences',
     'gallery_dirs': 'auto_examples',
-    'binder': {
-        # Required keys
-        'org': 'PlasmaPy',
-        'repo': 'PlasmaPy',
-        'branch': 'master',  # noqa: E501 Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
-        'binderhub_url': 'https://mybinder.org',  # noqa: E501 Any URL of a binderhub deployment. Must be full URL (e.g. https://mybinder.org).
-        'dependencies': [
-            '../requirements/environment.yml'
-        ],
-        'use_jupyter_lab': True,
-    },
 }


### PR DESCRIPTION
Reverts PlasmaPy/PlasmaPy#644. It seems I misunderstood how Binder works, and we'd need to host the notebooks themselves within a github repo (see https://github.com/sphinx-gallery/sphinx-gallery/issues/503 ).