### PR TITLE
Feature/improve particle comparison

### DIFF
--- a/changelog/697.trivial.rst
+++ b/changelog/697.trivial.rst
@@ -1,0 +1,1 @@
+Improve comparison of Particle class

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -75,6 +75,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Thomas Ulrich <https://github.com/Elfhelm>`__
 * `Sixue Xu <https://github.com/hzxusx>`__
 * `Carol Zhang <https://github.com/carolyz>`__
+* `Raymon Skjørten Hansen <https://github.com/raymonshansen>`__
 
 This list contains contributors to PlasmaPy's core package and vision
 statement, including a few people who do not show up as `PlasmaPy

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -10,6 +10,7 @@ import astropy.units as u
 import astropy.constants as const
 
 import plasmapy.utils.roman as roman
+from plasmapy.utils.collections_helpers import compare_default_dicts
 from plasmapy.atomic.elements import _Elements, _PeriodicTable
 from plasmapy.atomic.isotopes import _Isotopes
 from plasmapy.atomic.exceptions import (
@@ -492,22 +493,7 @@ class Particle:
             raise TypeError(f"The equality of {self} with {other} is undefined.")
 
         same_particle = self.particle == other.particle
-
-        # The following two loops are a hack to enable comparisons
-        # between defaultdicts.  By accessing all of the defined keys in
-        # each of the defaultdicts, this makes sure that
-        # self._attributes and other._attributes have the same keys.
-
-        # TODO: create function in utils to account for equality between
-        # defaultdicts, and implement it here
-
-        for attribute in self._attributes.keys():
-            other._attributes[attribute]
-
-        for attribute in other._attributes.keys():
-            self._attributes[attribute]
-
-        same_attributes = self._attributes == other._attributes
+        same_attributes = compare_default_dicts(self._attributes, other._attributes)
 
         if same_particle and not same_attributes:  # coverage: ignore
             raise AtomicError(

--- a/plasmapy/utils/__init__.py
+++ b/plasmapy/utils/__init__.py
@@ -4,6 +4,7 @@ code.
 """
 from . import decorators
 from . import roman
+from plasmapy.utils.collections_helpers import compare_default_dicts
 
 from plasmapy.utils.decorators.checks import (
     check_quantity,

--- a/plasmapy/utils/collections_helpers.py
+++ b/plasmapy/utils/collections_helpers.py
@@ -1,0 +1,46 @@
+from collections import defaultdict
+
+
+def compare_default_dicts(a: defaultdict, b: defaultdict) -> bool:
+    """Compare two defaultdicts, return True if equal, else False.
+    Does a benign or soft compare. If the defaultdicts COULD become
+    equal, they are considered equal.
+
+    * Does NOT change the memory imprint of any of the dictionaries.
+    * Any overlapping keys, must have same value.
+    * Keys unique to one, must have the default value of the other.
+    * Order of input does NOT matter.
+
+    Example:
+    a = defaultdict(lambda: "", a=42, b=42, c="")
+    b = defaultdict(lambda: 42, c="", d="")
+    compare_defaultdicts(a, b) -> True
+
+    Parameters
+    ----------
+    a : defaultdict
+        Default dictionary from collections
+    b : defaultdict:
+        Default dictionary from collections
+
+    Returns
+    -------
+    bool : True if equal, else False
+
+    """
+    a_keys = set(a)
+    b_keys = set(b)
+    a_unique_keys = (a_keys | b_keys) - b_keys
+    b_unique_keys = (a_keys | b_keys) - a_keys
+
+    # The intersecting keys must have the same value
+    if not all(a[key] == b[key] for key in (a_keys & b_keys)):
+        return False
+
+    # Keys unique to one, must have default value of other.
+    if not all(b.default_factory() == a[key] for key in a_unique_keys):
+        return False
+    if not all(a.default_factory() == b[key] for key in b_unique_keys):
+        return False
+
+    return True

--- a/plasmapy/utils/tests/collections_helpers_tests.py
+++ b/plasmapy/utils/tests/collections_helpers_tests.py
@@ -1,0 +1,100 @@
+import unittest
+from collections import defaultdict
+from plasmapy.utils import compare_default_dicts
+
+
+class TestDictCompare(unittest.TestCase):
+    """
+    Tests custom comparing of pythons defaultdicts.
+    Note that default value of int = 0 and default of
+    str = ''
+    """
+
+    def test_same_keys(self):
+        msg = "Two equal defaultdicts should be same."
+        a = defaultdict(int, a=1, b=1, c=1)
+        b = defaultdict(int, a=1, b=1, c=1)
+        result_a_first = compare_default_dicts(a, b)
+        result_b_first = compare_default_dicts(b, a)
+        self.assertEqual(result_a_first, True, msg)
+        self.assertEqual(result_b_first, True, msg)
+
+    def test_different_values_on_intersecting_keys_same_default(self):
+        msg = "Same key, same default, but different value should fail."
+        a = defaultdict(int, a=2, b=2, c=2)
+        b = defaultdict(int, a=1, b=1, c=1)
+        result_a_first = compare_default_dicts(a, b)
+        result_b_first = compare_default_dicts(b, a)
+        self.assertEqual(result_a_first, False, msg)
+        self.assertEqual(result_b_first, False, msg)
+
+    @unittest.skip("Awaiting specific requirements")
+    def test_disjoint_values_match_default_of_other(self):
+        msg = "???"
+        a = defaultdict(str, a=0, b=0, c="")
+        b = defaultdict(int, c="", d="", e="")
+        result_a_first = compare_default_dicts(a, b)
+        result_b_first = compare_default_dicts(b, a)
+        self.assertEqual(result_a_first, True, msg)
+        self.assertEqual(result_b_first, True, msg)
+
+    def test_two_empty_with_same_default_value(self):
+        msg = "Empty defaultdicts are equal."
+        a = defaultdict(int)
+        b = defaultdict(int)
+        result_a_first = compare_default_dicts(a, b)
+        result_b_first = compare_default_dicts(b, a)
+        self.assertEqual(result_a_first, True, msg)
+        self.assertEqual(result_b_first, True, msg)
+
+    @unittest.skip("Awaiting specific requirements")
+    def test_two_empty_with_different_default_value(self):
+        msg = "???"
+        a = defaultdict(int)
+        b = defaultdict(str)
+        result_a_first = compare_default_dicts(a, b)
+        result_b_first = compare_default_dicts(b, a)
+        self.assertEqual(result_a_first, True, msg)
+        self.assertEqual(result_b_first, True, msg)
+
+    def test_no_intersecting_keys_same_default_value(self):
+        msg = "No intersecting keys but same default value."
+        a = defaultdict(int, a=0, b=0, c=0)
+        b = defaultdict(int, d=0, e=0, f=0)
+        result_a_first = compare_default_dicts(a, b)
+        result_b_first = compare_default_dicts(b, a)
+        self.assertEqual(result_a_first, True, msg)
+        self.assertEqual(result_b_first, True, msg)
+
+    def test_no_intersecting_keys_different_default_value(self):
+        msg = "No intersecting keys but different disjoint \
+               values AND different default value are NOT equal."
+        a = defaultdict(str, a='', b='', c='')
+        b = defaultdict(int, d=0, e=0, f=0)
+        result_a_first = compare_default_dicts(a, b)
+        result_b_first = compare_default_dicts(b, a)
+        self.assertEqual(result_a_first, False, msg)
+        self.assertEqual(result_b_first, False, msg)
+
+    def test_some_intersecting_same_default_different_disjoint_values(self):
+        msg = "Keys unique to one should yield default value if \
+               queried on other."
+        a = defaultdict(int, a=10, b=10, c=5)
+        b = defaultdict(int, c=5, d=20, e=20)
+        result_a_first = compare_default_dicts(a, b)
+        result_b_first = compare_default_dicts(b, a)
+        self.assertEqual(result_a_first, False, msg)
+        self.assertEqual(result_b_first, False, msg)
+
+    def test_comparing_should_not_mutate_any_dict(self):
+        msg = "Comparing should not change any dict."
+        a = defaultdict(int, a='Hello', b=0.5, c=[])
+        a_copy = a.copy()
+        b = defaultdict(str, a=1001, b={}, c='World', d=[])
+        b_copy = b.copy()
+
+        # We're not interested in the actual dictionaries,
+        # just whether comparing mutated any of them.
+        _ = compare_default_dicts(a, b)
+        self.assertEqual(a.items(), a_copy.items(), msg)
+        self.assertEqual(b.items(), b_copy.items(), msg)


### PR DESCRIPTION
**Comparing defaultdicts**
As per discussion in Matrix chat, this pull request adds the following:
- A 'collections_helpers.py' file containing a function which compares defaultdicts without mutating them.
- A 'collections_helpers_tests.py' with unittests for above helper function.
- Slight modifications to the Particle class, using the new helper function.

**NOTE**
There are two skipped tests that concerns how dicts with differing default types are compared. See also chat for a slightly more confusing overview of the matter. :)

This particular part of the Particle class is ignored by codecoverage?? :(

All code should be PEP8 compliant. I have tried to conform to the going style(for docstrings) to the best of my ability. Please let me know about all the things I have missed and I'll update the PR as soon as I can.

Thanks for feedback and help with requirements and questions.

Raymon Skjørten Hansen
Tromsø, Norway
