### PR TITLE
Remove pytest filters for Coupling/RelatityWarning

### DIFF
--- a/plasmapy/classes/sources/tests/test_plasmablob.py
+++ b/plasmapy/classes/sources/tests/test_plasmablob.py
@@ -5,6 +5,7 @@ import astropy.units as u
 from plasmapy.classes.sources import plasma3d, plasmablob
 from plasmapy.physics import magnetostatics
 from plasmapy.atomic.exceptions import InvalidParticleError
+from plasmapy.utils.exceptions import CouplingWarning
 
 
 @pytest.mark.parametrize('grid_dimensions, expected_size', [
@@ -189,7 +190,8 @@ class Test_PlasmaBlobRegimes:
 
         expect_regime = 'Weakly coupled regime: Gamma = 0.0075178096952688445.'
 
-        regime, _ = blob.regimes()
+        with pytest.warns(CouplingWarning):
+            regime, _ = blob.regimes()
         testTrue = regime == expect_regime
 
         errStr = f"Regime should be {expect_regime}, but got {regime} instead."

--- a/plasmapy/transport/tests/test_collisions.py
+++ b/plasmapy/transport/tests/test_collisions.py
@@ -18,6 +18,7 @@ from plasmapy.transport import (Spitzer_resistivity,
 from plasmapy.utils import exceptions
 from plasmapy.utils.pytest_helpers import assert_can_handle_nparray
 from astropy.constants import m_p, m_e, c
+from plasmapy.utils.exceptions import CouplingWarning
 
 
 class Test_Coulomb_logarithm:
@@ -69,20 +70,21 @@ class Test_Coulomb_logarithm:
 
     def test_handle_invalid_V(self):
         """Test that V default, V = None, and V = np.nan all give the same result"""
-        methodVal_0 = Coulomb_logarithm(self.T_arr[0],
-                                        self.n_arr[0],
-                                        self.particles,
-                                        z_mean=1 * u.dimensionless_unscaled,
-                                        V=np.nan * u.m / u.s)
-        methodVal_1 = Coulomb_logarithm(self.T_arr[0],
-                                        self.n_arr[0],
-                                        self.particles,
-                                        z_mean=1 * u.dimensionless_unscaled,
-                                        V=None)
-        methodVal_2 = Coulomb_logarithm(self.T_arr[0],
-                                        self.n_arr[0],
-                                        self.particles,
-                                        z_mean=1 * u.dimensionless_unscaled)
+        with pytest.warns(CouplingWarning):
+            methodVal_0 = Coulomb_logarithm(self.T_arr[0],
+                                            self.n_arr[0],
+                                            self.particles,
+                                            z_mean=1 * u.dimensionless_unscaled,
+                                            V=np.nan * u.m / u.s)
+            methodVal_1 = Coulomb_logarithm(self.T_arr[0],
+                                            self.n_arr[0],
+                                            self.particles,
+                                            z_mean=1 * u.dimensionless_unscaled,
+                                            V=None)
+            methodVal_2 = Coulomb_logarithm(self.T_arr[0],
+                                            self.n_arr[0],
+                                            self.particles,
+                                            z_mean=1 * u.dimensionless_unscaled)
         assert_quantity_allclose(methodVal_0, methodVal_1)
         assert_quantity_allclose(methodVal_0, methodVal_2)
 
@@ -97,27 +99,29 @@ class Test_Coulomb_logarithm:
 
     def test_handle_V_arraysizes(self):
         """Test that different sized V input array gets handled by _boilerplate"""
-        methodVal_0 = Coulomb_logarithm(self.T_arr[0],
-                                        self.n_arr[0],
-                                        self.particles,
-                                        z_mean=1 * u.dimensionless_unscaled,
-                                        V=np.array([np.nan, 3e7]) * u.m / u.s)
-        methodVal_1 = Coulomb_logarithm(self.T_arr[1],
-                                        self.n_arr[0],
-                                        self.particles,
-                                        z_mean=1 * u.dimensionless_unscaled,
-                                        V=np.array([1e7, np.nan]) * u.m / u.s)
-        methodVal_2 = Coulomb_logarithm(self.T_arr,
-                                        self.n_arr[0],
-                                        self.particles,
-                                        z_mean=1 * u.dimensionless_unscaled,
-                                        V=np.array([np.nan, np.nan]) * u.m / u.s)
+        with pytest.warns(CouplingWarning):
+            methodVal_0 = Coulomb_logarithm(self.T_arr[0],
+                                            self.n_arr[0],
+                                            self.particles,
+                                            z_mean=1 * u.dimensionless_unscaled,
+                                            V=np.array([np.nan, 3e7]) * u.m / u.s)
+            methodVal_1 = Coulomb_logarithm(self.T_arr[1],
+                                            self.n_arr[0],
+                                            self.particles,
+                                            z_mean=1 * u.dimensionless_unscaled,
+                                            V=np.array([1e7, np.nan]) * u.m / u.s)
+            methodVal_2 = Coulomb_logarithm(self.T_arr,
+                                            self.n_arr[0],
+                                            self.particles,
+                                            z_mean=1 * u.dimensionless_unscaled,
+                                            V=np.array([np.nan, np.nan]) * u.m / u.s)
         assert_quantity_allclose(methodVal_0[0], methodVal_2[0])
         assert_quantity_allclose(methodVal_1[1], methodVal_2[1])
 
     def test_symmetry(self):
-        lnLambda = Coulomb_logarithm(self.temperature1, self.density2, self.particles)
-        lnLambdaRev = Coulomb_logarithm(self.temperature1, self.density2, self.particles[::-1])
+        with pytest.warns(CouplingWarning):
+            lnLambda = Coulomb_logarithm(self.temperature1, self.density2, self.particles)
+            lnLambdaRev = Coulomb_logarithm(self.temperature1, self.density2, self.particles[::-1])
         assert lnLambda == lnLambdaRev
 
     def test_Chen_Q_machine(self):
@@ -735,8 +739,9 @@ class Test_collision_frequency:
         self.True_zmean = 1346828153985.4646
 
     def test_symmetry(self):
-        result = collision_frequency(self.T, self.n, self.particles)
-        resultRev = collision_frequency(self.T, self.n, self.particles[::-1])
+        with pytest.warns(CouplingWarning):
+            result = collision_frequency(self.T, self.n, self.particles)
+            resultRev = collision_frequency(self.T, self.n, self.particles[::-1])
         assert result == resultRev
 
     def test_known1(self):
@@ -894,8 +899,9 @@ class Test_mean_free_path:
         self.True1 = 4.4047571877932046e-07
 
     def test_symmetry(self):
-        result = mean_free_path(self.T, self.n_e, self.particles)
-        resultRev = mean_free_path(self.T, self.n_e,  self.particles[::-1])
+        with pytest.warns(CouplingWarning):
+            result = mean_free_path(self.T, self.n_e, self.particles)
+            resultRev = mean_free_path(self.T, self.n_e,  self.particles[::-1])
         assert result == resultRev
 
     def test_known1(self):
@@ -1037,8 +1043,9 @@ class Test_mobility:
         self.True_zmean = 0.32665227217687254
 
     def test_symmetry(self):
-        result = mobility(self.T, self.n_e, self.particles)
-        resultRev = mobility(self.T, self.n_e,  self.particles[::-1])
+        with pytest.warns(CouplingWarning):
+            result = mobility(self.T, self.n_e, self.particles)
+            resultRev = mobility(self.T, self.n_e,  self.particles[::-1])
         assert result == resultRev
 
     def test_known1(self):
@@ -1119,8 +1126,9 @@ class Test_Knudsen_number:
         self.True1 = 440.4757187793204
 
     def test_symmetry(self):
-        result = Knudsen_number(self.length, self.T, self.n_e, self.particles)
-        resultRev = Knudsen_number(self.length, self.T, self.n_e,  self.particles[::-1])
+        with pytest.warns(CouplingWarning):
+            result = Knudsen_number(self.length, self.T, self.n_e, self.particles)
+            resultRev = Knudsen_number(self.length, self.T, self.n_e,  self.particles[::-1])
         assert result == resultRev
 
     def test_known1(self):

--- a/plasmapy/transport/tests/test_transport.py
+++ b/plasmapy/transport/tests/test_transport.py
@@ -133,9 +133,10 @@ class Test_classical_transport:
 
     def test_resistivity_units(self):
         """output should be a Quantity with units of Ohm m"""
-        testTrue = self.ct.resistivity().unit == u.Ohm * u.m
-        errStr = (f"Resistivity units should be {u.Ohm * u.m} and "
-                  f"not {self.ct.resistivity().unit}.")
+        with pytest.warns(RelativityWarning):
+            testTrue = self.ct.resistivity().unit == u.Ohm * u.m
+            errStr = (f"Resistivity units should be {u.Ohm * u.m} and "
+                      f"not {self.ct.resistivity().unit}.")
         assert testTrue, errStr
 
     def test_thermoelectric_conductivity_units(self):
@@ -155,11 +156,12 @@ class Test_classical_transport:
 
     def test_electron_thermal_conductivity_units(self):
         """output should be Quantity with units of W / (m K)"""
-        testTrue = (self.ct.electron_thermal_conductivity().unit ==
-                    u.W / u.m / u.K)
-        errStr = (f"Electron thermal conductivity units "
-                  f"should be {u.W / u.m / u.K} "
-                  f"and not {self.ct.electron_thermal_conductivity().unit}.")
+        with pytest.warns(RelativityWarning):
+            testTrue = (self.ct.electron_thermal_conductivity().unit ==
+                        u.W / u.m / u.K)
+            errStr = (f"Electron thermal conductivity units "
+                      f"should be {u.W / u.m / u.K} "
+                      f"and not {self.ct.electron_thermal_conductivity().unit}.")
         assert testTrue, errStr
 
     def test_ion_viscosity_units(self):
@@ -171,9 +173,10 @@ class Test_classical_transport:
 
     def test_electron_viscosity_units(self):
         """output should be Quantity with units of Pa s"""
-        testTrue = self.ct.electron_viscosity().unit == u.Pa * u.s
-        errStr = (f"Electron viscosity units should be {u.Pa * u.s} "
-                  f"and not {self.ct.electron_viscosity().unit}.")
+        with pytest.warns(RelativityWarning):
+            testTrue = self.ct.electron_viscosity().unit == u.Pa * u.s
+            errStr = (f"Electron viscosity units should be {u.Pa * u.s} "
+                      f"and not {self.ct.electron_viscosity().unit}.")
         assert testTrue, errStr
 
     def test_particle_mass(self):
@@ -226,7 +229,7 @@ class Test_classical_transport:
 
     def test_coulomb_log_errors(self):
         """should raise PhysicsError if coulomb log is < 1"""
-        with pytest.raises(PhysicsError):
+        with pytest.raises(PhysicsError), pytest.warns(CouplingWarning):
             ct2 = ClassicalTransport(T_e=self.T_e,
                                      n_e=self.n_e,
                                      T_i=self.T_i,
@@ -234,7 +237,7 @@ class Test_classical_transport:
                                      ion_particle=self.ion_particle,
                                      coulomb_log_ii=0.3)
 
-        with pytest.raises(PhysicsError):
+        with pytest.raises(PhysicsError), pytest.warns(CouplingWarning):
             ct2 = ClassicalTransport(T_e=self.T_e,
                                      n_e=self.n_e,
                                      T_i=self.T_i,

--- a/plasmapy/utils/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers.py
@@ -9,6 +9,8 @@ import astropy.units as u
 import astropy.constants as const
 import colorama
 import astropy.tests.helper as astrohelper
+import warnings
+from plasmapy.utils.exceptions import PlasmaPyWarning
 
 # These colors/styles are used to highlight certain parts of the error
 # messages in consistent ways.
@@ -870,10 +872,12 @@ def assert_can_handle_nparray(function_to_test, insert_some_nans=[], insert_all_
             )
 
     # call the function with the prepared argument sets:
-    result_0d = function_to_test(**args_0d)
-    result_1d = function_to_test(**args_1d)
-    result_2d = function_to_test(**args_2d)
-    result_3d = function_to_test(**args_3d)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=PlasmaPyWarning)
+        result_0d = function_to_test(**args_0d)
+        result_1d = function_to_test(**args_1d)
+        result_2d = function_to_test(**args_2d)
+        result_3d = function_to_test(**args_3d)
 
     # assert that the 1d, 2d, 3d versions get the same result (elementwise) as the 0d version:
     # (if the function returns multiple values, loop through and test each)

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,10 +75,6 @@ testpaths = "plasmapy" "docs"
 norecursedirs = "build" "docs/_build" "examples" "auto_examples"
 doctest_plus = enabled
 doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
-# TODO we probably need to get rid of the following...
-filterwarnings =
-    ignore::plasmapy.utils.exceptions.RelativityWarning
-    ignore::plasmapy.utils.exceptions.CouplingWarning
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This replaces the aforementioned filters from setup.cfg with `with pytest.warns(CouplingWarning)` statements in tests where we expect them.

Files remaining to be cover:
- [x] plasmapy/transport/tests/test_transport.py
- [x] plasmapy/transport/tests/test_collisions.py - some, but not all, occurences of `test_handle_nparrays`
