### PR TITLE
Tweaked add__magnetostatics

### DIFF
--- a/changelog/703.feature.rst
+++ b/changelog/703.feature.rst
@@ -1,0 +1,1 @@
+Tweaked add__magnetostatics function in plasma3d.py

--- a/changelog/703.feature.rst
+++ b/changelog/703.feature.rst
@@ -1,1 +1,1 @@
-Tweaked add__magnetostatics function in plasma3d.py
+Optimized `add__magnetostatics` for a 16x speedup in tests!

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -75,6 +75,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Thomas Ulrich <https://github.com/Elfhelm>`__
 * `Sixue Xu <https://github.com/hzxusx>`__
 * `Carol Zhang <https://github.com/carolyz>`__
+* `Aditya Magarde <https://github.com/adityamagarde>`__
 
 This list contains contributors to PlasmaPy's core package and vision
 statement, including a few people who do not show up as `PlasmaPy

--- a/plasmapy/classes/sources/plasma3d.py
+++ b/plasmapy/classes/sources/plasma3d.py
@@ -110,9 +110,10 @@ class Plasma3D(GenericPlasma):
 
     def add_magnetostatic(self, *mstats: MagnetoStatics):
         # for each MagnetoStatic argument
+        prod = itertools.product(*[list(range(n)) for n in self.domain_shape])
         for mstat in mstats:
             # loop over 3D-index (ix,iy,iz)
-            for point_index in itertools.product(*[list(range(n)) for n in self.domain_shape]):
+            for point_index in prod:
                 # get coordinate
                 p = self.grid[(slice(None),)+point_index]  # function as [:, *index]
                 # calculate magnetic field at this point and add back


### PR DESCRIPTION
Moved the itertools out of the mstat for loop, so it's calculated only once instead of being calculated for every mstat.

I tested that function with a timer; the changed function takes lesser time.





Thank you for contributing to PlasmaPy!  Please check out our development guide at:

http://docs.plasmapy.org/en/master/development/index.html

Here are a few things to keep in mind when making a pull request (PR).

* Tests and docstrings are required for new or changed functionality.
* Please take care to write helpful commit messages: https://chris.beams.io/posts/git-commit/
* As a PR nears completion, fellow developers will likely suggest changes
  to be made before the PR is merged.
* Every pull request should include a changelog entry. Please see
  `changelog/README.rst` for instructions.
* PlasmaPy follows the PEP 8 style guide: https://www.python.org/dev/peps/pep-0008
* Please double check that a new PR will not duplicate an existing PR.
* If this PR will solve an issue tracked by GitHub, please add a phrase like
  "Closes #404." to automatically close the issue once the pull request is
  merged.  If your PR will not completely solve the issue, please still
  reference the issue.
* If this is your first contribution, please add your name to the author
  list in `docs/about/credits.rst`.
* Feel free to chat with other developers on our Matrix channel at:
  https://riot.im/app/#/room/#plasmapy:matrix.org

