### PR TITLE
Remove lingering astropy-helpers references

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,8 +2,6 @@
 omit =
     ci-helpers/*
     */tests/*
-    astropy_helpers/*
-    ah_bootstrap.py
     plasmapy/setup_package.py
     plasmapy/version.py
     plasmapy/_base_init.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include LICENSE.md
 include setup.py
 include pyproject.toml
 
-include ah_bootstrap.py
 include setup.cfg
 include plasmapy/tests/coveragerc
 include plasmapy/version.py
@@ -15,26 +14,5 @@ recursive-include licenses *
 prune build
 prune docs/_build
 prune docs/api
-
-
-# the next few stanzas are for astropy_helpers.  It's derived from the
-# astropy_helpers/MANIFEST.in, but requires additional includes for the actual
-# package directory and egg-info.
-
-include astropy_helpers/README.rst
-include astropy_helpers/CHANGES.rst
-include astropy_helpers/LICENSE.rst
-recursive-include astropy_helpers/licenses *
-
-include astropy_helpers/ah_bootstrap.py
-
-recursive-include astropy_helpers/astropy_helpers *.py *.pyx *.c *.h *.rst
-recursive-include astropy_helpers/astropy_helpers.egg-info *
-# include the sphinx stuff with "*" because there are css/html/rst/etc.
-recursive-include astropy_helpers/astropy_helpers/sphinx *
-
-prune astropy_helpers/build
-prune astropy_helpers/astropy_helpers/tests
-
 
 global-exclude *.pyc *.o

--- a/docs/development/release_guide.rst
+++ b/docs/development/release_guide.rst
@@ -28,8 +28,6 @@ Pre-release
 
 * Edit ``setup.cfg`` to remove ``.dev`` from ``version = 0.2.0.dev``
 
-* Update ``astropy_helpers`` to the most recent release
-
 * Make sure tests pass (``python setup.py test``) and documentation builds without issue (``python setup.py build_docs -W``)
 
 * commit your changes up until now

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -513,9 +513,7 @@ the following example, lines 3 and 4 will be ignored in coverage tests.
       raise RuntimeError from exc
 
 The ``.coveragerc`` file is used to specify lines of code and files that
-should always be ignored in coverage tests.  For example, tests in
-``astropy-helpers`` should not be run because those tests are performed
-through the ``astropy-helpers`` repository.
+should always be ignored in coverage tests.
 
 .. note::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
 auto_use = True
 
 [flake8]
-exclude = extern,sphinx,*parsetab.py,astropy_helpers,ah_bootstrap.py,conftest.py,docs/conf.py,setup.py
+exclude = extern,sphinx,*parsetab.py,conftest.py,docs/conf.py,setup.py
 
 [pycodestyle]
 # E101 - mix of tabs and spaces
@@ -95,11 +95,10 @@ exclude = extern,sphinx,*parsetab.py,astropy_helpers,ah_bootstrap.py,conftest.py
 # E901 - SyntaxError or IndentationError
 # E902 - IOError
 # select = E226,E241,E242,E704,W504
-exclude = astropy_helpers,ah_bootstrap.py,ez_setup.py,version.py,build
+exclude = version.py,build
 max-line-length = 99
 
 [pydocstyle]
-
 # The error codes for pydocstyle include:
 #
 #  *D107: Missing docstring in __init__
@@ -125,7 +124,6 @@ max-line-length = 99
 # function. D205 and D400 are ignored to allow the "one-liner" to exceed one
 # line, which is sometimes necessary for even concise descriptions of plasma
 # physics functions and classes.
-
 convention = numpy
 add-select = D402,D413
 add-ignore = D202,D205,D302,D400
@@ -134,8 +132,6 @@ add-ignore = D202,D205,D302,D400
 omit =
     ci-helpers/*
     */tests/*
-    astropy_helpers/*
-    ah_bootstrap.py
     plasmapy/setup_package.py
     plasmapy/version.py
 [coverage:report]


### PR DESCRIPTION
Following up on #663.  Pretty insignificant changes.
