### PR TITLE
Fix h5py file warning

### DIFF
--- a/changelog/717.bugfix.rst
+++ b/changelog/717.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `h5py` warning in OpenPMD module, opening files in read mode by default

--- a/plasmapy/classes/sources/openpmd_hdf5.py
+++ b/plasmapy/classes/sources/openpmd_hdf5.py
@@ -78,7 +78,7 @@ class HDF5Reader(GenericPlasma):
         if not os.path.isfile(hdf5):
             raise FileNotFoundError(f"Could not find file: '{hdf5}'")
 
-        h5 = h5py.File(hdf5)
+        h5 = h5py.File(hdf5, 'r')
         self.h5 = h5
 
         self._check_valid_openpmd_version()
@@ -169,7 +169,7 @@ class HDF5Reader(GenericPlasma):
             raise FileNotFoundError(f"Could not find file: '{hdf5}'")
 
         if "openPMD" not in kwargs:
-            h5 = h5py.File(hdf5)
+            h5 = h5py.File(hdf5, 'r')
             try:
                 openPMD = h5.attrs["openPMD"]
             except KeyError:


### PR DESCRIPTION
 This PR fixes the [h5py warning](https://travis-ci.org/PlasmaPy/PlasmaPy/jobs/601759732#L5820) during the build.