### PR TITLE
Creating a Codemeta JSON file

### DIFF
--- a/changelog/676.trivial.rst
+++ b/changelog/676.trivial.rst
@@ -1,0 +1,1 @@
+Add a Codemeta file (``codemeta.json``)

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,7 +2,15 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "name": "PlasmaPy",
-  "license": "BSD+Patent",
+  "description": "An open source software package for plasma research and education",
+  "keywords": [
+    "plasma physics",
+    "open source",
+    "scientific software",
+    "Python"
+  ],
+  "version": "0.3.0",
+  "license": "https://github.com/PlasmaPy/PlasmaPy/blob/master/LICENSE.md",
   "creator": [
     {
       "@type": "Organization",
@@ -11,5 +19,37 @@
     {}
   ],
   "codeRepository": "https://github.com/PlasmaPy/PlasmaPy",
-  "programmingLanguage": "Python"
+  "programmingLanguage": [
+    "Python 3.6",
+    "Python 3.7"
+  ],
+  "copyrightHolder": "PlasmaPy Developers",
+  "isAccessibleForFree": true,
+  "issueTracker": "https://github.com/PlasmaPy/plasmapy/issues",
+  "readme": "https://github.com/PlasmaPy/PlasmaPy/blob/master/README.md",
+  "developmentStatus": "WIP",
+  "buildInstructions": "http://docs.plasmapy.org/en/stable/install.html",
+  "referencePublication": "https://doi.org/10.5281/zenodo.1238132",
+  "funder": [
+    {
+      "@id": "https://doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation"
+    },
+    {
+      "@id": "https://doi.org/10.13039/100000015",
+      "@type": "Organization",
+      "name": "U.S. Department of Energy"
+    },
+    {
+      "@id": "https://doi.org/10.03039/100000104",
+      "@type": "Organization",
+      "name": "NASA"
+    },
+    {
+      "@id": "https://doi.org/10.03039/100000014",
+      "@type": "Organization",
+      "name": "Smithsonian Institution"
+    }
+  ]
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "name": "PlasmaPy",
+  "license": "BSD+Patent",
+  "creator": [
+    {
+      "@type": "Organization",
+      "name": "PlasmaPy Community"
+    },
+    {}
+  ],
+  "codeRepository": "https://github.com/PlasmaPy/PlasmaPy",
+  "programmingLanguage": "Python"
+}

--- a/docs/development/release_guide.rst
+++ b/docs/development/release_guide.rst
@@ -8,43 +8,58 @@ during all releases.
 
 The following is a partial list of tasks to be performed for each
 release.  This list is currently under development.  Developers should
-expand the instructions while performing each release, and may use
-`Astropy's release procedures <http://docs.astropy.org/en/stable/development/releasing.html>`
-for guidance.
+expand the instructions while performing each release, and may refer to
+`Astropy's release procedures
+<http://docs.astropy.org/en/stable/development/releasing.html>` for
+guidance.
 
 Pre-release
 -----------
 
-* Check that the Continuous Integration is passing for the correct version `(see the latest commit on master) <https://github.com/PlasmaPy/PlasmaPy/commits/master>`_
+* Check that the Continuous Integration is passing for the correct
+  version `(see the latest commit on master)
+  <https://github.com/PlasmaPy/PlasmaPy/commits/master>`_
 
 * Update ``docs/about/change_log.rst``
 
 * Update ``docs/about/release_notes.rst``
 
-* Update ``.mailmap`` and ``docs/about/credits.rst`` to include new contributors
+* Update ``.mailmap`` and ``docs/about/credits.rst`` to include new
+  contributors
 
-  * use ``git shortlog -n -s -e`` for ``.mailmap``
-  * use ``astropy-tools/author_lists.py`` for ``credits.rst``
+  * Use ``git shortlog -n -s -e`` for ``.mailmap``
+  * Use ``astropy-tools/author_lists.py`` for ``credits.rst``
 
-* Edit ``setup.cfg`` to remove ``.dev`` from ``version = 0.2.0.dev``
+* Edit ``setup.cfg`` to remove ``.dev`` from ``version = x.y.z.dev``
 
-* Make sure tests pass (``python setup.py test``) and documentation builds without issue (``python setup.py build_docs -W``)
+* Reserve a digital object identifier on Zenodo, and update citation
+  information (e.g., in ``plasmapy.__citation__`` and ``README.md``)
 
-* commit your changes up until now
+* Update code metadata in ``codemeta.json``
 
-  * double-check CI on pushing this to a branch
+  * The `Codemeta standard <https://codemeta.github.io/>`_ is
+    relatively new, so check the standard for terms that have changed
+    and new terms that may apply
 
-* tag the new version with ``git tag -s v<version> -m "Tagging v<version>"``
+* Make sure that tests pass (``python setup.py test``) and that
+  documentation builds without issue (``python setup.py build_docs -W``)
 
-  * note that ``-s`` signs the commit with a GPG key
+* Commit your changes up until now
 
-* test that RTD is building the documentation correctly on release branch (and the version is correct)
+  * Double-check CI on pushing this to a branch
 
-* perform a source distribution release
+* Tag the new version with ``git tag -s v<version> -m "Tagging v<version>"``
 
-  * get a clean copy of the repository (``git clean -fxd`` or ``git clone``)
-  * use ``python setup.py build sdist``
-  * test that the sdist installs in a clean environment::
+  * Note that ``-s`` signs the commit with a GPG key
+
+* Test that RTD is building the documentation correctly on release
+  branch (and the version is correct)
+
+* Perform a source distribution release
+
+  * Get a clean copy of the repository (``git clean -fxd`` or ``git clone``)
+  * Use ``python setup.py build sdist``
+  * Test that the sdist installs in a clean environment::
 
        $ conda create -n plasmapy_release_test_v<version> numpy
        $ conda activate plasmapy_release_test_v<version>
@@ -52,7 +67,8 @@ Pre-release
        $ python -c 'import plasmapy; plasmapy.test()'
        $ conda deactivate
 
-  * Check that the `plasmapy.__version__` number is correct (``python -c 'import plasmapy; print(plasmapy.__version__)'``)
+  * Check that the `plasmapy.__version__` number is correct
+    (``python -c 'import plasmapy; print(plasmapy.__version__)'``)
 
 Release
 -------
@@ -60,7 +76,8 @@ Release
 * Create a new branch for the release that is separate from the master
   branch
   
-* Merge (via fast-forward merge with `git merge --ff-only`) changes from `master` into `stable`
+* Merge (via fast-forward merge with `git merge --ff-only`) changes
+  from ``master`` into ``stable``
 
 * Make sure all tests pass
 
@@ -73,11 +90,13 @@ Release
 Post-release
 ------------
 
-* Update ``docs/about/change_log.rst`` (Add a new heading for the next release)
+* Update ``docs/about/change_log.rst`` (Add a new heading for the next
+  release)
 
 * Update ``setup.cfg`` (increment version and add ``dev`` suffix)
 
-* Mint a release on Zenodo and get a digital object identifier (DOI)
+* Upload the release to the Zenodo record corresponding to the reserved
+  DOI
 
 * Notify plasma physics communities about the release
 
@@ -85,3 +104,4 @@ Post-release
 
 * Send release announcement to mailing list
 
+* Update the release guide to reflect any changes


### PR DESCRIPTION
This PR adds a [codemeta](https://codemeta.github.io/) JSON file that contains the metadata for our project.  I created this initially with their [online tool](https://codemeta.github.io/create/) (which I had to use Chrome for instead of Firefox; see https://github.com/codemeta/codemeta.github.io/issues/18), and added [terms from the codemeta schema](https://codemeta.github.io/terms/) to my heart's content.  Things I still need to do are:

 - [x] Add updating codemeta file to release procedure in docs
 - [x] Add a changelog entry

Closes #622.
