### PR TITLE
Add docstring to converter.py

### DIFF
--- a/changelog/729.doc.rst
+++ b/changelog/729.doc.rst
@@ -1,1 +1,1 @@
-Add docstrings to decorator :func:plasmapy.utils.decorators.converter.angular_freq_to_hz
+Add docstrings to decorator :func:`plasmapy.utils.decorators.converter.angular_freq_to_hz`

--- a/changelog/729.doc.rst
+++ b/changelog/729.doc.rst
@@ -1,1 +1,1 @@
-Add docstrings to decorator :func:`plasmapy.utils.decorators.converter.angular_freq_to_hz`
+Add docstrings to decorator :func:`plasmapy.utils.decorators.converter.angular_freq_to_hz`.

--- a/changelog/729.doc.rst
+++ b/changelog/729.doc.rst
@@ -1,0 +1,1 @@
+Added docstrings to the file `PlasmaPy/plasmapy/utils/decorators/converter.py`.

--- a/changelog/729.doc.rst
+++ b/changelog/729.doc.rst
@@ -1,1 +1,1 @@
-Added docstrings to the file `PlasmaPy/plasmapy/utils/decorators/converter.py`.
+Add docstrings to decorator :func:plasmapy.utils.decorators.converter.angular_freq_to_hz

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -26,7 +26,7 @@ def angular_freq_to_hz(fn):
     ValueError
         fn.__name__ can not be `to_hz`
 
-    Returns 
+    Returns
     -------
 
     _result

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -34,27 +34,36 @@ def angular_freq_to_hz(fn):
     callable
         The decorated function
 
-    Tests
-    -----
+    Examples
+    --------
 
-    >>> import astropy.units as u
-    >>> from plasmapy.utils.decorators.converter import angular_freq_to_hz
+        >>> import astropy.units as u
+        >>> from plasmapy.utils.decorators.converter import angular_freq_to_hz
+        >>>
+        >>> @angular_freq_to_hz
+        ... def foo(x):
+        ...     return x
+        >>>
+        >>> foo(5 * u.rad / u.s, to_hz=True)
+        <Quantity 0.79577472 Hz>
+        >>>
+        >>> foo(-1 * u.rad / u.s, to_hz=True)
+        <Quantity -0.15915494 Hz>
 
-    >>> @angular_freq_to_hz
-    ... def foo(x):
-    ...     return x
+    Decoration also works with methods
 
-    >>> foo(5 * u.rad / u.s, to_hz=True)
-    <Quantity 0.79577472 Hz>
+        >>> class Foo:
+        ...     def __init__(self, x):
+        ...         self.x = x
+        ...
+        ...     @angular_freq_to_hz
+        ...     def bar(self):
+        ...         return self.x
+        >>>
+        >>> foo = Foo(0.5 * u.rad / u.s)
+        >>> foo.bar(to_hz=True)
+        <Quantity 0.07957747 Hz>
 
-    >>> foo(-1 * u.rad / u.s, to_hz=True)
-    <Quantity -0.15915494 Hz>
-
-    >>> foo(0.5 * u.rad / u.s, to_hz=True)
-    <Quantity 0.07957747 Hz>
-
-    >>> foo((1/2) * u.rad / u.s, to_hz=True)
-    <Quantity 0.07957747 Hz>
     """
     # raise exception if fn uses the 'to_hz' kwarg
     sig = inspect.signature(fn)

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -34,6 +34,27 @@ def angular_freq_to_hz(fn):
     callable
         The decorated function
 
+    Notes
+    -----
+    * If `angular_freq_to_hz` is used with decorator
+      :func:`~plasmapy.utils.decorators.validate_quantities`, then
+      `angular_freq_to_hz` should be used inside
+      :func:`~plasmapy.utils.decorators.validate_quantities` but special
+      consideration is needed for setup.  The following is an example of an
+      appropriate setup::
+
+        import astropy.units as u
+        from plasmapy.utils.decorators.converter import angular_freq_to_hz
+        from plasmapy.utils.decorators.validators import validate_quantities
+
+        @validate_quantities(validations_on_return={'units': [u.rad / u.s, u.Hz]})
+        @angular_freq_to_hz
+        def foo(x: u.rad / u.s) -> u.rad / u.s
+            return x
+
+      Adding `u.Hz` to the allowed units allows the converted quantity to pass
+      the validations.
+
     Examples
     --------
 

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -11,11 +11,33 @@ from plasmapy.utils.decorators import preserve_signature
 
 
 def angular_freq_to_hz(fn):
+    """
+    Converts angular frequency (ω) frenquency to Hertz(hz)
+
+    Parameters
+    ----------
+
+    fn : obj
+        The object to be converted
+
+    Raises
+    ------
+
+    ValueError
+        fn.__name__ can not be `to_hz`
+
+    Returns 
+    -------
+
+    _result
+        result in Hertz(hz)
+
+    """
     # raise exception if fn uses the 'to_hz' kwarg
     sig = inspect.signature(fn)
     if 'to_hz' in sig.parameters:
         raise ValueError(f"Wrapped function '{fn.__name__}' can not use keyword 'to_hz'." +
-                         f" Keyword reserved for decorator functionality.")
+                         " Keyword reserved for decorator functionality.")
 
     # make new signature for fn
     new_params = sig.parameters.copy()

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -9,29 +9,54 @@ import inspect
 from astropy import units as u
 from plasmapy.utils.decorators import preserve_signature
 
-
 def angular_freq_to_hz(fn):
     """
-    Converts angular frequency (ω) frenquency to Hertz(hz)
+    A decorator that adds to a function the ability to convert the function's return from angular frequency (rad/s)(ω) to frequency (Hz).
+
+    A kwarg to_hz is added to the function's signature, with a default value of False. 
+    The keyword is also added to the function's docstring under the Other Parameters heading.
 
     Parameters
     ----------
 
-    fn : obj
-        The object to be converted
+    fn : function
+        The function to be decorated
 
     Raises
     ------
 
     ValueError
-        fn.__name__ can not be `to_hz`
+        If `fn` has already defined a kwarg `to_hz`
 
     Returns
     -------
 
-    _result
-        result in Hertz(hz)
+    callable
+        The decorated function
 
+    Tests
+    -----
+
+    >>> import astropy.units as u
+    >>> from plasmapy.utils.decorators.converter import angular_freq_to_hz
+
+    >>> @angular_freq_to_hz
+    ... def foo(x):
+    ...     return x
+
+    >>> foo(5 * u.rad / u.s, to_hz=True)
+    <Quantity 0.79577472 Hz>
+
+    >>> foo(-1 * u.rad / u.s, to_hz=True)
+    <Quantity -0.15915494 Hz>
+
+    >>> foo(0.5 * u.rad / u.s, to_hz=True)
+    <Quantity 0.07957747 Hz>
+
+    >>> foo((1/2) * u.rad / u.s, to_hz=True)
+    <Quantity 0.07957747 Hz>
+
+    
     """
     # raise exception if fn uses the 'to_hz' kwarg
     sig = inspect.signature(fn)
@@ -66,3 +91,4 @@ def angular_freq_to_hz(fn):
         wrapper.__doc__ = added_doc_bit
 
     return wrapper
+    

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -37,7 +37,7 @@ def angular_freq_to_hz(fn):
     sig = inspect.signature(fn)
     if 'to_hz' in sig.parameters:
         raise ValueError(f"Wrapped function '{fn.__name__}' can not use keyword 'to_hz'." +
-                         " Keyword reserved for decorator functionality.")
+                         f" Keyword reserved for decorator functionality.")
 
     # make new signature for fn
     new_params = sig.parameters.copy()

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -11,9 +11,10 @@ from plasmapy.utils.decorators import preserve_signature
 
 def angular_freq_to_hz(fn):
     """
-    A decorator that adds to a function the ability to convert the function's return from angular frequency (rad/s)(ω) to frequency (Hz).
+    A decorator that adds to a function the ability to convert the function's return from 
+    angular frequency (rad/s or ω) to frequency (Hz).
 
-    A kwarg to_hz is added to the function's signature, with a default value of False. 
+    A kwarg to_hz is added to the function's signature, with a default value of False.
     The keyword is also added to the function's docstring under the Other Parameters heading.
 
     Parameters
@@ -54,9 +55,7 @@ def angular_freq_to_hz(fn):
     <Quantity 0.07957747 Hz>
 
     >>> foo((1/2) * u.rad / u.s, to_hz=True)
-    <Quantity 0.07957747 Hz>
-
-    
+    <Quantity 0.07957747 Hz> 
     """
     # raise exception if fn uses the 'to_hz' kwarg
     sig = inspect.signature(fn)
@@ -91,4 +90,3 @@ def angular_freq_to_hz(fn):
         wrapper.__doc__ = added_doc_bit
 
     return wrapper
-    

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -19,19 +19,16 @@ def angular_freq_to_hz(fn):
 
     Parameters
     ----------
-
     fn : function
         The function to be decorated
 
     Raises
     ------
-
     ValueError
         If `fn` has already defined a kwarg `to_hz`
 
     Returns
     -------
-
     callable
         The decorated function
 
@@ -60,7 +57,7 @@ def angular_freq_to_hz(fn):
     # raise exception if fn uses the 'to_hz' kwarg
     sig = inspect.signature(fn)
     if 'to_hz' in sig.parameters:
-        raise ValueError(f"Wrapped function '{fn.__name__}' can not use keyword 'to_hz'." +
+        raise ValueError(f"Wrapped function '{fn.__name__}' can not use keyword 'to_hz'."
                          f" Keyword reserved for decorator functionality.")
 
     # make new signature for fn

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -9,13 +9,15 @@ import inspect
 from astropy import units as u
 from plasmapy.utils.decorators import preserve_signature
 
+
 def angular_freq_to_hz(fn):
     """
     A decorator that adds to a function the ability to convert the function's return from
-    angular frequency (rad/s or ω) to frequency (Hz).
+    angular frequency (rad/s) to frequency (Hz).
 
-    A kwarg to_hz is added to the function's signature, with a default value of False.
-    The keyword is also added to the function's docstring under the Other Parameters heading.
+    A kwarg `to_hz` is added to the function's signature, with a default value of `False`.
+    The keyword is also added to the function's docstring under the **"Other Parameters"**
+    heading.
 
     Parameters
     ----------

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -11,7 +11,7 @@ from plasmapy.utils.decorators import preserve_signature
 
 def angular_freq_to_hz(fn):
     """
-    A decorator that adds to a function the ability to convert the function's return from 
+    A decorator that adds to a function the ability to convert the function's return from
     angular frequency (rad/s or ω) to frequency (Hz).
 
     A kwarg to_hz is added to the function's signature, with a default value of False.
@@ -55,7 +55,7 @@ def angular_freq_to_hz(fn):
     <Quantity 0.07957747 Hz>
 
     >>> foo((1/2) * u.rad / u.s, to_hz=True)
-    <Quantity 0.07957747 Hz> 
+    <Quantity 0.07957747 Hz>
     """
     # raise exception if fn uses the 'to_hz' kwarg
     sig = inspect.signature(fn)


### PR DESCRIPTION
Added docstrings to  plasmapy/utils/decorators/converter.py
angular_freq_to_hz method

#723

- [x] I have added a changelog entry for this pull request (please see
  `changelog/README.rst` for instructions, and if you need help with picking the PR type, ask!)
- [ ] If adding new functionality, I have added (passing) tests and
      docstrings. (Tests pop up at the bottom, in the checks box).
- [ ] I have fixed any new failing tests (if you're unsure why
  they're failing, ask!).
