### PR TITLE
Enable skipping of slow tests when using pytest from the command line

### DIFF
--- a/changelog/677.feature.rst
+++ b/changelog/677.feature.rst
@@ -1,3 +1,1 @@
 Added pytest.mark.slow to pytest markers.
-Added --not-slow pytest invocation to skip tests marked slow.
-added --slow pytest invocation to only run tests marked slow.

--- a/changelog/677.feature.rst
+++ b/changelog/677.feature.rst
@@ -1,0 +1,3 @@
+Added pytest.mark.slow to pytest markers.
+Added --not-slow pytest invocation to skip tests marked slow.
+added --slow pytest invocation to only run tests marked slow.

--- a/changelog/677.feature.rst
+++ b/changelog/677.feature.rst
@@ -1,1 +1,2 @@
 Added pytest.mark.slow to pytest markers.
+Updated documentation to notify developers of functionality.

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -74,6 +74,8 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Sixue Xu <https://github.com/hzxusx>`__
 * `Carol Zhang <https://github.com/carolyz>`__
 * `Angad Singh <https://github.com/singha95>`__
+* `Brian Goodall <https://github.com/goodab>`__
+
 
 This list contains contributors to PlasmaPy's core package and vision
 statement, including a few people who do not show up as `PlasmaPy

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -117,6 +117,11 @@ short traceback reports, and run tests only if the test path contains
 
 One may also run ``pytest`` from the command line.
 
+Some tests in the test suite can take a long time to run, which can
+slow down development. These tests can be identified with the pytest annotation
+``@pytest.mark.slow``. To skip these tests, execute ``pytest -m 'not slow'``.
+To exclusively test the slow tests, execute ``pytest -m slow``.
+
 .. _testing-guidelines-running-tests-python:
 
 Running tests within Python
@@ -156,6 +161,8 @@ maintainable, and robust tests.
 * Tests are run frequently during code development, and slow tests may
   interrupt the flow of a contributor.  Tests should be minimal,
   sufficient enough to be complete, and as efficient as possible.
+
+* Slow tests can be annotated with ``@pytest.mark.slow`` when they cannot be made more efficient.
 
 .. _testing-guidelines-writing-tests-organization:
 

--- a/plasmapy/classes/sources/tests/test_plasmablob.py
+++ b/plasmapy/classes/sources/tests/test_plasmablob.py
@@ -99,6 +99,7 @@ def test_Plasma3D_derived_vars():
     assert test_plasma.alfven_speed.unit.si == u.m / u.s
     assert np.allclose(test_plasma.alfven_speed.value, 10.92548431)
 
+@pytest.mark.slow
 def test_Plasma3D_add_magnetostatics():
     r"""Function to test add_magnetostatic function
     """
@@ -111,7 +112,7 @@ def test_Plasma3D_add_magnetostatics():
                 domain_z=np.linspace(-2, 2, 20) * u.m)
 
     plasma.add_magnetostatic(dipole, cw, gw_cw, iw)
-    
+
 class Test_PlasmaBlobRegimes:
     def test_intermediate_coupling(self):
         r"""

--- a/plasmapy/classes/sources/tests/test_plasmablob.py
+++ b/plasmapy/classes/sources/tests/test_plasmablob.py
@@ -99,6 +99,7 @@ def test_Plasma3D_derived_vars():
     assert test_plasma.alfven_speed.unit.si == u.m / u.s
     assert np.allclose(test_plasma.alfven_speed.value, 10.92548431)
 
+
 @pytest.mark.slow
 def test_Plasma3D_add_magnetostatics():
     r"""Function to test add_magnetostatic function

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -17,11 +17,14 @@ def pytest_addoption(parser):
     )
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", ("slow: mark test as slow to run. Test can be skipped with"
-        " --not-slow or exclusively executed with --slow."))
+    config.addinivalue_line(
+        "markers",
+        ("slow: mark test as slow to run. Test can be skipped with --not-slow or exclusively "
+        "executed with --slow.")
+    )
 
 def pytest_collection_modifyitems(config, items):
-    skip_mark = None
+    skip_condtion = None
     if config.getoption("--not-slow") and config.getoption("--slow"):
         # User wants to run both the not-slow tests and the slow tests, which is the same as running
         #   with no options
@@ -33,7 +36,7 @@ def pytest_collection_modifyitems(config, items):
     elif config.getoption("--slow"):
         skip_mark = pytest.mark.skip(reason="Test isn't marked slow.")
         skip_condition = lambda x: "slow" not in x.keywords
-    if skip_mark is not None:
+    if skip_condition is not None:
         for item in items:
             if skip_condition(item):
                 item.add_marker(skip_mark)

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -1,6 +1,7 @@
-# Force MPL to use non-gui backends for testing.
+'''Adds slow marker and forces matplotlib to use non-gui backends during tests'''
 import pytest
 
+# Force MPL to use non-gui backends for testing.
 try:
     import matplotlib
 except ImportError:
@@ -8,19 +9,11 @@ except ImportError:
 else:
     matplotlib.use('Agg')
 
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--not-slow", action="store_true", default=False, help='Pytest will skip slow tests.'
-    )
-    parser.addoption(
-        "--slow", action="store_true", default=False, help='Pytest will only run slow tests.'
-    )
-
-
+# Add slow marker
+# coverage : ignore
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
-        ("slow: mark test as slow to run. Test can be skipped with --not-slow or exclusively "
-        "executed with --slow.")
+        ("slow: mark test as slow to run. Used to mark tests that execute in more than 1000x the "
+        "time of the median test.")
     )

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -1,4 +1,4 @@
-# Force MPL to use non-gui backends for testing.
+    # Force MPL to use non-gui backends for testing.
 import pytest
 
 try:
@@ -22,21 +22,3 @@ def pytest_configure(config):
         ("slow: mark test as slow to run. Test can be skipped with --not-slow or exclusively "
         "executed with --slow.")
     )
-
-def pytest_collection_modifyitems(config, items):
-    skip_condtion = None
-    if config.getoption("--not-slow") and config.getoption("--slow"):
-        # User wants to run both the not-slow tests and the slow tests, which is the same as running
-        #   with no options
-        pass
-    elif config.getoption("--not-slow"):
-        # Skip slow tests
-        skip_mark = pytest.mark.skip(reason="Test is marked slow.")
-        skip_condition = lambda x: "slow" in x.keywords
-    elif config.getoption("--slow"):
-        skip_mark = pytest.mark.skip(reason="Test isn't marked slow.")
-        skip_condition = lambda x: "slow" not in x.keywords
-    if skip_condition is not None:
-        for item in items:
-            if skip_condition(item):
-                item.add_marker(skip_mark)

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -1,7 +1,39 @@
 # Force MPL to use non-gui backends for testing.
+import pytest
+
 try:
     import matplotlib
 except ImportError:
     pass
 else:
     matplotlib.use('Agg')
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--not-slow", action="store_true", default=False, help='Pytest will skip slow tests.'
+    )
+    parser.addoption(
+        "--slow", action="store_true", default=False, help='Pytest will only run slow tests.'
+    )
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", ("slow: mark test as slow to run. Test can be skipped with"
+        " --not-slow or exclusively executed with --slow."))
+
+def pytest_collection_modifyitems(config, items):
+    skip_mark = None
+    if config.getoption("--not-slow") and config.getoption("--slow"):
+        # User wants to run both the not-slow tests and the slow tests, which is the same as running
+        #   with no options
+        pass
+    elif config.getoption("--not-slow"):
+        # Skip slow tests
+        skip_mark = pytest.mark.skip(reason="Test is marked slow.")
+        skip_condition = lambda x: "slow" in x.keywords
+    elif config.getoption("--slow"):
+        skip_mark = pytest.mark.skip(reason="Test isn't marked slow.")
+        skip_condition = lambda x: "slow" not in x.keywords
+    if skip_mark is not None:
+        for item in items:
+            if skip_condition(item):
+                item.add_marker(skip_mark)

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -1,6 +1,4 @@
-'''Adds slow marker and forces matplotlib to use non-gui backends during tests'''
-import pytest
-
+'''Adds custom functionality to pytest'''
 # Force MPL to use non-gui backends for testing.
 try:
     import matplotlib
@@ -9,11 +7,12 @@ except ImportError:
 else:
     matplotlib.use('Agg')
 
-# Add slow marker
 # coverage : ignore
 def pytest_configure(config):
+    '''Adds @pytest.mark.slow annotation for marking slow tests for optional skipping'''
     config.addinivalue_line(
         "markers",
         ("slow: mark test as slow to run. Used to mark tests that execute in more than 1000x the "
-        "time of the median test.")
+         "time of the median test. Tests marked slow may be skipped with 'pytest -m 'not slow'' "
+         "or exclusively executed with 'pytest -m slow'.")
     )

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -1,4 +1,4 @@
-    # Force MPL to use non-gui backends for testing.
+# Force MPL to use non-gui backends for testing.
 import pytest
 
 try:
@@ -8,6 +8,7 @@ except ImportError:
 else:
     matplotlib.use('Agg')
 
+
 def pytest_addoption(parser):
     parser.addoption(
         "--not-slow", action="store_true", default=False, help='Pytest will skip slow tests.'
@@ -15,6 +16,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--slow", action="store_true", default=False, help='Pytest will only run slow tests.'
     )
+
 
 def pytest_configure(config):
     config.addinivalue_line(

--- a/plasmapy/simulation/tests/test_particletracker.py
+++ b/plasmapy/simulation/tests/test_particletracker.py
@@ -97,7 +97,7 @@ def fit_sine_curve(position, t, expected_gyrofrequency, phase=0):
 #     s.test_kinetic_energy()
 #     # s.plot_trajectories()
 
-
+@pytest.mark.slow
 def test_particle_exb_drift(uniform_magnetic_field):
     r"""
         Tests the particle stepper for a field with magnetic field in the Z


### PR DESCRIPTION
Adds the functionality requested in #673

Adds a marker and two options to pytest to speed up the test suite for routine tests. Slow tests can be marked with ```@pytest.mark.slow```. These tests can then be skipped with ```pytest --not-slow``` or exclusively executed with ```pytest --slow```.