### PR TITLE
Set codecov failure threshold to 0.2%

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,7 @@
+codecov:
+  token: 85c13d8a-e9e1-49fd-97d4-7ba103f3e830
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.2%


### PR DESCRIPTION
As per SunPy's codecov configuration.


<!--
Thank you for contributing to PlasmaPy! Here's a bunch of pointers to
make things easier for all of us:

* If this PR will solve an issue tracked by GitHub, please add a phrase like
  "Closes #404." to automatically close the issue once the pull request is
  merged.  If your PR will not completely solve the issue, please still
  reference the issue. For an overview of this functionality, see
  https://help.github.com/articles/closing-issues-using-keywords/

* Remember to add some description of your changes in this text box.

* Tests and docstrings are required for new or changed functionality.
  Please make sure tests are passing before requesting a review - they
  will pop up at the bottom, in the Checks box. If you're unsure why
  they're failing, ask!
  
* If your pull request is not yet ready for review, submit it as a draft.
  Remember to change its' status once it's ready.

* If this is your first contribution, please add your name to the author
  list in `docs/about/credits.rst`.
  
* Feel free to chat with other developers on our Matrix channel at:
   https://riot.im/app/#/room/#plasmapy:openastronomy.org
  
* We have a developer's guide, where some answers to your questions may
  possibly be found, at
  http://docs.plasmapy.org/en/master/development/index.html

Many thanks in advance for following these pointers and for being willing to contribute!

When submitting a pull request, please ensure that you can (eventually,
sometime before it is merged) check the following basic requirements:

-->

- [ ] I have added a changelog entry for this pull request (please see
  `changelog/README.rst` for instructions, and if you need help with picking the PR type, ask!)
- [x] If adding new functionality, I have added (passing) tests and
      docstrings. (Tests pop up at the bottom, in the checks box).
- [x] I have fixed any new failing tests (if you're unsure why
  they're failing, ask!).