### PR TITLE
Added examples in documentation to mass_density  and Hall_parame…

### DIFF
--- a/changelog/709.doc.rst
+++ b/changelog/709.doc.rst
@@ -1,0 +1,2 @@
+Added exampes to the documentation to mass_density
+ and Hall_parameter functions

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -77,6 +77,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Carol Zhang <https://github.com/carolyz>`__
 * `Thomas Varnish <https://github.com/tvarnish>`__
 * `Aditya Magarde <https://github.com/adityamagarde>`__
+* `Diego A. Diaz Riega <https://github.com/diego7319>`__
 
 This list contains contributors to PlasmaPy's core package and vision
 statement, including a few people who do not show up as `PlasmaPy

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -709,7 +709,7 @@ def Hall_parameter(n,
     >>> Hall_parameter(1e10 * u.m**-3, 2.8e3 * u.eV, 2.3 * u.T, 'He-4 +1')
     <Quantity 7.26446755e+16>
     >>> Hall_parameter(1e10 * u.m**-3, 5.8e3 * u.eV, 2.3 * u.T, 'He-4 +1')
-    <Quantity 3.25995498e+17>
+    <Quantity 2.11158408e+17>
 
     """
     from plasmapy.formulary.collisions import (fundamental_ion_collision_freq,

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -92,6 +92,14 @@ def mass_density(density, particle: Optional[str] = None, z_mean: Optional[numbe
     ~astropy.units.Quantity
         The mass density calculated from all the provided sources of information.
 
+    Examples
+    -------
+    >>> from astropy import units as u
+    >>> mass_density(1 * u.m ** -3,'p')
+    <Quantity 1.67353284e-27 kg / m3>
+    >>> mass_density(4 * u.m ** -3,'D+')
+    <Quantity 1.33779786e-26 kg / m3>
+
     """
     if density.unit.is_equivalent(u.kg / u.m ** 3):
         rho = density
@@ -101,8 +109,8 @@ def mass_density(density, particle: Optional[str] = None, z_mean: Optional[numbe
             Z = _grab_charge(particle, z_mean)
             rho = density * m_i + Z * density * m_e
         else:
-            raise ValueError(f"You must pass a particle (not {particle}) to calculate the "
-                             f"mass density!")
+            raise ValueError(f"If passing a number density, you must pass a"
+                             f"particle (not {particle}) to calculate the mass density!")
     else:
         raise ValueError(f"mass_density accepts either particle (m**-3)"
                          " or mass (kg * m**-3) density, not {density.unit}!")
@@ -694,6 +702,15 @@ def Hall_parameter(n,
     Returns
     -------
     astropy.units.quantity.Quantity
+
+    Examples
+    --------
+    >>> from astropy import units as u
+    >>> Hall_parameter(1e10 * u.m**-3, 2.8e3 * u.eV, 2.3 * u.T, 'He-4 +1')
+    <Quantity 7.26446755e+16>
+    >>> Hall_parameter(1e10 * u.m**-3, 5.8e3 * u.eV, 2.3 * u.T, 'He-4 +1')
+    <Quantity 3.25995498e+17>
+
     """
     from plasmapy.formulary.collisions import (fundamental_ion_collision_freq,
                                                fundamental_electron_collision_freq)


### PR DESCRIPTION
-Closes #708.
-Added examples to documentation to mass_density  and Hall_parameter functions that were missing.
-Changed a ValueError in mass_density with a clearer message :
From : You must pass a particle (not None) to calculate the mass density!
to: If passing a number density, you must pass a particle (not None) to calculate the mass density!