### PR TITLE
Fix failing Pytests (deprecation of `raises(message=)`)

### DIFF
--- a/changelog/666.bugfix.rst
+++ b/changelog/666.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Pytest deprecations of `message` argument to `raise` and `warn` functions.

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -252,8 +252,9 @@ To test that a function raises an appropriate exception, use
       raise Exception
 
   def test_raise_exception():
-      with pytest.raises(Exception, message="Exception not raised."):
+      with pytest.raises(Exception):
           raise_exception()
+          pytest.fail("Exception not raised.")
 
 .. _testing-guidelines-writing-tests-parametrize:
 

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -240,7 +240,7 @@ To test that a function issues an appropriate warning, use
       warnings.warn("grumblemuffins", UserWarning)
 
   def test_issue_warning():
-      with pytest.warns(UserWarning, message="UserWarning not issued."):
+      with pytest.warns(UserWarning):
           issue_warning()
 
 To test that a function raises an appropriate exception, use

--- a/plasmapy/atomic/tests/test_particle_input.py
+++ b/plasmapy/atomic/tests/test_particle_input.py
@@ -609,11 +609,12 @@ def test_not_isotope(particle):
     `~plasmapy.atomic.Particle` is named 'isotope', but the annotated
     argument ends up not being an isotope or an ion of an isotope.
     """
-    with pytest.raises(InvalidIsotopeError, message=(
+    with pytest.raises(InvalidIsotopeError):
+        function_with_isotope_argument(particle)
+        pytest.fail(
             "@particle_input is not raising an InvalidIsotopeError for "
             f"{repr(particle)} even though the annotated argument is named "
-            "'isotope'.")):
-        function_with_isotope_argument(particle)
+            "'isotope'.")
 
 
 @pytest.mark.parametrize('ion', is_ion)
@@ -634,8 +635,9 @@ def test_not_ion(particle):
     `~plasmapy.atomic.Particle` is named 'ion', but the annotated
     argument ends up not being an ion.
     """
-    with pytest.raises(InvalidIonError, message=(
+    with pytest.raises(InvalidIonError):
+        function_with_ion_argument(particle)
+        pytest.fail(
             "@particle_input is not raising an InvalidIonError for "
             f"{repr(particle)} even though the annotated argument is named "
-            "'ion'.")):
-        function_with_ion_argument(particle)
+            "'ion'.")

--- a/plasmapy/classes/sources/plasma3d.py
+++ b/plasmapy/classes/sources/plasma3d.py
@@ -112,9 +112,7 @@ class Plasma3D(GenericPlasma):
     @classmethod
     def is_datasource_for(cls, **kwargs):
         if len(kwargs) == 3:
-            match = kwargs.get('domain_x') and \
-                    kwargs.get('domain_y') and \
-                    kwargs.get('domain_z')
+            match = all(f'domain_{direction}' in kwargs.keys() for direction in 'xyz')
         else:
             match = False
         return match

--- a/plasmapy/classes/sources/plasmablob.py
+++ b/plasmapy/classes/sources/plasmablob.py
@@ -156,5 +156,5 @@ class PlasmaBlob(GenericPlasma):
 
     @classmethod
     def is_datasource_for(cls, **kwargs):
-        match = kwargs.get('T_e') and kwargs.get('n_e')
+        match = 'T_e' in kwargs.keys() and 'n_e' in kwargs.keys()
         return match

--- a/plasmapy/classes/sources/tests/test_openpmd_hdf5.py
+++ b/plasmapy/classes/sources/tests/test_openpmd_hdf5.py
@@ -39,7 +39,8 @@ class TestOpenPMD2D:
         assert h5_2d.electric_field.shape == (3, 51, 201)
 
     def test_has_charge_density_with_units(self, h5_2d):
-        assert h5_2d.charge_density.to(u.C / u.m**3)
+        # this should simply pass without exception
+        h5_2d.charge_density.to(u.C / u.m**3)
 
     def test_correct_shape_charge_density(self, h5_2d):
         assert h5_2d.charge_density.shape == (51, 201)

--- a/plasmapy/mathematics/tests/test_dispersion.py
+++ b/plasmapy/mathematics/tests/test_dispersion.py
@@ -182,19 +182,19 @@ plasma_disp_func_errors_table = [
 def test_plasma_dispersion_func_errors(w, expected_error):
     """Test errors that should be raised by plasma_dispersion_func."""
 
-    with pytest.raises(expected_error, message=(
-            f"plasma_dispersion_func({w}) did not raise "
-            f"{expected_error.__name__} as expected.")):
-
+    with pytest.raises(expected_error):
         plasma_dispersion_func(w)
+        pytest.fail(
+            f"plasma_dispersion_func({w}) did not raise "
+            f"{expected_error.__name__} as expected.")
 
 
 @pytest.mark.parametrize('w, expected_error', plasma_disp_func_errors_table)
 def test_plasma_dispersion_deriv_errors(w, expected_error):
     """Test errors that should be raised by plasma_dispersion_func_deriv."""
 
-    with pytest.raises(expected_error, message=(
-            f"plasma_dispersion_func_deriv({w}) did not raise "
-            f"{expected_error.__name__} as expected.")):
-
+    with pytest.raises(expected_error):
         plasma_dispersion_func_deriv(w)
+        pytest.fail(
+            f"plasma_dispersion_func_deriv({w}) did not raise "
+            f"{expected_error.__name__} as expected.")

--- a/plasmapy/utils/tests/test_exceptions.py
+++ b/plasmapy/utils/tests/test_exceptions.py
@@ -33,17 +33,18 @@ plasmapy_exceptions = [
 def test_exceptions(exception):
     r"""Test that custom PlasmaPy exceptions can be raised with an
     error message."""
-    with pytest.raises(exception, message=f"Problem raising {exception}"):
+    with pytest.raises(exception):
         raise exception("What an exceptionally exceptional exception!")
+        pytest.fail(f"Problem raising {exception}")
 
 
 @pytest.mark.parametrize("exception", plasmapy_exceptions)
 def test_PlasmaPyError_subclassing(exception):
     r"""Test that each custom PlasmaPy exception can be caught
     as a PlasmaPyError."""
-    with pytest.raises(PlasmaPyError, message=(
-            f"Problem with subclassing of {exception}")):
+    with pytest.raises(PlasmaPyError):
         raise exception("I'm sorry, Dave.  I'm afraid I can't do that.")
+        pytest.fail(f"Problem with subclassing of {exception}")
 
 
 plasmapy_warnings = [

--- a/plasmapy/utils/tests/test_exceptions.py
+++ b/plasmapy/utils/tests/test_exceptions.py
@@ -60,7 +60,7 @@ plasmapy_warnings = [
 def test_warnings(warning):
     r"""Test that custom PlasmaPy warnings can be issued with a
     warning message."""
-    with pytest.warns(warning, message=f"Problem issuing {warning}"):
+    with pytest.warns(warning):
         warnings.warn("Coverage decreased (-0.00002%)", warning)
 
 
@@ -68,6 +68,5 @@ def test_warnings(warning):
 def test_PlasmaPyWarning_subclassing(warning):
     r"""Test that custom PlasmaPy warnings can all be caught
     as a PlasmaPyWarning."""
-    with pytest.warns(PlasmaPyWarning, message=(
-            f"Problem with subclassing of {warning}")):
+    with pytest.warns(PlasmaPyWarning):
         warnings.warn("Electrons are WEIRD.", warning)

--- a/plasmapy/utils/tests/test_pytest_helpers.py
+++ b/plasmapy/utils/tests/test_pytest_helpers.py
@@ -169,12 +169,13 @@ def test_run_test(f, args, kwargs, expected, whaterror):
         if whaterror is None:
             run_test(f, args, kwargs, expected)
         else:
-            with pytest.raises(whaterror, message = (
+            with pytest.raises(whaterror):
+                run_test(f, args, kwargs, expected)
+                pytest.fail(
                     f"run_test did not raise an exception for "
                     f"{call_string(f, args, kwargs, color=None)} "
                     f"with expected = {repr(expected)} and "
-                    f"whaterror = {repr(whaterror)}.")):
-                run_test(f, args, kwargs, expected)
+                    f"whaterror = {repr(whaterror)}.")
     except Exception as spectacular_exception:
         raise Exception(
             f"An unexpected exception was raised while running "
@@ -188,8 +189,9 @@ def test_run_test_rtol():
 
 
 def test_run_test_rtol_failure():
-    with pytest.raises(UnexpectedResultError, message="No exception raised for rtol test."):
+    with pytest.raises(UnexpectedResultError):
         run_test(return_arg, 1.0, {}, 0.999999, rtol=1e-7)
+        pytest.fail("No exception raised for rtol test.")
 
 
 def test_run_test_atol():
@@ -197,8 +199,9 @@ def test_run_test_atol():
 
 
 def test_run_test_atol_failure():
-    with pytest.raises(UnexpectedResultError, message="No exception raised for atol test."):
+    with pytest.raises(UnexpectedResultError):
         run_test(return_arg, (1.0,), {}, 0.999999, atol=1e-7)
+        pytest.fail("No exception raised for atol test.")
 
 
 def func(x, raise_exception=False, issue_warning=False):

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,8 +77,6 @@ doctest_plus = enabled
 doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
 # TODO we probably need to get rid of the following...
 filterwarnings =
-    once::DeprecationWarning
-    once::PendingDeprecationWarning
     ignore::plasmapy.utils.exceptions.RelativityWarning
     ignore::plasmapy.utils.exceptions.CouplingWarning
 


### PR DESCRIPTION
This PR fixes currently failing tests caused by the final deprecation in Pytest 5.1 of the `message` argument to `pytest.raises`, which we had unwisely muted along with all deprecation warnings in setup.cfg.

It also removes the same argument used in pytest.warns, which is slated for deprecation
in a future release.