### PR TITLE
Turn ClassicalTransport methods into attributes

### DIFF
--- a/changelog/705.breaking.rst
+++ b/changelog/705.breaking.rst
@@ -1,0 +1,1 @@
+Change `ClassicalTransport` methods into attributes

--- a/plasmapy/examples/plot_braginskii.py
+++ b/plasmapy/examples/plot_braginskii.py
@@ -43,10 +43,10 @@ print(braginskii.hall_i)
 # referred to via methods. To signify the need to calculate them, we
 # call them via ().
 
-print(braginskii.resistivity())
-print(braginskii.thermoelectric_conductivity())
-print(braginskii.electron_thermal_conductivity())
-print(braginskii.ion_thermal_conductivity())
+print(braginskii.resistivity)
+print(braginskii.thermoelectric_conductivity)
+print(braginskii.electron_thermal_conductivity)
+print(braginskii.ion_thermal_conductivity)
 
 ######################################################
 # They also change with magnetization:
@@ -58,10 +58,10 @@ mag_braginskii = ClassicalTransport(thermal_energy_per_electron,
                                     ion_particle,
                                     B = 0.1 * u.T)
 
-print(mag_braginskii.resistivity())
-print(mag_braginskii.thermoelectric_conductivity())
-print(mag_braginskii.electron_thermal_conductivity())
-print(mag_braginskii.ion_thermal_conductivity())
+print(mag_braginskii.resistivity)
+print(mag_braginskii.thermoelectric_conductivity)
+print(mag_braginskii.electron_thermal_conductivity)
+print(mag_braginskii.ion_thermal_conductivity)
 
 ######################################################
 # They also change with direction with respect to the magnetic field. Here,
@@ -77,15 +77,15 @@ all_direction_braginskii = ClassicalTransport(thermal_energy_per_electron,
                                     B = 0.1 * u.T,
                                     field_orientation = 'all')
 
-print(all_direction_braginskii.resistivity())
-print(all_direction_braginskii.thermoelectric_conductivity())
-print(all_direction_braginskii.electron_thermal_conductivity())
-print(all_direction_braginskii.ion_thermal_conductivity())
+print(all_direction_braginskii.resistivity)
+print(all_direction_braginskii.thermoelectric_conductivity)
+print(all_direction_braginskii.electron_thermal_conductivity)
+print(all_direction_braginskii.ion_thermal_conductivity)
 
 ######################################################
 # The viscosities return arrays:
 
-print(braginskii.electron_viscosity())
-print(mag_braginskii.electron_viscosity())
-print(braginskii.ion_viscosity())
-print(mag_braginskii.ion_viscosity())
+print(braginskii.electron_viscosity)
+print(mag_braginskii.electron_viscosity)
+print(braginskii.ion_viscosity)
+print(mag_braginskii.ion_viscosity)

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -262,18 +262,18 @@ class ClassicalTransport:
     >>> from astropy import units as u
     >>> t = ClassicalTransport(1*u.eV, 1e20/u.m**3,
     ...                         1*u.eV, 1e20/u.m**3, 'p')
-    >>> t.resistivity()
+    >>> t.resistivity
     <Quantity 0.00036701 m Ohm>
-    >>> t.thermoelectric_conductivity()
+    >>> t.thermoelectric_conductivity
     <Quantity 0.711084>
-    >>> t.ion_thermal_conductivity()
+    >>> t.ion_thermal_conductivity
     <Quantity 0.01552066 W / (K m)>
-    >>> t.electron_thermal_conductivity()
+    >>> t.electron_thermal_conductivity
     <Quantity 0.38064293 W / (K m)>
-    >>> t.ion_viscosity()
+    >>> t.ion_viscosity
     <Quantity [4.62129725e-07, 4.60724824e-07, 4.60724824e-07, 0.00000000e+00,
                0.00000000e+00] Pa s>
-    >>> t.electron_viscosity()
+    >>> t.electron_viscosity
     <Quantity [5.82273805e-09, 5.82082061e-09, 5.82082061e-09, 0.00000000e+00,
                0.00000000e+00] Pa s>
 
@@ -439,6 +439,7 @@ class ClassicalTransport:
         # self.mu = m_e / self.m_i  # enable the JH special features
         self.theta = self.T_e / self.T_i if theta is None else theta
 
+    @property
     def resistivity(self) -> u.Ohm * u.m:
         """
         Calculate the resistivity.
@@ -477,6 +478,7 @@ class ClassicalTransport:
         alpha = alpha_hat / (self.n_e * e ** 2 * tau_e / m_e)
         return alpha.to(u.ohm * u.m)
 
+    @property
     def thermoelectric_conductivity(self):
         """
         Calculate the thermoelectric conductivity.
@@ -497,6 +499,7 @@ class ClassicalTransport:
                                            self.field_orientation)
         return u.Quantity(beta_hat)
 
+    @property
     def ion_thermal_conductivity(self) -> u.W / u.m / u.K:
         """
         Calculate the thermal conductivity for ions.
@@ -536,6 +539,7 @@ class ClassicalTransport:
         kappa = kappa_hat * (self.n_i * k_B ** 2 * self.T_i * tau_i / self.m_i)
         return kappa.to(u.W / u.m / u.K)
 
+    @property
     def electron_thermal_conductivity(self) -> u.W / u.m / u.K:
         """
         Calculate the thermal conductivity for electrons.
@@ -587,6 +591,7 @@ class ClassicalTransport:
         kappa = kappa_hat * (self.n_e * k_B ** 2 * self.T_e * tau_e / m_e)
         return kappa.to(u.W / u.m / u.K)
 
+    @property
     def ion_viscosity(self) -> u.Pa * u.s:
         """
         Calculate the ion viscosity.
@@ -630,6 +635,7 @@ class ClassicalTransport:
             eta = (eta1.value * unit_val).to(u.Pa * u.s)
         return eta
 
+    @property
     def electron_viscosity(self) -> u.Pa * u.s:
         """
         Calculate the electron viscosity.
@@ -685,6 +691,7 @@ class ClassicalTransport:
                              eta1[4].value)) * unit_val).to(u.Pa * u.s)
         return eta
 
+    @property
     def all_variables(self) -> dict:
         """
         Return all transport variables as a dictionary.
@@ -695,13 +702,13 @@ class ClassicalTransport:
 
         """
         d = {}
-        d['resistivity'] = self.resistivity()
-        d['thermoelectric conductivity'] = self.thermoelectric_conductivity()
-        d['electron thermal conductivity'] = self.electron_thermal_conductivity()
-        d['electron viscosity'] = self.electron_viscosity()
+        d['resistivity'] = self.resistivity
+        d['thermoelectric conductivity'] = self.thermoelectric_conductivity
+        d['electron thermal conductivity'] = self.electron_thermal_conductivity
+        d['electron viscosity'] = self.electron_viscosity
         if self.model != "spitzer":
-            d['ion thermal conductivity'] = self.ion_thermal_conductivity()
-            d['ion viscosity'] = self.ion_viscosity()
+            d['ion thermal conductivity'] = self.ion_thermal_conductivity
+            d['ion viscosity'] = self.ion_viscosity
         return d
 
 
@@ -746,7 +753,7 @@ def resistivity(T_e,
                             field_orientation=field_orientation,
                             mu=mu, theta=theta,
                             coulomb_log_method=coulomb_log_method)
-    return ct.resistivity()
+    return ct.resistivity
 
 
 def thermoelectric_conductivity(T_e,
@@ -776,7 +783,7 @@ def thermoelectric_conductivity(T_e,
                             mu=mu,
                             theta=theta,
                             coulomb_log_method=coulomb_log_method)
-    return ct.thermoelectric_conductivity()
+    return ct.thermoelectric_conductivity
 
 def ion_thermal_conductivity(T_e,
                              n_e,
@@ -827,7 +834,7 @@ def ion_thermal_conductivity(T_e,
                             mu=mu,
                             theta=theta,
                             coulomb_log_method=coulomb_log_method)
-    return ct.ion_thermal_conductivity()
+    return ct.ion_thermal_conductivity
 
 
 def electron_thermal_conductivity(T_e,
@@ -891,7 +898,7 @@ def electron_thermal_conductivity(T_e,
                             mu=mu,
                             theta=theta,
                             coulomb_log_method=coulomb_log_method)
-    return ct.electron_thermal_conductivity()
+    return ct.electron_thermal_conductivity
 
 
 def ion_viscosity(T_e,
@@ -940,7 +947,7 @@ def ion_viscosity(T_e,
                             mu=mu,
                             theta=theta,
                             coulomb_log_method=coulomb_log_method)
-    return ct.ion_viscosity()
+    return ct.ion_viscosity
 
 
 def electron_viscosity(T_e,
@@ -989,7 +996,7 @@ def electron_viscosity(T_e,
                             mu=mu,
                             theta=theta,
                             coulomb_log_method=coulomb_log_method)
-    return ct.electron_viscosity()
+    return ct.electron_viscosity
 
 
 def _nondim_thermal_conductivity(hall, Z,

--- a/plasmapy/formulary/tests/test_transport.py
+++ b/plasmapy/formulary/tests/test_transport.py
@@ -107,7 +107,7 @@ class Test_classical_transport:
                 mu=self.mu,
                 theta=self.theta,
                 )
-            self.all_variables = self.ct.all_variables()
+            self.all_variables = self.ct.all_variables
 
     def test_spitzer_vs_formulary(self):
         """Spitzer resistivity should agree with approx. in NRL formulary"""
@@ -123,60 +123,60 @@ class Test_classical_transport:
                                       ct2.coulomb_log_ei *
                                       (ct2.T_e.to(u.eV)).value ** (-3 / 2) *
                                       u.Ohm * u.m)
-            testTrue = np.isclose(ct2.resistivity().value,
+            testTrue = np.isclose(ct2.resistivity.value,
                                   alpha_spitzer_perp_NRL.value,
                                   rtol=2e-2)
             errStr = (f"Resistivity should be close to "
                       f"{alpha_spitzer_perp_NRL.value} "
-                      f"and not {ct2.resistivity().value}.")
+                      f"and not {ct2.resistivity.value}.")
         assert testTrue, errStr
 
     def test_resistivity_units(self):
         """output should be a Quantity with units of Ohm m"""
         with pytest.warns(RelativityWarning):
-            testTrue = self.ct.resistivity().unit == u.Ohm * u.m
+            testTrue = self.ct.resistivity.unit == u.Ohm * u.m
             errStr = (f"Resistivity units should be {u.Ohm * u.m} and "
-                      f"not {self.ct.resistivity().unit}.")
+                      f"not {self.ct.resistivity.unit}.")
         assert testTrue, errStr
 
     def test_thermoelectric_conductivity_units(self):
         """output should be a Quantity with units of dimensionless"""
-        testTrue = self.ct.thermoelectric_conductivity().unit == u.m / u.m
+        testTrue = self.ct.thermoelectric_conductivity.unit == u.m / u.m
         errStr = (f"Thermoelectric conductivity units should be dimensionless "
-                  f"and not {self.ct.thermoelectric_conductivity().unit}.")
+                  f"and not {self.ct.thermoelectric_conductivity.unit}.")
         assert testTrue, errStr
 
     def test_ion_thermal_conductivity_units(self):
         """output should be Quantity with units of W / (m K)"""
-        testTrue = self.ct.ion_thermal_conductivity().unit == u.W / u.m / u.K
+        testTrue = self.ct.ion_thermal_conductivity.unit == u.W / u.m / u.K
         errStr = (f"Ion thermal conductivity units "
                   f"should be {u.W / u.m / u.K} "
-                  f"and not {self.ct.ion_thermal_conductivity().unit}.")
+                  f"and not {self.ct.ion_thermal_conductivity.unit}.")
         assert testTrue, errStr
 
     def test_electron_thermal_conductivity_units(self):
         """output should be Quantity with units of W / (m K)"""
         with pytest.warns(RelativityWarning):
-            testTrue = (self.ct.electron_thermal_conductivity().unit ==
+            testTrue = (self.ct.electron_thermal_conductivity.unit ==
                         u.W / u.m / u.K)
             errStr = (f"Electron thermal conductivity units "
                       f"should be {u.W / u.m / u.K} "
-                      f"and not {self.ct.electron_thermal_conductivity().unit}.")
+                      f"and not {self.ct.electron_thermal_conductivity.unit}.")
         assert testTrue, errStr
 
     def test_ion_viscosity_units(self):
         """output should be Quantity with units of Pa s """
-        testTrue = self.ct.ion_viscosity().unit == u.Pa * u.s
+        testTrue = self.ct.ion_viscosity.unit == u.Pa * u.s
         errStr = (f"Ion viscosity units should be {u.Pa * u.s} "
-                  f"and not {self.ct.ion_viscosity().unit}.")
+                  f"and not {self.ct.ion_viscosity.unit}.")
         assert testTrue, errStr
 
     def test_electron_viscosity_units(self):
         """output should be Quantity with units of Pa s"""
         with pytest.warns(RelativityWarning):
-            testTrue = self.ct.electron_viscosity().unit == u.Pa * u.s
+            testTrue = self.ct.electron_viscosity.unit == u.Pa * u.s
             errStr = (f"Electron viscosity units should be {u.Pa * u.s} "
-                      f"and not {self.ct.electron_viscosity().unit}.")
+                      f"and not {self.ct.electron_viscosity.unit}.")
         assert testTrue, errStr
 
     def test_particle_mass(self):
@@ -328,22 +328,21 @@ class Test_classical_transport:
                                      ion_particle=self.ion_particle,
                                      hall_i=0,
                                      hall_e=0)
-            testTrue = np.isclose(ct2.resistivity(),
+            testTrue = np.isclose(ct2.resistivity,
                                   2.8184954e-8 * u.Ohm * u.m,
                                   atol=1e-6 * u.Ohm * u.m)
             errStr = (f"Resistivity should be close to "
-                      f"{2.8184954e-8 * u.Ohm * u.m} and not {ct2.resistivity()}.")
+                      f"{2.8184954e-8 * u.Ohm * u.m} and not {ct2.resistivity}.")
         assert testTrue, errStr
 
-    @pytest.mark.parametrize("model, method, field_orientation, expected", [
+    @pytest.mark.parametrize("model, attr_name, field_orientation, expected", [
         ("ji-held", "resistivity", "all", 3),
         ("ji-held", "thermoelectric_conductivity", "all", 3),
         ("ji-held", "electron_thermal_conductivity", "all", 3),
         ("ji-held", "ion_thermal_conductivity", "all", 3),
         ("spitzer", "resistivity", "all", 2),
         ])
-    def test_number_of_returns(self, model, method, field_orientation,
-                               expected):
+    def test_number_of_returns(self, model, attr_name, field_orientation, expected):
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(T_e=self.T_e,
                                      n_e=self.n_e,
@@ -352,10 +351,10 @@ class Test_classical_transport:
                                      ion_particle=self.ion_particle,
                                      model=model,
                                      field_orientation=field_orientation)
-            method_to_call = getattr(ct2, method)
-            testTrue = np.size(method_to_call()) == expected
-            errStr = (f"{method} in {model} model returns "
-                      f"{np.size(method_to_call())} objects. "
+            attr_to_test = getattr(ct2, attr_name)
+            testTrue = np.size(attr_to_test) == expected
+            errStr = (f"{attr_name} in {model} model returns "
+                      f"{np.size(attr_to_test)} objects. "
                       f"Expected to return {expected} objects.")
         assert testTrue, errStr
 
@@ -372,11 +371,11 @@ class Test_classical_transport:
                                      n_i=self.n_i,
                                      ion_particle=self.ion_particle,
                                      model=model)
-            testTrue = np.isclose(ct2.resistivity(),
+            testTrue = np.isclose(ct2.resistivity,
                                   expected,
                                   atol=1e-6 * u.Ohm * u.m)
             errStr = (f"Resistivity in {model} model should be "
-                      f"close to {expected} and not {ct2.resistivity()}.")
+                      f"close to {expected} and not {ct2.resistivity}.")
         assert testTrue, errStr
 
     @pytest.mark.parametrize("model, expected", [
@@ -392,12 +391,12 @@ class Test_classical_transport:
                                      n_i=self.n_i,
                                      ion_particle=self.ion_particle,
                                      model=model)
-            testTrue = np.isclose(ct2.thermoelectric_conductivity(),
+            testTrue = np.isclose(ct2.thermoelectric_conductivity,
                                   expected,
                                   atol=1e-6 * u.s / u.s)
             errStr = (f"Thermoelectric conductivity in {model} model "
                       f"should be close {expected} and not "
-                      f"{ct2.thermoelectric_conductivity()}.")
+                      f"{ct2.thermoelectric_conductivity}.")
         assert testTrue, errStr
 
     @pytest.mark.parametrize("model, expected", [
@@ -414,11 +413,11 @@ class Test_classical_transport:
                                      n_i=self.n_i,
                                      ion_particle=self.ion_particle,
                                      model=model)
-            testTrue = np.allclose(ct2.electron_viscosity(),
+            testTrue = np.allclose(ct2.electron_viscosity,
                                    expected,
                                    atol=1e-6 * u.Pa * u.s)
             errStr = (f"Electron viscosity in {model} model should be close to "
-                      f"{expected} and not {ct2.electron_viscosity()}.")
+                      f"{expected} and not {ct2.electron_viscosity}.")
         assert testTrue, errStr
 
     @pytest.mark.parametrize("model, expected", [
@@ -435,11 +434,11 @@ class Test_classical_transport:
                                      n_i=self.n_i,
                                      ion_particle=self.ion_particle,
                                      model=model)
-            testTrue = np.allclose(ct2.ion_viscosity(),
+            testTrue = np.allclose(ct2.ion_viscosity,
                                    expected,
                                    atol=1e-6 * u.Pa * u.s)
             errStr = (f"Electron viscosity in {model} model should be close to "
-                      f"{expected} and not {ct2.electron_viscosity()}")
+                      f"{expected} and not {ct2.electron_viscosity}")
         assert testTrue, errStr
 
     @pytest.mark.parametrize("model, expected", [
@@ -455,12 +454,12 @@ class Test_classical_transport:
                                      n_i=self.n_i,
                                      ion_particle=self.ion_particle,
                                      model=model)
-            testTrue = np.allclose(ct2.electron_thermal_conductivity(),
+            testTrue = np.allclose(ct2.electron_thermal_conductivity,
                                    expected,
                                    atol=1e-6 * u.W / (u.K * u.m))
             errStr = (f"Electron thermal conductivity in {model} model "
                       f"should be close to {expected} and not "
-                      f"{ct2.electron_thermal_conductivity()}.")
+                      f"{ct2.electron_thermal_conductivity}.")
         assert testTrue, errStr
 
     @pytest.mark.parametrize("model, expected", [
@@ -475,12 +474,12 @@ class Test_classical_transport:
                                      n_i=self.n_i,
                                      ion_particle=self.ion_particle,
                                      model=model)
-            testTrue = np.allclose(ct2.ion_thermal_conductivity(),
+            testTrue = np.allclose(ct2.ion_thermal_conductivity,
                                    expected,
                                    atol=1e-6 * u.W / (u.K * u.m))
             errStr = (f"Ion thermal conductivity in {model} model "
                       f"should be close to {expected} and not "
-                      f"{ct2.ion_thermal_conductivity()}.")
+                      f"{ct2.ion_thermal_conductivity}.")
         assert testTrue, errStr
 
     @pytest.mark.parametrize("key, expected", {
@@ -533,7 +532,7 @@ class Test_classical_transport:
                                                  mu=self.mu,
                                                  theta=self.theta,
                                                  ),
-                                     self.ct_wrapper.resistivity())
+                                     self.ct_wrapper.resistivity)
 
     def test_thermoelectric_conductivity_wrapper(self):
         with pytest.warns(RelativityWarning):
@@ -549,7 +548,7 @@ class Test_classical_transport:
                                                mu=self.mu,
                                                theta=self.theta,
                                                )
-            val2 = self.ct_wrapper.thermoelectric_conductivity()
+            val2 = self.ct_wrapper.thermoelectric_conductivity
             assert_quantity_allclose(val1, val2)
 
     def test_ion_thermal_conductivity_wrapper(self):
@@ -566,7 +565,7 @@ class Test_classical_transport:
                                                mu=self.mu,
                                                theta=self.theta,
                                                )
-            assert_quantity_allclose(wrapped, self.ct_wrapper.ion_thermal_conductivity())
+            assert_quantity_allclose(wrapped, self.ct_wrapper.ion_thermal_conductivity)
 
     def test_electron_thermal_conductivity_wrapper(self):
         with pytest.warns(RelativityWarning):
@@ -582,7 +581,7 @@ class Test_classical_transport:
                                                     mu=self.mu,
                                                     theta=self.theta,
                                                     )
-            assert_quantity_allclose(wrapped, self.ct_wrapper.electron_thermal_conductivity())
+            assert_quantity_allclose(wrapped, self.ct_wrapper.electron_thermal_conductivity)
 
     def test_ion_viscosity_wrapper(self):
         with pytest.warns(RelativityWarning):
@@ -598,7 +597,7 @@ class Test_classical_transport:
                                                    mu=self.mu,
                                                    theta=self.theta,
                                                    ),
-                                     self.ct_wrapper.ion_viscosity())
+                                     self.ct_wrapper.ion_viscosity)
 
     def test_electron_viscosity_wrapper(self):
         with pytest.warns(RelativityWarning):
@@ -614,7 +613,7 @@ class Test_classical_transport:
                                                     mu=self.mu,
                                                     theta=self.theta,
                                                     ),
-                                     self.ct_wrapper.electron_viscosity())
+                                     self.ct_wrapper.electron_viscosity)
 
 @pytest.mark.parametrize(["particle"], ['e', 'p'])
 def test_nondim_thermal_conductivity_unrecognized_model(particle):


### PR DESCRIPTION
I went through the `ClassicalTransport` class and made all of the methods into attributes by using the `@property` decorator.  Before, we had to do:
```Python
>>> classical_transport_instance.resistivity()
```
Now, we have to do:
```Python
>>> classical_transport_instance.resistivity
```

This pull request is brought to you by procrastinating working on my poster for the APS DPP meeting.