### PR TITLE
Guidelines for supporting old versions of Python, NumPy, and Astropy

### DIFF
--- a/docs/development/release_guide.rst
+++ b/docs/development/release_guide.rst
@@ -30,7 +30,11 @@ Pre-release
   * Use ``git shortlog -n -s -e`` for ``.mailmap``
   * Use ``astropy-tools/author_lists.py`` for ``credits.rst``
 
-* Edit ``setup.cfg`` to remove ``.dev`` from ``version = x.y.z.dev``
+* Update ``setup.cfg``
+
+  * Remove ``.dev`` from ``version = x.y.z.dev``
+  * Update minimum versions of required packages, including
+    ``python_requires``, ``install_requires``, and other variables
 
 * Reserve a digital object identifier on Zenodo, and update citation
   information (e.g., in ``plasmapy.__citation__`` and ``README.md``)
@@ -105,3 +109,31 @@ Post-release
 * Send release announcement to mailing list
 
 * Update the release guide to reflect any changes
+
+Compatibility with Prior Versions of Python, NumPy, and Astropy
+===============================================================
+
+PlasmaPy releases will generally abide by the following standards,
+which are adapted from `NumPy Enhancement Proposal 29
+<https://numpy.org/neps/nep-0029-deprecation_policy.html>`_ for the
+support of old versions of Python, NumPy, and Astropy.
+
+* PlasmaPy should support at least the minor versions of Python
+  initially released 42 months prior to a planned project release date.
+* PlasmaPy should support at least the 2 latest minor versions of
+  Python.
+* PlasmaPy should support minor versions of NumPy initially released
+  in the 24 months prior to a planned project release date or the
+  oldest version that supports the minimum Python version (whichever is
+  higher).
+* PlasmaPy should support at least the 3 latest minor versions of
+  NumPy and Astropy.
+
+Upstream package requirements should only change during major or minor
+releases, and never during a patch release.  All supported minor
+versions of Python should be in the test matrix and have binary
+artifacts built for releases.
+
+Exceptions to these guidelines should only be made when there are major
+improvements or fixes to upstream functionality or when other required
+packages have stricter requirements.

--- a/docs/development/release_guide.rst
+++ b/docs/development/release_guide.rst
@@ -129,10 +129,9 @@ support of old versions of Python, NumPy, and Astropy.
 * PlasmaPy should support at least the 3 latest minor versions of
   NumPy and Astropy.
 
-Upstream package requirements should only change during major or minor
-releases, and never during a patch release.  All supported minor
-versions of Python should be in the test matrix and have binary
-artifacts built for releases.
+The required major and minor version numbers of upstream packages may
+only change during major or minor releases of PlasmaPy, and never during
+patch releases.
 
 Exceptions to these guidelines should only be made when there are major
 improvements or fixes to upstream functionality or when other required


### PR DESCRIPTION
[NumPy Enhancement Proposal (NEP) 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) includes suggested community guidelines for the support of old versions of Python and NumPy.  The idea behind NEP 29 is to provide predictability to when old packages stop being supported throughout the scientific Python ecosystem.  This pull request adapts these guidelines for PlasmaPy, in particular by including requirements for older versions of Astropy.  

The guidelines were adjusted to allow us some flexibility, since there may be situations where it would provide a much greater benefit to update sooner.  While we are still early in the development phase, we can get away with being less strict with supporting older versions of packages.  As we build up a user base and improve package stability, we should depart from these guidelines more sparingly.

