### PR TITLE
bump sphinx version (>2) to generate binder link

### DIFF
--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -18,7 +18,7 @@ dependencies:
     - numpydoc
     - pytest
     - lmfit
-    - sphinx
+    - sphinx>2
     - sphinx-gallery
     - sphinx-automodapi
     - sphinx_rtd_theme


### PR DESCRIPTION
I just read and went through @StanczakDominik's [helpful guide](https://stanczakdominik.github.io/posts/simple-binder-usage-with-sphinx-gallery-through-jupytext/) and applied it to my own repository, but I noticed the binder badges are not showing at the [end of the tutorials](http://docs.plasmapy.org/en/stable/auto_examples/particle_stepper.html#sphx-glr-auto-examples-particle-stepper-py).

For my repository the solution was [bumping the version of sphinx that needed to be installed](https://github.com/HBClab/NiBetaSeries/blob/76f9779c17ef8069410eb6774ac0bb95b917cefd/setup.cfg#L66) since readthedocs by default installs `sphinx==1.8.5`.

I'm hoping this solution works for this repository as a way of saying thank you for providing that guide.

P.S., I do not know if it is necessary, but [I wiped the build environment](https://docs.readthedocs.io/en/stable/guides/wipe-environment.html) before trying to change the sphinx version readthedocs uses