### PR TITLE
Reformat 'requirements/requirements.txt'

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,8 +1,9 @@
-numpy (>= 1.14)
-scipy (>= 0.19)
-astropy (>= 3.1)
-mpmath (>= 1.0.0)
-h5py (>= 2.8)
-lmfit (>= 0.9.7)
-matplotlib (>= 2.0)
-colorama (>= 0.3)
+# Required Pacakges w/ version
+astropy >= 3.1
+colorama >= 0.3
+h5py >= 2.8
+lmfit >= 0.9.7
+matplotlib >= 2.0
+mpmath >= 1.0.0
+numpy >= 1.14
+scipy >= 0.19


### PR DESCRIPTION
Remove parenthesis from `requirements.txt`.  Parenthesis are not consistent with [expected `requirements.txt` format](https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format) and cause issues with IDE interpreters.