### PR TITLE
Use `...` in doctests to avoid floating point errors

### DIFF
--- a/changelog/731.trivial.rst
+++ b/changelog/731.trivial.rst
@@ -1,0 +1,2 @@
+Reduce precision of tests and doctests to allow for refinements of
+fundamental constants.

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -225,6 +225,26 @@ be included in the error message by using `f-strings
 
 .. _testing-guidelines-writing-tests-warnings:
 
+Floating point comparisons
+--------------------------
+
+Comparisons between floating point numbers with `==` is fraught with
+peril because of limited precision and rounding errors.  Moreover, the
+values of fundamental constants in `astropy.constants` are occasionally
+refined as improvements become available.
+
+Using `numpy.isclose` when comparing floating point numbers and
+`astropy.units.isclose` for `astropy.units.Quantity` instances lets us
+avoid these difficulties.  The ``rtol`` keyword for each of these
+functions allows us to set an acceptable relative tolerance.  For
+mathematical functions, a value of ``rtol=1e-14`` may be appropriate.
+For quantities that depend on physical constants, a value between
+``rtol=1e-8`` and ``rtol=1e-5`` may be required, depending on
+how much the accepted values for fundamental constants are likely to
+change.   When comparing arrays, we should use `numpy.allclose` and
+`astropy.units.allclose` instead.
+
+
 Testing warnings and exceptions
 -------------------------------
 
@@ -244,7 +264,7 @@ To test that a function issues an appropriate warning, use
   import warnings
 
   def issue_warning():
-      warnings.warn("grumblemuffins", UserWarning)
+      warnings.warn("Beware the ides of March", UserWarning)
 
   def test_issue_warning():
       with pytest.warns(UserWarning):

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -236,14 +236,14 @@ refined as improvements become available.
 Using `numpy.isclose` when comparing floating point numbers and
 `astropy.units.isclose` for `astropy.units.Quantity` instances lets us
 avoid these difficulties.  The ``rtol`` keyword for each of these
-functions allows us to set an acceptable relative tolerance.  For
-mathematical functions, a value of ``rtol=1e-14`` may be appropriate.
-For quantities that depend on physical constants, a value between
-``rtol=1e-8`` and ``rtol=1e-5`` may be required, depending on
-how much the accepted values for fundamental constants are likely to
-change.   When comparing arrays, we should use `numpy.allclose` and
-`astropy.units.allclose` instead.
-
+functions allows us to set an acceptable relative tolerance.  Ideally,
+``rtol`` should be set to be an order of magnitude or two greater than
+the expected uncertainty.  For mathematical functions, a value of
+``rtol=1e-14`` may be appropriate.  For quantities that depend on
+physical constants, a value between ``rtol=1e-8`` and ``rtol=1e-5`` may
+be required, depending on how much the accepted values for fundamental
+constants are likely to change.  For comparing arrays, `numpy.allclose`
+and `astropy.units.allclose` should be used instead.
 
 Testing warnings and exceptions
 -------------------------------

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -792,7 +792,7 @@ class Particle:
         --------
         >>> oxygen = Particle('O')
         >>> oxygen.standard_atomic_weight
-        <Quantity 2.65669641e-26 kg>
+        <Quantity 2.656696...e-26 kg>
 
         """
         if self.isotope or self.is_ion or not self.element:
@@ -869,13 +869,13 @@ class Particle:
         Examples
         --------
         >>> Particle('He').mass
-        <Quantity 6.64647688e-27 kg>
+        <Quantity 6.64647...e-27 kg>
         >>> Particle('He+').mass
-        <Quantity 6.64556594e-27 kg>
+        <Quantity 6.64556...e-27 kg>
         >>> Particle('He-4 +1').mass
-        <Quantity 6.64556803e-27 kg>
+        <Quantity 6.64556...e-27 kg>
         >>> Particle('alpha').mass
-        <Quantity 6.64465709e-27 kg>
+        <Quantity 6.64465...e-27 kg>
 
         """
 
@@ -965,15 +965,15 @@ class Particle:
         --------
         >>> proton = Particle('p+')
         >>> proton.mass_energy
-        <Quantity 1.50327759e-10 J>
+        <Quantity 1.503277...e-10 J>
 
         >>> protium = Particle('H-1 0+')
         >>> protium.mass_energy
-        <Quantity 1.50327759e-10 J>
+        <Quantity 1.503277...e-10 J>
 
         >>> electron = Particle('electron')
         >>> electron.mass_energy.to('MeV')
-        <Quantity 0.51099895 MeV>
+        <Quantity 0.510998... MeV>
 
         """
         try:
@@ -998,9 +998,9 @@ class Particle:
         --------
         >>> alpha = Particle('alpha')
         >>> alpha.binding_energy
-        <Quantity 4.53346938e-12 J>
+        <Quantity 4.53346...e-12 J>
         >>> Particle('T').binding_energy.to('MeV')
-        <Quantity 8.48179621 MeV>
+        <Quantity 8.481... MeV>
 
         The binding energy of a nucleon equals 0 joules.
 

--- a/plasmapy/atomic/particle_class.py
+++ b/plasmapy/atomic/particle_class.py
@@ -214,9 +214,9 @@ class Particle:
     >>> deuteron.mass_number
     2
     >>> deuteron.binding_energy.to('MeV')
-    <Quantity 2.22456652 MeV>
+    <Quantity 2.224... MeV>
     >>> alpha.charge
-    <Quantity 3.20435324e-19 C>
+    <Quantity 3.20435...e-19 C>
     >>> neutron.half_life
     <Quantity 881.5 s>
     >>> Particle('C-14').half_life.to(u.year)

--- a/plasmapy/atomic/tests/test_atomic.py
+++ b/plasmapy/atomic/tests/test_atomic.py
@@ -575,15 +575,15 @@ def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected):
     result1 = particle_mass(arg1, **kwargs1)
     result2 = particle_mass(arg2, **kwargs2)
 
-    assert result1 == result2, \
+    assert u.isclose(result1, result2), \
         (f"particle_mass({repr(arg1)}, **{kwargs1}) = {repr(result1)}, whereas "
          f"particle_mass({repr(arg2)}, **{kwargs2}) = {repr(result2)}.  "
          f"These results are not equivalent as expected.")
 
     if expected is not None:
-        assert result1 == result2 == expected, \
+        assert u.isclose(result1, result2) and u.isclose(result2, expected), \
             (f"particle_mass({repr(arg1)}, **{kwargs1}) = {repr(result1)} and "
-             f"particle_mass({repr(arg2)}, **{kwargs2}) = {repr(result2)}, but  "
+             f"particle_mass({repr(arg2)}, **{kwargs2}) = {repr(result2)}, but "
              f"these results are not equal to {repr(expected)} as expected.")
 
 

--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -450,7 +450,7 @@ def test_Particle_class(arg, kwargs, expected_dict):
 
             try:
                 result = eval(f"particle.{key}")
-                assert result == expected
+                assert result == expected or u.isclose(result, expected)
             except AssertionError:
                 errmsg += (f"\n{call}.{key} returns {result} instead "
                            f"of the expected value of {expected}.")

--- a/plasmapy/classes/sources/plasmablob.py
+++ b/plasmapy/classes/sources/plasmablob.py
@@ -47,8 +47,8 @@ class PlasmaBlob(GenericPlasma):
         --------
         >>> print(PlasmaBlob(1e4*u.K, 1e20/u.m**3, particle='p'))
         PlasmaBlob(T_e=10000.0*u.K, n_e=1e+20*u.m**-3, particle='p', Z=1)
-        Intermediate coupling regime: Gamma = 0.012502837623108332.
-        Thermal kinetic energy dominant: Theta = 109690.53176225389
+        Intermediate coupling regime: Gamma = 0.01250283...
+        Thermal kinetic energy dominant: Theta = 109690.5...
 
         """
         return self.__repr__() + "\n" + "\n".join(self.regimes())

--- a/plasmapy/classes/sources/tests/test_plasmablob.py
+++ b/plasmapy/classes/sources/tests/test_plasmablob.py
@@ -356,7 +356,7 @@ class Test_PlasmaBlob:
                   f"and not {methodVal.si.value}.")
         testTrue = np.isclose(methodVal.value,
                               self.couplingVal,
-                              rtol=1e-8,
+                              rtol=1e-6,
                               atol=0.0)
         assert testTrue, errStr
 
@@ -369,6 +369,6 @@ class Test_PlasmaBlob:
                   f"and not {methodVal.si.value}.")
         testTrue = np.isclose(methodVal.value,
                               self.thetaVal,
-                              rtol=1e-8,
+                              rtol=1e-6,
                               atol=0.0)
         assert testTrue, errStr

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -264,19 +264,19 @@ class ClassicalTransport:
     >>> t = ClassicalTransport(1*u.eV, 1e20/u.m**3,
     ...                         1*u.eV, 1e20/u.m**3, 'p')
     >>> t.resistivity
-    <Quantity 0.00036701 m Ohm>
+    <Quantity 0.0003670... m Ohm>
     >>> t.thermoelectric_conductivity
-    <Quantity 0.711084>
+    <Quantity 0.71108...>
     >>> t.ion_thermal_conductivity
-    <Quantity 0.01552066 W / (K m)>
+    <Quantity 0.01552... W / (K m)>
     >>> t.electron_thermal_conductivity
-    <Quantity 0.38064293 W / (K m)>
+    <Quantity 0.38064... W / (K m)>
     >>> t.ion_viscosity
-    <Quantity [4.62129725e-07, 4.60724824e-07, 4.60724824e-07, 0.00000000e+00,
-               0.00000000e+00] Pa s>
+    <Quantity [4.621297...e-07, 4.607248...e-07, 4.607248...e-07, 0.000000...e+00,
+               0.000000...e+00] Pa s>
     >>> t.electron_viscosity
-    <Quantity [5.82273805e-09, 5.82082061e-09, 5.82082061e-09, 0.00000000e+00,
-               0.00000000e+00] Pa s>
+    <Quantity [5.822738...e-09, 5.820820...e-09, 5.820820...e-09, 0.000000...e+00,
+               0.000000...e+00] Pa s>
 
     References
     ----------

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -237,9 +237,9 @@ def Coulomb_logarithm(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> Coulomb_logarithm(T, n, particles)
-    14.545527226436974
+    14.545527...
     >>> Coulomb_logarithm(T, n, particles, V=1e6 * u.m / u.s)
-    11.363478214139432
+    11.363478...
 
     References
     ----------
@@ -405,7 +405,7 @@ def impact_parameter_perp(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> impact_parameter_perp(T, particles)
-    <Quantity 8.35505011e-12 m>
+    <Quantity 8.3550...e-12 m>
 
 
     References
@@ -529,9 +529,9 @@ def impact_parameter(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> impact_parameter(T, n, particles)
-    (<Quantity 1.05163088e-11 m>, <Quantity 2.18225522e-05 m>)
+    (<Quantity 1.051...e-11 m>, <Quantity 2.182...e-05 m>)
     >>> impact_parameter(T, n, particles, V=1e6 * u.m / u.s)
-    (<Quantity 2.53401778e-10 m>, <Quantity 2.18225522e-05 m>)
+    (<Quantity 2.534...e-10 m>, <Quantity 2.182...e-05 m>)
 
     References
     ----------
@@ -733,7 +733,7 @@ def collision_frequency(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> collision_frequency(T, n, particles)
-    <Quantity 702492.01188504 Hz>
+    <Quantity 702492.011... Hz>
 
     References
     ----------
@@ -823,9 +823,9 @@ def Coulomb_cross_section(impact_param: u.m) -> u.m**2:
     Examples
     --------
     >>> Coulomb_cross_section(7e-10*u.m)
-    <Quantity 6.1575216e-18 m2>
+    <Quantity 6.157...e-18 m2>
     >>> Coulomb_cross_section(0.5*u.m)
-    <Quantity 3.14159265 m2>
+    <Quantity 3.141... m2>
 
     Notes
     -----
@@ -929,17 +929,17 @@ def fundamental_electron_collision_freq(T_e: u.K,
     --------
     >>> from astropy import units as u
     >>> fundamental_electron_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p')
-    <Quantity 0.00180167 1 / s>
+    <Quantity 0.001801... 1 / s>
     >>> fundamental_electron_collision_freq(1e6 * u.K, 1e6 / u.m ** 3, 'p')
-    <Quantity 1.07221863e-07 1 / s>
+    <Quantity 1.072218...e-07 1 / s>
     >>> fundamental_electron_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p')
-    <Quantity 3935958.7396539 1 / s>
+    <Quantity 3935958.739... 1 / s>
     >>> fundamental_electron_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log_method = 'GMS-1')
-    <Quantity 3872815.52840036 1 / s>
+    <Quantity 3872815.5284... 1 / s>
     >>> fundamental_electron_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p', V = c / 100)
-    <Quantity 5.65897885e-07 1 / s>
+    <Quantity 5.65897...e-07 1 / s>
     >>> fundamental_electron_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log = 20)
-    <Quantity 5812633.74935004 1 / s>
+    <Quantity 5812633.749... 1 / s>
 
     See Also
     --------
@@ -1062,17 +1062,17 @@ def fundamental_ion_collision_freq(T_i: u.K,
     --------
     >>> from astropy import units as u
     >>> fundamental_ion_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p')
-    <Quantity 2.86803251e-05 1 / s>
+    <Quantity 2.868...e-05 1 / s>
     >>> fundamental_ion_collision_freq(1e6 * u.K, 1e6 / u.m ** 3, 'p')
-    <Quantity 1.74160353e-09 1 / s>
+    <Quantity 1.7416...e-09 1 / s>
     >>> fundamental_ion_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p')
-    <Quantity 63087.51217732 1 / s>
+    <Quantity 63087.512... 1 / s>
     >>> fundamental_ion_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log_method='GMS-1')
-    <Quantity 63085.11369283 1 / s>
+    <Quantity 63085.113... 1 / s>
     >>> fundamental_ion_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', V = c / 100)
-    <Quantity 9.11173204 1 / s>
+    <Quantity 9.111... 1 / s>
     >>> fundamental_ion_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log=20)
-    <Quantity 95918.76240877 1 / s>
+    <Quantity 95918.762... 1 / s>
 
     See Also
     --------
@@ -1206,9 +1206,9 @@ def mean_free_path(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> mean_free_path(T, n, particles)
-    <Quantity 7.83950983 m>
+    <Quantity 7.839... m>
     >>> mean_free_path(T, n, particles, V=1e6 * u.m / u.s)
-    <Quantity 0.01091773 m>
+    <Quantity 0.0109... m>
 
     References
     ----------
@@ -1334,9 +1334,9 @@ def Spitzer_resistivity(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> Spitzer_resistivity(T, n, particles)
-    <Quantity 2.49157026e-06 m Ohm>
+    <Quantity 2.4915...e-06 m Ohm>
     >>> Spitzer_resistivity(T, n, particles, V=1e6 * u.m / u.s)
-    <Quantity 0.00032486 m Ohm>
+    <Quantity 0.000324... m Ohm>
 
     References
     ----------
@@ -1463,9 +1463,9 @@ def mobility(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> mobility(T, n, particles)
-    <Quantity 250505.04164488 m2 / (s V)>
+    <Quantity 250505.0416... m2 / (s V)>
     >>> mobility(T, n, particles, V=1e6 * u.m / u.s)
-    <Quantity 1921.27848189 m2 / (s V)>
+    <Quantity 1921.2784... m2 / (s V)>
 
     References
     ----------
@@ -1503,7 +1503,7 @@ def Knudsen_number(characteristic_length,
                    z_mean: u.dimensionless_unscaled = np.nan * u.dimensionless_unscaled,
                    V: u.m / u.s = np.nan * u.m / u.s,
                    method="classical") -> u.dimensionless_unscaled:
-    r"""Knudsen number (dimless)
+    r"""Knudsen number (dimensionless)
 
     Parameters
     ----------
@@ -1593,9 +1593,9 @@ def Knudsen_number(characteristic_length,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> Knudsen_number(L, T, n, particles)
-    <Quantity 7839.5098286>
+    <Quantity 7839.5...>
     >>> Knudsen_number(L, T, n, particles, V=1e6 * u.m / u.s)
-    <Quantity 10.91773271>
+    <Quantity 10.91773...>
 
     References
     ----------
@@ -1740,9 +1740,9 @@ def coupling_parameter(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> coupling_parameter(T, n, particles)
-    <Quantity 5.80330315e-05>
+    <Quantity 5.803303...e-05>
     >>> coupling_parameter(T, n, particles, V=1e6 * u.m / u.s)
-    <Quantity 5.80330315e-05>
+    <Quantity 5.803303...e-05>
 
     References
     ----------

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -733,7 +733,7 @@ def collision_frequency(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> collision_frequency(T, n, particles)
-    <Quantity 702492.011... Hz>
+    <Quantity 70249... Hz>
 
     References
     ----------
@@ -931,15 +931,15 @@ def fundamental_electron_collision_freq(T_e: u.K,
     >>> fundamental_electron_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p')
     <Quantity 0.001801... 1 / s>
     >>> fundamental_electron_collision_freq(1e6 * u.K, 1e6 / u.m ** 3, 'p')
-    <Quantity 1.072218...e-07 1 / s>
+    <Quantity 1.07221...e-07 1 / s>
     >>> fundamental_electron_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p')
-    <Quantity 3935958.739... 1 / s>
+    <Quantity 3935958.7... 1 / s>
     >>> fundamental_electron_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log_method = 'GMS-1')
-    <Quantity 3872815.5284... 1 / s>
+    <Quantity 3872815.5... 1 / s>
     >>> fundamental_electron_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p', V = c / 100)
-    <Quantity 5.65897...e-07 1 / s>
+    <Quantity 5.6589...e-07 1 / s>
     >>> fundamental_electron_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log = 20)
-    <Quantity 5812633.749... 1 / s>
+    <Quantity 5812633.7... 1 / s>
 
     See Also
     --------
@@ -1064,15 +1064,15 @@ def fundamental_ion_collision_freq(T_i: u.K,
     >>> fundamental_ion_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p')
     <Quantity 2.868...e-05 1 / s>
     >>> fundamental_ion_collision_freq(1e6 * u.K, 1e6 / u.m ** 3, 'p')
-    <Quantity 1.7416...e-09 1 / s>
+    <Quantity 1.741...e-09 1 / s>
     >>> fundamental_ion_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p')
-    <Quantity 63087.512... 1 / s>
+    <Quantity 63087.5... 1 / s>
     >>> fundamental_ion_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log_method='GMS-1')
-    <Quantity 63085.113... 1 / s>
+    <Quantity 63085.1... 1 / s>
     >>> fundamental_ion_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', V = c / 100)
     <Quantity 9.111... 1 / s>
     >>> fundamental_ion_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log=20)
-    <Quantity 95918.762... 1 / s>
+    <Quantity 95918.7... 1 / s>
 
     See Also
     --------
@@ -1740,9 +1740,9 @@ def coupling_parameter(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> coupling_parameter(T, n, particles)
-    <Quantity 5.803303...e-05>
+    <Quantity 5.8033...e-05>
     >>> coupling_parameter(T, n, particles, V=1e6 * u.m / u.s)
-    <Quantity 5.803303...e-05>
+    <Quantity 5.8033...e-05>
 
     References
     ----------

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -939,7 +939,7 @@ def fundamental_electron_collision_freq(T_e: u.K,
     >>> fundamental_electron_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p', V = c / 100)
     <Quantity 5.6589...e-07 1 / s>
     >>> fundamental_electron_collision_freq(100 * u.eV, 1e20 / u.m ** 3, 'p', coulomb_log = 20)
-    <Quantity 5812633.7... 1 / s>
+    <Quantity 5812633... 1 / s>
 
     See Also
     --------
@@ -1463,7 +1463,7 @@ def mobility(T: u.K,
     >>> T = 1e6*u.K
     >>> particles = ('e', 'p')
     >>> mobility(T, n, particles)
-    <Quantity 250505.0416... m2 / (s V)>
+    <Quantity 250505... m2 / (s V)>
     >>> mobility(T, n, particles, V=1e6 * u.m / u.s)
     <Quantity 1921.2784... m2 / (s V)>
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -749,7 +749,7 @@ def collision_frequency(T: u.K,
     # using a more descriptive name for the thermal velocity using
     # reduced mass
     V_reduced = V_r
-    if particles[0] in ('e','e-') and particles[1] in ('e','e-'):
+    if particles[0] in ('e', 'e-') and particles[1] in ('e', 'e-'):
         # electron-electron collision
         # if a velocity was passed, we use that instead of the reduced
         # thermal velocity
@@ -766,7 +766,7 @@ def collision_frequency(T: u.K,
                                     z_mean,
                                     V=V,
                                     method=method)
-    elif particles[0] in ('e','e-') or particles[1] in ('e','e-'):
+    elif particles[0] in ('e', 'e-') or particles[1] in ('e', 'e-'):
         # electron-ion collision
         # Need to manually pass electron thermal velocity to obtain
         # correct perpendicular collision radius

--- a/plasmapy/formulary/dielectric.py
+++ b/plasmapy/formulary/dielectric.py
@@ -220,7 +220,7 @@ def permittivity_1D_Maxwellian(
         z_mean: u.dimensionless_unscaled = None
 ) -> u.dimensionless_unscaled:
     r"""
-    The classical dielectric permittivity for a 1D Maxwellian plasma. This 
+    The classical dielectric permittivity for a 1D Maxwellian plasma. This
     function can calculate both the ion and electron permittivities. No
     additional effects are considered (e.g. magnetic fields, relativistic
     effects, strongly coupled regime, etc.)
@@ -262,14 +262,14 @@ def permittivity_1D_Maxwellian(
     -----
     The dielectric permittivities for a Maxwellian plasma are described
     by the following equations [1]_
-    
+
     .. math::
         \chi_e(k, \omega) = - \frac{\alpha_e^2}{2} Z'(x_e)
-        
+
         \chi_i(k, \omega) = - \frac{\alpha_i^2}{2}\frac{Z}{} Z'(x_i)
-        
+
         \alpha = \frac{\omega_p}{k v_{Th}}
-        
+
         x = \frac{\omega}{k v_{Th}}
 
     :math:`chi_e` and :math:`chi_i` are the electron and ion permittivities

--- a/plasmapy/formulary/dielectric.py
+++ b/plasmapy/formulary/dielectric.py
@@ -96,13 +96,13 @@ def cold_plasma_permittivity_SDP(B: u.T, species, n, omega: u.rad / u.s):
     >>> omega = 3.7e9*(2*pi)*(u.rad/u.s)
     >>> permittivity = S, D, P = cold_plasma_permittivity_SDP(B, species, n, omega)
     >>> S
-    <Quantity 1.02422902>
+    <Quantity 1.02422...>
     >>> permittivity.sum   # namedtuple-style access
-    <Quantity 1.02422902>
+    <Quantity 1.02422...>
     >>> D
-    <Quantity 0.39089352>
+    <Quantity 0.39089...>
     >>> P
-    <Quantity -4.8903104>
+    <Quantity -4.8903...>
     """
     S, D, P = 1, 0, 1
 
@@ -189,13 +189,13 @@ def cold_plasma_permittivity_LRP(B: u.T, species, n, omega: u.rad / u.s):
     >>> omega = 3.7e9*(2*pi)*(u.rad/u.s)
     >>> L, R, P = permittivity = cold_plasma_permittivity_LRP(B, species, n, omega)
     >>> L
-    <Quantity 0.63333549>
+    <Quantity 0.63333...>
     >>> permittivity.left    # namedtuple-style access
-    <Quantity 0.63333549>
+    <Quantity 0.63333...>
     >>> R
-    <Quantity 1.41512254>
+    <Quantity 1.41512...>
     >>> P
-    <Quantity -4.8903104>
+    <Quantity -4.8903...>
     """
     L, R, P = 1, 1, 1
 
@@ -298,7 +298,7 @@ def permittivity_1D_Maxwellian(
     >>> omega = 5.635e14 * 2 * pi * u.rad / u.s
     >>> kWave = omega / vTh
     >>> permittivity_1D_Maxwellian(omega, kWave, T, n, particle, z_mean)
-    <Quantity -6.72809257e-08+5.76037956e-07j>
+    <Quantity -6.72809...e-08+5.76037...e-07j>
     """
     # thermal velocity
     vTh = parameters.thermal_speed(T=T,

--- a/plasmapy/formulary/dimensionless.py
+++ b/plasmapy/formulary/dimensionless.py
@@ -35,13 +35,13 @@ def quantum_theta(T: u.K, n_e: u.m**-3) -> u.dimensionless_unscaled:
     --------
     >>> import astropy.units as u
     >>> quantum_theta(1*u.eV, 1e20*u.m**-3)
-    <Quantity 127290.61956522>
+    <Quantity 127290.619...>
     >>> quantum_theta(1*u.eV, 1e16*u.m**-3)
-    <Quantity 59083071.83975738>
+    <Quantity 59083071.8...>
     >>> quantum_theta(1*u.eV, 1e26*u.m**-3)
-    <Quantity 12.72906196>
+    <Quantity 12.72906...>
     >>> quantum_theta(1*u.K, 1e26*u.m**-3)
-    <Quantity 0.00109691>
+    <Quantity 0.00109...>
 
     Returns
     -------
@@ -74,9 +74,9 @@ def beta(T: u.K, n: u.m**-3, B: u.T) -> u.dimensionless_unscaled:
     --------
     >>> import astropy.units as u
     >>> beta(1*u.eV, 1e20*u.m**-3, 1*u.T)
-    <Quantity 4.02670904e-05>
+    <Quantity 4.0267...e-05>
     >>> beta(8.8e3*u.eV, 1e20*u.m**-3, 5.3*u.T)
-    <Quantity 0.01261482>
+    <Quantity 0.01261...>
 
     Returns
     -------

--- a/plasmapy/formulary/dimensionless.py
+++ b/plasmapy/formulary/dimensionless.py
@@ -37,7 +37,7 @@ def quantum_theta(T: u.K, n_e: u.m**-3) -> u.dimensionless_unscaled:
     >>> quantum_theta(1*u.eV, 1e20*u.m**-3)
     <Quantity 127290.619...>
     >>> quantum_theta(1*u.eV, 1e16*u.m**-3)
-    <Quantity 59083071.8...>
+    <Quantity 59083071...>
     >>> quantum_theta(1*u.eV, 1e26*u.m**-3)
     <Quantity 12.72906...>
     >>> quantum_theta(1*u.K, 1e26*u.m**-3)

--- a/plasmapy/formulary/dispersionfunction.py
+++ b/plasmapy/formulary/dispersionfunction.py
@@ -68,8 +68,9 @@ def plasma_dispersion_func(zeta: Union[complex, int, float, np.ndarray, u.Quanti
     (0.6088888957234254+0.33494583882874024j)
 
     """
-
-    if not isinstance(zeta, (numbers.Integral, numbers.Real, numbers.Complex, np.ndarray, u.Quantity)):
+    if not isinstance(
+            zeta,
+            (numbers.Integral, numbers.Real, numbers.Complex, np.ndarray, u.Quantity)):
         raise TypeError("The argument to plasma_dispersion_function "
                         "must be one of the following types: complex, float, "
                         "int, ndarray, or Quantity.")
@@ -136,13 +137,15 @@ def plasma_dispersion_func_deriv(zeta: Union[complex, int, float, np.ndarray, u.
     >>> plasma_dispersion_func_deriv(0)
     (-2+0j)
     >>> plasma_dispersion_func_deriv(1j)
-    (-0.48425568771737604+0j)
+    (-0.484255687717376...+0j)
     >>> plasma_dispersion_func_deriv(-1.52+0.47j)
-    (0.16587133149822897+0.44587978805935047j)
+    (0.165871331498228...+0.445879788059350...j)
 
     """
 
-    if not isinstance(zeta, (numbers.Integral, numbers.Real, numbers.Complex, np.ndarray, u.Quantity)):
+    if not isinstance(
+            zeta,
+            (numbers.Integral, numbers.Real, numbers.Complex, np.ndarray, u.Quantity)):
         raise TypeError("The argument to plasma_dispersion_function_deriv "
                         "must be one of the following types: complex, float, "
                         "int, ndarray, or Quantity.")

--- a/plasmapy/formulary/distribution.py
+++ b/plasmapy/formulary/distribution.py
@@ -104,7 +104,7 @@ def Maxwellian_1D(v,
     >>> from astropy import units as u
     >>> v=1*u.m/u.s
     >>> Maxwellian_1D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
-    <Quantity 5.91632969e-07 s / m>
+    <Quantity 5.9163...e-07 s / m>
     """
 
     if units == "units":
@@ -239,7 +239,7 @@ def Maxwellian_velocity_2D(vx,
     ... particle='e',
     ... vx_drift=0 * u.m / u.s,
     ... vy_drift=0 * u.m / u.s)
-    <Quantity 3.5002957e-13 s2 / m2>
+    <Quantity 3.5002...e-13 s2 / m2>
 
 
     """
@@ -387,7 +387,7 @@ def Maxwellian_velocity_3D(vx,
     ... vx_drift=0 * u.m / u.s,
     ... vy_drift=0 * u.m / u.s,
     ... vz_drift=0 * u.m / u.s)
-    <Quantity 2.07089033e-19 s3 / m3>
+    <Quantity 2.07089...e-19 s3 / m3>
 
 
     """
@@ -508,7 +508,7 @@ def Maxwellian_speed_1D(v,
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_speed_1D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
-    <Quantity 1.18326594e-06 s / m>
+    <Quantity 1.1832...e-06 s / m>
 
     """
     if units == "units":
@@ -629,7 +629,7 @@ def Maxwellian_speed_2D(v,
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_speed_2D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
-    <Quantity 2.19930065e-12 s / m>
+    <Quantity 2.1993...e-12 s / m>
 
     """
     if v_drift != 0:
@@ -753,7 +753,7 @@ def Maxwellian_speed_3D(v,
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_speed_3D(v=v, T=30000*u.K, particle='e', v_drift=0 * u.m / u.s)
-    <Quantity 2.60235754e-18 s / m>
+    <Quantity 2.60235...e-18 s / m>
 
     """
     if v_drift != 0:
@@ -886,7 +886,7 @@ def kappa_velocity_1D(v,
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> kappa_velocity_1D(v=v, T=30000*u.K, kappa=4, particle='e', v_drift=0 * u.m / u.s)
-    <Quantity 6.75549854e-07 s / m>
+    <Quantity 6.75549...e-07 s / m>
 
     See Also
     --------
@@ -1056,7 +1056,7 @@ def kappa_velocity_3D(vx,
     ... vx_drift=0 * u.m / u.s,
     ... vy_drift=0 * u.m / u.s,
     ... vz_drift=0 * u.m / u.s)
-    <Quantity 3.7833988e-19 s3 / m3>
+    <Quantity 3.7833...e-19 s3 / m3>
     """
     # must have kappa > 3/2 for distribution function to be valid
     if kappa <= 3 / 2:

--- a/plasmapy/formulary/distribution.py
+++ b/plasmapy/formulary/distribution.py
@@ -18,14 +18,15 @@ __all__ = ["Maxwellian_1D",
            "kappa_velocity_1D",
            "kappa_velocity_3D"]
 
+
 def _v_drift_units(v_drift):
     # Helper method to assign units to  v_drift if it takes a default value
-    if (v_drift == 0 and
-        not isinstance(v_drift, astropy.units.quantity.Quantity)):
+    if (v_drift == 0 and not isinstance(v_drift, astropy.units.quantity.Quantity)):
         v_drift = v_drift * u.m / u.s
     else:
         v_drift = v_drift.to(u.m / u.s)
     return v_drift
+
 
 def Maxwellian_1D(v,
                   T,
@@ -34,7 +35,7 @@ def Maxwellian_1D(v,
                   vTh=np.nan,
                   units="units"):
     r"""
-    Probability distribution function of velocity for a Maxwellian 
+    Probability distribution function of velocity for a Maxwellian
     distribution in 1D.
 
     Returns the probability density function at the velocity `v` in m/s
@@ -152,12 +153,12 @@ def Maxwellian_velocity_2D(vx,
                            vTh=np.nan,
                            units="units"):
     r"""
-    Probability distribution function of velocity for a Maxwellian 
+    Probability distribution function of velocity for a Maxwellian
     distribution in 2D.
 
-    Return the probability density function for finding a particle with 
-    velocity components `vx` and `vy` in m/s in an equilibrium plasma of 
-    temperature `T` which follows the 2D Maxwellian distribution function. 
+    Return the probability density function for finding a particle with
+    velocity components `vx` and `vy` in m/s in an equilibrium plasma of
+    temperature `T` which follows the 2D Maxwellian distribution function.
     This function assumes Cartesian coordinates.
 
     Parameters
@@ -292,12 +293,12 @@ def Maxwellian_velocity_3D(vx,
                            vTh=np.nan,
                            units="units"):
     r"""
-    Probability distribution function of velocity for a Maxwellian 
+    Probability distribution function of velocity for a Maxwellian
     distribution in 3D.
 
-    Return the probability density function for finding a particle with 
-    velocity components `vx`, `vy`, and `vz` in m/s in an equilibrium 
-    plasma of temperature `T` which follows the 3D Maxwellian distribution 
+    Return the probability density function for finding a particle with
+    velocity components `vx`, `vy`, and `vz` in m/s in an equilibrium
+    plasma of temperature `T` which follows the 3D Maxwellian distribution
     function. This function assumes Cartesian coordinates.
 
     Parameters
@@ -441,8 +442,8 @@ def Maxwellian_speed_1D(v,
     Probability distribution function of speed for a Maxwellian distribution
     in 1D.
 
-    Return the probability density function for finding a particle with 
-    speed `v` in m/s in an equilibrium plasma of temperature `T` which 
+    Return the probability density function for finding a particle with
+    speed `v` in m/s in an equilibrium plasma of temperature `T` which
     follows the Maxwellian distribution function.
 
     Parameters
@@ -681,9 +682,9 @@ def Maxwellian_speed_3D(v,
     Probability distribution function of speed for a Maxwellian
     distribution in 3D.
 
-    Return the probability density function for finding a particle with 
-    speed components `vx`, `vy`, and `vz` in m/s in an equilibrium 
-    plasma of temperature `T` which follows the 3D Maxwellian 
+    Return the probability density function for finding a particle with
+    speed components `vx`, `vy`, and `vz` in m/s in an equilibrium
+    plasma of temperature `T` which follows the 3D Maxwellian
     distribution function. This function assumes Cartesian coordinates.
 
     Parameters
@@ -949,10 +950,10 @@ def kappa_velocity_3D(vx,
                       vTh=np.nan,
                       units="units"):
     r"""
-    Return the probability density function for finding a particle with 
-    velocity components `v_x`, `v_y`, and `v_z`in m/s in a suprathermal 
-    plasma of temperature `T` and parameter 'kappa' which follows the 
-    3D Kappa distribution function. This function assumes Cartesian 
+    Return the probability density function for finding a particle with
+    velocity components `v_x`, `v_y`, and `v_z`in m/s in a suprathermal
+    plasma of temperature `T` and parameter 'kappa' which follows the
+    3D Kappa distribution function. This function assumes Cartesian
     coordinates.
 
     Parameters

--- a/plasmapy/formulary/distribution.py
+++ b/plasmapy/formulary/distribution.py
@@ -387,7 +387,7 @@ def Maxwellian_velocity_3D(vx,
     ... vx_drift=0 * u.m / u.s,
     ... vy_drift=0 * u.m / u.s,
     ... vz_drift=0 * u.m / u.s)
-    <Quantity 2.07089...e-19 s3 / m3>
+    <Quantity 2.0708...e-19 s3 / m3>
 
 
     """
@@ -629,7 +629,7 @@ def Maxwellian_speed_2D(v,
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_speed_2D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
-    <Quantity 2.1993...e-12 s / m>
+    <Quantity 2.199...e-12 s / m>
 
     """
     if v_drift != 0:

--- a/plasmapy/formulary/drifts.py
+++ b/plasmapy/formulary/drifts.py
@@ -56,7 +56,7 @@ def ExB_drift(E: u.V/u.m, B: u.T) -> u.m/u.s:
     """
 
     # np.cross drops units right now, thus this hack: see
-    # https://github.com/PlasmaPy/PlasmaPy/issues/59 
+    # https://github.com/PlasmaPy/PlasmaPy/issues/59
     cross = np.cross(E.si.value, B.si.value) * E.unit * B.unit
     return cross / (B*B).sum(-1)
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -102,9 +102,9 @@ def mass_density(density: [u.m ** -3, u.kg / (u.m ** 3)],
     -------
     >>> from astropy import units as u
     >>> mass_density(1 * u.m ** -3,'p')
-    <Quantity 1.67353284e-27 kg / m3>
+    <Quantity 1.67353...e-27 kg / m3>
     >>> mass_density(4 * u.m ** -3,'D+')
-    <Quantity 1.33779786e-26 kg / m3>
+    <Quantity 1.33779...e-26 kg / m3>
 
     """
     # validate_quantities ensures we have units of u.kg/u.m**3 or 1/u.m**3
@@ -206,11 +206,11 @@ def Alfven_speed(B: u.T,
     >>> rho = n*(m_p+m_e)
     >>> ion = 'p'
     >>> Alfven_speed(B, n, ion)
-    <Quantity 43173.87029559 m / s>
+    <Quantity 43173.870... m / s>
     >>> Alfven_speed(B, rho, ion)
-    <Quantity 43173.87029559 m / s>
+    <Quantity 43173.870... m / s>
     >>> Alfven_speed(B, rho, ion).to(u.cm/u.us)
-    <Quantity 4.31738703 cm / us>
+    <Quantity 4.31738... cm / us>
 
     """
     rho = mass_density(density, ion, z_mean)
@@ -352,15 +352,15 @@ def ion_sound_speed(T_e: u.K,
     >>> k_1 = 3e1*u.m**-1
     >>> k_2 = 3e7*u.m**-1
     >>> ion_sound_speed(T_e=5e6*u.K, T_i=0*u.K, ion='p', gamma_e=1, gamma_i=3)
-    <Quantity 203155.0764042 m / s>
+    <Quantity 203155.07... m / s>
     >>> ion_sound_speed(T_e=5e6*u.K, T_i=0*u.K, n_e=n, k=k_1, ion='p', gamma_e=1, gamma_i=3)
-    <Quantity 203155.03286794 m / s>
+    <Quantity 203155.03... m / s>
     >>> ion_sound_speed(T_e=5e6*u.K, T_i=0*u.K, n_e=n, k=k_2, ion='p', gamma_e=1, gamma_i=3)
-    <Quantity 310.31329069 m / s>
+    <Quantity 310.3132... m / s>
     >>> ion_sound_speed(T_e=5e6*u.K, T_i=0*u.K, n_e=n, k=k_1)
-    <Quantity 203155.03286794 m / s>
+    <Quantity 203155.03... m / s>
     >>> ion_sound_speed(T_e=500*u.eV, T_i=200*u.eV, n_e=n, k=k_1, ion='D+')
-    <Quantity 229585.96150738 m / s>
+    <Quantity 229585.96... m / s>
 
     """
     
@@ -472,17 +472,17 @@ def thermal_speed(T: u.K,
     --------
     >>> from astropy import units as u
     >>> thermal_speed(5*u.eV, 'p')
-    <Quantity 30949.69018286 m / s>
+    <Quantity 30949.69... m / s>
     >>> thermal_speed(1e6*u.K, particle='p')
-    <Quantity 128486.55193256 m / s>
+    <Quantity 128486.5... m / s>
     >>> thermal_speed(5*u.eV)
-    <Quantity 1326205.12123959 m / s>
+    <Quantity 1326205.1... m / s>
     >>> thermal_speed(1e6*u.K)
-    <Quantity 5505693.98842538 m / s>
+    <Quantity 5505693.9... m / s>
     >>> thermal_speed(1e6*u.K, method="rms")
-    <Quantity 6743070.47577549 m / s>
+    <Quantity 6743070.4... m / s>
     >>> thermal_speed(1e6*u.K, method="mean_magnitude")
-    <Quantity 6212510.3969422 m / s>
+    <Quantity 6212510.3... m / s>
 
     """
     m = mass if np.isfinite(mass) else atomic.particle_mass(particle)
@@ -519,9 +519,9 @@ def thermal_pressure(T: u.K, n: u.m ** -3) -> u.Pa:
     --------
     >>> import astropy.units as u
     >>> thermal_pressure(1*u.eV, 1e20/u.m**3)
-    <Quantity 16.02176621 Pa>
+    <Quantity 16.021... Pa>
     >>> thermal_pressure(10*u.eV, 1e20/u.m**3)
-    <Quantity 160.21766208 Pa>
+    <Quantity 160.21... Pa>
 
     Returns
     -------
@@ -616,11 +616,11 @@ def kappa_thermal_speed(T: u.K, kappa, particle="e-", method="most_probable") ->
     --------
     >>> from astropy import units as u
     >>> kappa_thermal_speed(5*u.eV, 4, 'p') # defaults to most probable
-    <Quantity 24467.87846359 m / s>
+    <Quantity 24467.87... m / s>
     >>> kappa_thermal_speed(5*u.eV, 4, 'p', 'rms')
-    <Quantity 37905.47432261 m / s>
+    <Quantity 37905.47... m / s>
     >>> kappa_thermal_speed(5*u.eV, 4, 'p', 'mean_magnitude')
-    <Quantity 34922.9856304 m / s>
+    <Quantity 34922.98... m / s>
 
     References
     ----------
@@ -701,9 +701,9 @@ def Hall_parameter(n: u.m ** -3,
     --------
     >>> from astropy import units as u
     >>> Hall_parameter(1e10 * u.m**-3, 2.8e3 * u.eV, 2.3 * u.T, 'He-4 +1')
-    <Quantity 7.26446755e+16>
+    <Quantity 7.26446...e+16>
     >>> Hall_parameter(1e10 * u.m**-3, 5.8e3 * u.eV, 2.3 * u.T, 'He-4 +1')
-    <Quantity 2.11158408e+17>
+    <Quantity 2.11158...e+17>
 
     """
     from plasmapy.formulary.collisions import (fundamental_ion_collision_freq,
@@ -795,25 +795,25 @@ def gyrofrequency(B: u.T, particle='e-', signed=False, Z=None) -> u.rad / u.s:
     --------
     >>> from astropy import units as u
     >>> gyrofrequency(0.1*u.T)
-    <Quantity 1.75882002e+10 rad / s>
+    <Quantity 1.7588...e+10 rad / s>
     >>> gyrofrequency(0.1*u.T, to_hz=True)
-    <Quantity 2.79924901e+09 Hz>
+    <Quantity 2.79924...e+09 Hz>
     >>> gyrofrequency(0.1*u.T, signed=True)
-    <Quantity -1.75882002e+10 rad / s>
+    <Quantity -1.75882...e+10 rad / s>
     >>> gyrofrequency(0.01*u.T, 'p')
-    <Quantity 957883.32241481 rad / s>
+    <Quantity 957883.32... rad / s>
     >>> gyrofrequency(0.01*u.T, 'p', signed=True)
-    <Quantity 957883.32241481 rad / s>
+    <Quantity 957883.32... rad / s>
     >>> gyrofrequency(0.01*u.T, particle='T+')
-    <Quantity 319964.54975911 rad / s>
+    <Quantity 319964.5... rad / s>
     >>> gyrofrequency(0.01*u.T, particle='T+', to_hz=True)
-    <Quantity 50923.93970833 Hz>
+    <Quantity 50923.939... Hz>
     >>> omega_ce = gyrofrequency(0.1*u.T)
     >>> print(omega_ce)
-    17588200236.02124 rad / s
+    17588200236.0... rad / s
     >>> f_ce = omega_ce.to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])
     >>> print(f_ce)
-    2799249007.6528206 Hz
+    2799249007.6... Hz
 
     """
     m_i = atomic.particle_mass(particle)
@@ -906,23 +906,23 @@ def gyroradius(B: u.T,
     --------
     >>> from astropy import units as u
     >>> gyroradius(0.2*u.T,particle='p+',T_i=1e5*u.K)
-    <Quantity 0.00212087 m>
+    <Quantity 0.002120... m>
     >>> gyroradius(0.2*u.T,particle='p+',T_i=1e5*u.K)
-    <Quantity 0.00212087 m>
+    <Quantity 0.002120... m>
     >>> gyroradius(5*u.uG,particle='alpha',T_i=1*u.eV)
-    <Quantity 288002.38837768 m>
+    <Quantity 288002.38... m>
     >>> gyroradius(400*u.G,particle='Fe+++',Vperp=1e7*u.m/u.s)
-    <Quantity 48.23129811 m>
+    <Quantity 48.23129... m>
     >>> gyroradius(B=0.01*u.T,T_i=1e6*u.K)
-    <Quantity 0.00313033 m>
+    <Quantity 0.003130... m>
     >>> gyroradius(B=0.01*u.T,Vperp=1e6*u.m/u.s)
-    <Quantity 0.00056856 m>
+    <Quantity 0.000568... m>
     >>> gyroradius(0.2*u.T,T_i=1e5*u.K)
-    <Quantity 4.94949252e-05 m>
+    <Quantity 4.94949...e-05 m>
     >>> gyroradius(5*u.uG,T_i=1*u.eV)
-    <Quantity 6744.2598183 m>
+    <Quantity 6744.25... m>
     >>> gyroradius(400*u.G,Vperp=1e7*u.m/u.s)
-    <Quantity 0.00142141 m>
+    <Quantity 0.001421... m>
 
     """
 
@@ -1039,15 +1039,15 @@ def plasma_frequency(n: u.m**-3, particle='e-', z_mean=None) -> u.rad / u.s:
     -------
     >>> from astropy import units as u
     >>> plasma_frequency(1e19*u.m**-3, particle='p')
-    <Quantity 4.16329453e+09 rad / s>
+    <Quantity 4.16329...e+09 rad / s>
     >>> plasma_frequency(1e19*u.m**-3, particle='p', to_hz=True)
-    <Quantity 6.62608904e+08 Hz>
+    <Quantity 6.62608...e+08 Hz>
     >>> plasma_frequency(1e19*u.m**-3, particle='D+')
-    <Quantity 2.94462452e+09 rad / s>
+    <Quantity 2.94462...e+09 rad / s>
     >>> plasma_frequency(1e19*u.m**-3)
-    <Quantity 1.78398636e+11 rad / s>
+    <Quantity 1.78398...e+11 rad / s>
     >>> plasma_frequency(1e19*u.m**-3, to_hz=True)
-    <Quantity 2.83930248e+10 Hz>
+    <Quantity 2.83930...e+10 Hz>
 
     """
 
@@ -1134,7 +1134,7 @@ def Debye_length(T_e: u.K, n_e: u.m ** -3) -> u.m:
     -------
     >>> from astropy import units as u
     >>> Debye_length(5e6*u.K, 5e15*u.m**-3)
-    <Quantity 0.00218226 m>
+    <Quantity 0.002182... m>
 
     """
     lambda_D = np.sqrt(eps0 * k_B * T_e / (n_e * e ** 2))
@@ -1197,7 +1197,7 @@ def Debye_number(T_e: u.K, n_e: u.m ** -3) -> u.dimensionless_unscaled:
     -------
     >>> from astropy import units as u
     >>> Debye_number(5e6*u.K, 5e9*u.cm**-3)
-    <Quantity 2.17658302e+08>
+    <Quantity 2.17658...e+08>
 
     """
 
@@ -1261,9 +1261,9 @@ def inertial_length(n: u.m ** -3, particle: atomic.Particle) -> u.m:
     -------
     >>> from astropy import units as u
     >>> inertial_length(5 * u.m ** -3, 'He+')
-    <Quantity 2.02985802e+08 m>
+    <Quantity 2.02985...e+08 m>
     >>> inertial_length(5 * u.m ** -3, 'e-')
-    <Quantity 2376534.75601976 m>
+    <Quantity 2376534.75... m>
 
     """
     omega_p = plasma_frequency(n, particle=particle)
@@ -1324,7 +1324,7 @@ def magnetic_pressure(B: u.T) -> u.Pa:
     -------
     >>> from astropy import units as u
     >>> magnetic_pressure(0.1*u.T).to(u.Pa)
-    <Quantity 3978.8735773 Pa>
+    <Quantity 3978.87... Pa>
 
     """
     return (B ** 2) / (2 * mu0)
@@ -1383,7 +1383,7 @@ def magnetic_energy_density(B: u.T) -> u.J / u.m ** 3:
     -------
     >>> from astropy import units as u
     >>> magnetic_energy_density(0.1*u.T)
-    <Quantity 3978.8735773 J / m3>
+    <Quantity 3978.87... J / m3>
 
     """
     return magnetic_pressure(B)
@@ -1441,9 +1441,9 @@ def upper_hybrid_frequency(B: u.T, n_e: u.m ** -3) -> u.rad / u.s:
     -------
     >>> from astropy import units as u
     >>> upper_hybrid_frequency(0.2*u.T, n_e=5e19*u.m**-3)
-    <Quantity 4.00459419e+11 rad / s>
+    <Quantity 4.00459...e+11 rad / s>
     >>> upper_hybrid_frequency(0.2*u.T, n_e=5e19*u.m**-3, to_hz = True)
-    <Quantity 6.37350961e+10 Hz>
+    <Quantity 6.37350...e+10 Hz>
 
     """
     omega_pe = plasma_frequency(n=n_e)
@@ -1515,9 +1515,9 @@ def lower_hybrid_frequency(B: u.T, n_i: u.m ** -3, ion='p+') -> u.rad / u.s:
     -------
     >>> from astropy import units as u
     >>> lower_hybrid_frequency(0.2*u.T, n_i=5e19*u.m**-3, ion='D+')
-    <Quantity 5.78372733e+08 rad / s>
+    <Quantity 5.78372...e+08 rad / s>
     >>> lower_hybrid_frequency(0.2*u.T, n_i=5e19*u.m**-3, ion='D+', to_hz = True)
-    <Quantity 92050879.32941628 Hz>
+    <Quantity 92050879.32... Hz>
 
     """
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -253,14 +253,14 @@ def ion_sound_speed(T_e: u.K,
 
     n_e : ~astropy.units.Quantity
         Electron number density. If this is not given, then ion_sound_speed
-        will be approximated in the non-dispersive limit 
-        (:math:`k^2 \lambda_{D}^2` will be assumed zero). If n_e is given, 
+        will be approximated in the non-dispersive limit
+        (:math:`k^2 \lambda_{D}^2` will be assumed zero). If n_e is given,
         a value for k must also be given.
-        
+
     k : ~astropy.units.Quantity
-        Wavenumber (in units of inverse length, e.g. per meter). If this 
-        is not given, then ion_sound_speed will be approximated in the 
-        non-dispersive limit (:math:`k^2 \lambda_{D}^2` will be assumed zero). 
+        Wavenumber (in units of inverse length, e.g. per meter). If this
+        is not given, then ion_sound_speed will be approximated in the
+        non-dispersive limit (:math:`k^2 \lambda_{D}^2` will be assumed zero).
         If k is given, a value for n_e must also be given.
 
     gamma_e : float or int
@@ -306,7 +306,7 @@ def ion_sound_speed(T_e: u.K,
         If an adiabatic index is less than one.
 
     ~astropy.units.UnitConversionError
-        If the temperature, electron number density, or wavenumber 
+        If the temperature, electron number density, or wavenumber
         is in incorrect units.
 
     Warns
@@ -316,9 +316,9 @@ def ion_sound_speed(T_e: u.K,
 
     ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed.
-        
+
     PhysicsWarning
-        If only one of (k, n_e) is given, the non-dispersive limit 
+        If only one of (k, n_e) is given, the non-dispersive limit
         is assumed.
 
     Notes
@@ -333,11 +333,11 @@ def ion_sound_speed(T_e: u.K,
     ion adiabatic indices, :math:`k_B` is the Boltzmann constant,
     :math:`T_e` and :math:`T_i` are the electron and ion temperatures,
     :math:`Z` is the charge state of the ion, :math:`m_i` is the
-    ion mass, :math:`\lambda_{D}` is the Debye length, and :math:`k` is the 
+    ion mass, :math:`\lambda_{D}` is the Debye length, and :math:`k` is the
     wavenumber.
-    
-    In the non-dispersive limit (:math:`k^2 \lambda_{D}^2` is small) the 
-    equation for :math:`V_S` is approximated (the denominator reduces 
+
+    In the non-dispersive limit (:math:`k^2 \lambda_{D}^2` is small) the
+    equation for :math:`V_S` is approximated (the denominator reduces
     to :math:`m_i`).
 
     When the electron temperature is much greater than the ion
@@ -363,7 +363,7 @@ def ion_sound_speed(T_e: u.K,
     <Quantity 229585... m / s>
 
     """
-    
+
     m_i = atomic.particle_mass(ion)
     Z = _grab_charge(ion, z_mean)
 
@@ -374,7 +374,7 @@ def ion_sound_speed(T_e: u.K,
         if gamma < 1:
             raise PhysicsError(f"The adiabatic index for {particles} must be between "
                                f"one and infinity")
-    
+
     # Assume non-dispersive limit if values for n_e (or k) are not specified
     klD2 = 0.0
     if (n_e is None) ^ (k is None):

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -250,9 +250,9 @@ def ion_sound_speed(T_e: u.K,
         Ion temperature in units of temperature or energy per
         particle.  If this is not given, then the ion temperature is
         assumed to be zero.
-        
+
     n_e : ~astropy.units.Quantity
-        Electron number density. If this is not given, then ion_sound_speed 
+        Electron number density. If this is not given, then ion_sound_speed
         will be approximated in the non-dispersive limit 
         (:math:`k^2 \lambda_{D}^2` will be assumed zero). If n_e is given, 
         a value for k must also be given.

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -352,15 +352,15 @@ def ion_sound_speed(T_e: u.K,
     >>> k_1 = 3e1*u.m**-1
     >>> k_2 = 3e7*u.m**-1
     >>> ion_sound_speed(T_e=5e6*u.K, T_i=0*u.K, ion='p', gamma_e=1, gamma_i=3)
-    <Quantity 203155.07... m / s>
+    <Quantity 203155... m / s>
     >>> ion_sound_speed(T_e=5e6*u.K, T_i=0*u.K, n_e=n, k=k_1, ion='p', gamma_e=1, gamma_i=3)
-    <Quantity 203155.03... m / s>
+    <Quantity 203155... m / s>
     >>> ion_sound_speed(T_e=5e6*u.K, T_i=0*u.K, n_e=n, k=k_2, ion='p', gamma_e=1, gamma_i=3)
-    <Quantity 310.3132... m / s>
+    <Quantity 310.31... m / s>
     >>> ion_sound_speed(T_e=5e6*u.K, T_i=0*u.K, n_e=n, k=k_1)
-    <Quantity 203155.03... m / s>
+    <Quantity 203155... m / s>
     >>> ion_sound_speed(T_e=500*u.eV, T_i=200*u.eV, n_e=n, k=k_1, ion='D+')
-    <Quantity 229585.96... m / s>
+    <Quantity 229585... m / s>
 
     """
     
@@ -472,17 +472,17 @@ def thermal_speed(T: u.K,
     --------
     >>> from astropy import units as u
     >>> thermal_speed(5*u.eV, 'p')
-    <Quantity 30949.69... m / s>
+    <Quantity 30949.6... m / s>
     >>> thermal_speed(1e6*u.K, particle='p')
-    <Quantity 128486.5... m / s>
-    >>> thermal_speed(5*u.eV)
-    <Quantity 1326205.1... m / s>
-    >>> thermal_speed(1e6*u.K)
-    <Quantity 5505693.9... m / s>
+    <Quantity 128486... m / s>
+    >>> thermal_speed(5*u.eV, particle='e-')
+    <Quantity 132620... m / s>
+    >>> thermal_speed(1e6*u.K, particle='e-')
+    <Quantity 550569... m / s>
     >>> thermal_speed(1e6*u.K, method="rms")
-    <Quantity 6743070.4... m / s>
+    <Quantity 674307... m / s>
     >>> thermal_speed(1e6*u.K, method="mean_magnitude")
-    <Quantity 6212510.3... m / s>
+    <Quantity 621251... m / s>
 
     """
     m = mass if np.isfinite(mass) else atomic.particle_mass(particle)
@@ -807,13 +807,13 @@ def gyrofrequency(B: u.T, particle='e-', signed=False, Z=None) -> u.rad / u.s:
     >>> gyrofrequency(0.01*u.T, particle='T+')
     <Quantity 319964.5... rad / s>
     >>> gyrofrequency(0.01*u.T, particle='T+', to_hz=True)
-    <Quantity 50923.939... Hz>
+    <Quantity 50923.9... Hz>
     >>> omega_ce = gyrofrequency(0.1*u.T)
     >>> print(omega_ce)
     17588200236.0... rad / s
     >>> f_ce = omega_ce.to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])
     >>> print(f_ce)
-    2799249007.6... Hz
+    279924... Hz
 
     """
     m_i = atomic.particle_mass(particle)
@@ -1517,7 +1517,7 @@ def lower_hybrid_frequency(B: u.T, n_i: u.m ** -3, ion='p+') -> u.rad / u.s:
     >>> lower_hybrid_frequency(0.2*u.T, n_i=5e19*u.m**-3, ion='D+')
     <Quantity 5.78372...e+08 rad / s>
     >>> lower_hybrid_frequency(0.2*u.T, n_i=5e19*u.m**-3, ion='D+', to_hz = True)
-    <Quantity 92050879.32... Hz>
+    <Quantity 92050879.3... Hz>
 
     """
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -810,7 +810,7 @@ def gyrofrequency(B: u.T, particle='e-', signed=False, Z=None) -> u.rad / u.s:
     <Quantity 50923.9... Hz>
     >>> omega_ce = gyrofrequency(0.1*u.T)
     >>> print(omega_ce)
-    17588200236.0... rad / s
+    1758820... rad / s
     >>> f_ce = omega_ce.to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])
     >>> print(f_ce)
     279924... Hz

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -251,7 +251,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-1")
         testTrue = np.isclose(methodVal,
                               self.gms1,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-1 should be "
                   f"{self.gms1} and not {methodVal}.")
@@ -285,7 +285,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-2")
         testTrue = np.isclose(methodVal,
                               self.gms2,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-2 should be "
                   f"{self.gms2} and not {methodVal}.")
@@ -319,7 +319,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-3")
         testTrue = np.isclose(methodVal,
                               self.gms3,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-3 should be "
                   f"{self.gms3} and not {methodVal}.")
@@ -341,7 +341,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-3")
         testTrue = np.isclose(methodVal,
                               self.gms3_negative,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-3 should be "
                   f"{self.gms3_negative} and not {methodVal}.")
@@ -363,7 +363,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-3")
         testTrue = np.isclose(methodVal,
                               self.gms3_non_scalar,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-3 should be "
                   f"{self.gms3_non_scalar} and not {methodVal}.")
@@ -383,7 +383,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-4")
         testTrue = np.isclose(methodVal,
                               self.gms4,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-4 should be "
                   f"{self.gms4} and not {methodVal}.")
@@ -405,7 +405,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-4")
         testTrue = np.isclose(methodVal,
                               self.gms4_negative,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-4 should be "
                   f"{self.gms4_negative} and not {methodVal}.")
@@ -425,7 +425,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-5")
         testTrue = np.isclose(methodVal,
                               self.gms5,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-5 should be "
                   f"{self.gms5} and not {methodVal}.")
@@ -447,7 +447,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-5")
         testTrue = np.isclose(methodVal,
                               self.gms5_negative,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-5 should be "
                   f"{self.gms5_negative} and not {methodVal}.")
@@ -467,7 +467,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-6")
         testTrue = np.isclose(methodVal,
                               self.gms6,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-6 should be "
                   f"{self.gms6} and not {methodVal}.")
@@ -489,7 +489,7 @@ class Test_Coulomb_logarithm:
                                           method="GMS-6")
         testTrue = np.isclose(methodVal,
                               self.gms6_negative,
-                              rtol=1e-15,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Coulomb logarithm for GMS-6 should be "
                   f"{self.gms6_negative} and not {methodVal}.")

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -129,7 +129,7 @@ class Test_permittivity_1D_Maxwellian:
                                                self.z_mean)
         testTrue = np.isclose(methodVal,
                               self.True1,
-                              rtol=1e-8,
+                              rtol=1e-16,
                               atol=0.0)
         errStr = (f"Permittivity value should be {self.True1} and not "
                   f"{methodVal}.")
@@ -149,7 +149,7 @@ class Test_permittivity_1D_Maxwellian:
                                                self.z_mean)
         testTrue = not np.isclose(methodVal,
                                   fail1,
-                                  rtol=1e-8,
+                                  rtol=1e-16,
                                   atol=0.0)
         errStr = (f"Permittivity value test gives {methodVal} "
                   f"and should not be equal to {fail1}.")

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -129,7 +129,7 @@ class Test_permittivity_1D_Maxwellian:
                                                self.z_mean)
         testTrue = np.isclose(methodVal,
                               self.True1,
-                              rtol=1e-16,
+                              rtol=1e-8,
                               atol=0.0)
         errStr = (f"Permittivity value should be {self.True1} and not "
                   f"{methodVal}.")
@@ -149,7 +149,7 @@ class Test_permittivity_1D_Maxwellian:
                                                self.z_mean)
         testTrue = not np.isclose(methodVal,
                                   fail1,
-                                  rtol=1e-16,
+                                  rtol=1e-8,
                                   atol=0.0)
         errStr = (f"Permittivity value test gives {methodVal} "
                   f"and should not be equal to {fail1}.")

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -93,13 +93,18 @@ class Test_ColdPlasmaPermittivity(object):
         assert np.isclose(D, (R - L) / 2)
 
     def test_numpy_array_workflow(self):
-        """as per @jhillairet at https://github.com/PlasmaPy/PlasmaPy/issues/539#issuecomment-425337810 """
+        """
+        As per @jhillairet at:
+        https://github.com/PlasmaPy/PlasmaPy/issues/539#issuecomment-425337810
+        """
         ns = np.logspace(17, 19, 50)/u.m**3
         B0 = 4*u.T
         omega_RF = 2*np.pi*50e6*(u.rad/u.s)
 
-        S, D, P = cold_plasma_permittivity_SDP(B=B0, species=['e', 'D+'], n=[ns, ns], omega=omega_RF)
+        S, D, P = \
+            cold_plasma_permittivity_SDP(B=B0, species=['e', 'D+'], n=[ns, ns], omega=omega_RF)
         assert S.shape == D.shape == P.shape == (50,)
+
 
 class Test_permittivity_1D_Maxwellian:
     @classmethod

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -129,7 +129,7 @@ class Test_permittivity_1D_Maxwellian:
                                                self.z_mean)
         testTrue = np.isclose(methodVal,
                               self.True1,
-                              rtol=1e-16,
+                              rtol=1e-6,
                               atol=0.0)
         errStr = (f"Permittivity value should be {self.True1} and not "
                   f"{methodVal}.")

--- a/plasmapy/formulary/tests/test_dispersion.py
+++ b/plasmapy/formulary/tests/test_dispersion.py
@@ -5,7 +5,10 @@
 import numpy as np
 import pytest
 from astropy import units as u
-from plasmapy.formulary.dispersionfunction import plasma_dispersion_func, plasma_dispersion_func_deriv
+from plasmapy.formulary.dispersionfunction import (
+    plasma_dispersion_func,
+    plasma_dispersion_func_deriv,
+)
 from numpy import pi as π
 from scipy.special import gamma as Γ
 

--- a/plasmapy/formulary/tests/test_distribution.py
+++ b/plasmapy/formulary/tests/test_distribution.py
@@ -118,7 +118,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -134,7 +134,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -152,7 +152,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -171,7 +171,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -188,7 +188,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -205,7 +205,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
 
@@ -252,7 +252,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -268,7 +268,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -286,7 +286,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -305,7 +305,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -322,7 +322,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -338,7 +338,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncDrift.value,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
 
@@ -407,7 +407,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -424,7 +424,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -443,7 +443,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -463,7 +463,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -482,7 +482,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -501,7 +501,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
 
@@ -547,7 +547,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -563,7 +563,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -581,7 +581,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -600,7 +600,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -617,7 +617,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -634,7 +634,7 @@ class Test_Maxwellian_speed_2D(object):
 #                  f"and not {distFunc}.")
 #        assert np.isclose(distFunc.value,
 #                          0.0,
-#                          rtol=1e-6,
+#                          rtol=1e-5,
 #                          atol=0.0), errStr
 
 
@@ -710,7 +710,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -728,7 +728,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -748,7 +748,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -769,7 +769,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -790,7 +790,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -811,7 +811,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
 
@@ -857,7 +857,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -873,7 +873,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -891,7 +891,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -910,7 +910,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -927,7 +927,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -944,7 +944,7 @@ class Test_Maxwellian_speed_3D(object):
 #                  f"and not {distFunc}.")
 #        assert np.isclose(distFunc.value,
 #                          0.0,
-#                          rtol=1e-6,
+#                          rtol=1e-5,
 #                          atol=0.0), errStr
 
 
@@ -1072,7 +1072,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -1089,7 +1089,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -1108,7 +1108,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -1128,7 +1128,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -1146,7 +1146,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -1164,7 +1164,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
 
@@ -1236,7 +1236,7 @@ class Test_kappa_velocity_3D(object):
 #                  f"and not {kappaDistFunc}.")
 #        assert np.isclose(kappaDistFunc.value,
 #                          maxwellDistFunc.value,
-#                          rtol=1e-6,
+#                          rtol=1e-5,
 #                          atol=0.0), errStr
 #
 #        return
@@ -1293,7 +1293,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -1312,7 +1312,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -1333,7 +1333,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -1355,7 +1355,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -1377,7 +1377,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -1399,5 +1399,5 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-6,
+                          rtol=1e-5,
                           atol=0.0), errStr

--- a/plasmapy/formulary/tests/test_distribution.py
+++ b/plasmapy/formulary/tests/test_distribution.py
@@ -118,7 +118,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -134,7 +134,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -152,7 +152,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -171,7 +171,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -188,7 +188,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -205,7 +205,7 @@ class Test_Maxwellian_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
 
@@ -252,7 +252,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -268,7 +268,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -286,7 +286,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -305,7 +305,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -322,7 +322,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -338,7 +338,7 @@ class Test_Maxwellian_speed_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncDrift.value,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
 
@@ -407,7 +407,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -424,7 +424,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -443,7 +443,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -463,7 +463,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -482,7 +482,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -501,7 +501,7 @@ class Test_Maxwellian_velocity_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
 
@@ -547,7 +547,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -563,7 +563,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -581,7 +581,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -600,7 +600,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -617,7 +617,7 @@ class Test_Maxwellian_speed_2D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -634,7 +634,7 @@ class Test_Maxwellian_speed_2D(object):
 #                  f"and not {distFunc}.")
 #        assert np.isclose(distFunc.value,
 #                          0.0,
-#                          rtol=1e-8,
+#                          rtol=1e-6,
 #                          atol=0.0), errStr
 
 
@@ -710,7 +710,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -728,7 +728,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -748,7 +748,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -769,7 +769,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -790,7 +790,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -811,7 +811,7 @@ class Test_Maxwellian_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
 
@@ -857,7 +857,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -873,7 +873,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -891,7 +891,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -910,7 +910,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -927,7 +927,7 @@ class Test_Maxwellian_speed_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -944,7 +944,7 @@ class Test_Maxwellian_speed_3D(object):
 #                  f"and not {distFunc}.")
 #        assert np.isclose(distFunc.value,
 #                          0.0,
-#                          rtol=1e-8,
+#                          rtol=1e-6,
 #                          atol=0.0), errStr
 
 
@@ -1072,7 +1072,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -1089,7 +1089,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -1108,7 +1108,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -1128,7 +1128,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -1146,7 +1146,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -1164,7 +1164,7 @@ class Test_kappa_velocity_1D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
 
@@ -1236,7 +1236,7 @@ class Test_kappa_velocity_3D(object):
 #                  f"and not {kappaDistFunc}.")
 #        assert np.isclose(kappaDistFunc.value,
 #                          maxwellDistFunc.value,
-#                          rtol=1e-8,
+#                          rtol=1e-6,
 #                          atol=0.0), errStr
 #
 #        return
@@ -1293,7 +1293,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_units_vTh(self):
@@ -1312,7 +1312,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_no_vTh(self):
@@ -1333,7 +1333,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_unitless_vTh(self):
@@ -1355,7 +1355,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_zero_drift_units(self):
@@ -1377,7 +1377,7 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           self.distFuncTrue,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr
 
     def test_value_drift_units(self):
@@ -1399,5 +1399,5 @@ class Test_kappa_velocity_3D(object):
                   f"and not {distFunc}.")
         assert np.isclose(distFunc.value,
                           testVal,
-                          rtol=1e-8,
+                          rtol=1e-6,
                           atol=0.0), errStr

--- a/plasmapy/formulary/tests/test_magnetostatics.py
+++ b/plasmapy/formulary/tests/test_magnetostatics.py
@@ -8,20 +8,19 @@ from plasmapy.formulary.magnetostatics import (MagneticDipole,
                                                InfiniteStraightWire,
                                                CircularWire)
 
-
 mu0_4pi = constants.mu0/4/np.pi
 
 
 class Test_MagneticDipole:
     def setup_method(self):
-        self.moment = np.array([0, 0, 1])*u.A*u.m*u.m
-        self.p0 = np.array([0, 0, 0])*u.m
+        self.moment = np.array([0, 0, 1]) * u.A * u.m * u.m
+        self.p0 = np.array([0, 0, 0]) * u.m
 
     def test_value1(self):
         "Test a known solution"
         p = np.array([1, 0, 0])
         B1 = MagneticDipole(self.moment, self.p0).magnetic_field(p)
-        B1_expected = np.array([0, 0, -1])*1e-7*u.T
+        B1_expected = np.array([0, 0, -1]) * 1e-7 * u.T
         assert np.all(np.isclose(B1.value, B1_expected.value))
         assert B1.unit == u.T
 
@@ -29,22 +28,22 @@ class Test_MagneticDipole:
         "Test a known solution"
         p = np.array([0, 0, 1])
         B2 = MagneticDipole(self.moment, self.p0).magnetic_field(p)
-        B2_expected = np.array([0, 0, 2])*1e-7*u.T
+        B2_expected = np.array([0, 0, 2]) * 1e-7 * u.T
         assert np.all(np.isclose(B2.value, B2_expected.value))
         assert B2.unit == u.T
 
 
 class Test_GeneralWire:
     def setup_method(self):
-        self.cw = CircularWire(np.array([0, 0, 1]), np.array([0, 0, 0])*u.m, 1*u.m, 1*u.A)
-        p1 = np.array([0., 0., 0.])*u.m
-        p2 = np.array([0., 0., 1.])*u.m
-        self.fw = FiniteStraightWire(p1, p2, 1*u.A)
+        self.cw = CircularWire(np.array([0, 0, 1]), np.array([0, 0, 0]) * u.m, 1 * u.m, 1 * u.A)
+        p1 = np.array([0., 0., 0.]) * u.m
+        p2 = np.array([0., 0., 1.]) * u.m
+        self.fw = FiniteStraightWire(p1, p2, 1 * u.A)
 
     def test_not_callable(self):
         "Test that `GeneralWire` raises `ValueError` if its first argument is not callale"
         with pytest.raises(ValueError):
-            GeneralWire("wire", 0, 1, 1*u.A)
+            GeneralWire("wire", 0, 1, 1 * u.A)
 
     def test_close_cw(self):
         "Test if the GeneralWire is close to the CircularWire it converted from"
@@ -65,11 +64,11 @@ class Test_GeneralWire:
 
         assert np.all(np.isclose(B_fw.value, B_gw_fw.value))
         assert B_fw.unit == B_gw_fw.unit
-    
+
     def test_value_error(self):
         "Test GeneralWire raise ValueError when argument t1>t2"
-        with pytest.raises(ValueError) as e:
-            gw_cw = GeneralWire(lambda t: [0,0,t], 2, 1, 1.*u.A)
+        with pytest.raises(ValueError):
+            gw_cw = GeneralWire(lambda t: [0, 0, t], 2, 1, 1.*u.A)
 
 
 class Test_FiniteStraightWire:
@@ -97,7 +96,6 @@ class Test_FiniteStraightWire:
         assert repr(fw) == r"FiniteStraightWire(p1=[ 0.  0. -1.], p2=[0. 0. 1.], current=1.0)"
 
 
-
 class Test_InfiniteStraightWire:
     def setup_method(self):
         self.direction = np.array([0, 1, 0])
@@ -115,7 +113,9 @@ class Test_InfiniteStraightWire:
     def test_repr(self):
         "Test __repr__ function"
         iw = InfiniteStraightWire(self.direction, self.p0, self.current)
-        assert repr(iw) == r"InfiniteStraightWire(direction=[0. 1. 0.], p0=[0. 0. 0.], current=1.0)"
+        assert repr(iw) == \
+            r"InfiniteStraightWire(direction=[0. 1. 0.], p0=[0. 0. 0.], current=1.0)"
+
 
 class Test_CircularWire:
     def setup_method(self):
@@ -149,4 +149,5 @@ class Test_CircularWire:
     def test_repr(self):
         "Test __repr__ function"
         cw = CircularWire(self.normalz, self.center, self.radius, self.current)
-        assert repr(cw) == r"CircularWire(normal=[0. 0. 1.], center=[0. 0. 0.], radius=1.0, current=1.0)"
+        assert repr(cw) == \
+            r"CircularWire(normal=[0. 0. 1.], center=[0. 0. 0.], radius=1.0, current=1.0)"

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -181,7 +181,7 @@ def test_Alfven_speed():
     assert np.isclose(testMeth1,
                       testTrue1,
                       atol=0.0,
-                      rtol=1e-15), errStr
+                      rtol=1e-6), errStr
 
     assert_can_handle_nparray(Alfven_speed)
 

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -85,8 +85,10 @@ class Test_mass_density:
 def test_Alfven_speed():
     r"""Test the Alfven_speed function in parameters.py."""
 
+    # TODO: break this test up until multiple tests
+
     assert np.isclose(Alfven_speed(1 * u.T, 1e-8 * u.kg * u.m ** -3).value,
-                      8920620.580763856)
+                      8920620.580763856, rtol=1e-6)
 
     V_A = Alfven_speed(B, n_i)
     assert np.isclose(
@@ -289,12 +291,12 @@ def test_ion_sound_speed():
     # testing for user input z_mean
     testMeth1 = ion_sound_speed(T_e=1.2e6 * u.K, T_i=0 * u.K, n_e=n_e, 
                                 k=0 * u.m ** -1, z_mean=0.8).si.value
-    testTrue1 = 89018.0944146141
+    testTrue1 = 89018.09
     errStr = f"ion_sound_speed() gave {testMeth1}, should be {testTrue1}."
     assert np.isclose(testMeth1,
                       testTrue1,
                       atol=0.0,
-                      rtol=1e-15), errStr
+                      rtol=1e-6), errStr
 
     assert_can_handle_nparray(ion_sound_speed)
 
@@ -545,7 +547,7 @@ def test_gyrofrequency():
     assert np.isclose(testMeth1,
                       testTrue1,
                       atol=0.0,
-                      rtol=1e-15), errStr
+                      rtol=1e-5), errStr
 
     assert_can_handle_nparray(gyrofrequency, kwargs={"signed": True})
 
@@ -743,7 +745,7 @@ def test_plasma_frequency():
     assert np.isclose(testMeth1,
                       testTrue1,
                       atol=0.0,
-                      rtol=1e-15), errStr
+                      rtol=1e-6), errStr
 
     assert_can_handle_nparray(plasma_frequency)
 

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -192,14 +192,14 @@ def test_ion_sound_speed():
     assert np.isclose(ion_sound_speed(T_i=1.3232 * u.MK, T_e=1.831 * u.MK,
                                       ion='p', gamma_e=1, gamma_i=3).value,
                       218816.06086407552)
-    
+
     assert np.isclose(ion_sound_speed(T_i=1.3232 * u.MK, T_e=1.831 * u.MK,
-                                      n_e=n_e, k=k_1, ion='p', gamma_e=1, 
+                                      n_e=n_e, k=k_1, ion='p', gamma_e=1,
                                       gamma_i=3).value,
                       218816.06086407552)
-    
+
     assert np.isclose(ion_sound_speed(T_i=1.3232 * u.MK, T_e=1.831 * u.MK,
-                                      n_e=n_e, k=k_2, ion='p', gamma_e=1, 
+                                      n_e=n_e, k=k_2, ion='p', gamma_e=1,
                                       gamma_i=3).value,
                       552.3212936293337)
 
@@ -211,16 +211,16 @@ def test_ion_sound_speed():
     # assert ion_sound_speed(T_i=T_i, T_e=T_e, ion='p+') == ion_sound_speed(T_i=T_i, T_e=T_e,
     # ion='H-1')
 
-    assert ion_sound_speed(T_i=T_i, T_e=0 * u.K, n_e=n_e, 
+    assert ion_sound_speed(T_i=T_i, T_e=0 * u.K, n_e=n_e,
                            k=k_1, ion='p+').unit.is_equivalent(u.m / u.s)
 
     with pytest.raises(RelativityError):
-        ion_sound_speed(T_i=T_i, T_e=T_e, n_e=n_e, 
+        ion_sound_speed(T_i=T_i, T_e=T_e, n_e=n_e,
                         k=k_1, gamma_i=np.inf)
-        
+
     with pytest.warns(PhysicsWarning):
         ion_sound_speed(T_i=T_i, T_e=T_e, n_e=n_e)
-        
+
     with pytest.warns(PhysicsWarning):
         ion_sound_speed(T_i=T_i, T_e=T_e, k=k_1)
 
@@ -253,10 +253,10 @@ def test_ion_sound_speed():
 
     with pytest.raises(ValueError):
         ion_sound_speed(T_i=-np.abs(T_i), T_e=0 * u.K)
-    
+
     with pytest.raises(ValueError):
         ion_sound_speed(T_i=T_i, T_e=0 * u.K, n_e=-np.abs(n_e), k=k_1)
-        
+
     with pytest.raises(ValueError):
         ion_sound_speed(T_i=T_i, T_e=0 * u.K, n_e=n_e, k=-np.abs(k_1))
 
@@ -289,7 +289,7 @@ def test_ion_sound_speed():
 
     ion_sound_speed(T_e=1.2e6 * u.K, T_i=0 * u.K, n_e=n_e, k=k_1)
     # testing for user input z_mean
-    testMeth1 = ion_sound_speed(T_e=1.2e6 * u.K, T_i=0 * u.K, n_e=n_e, 
+    testMeth1 = ion_sound_speed(T_e=1.2e6 * u.K, T_i=0 * u.K, n_e=n_e,
                                 k=0 * u.m ** -1, z_mean=0.8).si.value
     testTrue1 = 89018.09
     errStr = f"ion_sound_speed() gave {testMeth1}, should be {testTrue1}."
@@ -488,7 +488,6 @@ def test_gyrofrequency():
 
     assert np.isclose(gyrofrequency(1 * u.G).cgs.value,
                       1.76e7, rtol=1e-3)
-
 
     with pytest.raises(TypeError):
         gyrofrequency(u.m)

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -159,9 +159,9 @@ class Test_chemical_potential:
         """
         methodVal = chemical_potential(self.n_e, self.T)
         testTrue = u.isclose(methodVal,
-                              self.True1,
-                              rtol=1e-16,
-                              atol=0.0)
+                             self.True1,
+                             rtol=1e-16,
+                             atol=0.0)
         errStr = (f"Chemical potential value should be {self.True1} and not "
                   f"{methodVal}.")
         assert testTrue, errStr
@@ -175,9 +175,9 @@ class Test_chemical_potential:
         fail1 = self.True1 + 1e-15
         methodVal = chemical_potential(self.n_e, self.T)
         testTrue = not u.isclose(methodVal,
-                                  fail1,
-                                  rtol=1e-16,
-                                  atol=0.0)
+                                 fail1,
+                                 rtol=1e-16,
+                                 atol=0.0)
         errStr = (f"Chemical potential value test gives {methodVal} and "
                   f"should not be equal to {fail1}.")
         assert testTrue, errStr
@@ -197,10 +197,7 @@ class Test__chemical_potential_interp:
         Tests Fermi_integral for expected value.
         """
         methodVal = _chemical_potential_interp(self.n_e, self.T)
-        testTrue = u.isclose(methodVal,
-                              self.True1,
-                              rtol=1e-16,
-                              atol=0.0)
+        testTrue = u.isclose(methodVal, self.True1, rtol=1e-16, atol=0.0)
         errStr = (f"Chemical potential value should be {self.True1} and not "
                   f"{methodVal}.")
         assert testTrue, errStr
@@ -213,10 +210,7 @@ class Test__chemical_potential_interp:
         """
         fail1 = self.True1 + 1e-15
         methodVal = _chemical_potential_interp(self.n_e, self.T)
-        testTrue = not u.isclose(methodVal,
-                                  fail1,
-                                  rtol=1e-16,
-                                  atol=0.0)
+        testTrue = not u.isclose(methodVal, fail1, rtol=1e-16, atol=0.0)
         errStr = (f"Chemical potential value test gives {methodVal} "
                   f"and should not be equal to {fail1}.")
         assert testTrue, errStr

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -135,7 +135,7 @@ def test_Wigner_Seitz_radius():
     n_e = 1e23 * u.cm ** -3
     radiusTrue = 1.3365046175719772e-10 * u.m
     radiusMeth = Wigner_Seitz_radius(n_e)
-    testTrue = np.isclose(radiusMeth,
+    testTrue = u.isclose(radiusMeth,
                           radiusTrue,
                           rtol=1e-5)
     errStr = (f"Error in Wigner_Seitz_radius(), got {radiusMeth}, "
@@ -158,7 +158,7 @@ class Test_chemical_potential:
         Tests Fermi_integral for expected value.
         """
         methodVal = chemical_potential(self.n_e, self.T)
-        testTrue = np.isclose(methodVal,
+        testTrue = u.isclose(methodVal,
                               self.True1,
                               rtol=1e-16,
                               atol=0.0)
@@ -174,7 +174,7 @@ class Test_chemical_potential:
         """
         fail1 = self.True1 + 1e-15
         methodVal = chemical_potential(self.n_e, self.T)
-        testTrue = not np.isclose(methodVal,
+        testTrue = not u.isclose(methodVal,
                                   fail1,
                                   rtol=1e-16,
                                   atol=0.0)
@@ -197,7 +197,7 @@ class Test__chemical_potential_interp:
         Tests Fermi_integral for expected value.
         """
         methodVal = _chemical_potential_interp(self.n_e, self.T)
-        testTrue = np.isclose(methodVal,
+        testTrue = u.isclose(methodVal,
                               self.True1,
                               rtol=1e-16,
                               atol=0.0)
@@ -213,7 +213,7 @@ class Test__chemical_potential_interp:
         """
         fail1 = self.True1 + 1e-15
         methodVal = _chemical_potential_interp(self.n_e, self.T)
-        testTrue = not np.isclose(methodVal,
+        testTrue = not u.isclose(methodVal,
                                   fail1,
                                   rtol=1e-16,
                                   atol=0.0)

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -75,7 +75,7 @@ def test_thermal_deBroglie_wavelength():
                  f"{lambda_dbTh_true} and not {lambda_dbTh}")
     assert np.isclose(lambda_dbTh.value,
                       lambda_dbTh_true,
-                      rtol=1e-15,
+                      rtol=1e-5,
                       atol=0.0), expectStr
     # testing returned units
     assert lambda_dbTh.unit == u.m
@@ -96,7 +96,7 @@ def test_Fermi_energy():
                  f"{energy_F_true} and not {energy_F}.")
     assert np.isclose(energy_F.value,
                       energy_F_true,
-                      rtol=1e-15,
+                      rtol=1e-5,
                       atol=0.0), expectStr
     # testing returned units
     assert energy_F.unit == u.J
@@ -117,7 +117,7 @@ def test_Thomas_Fermi_length():
                  f"{lambda_TF_true} and not {lambda_TF}.")
     assert np.isclose(lambda_TF.value,
                       lambda_TF_true,
-                      rtol=1e-15,
+                      rtol=1e-5,
                       atol=0.0), expectStr
     # testing returned units
     assert lambda_TF.unit == u.m
@@ -137,8 +137,7 @@ def test_Wigner_Seitz_radius():
     radiusMeth = Wigner_Seitz_radius(n_e)
     testTrue = np.isclose(radiusMeth,
                           radiusTrue,
-                          rtol=0.0,
-                          atol=1e-15 * u.m)
+                          rtol=1e-5)
     errStr = (f"Error in Wigner_Seitz_radius(), got {radiusMeth}, "
               f"should be {radiusTrue}")
     assert testTrue, errStr
@@ -200,7 +199,7 @@ class Test__chemical_potential_interp:
         methodVal = _chemical_potential_interp(self.n_e, self.T)
         testTrue = np.isclose(methodVal,
                               self.True1,
-                              rtol=1e-14,
+                              rtol=1e-16,
                               atol=0.0)
         errStr = (f"Chemical potential value should be {self.True1} and not "
                   f"{methodVal}.")

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -73,10 +73,7 @@ def test_thermal_deBroglie_wavelength():
     # test a simple case for expected value
     expectStr = ("Thermal deBroglie wavelength at 1 eV should be "
                  f"{lambda_dbTh_true} and not {lambda_dbTh}")
-    assert np.isclose(lambda_dbTh.value,
-                      lambda_dbTh_true,
-                      rtol=1e-5,
-                      atol=0.0), expectStr
+    assert np.isclose(lambda_dbTh.value, lambda_dbTh_true, rtol=1e-5, atol=0.0), expectStr
     # testing returned units
     assert lambda_dbTh.unit == u.m
     # testing exceptions
@@ -94,10 +91,7 @@ def test_Fermi_energy():
     # test a simple case for expected value
     expectStr = ("Fermi energy at 1e23 cm^-3 should be "
                  f"{energy_F_true} and not {energy_F}.")
-    assert np.isclose(energy_F.value,
-                      energy_F_true,
-                      rtol=1e-5,
-                      atol=0.0), expectStr
+    assert np.isclose(energy_F.value, energy_F_true, rtol=1e-5, atol=0.0), expectStr
     # testing returned units
     assert energy_F.unit == u.J
     # testing exceptions
@@ -115,10 +109,7 @@ def test_Thomas_Fermi_length():
     # test a simple case for expected value
     expectStr = ("Thomas-Fermi length at 1e23 cm^-3 should be "
                  f"{lambda_TF_true} and not {lambda_TF}.")
-    assert np.isclose(lambda_TF.value,
-                      lambda_TF_true,
-                      rtol=1e-5,
-                      atol=0.0), expectStr
+    assert np.isclose(lambda_TF.value, lambda_TF_true, rtol=1e-5, atol=0.0), expectStr
     # testing returned units
     assert lambda_TF.unit == u.m
     # testing exceptions
@@ -135,9 +126,7 @@ def test_Wigner_Seitz_radius():
     n_e = 1e23 * u.cm ** -3
     radiusTrue = 1.3365046175719772e-10 * u.m
     radiusMeth = Wigner_Seitz_radius(n_e)
-    testTrue = u.isclose(radiusMeth,
-                          radiusTrue,
-                          rtol=1e-5)
+    testTrue = u.isclose(radiusMeth, radiusTrue, rtol=1e-5)
     errStr = (f"Error in Wigner_Seitz_radius(), got {radiusMeth}, "
               f"should be {radiusTrue}")
     assert testTrue, errStr
@@ -158,10 +147,7 @@ class Test_chemical_potential:
         Tests Fermi_integral for expected value.
         """
         methodVal = chemical_potential(self.n_e, self.T)
-        testTrue = u.isclose(methodVal,
-                             self.True1,
-                             rtol=1e-16,
-                             atol=0.0)
+        testTrue = u.isclose(methodVal, self.True1, rtol=1e-16, atol=0.0)
         errStr = (f"Chemical potential value should be {self.True1} and not "
                   f"{methodVal}.")
         assert testTrue, errStr
@@ -174,10 +160,7 @@ class Test_chemical_potential:
         """
         fail1 = self.True1 + 1e-15
         methodVal = chemical_potential(self.n_e, self.T)
-        testTrue = not u.isclose(methodVal,
-                                 fail1,
-                                 rtol=1e-16,
-                                 atol=0.0)
+        testTrue = not u.isclose(methodVal, fail1, rtol=1e-16, atol=0.0)
         errStr = (f"Chemical potential value test gives {methodVal} and "
                   f"should not be equal to {fail1}.")
         assert testTrue, errStr

--- a/plasmapy/formulary/tests/test_relativity.py
+++ b/plasmapy/formulary/tests/test_relativity.py
@@ -30,7 +30,7 @@ def test_Lorentz_factor():
         Lorentz_factor(1.0000000001 * c)
 
     with pytest.raises(ValueError), pytest.warns(u.UnitsWarning):
-            Lorentz_factor(299792459)
+        Lorentz_factor(299792459)
 
     with pytest.warns(u.UnitsWarning):
         Lorentz_factor(2.2)

--- a/plasmapy/formulary/tests/test_transport.py
+++ b/plasmapy/formulary/tests/test_transport.py
@@ -605,18 +605,19 @@ class Test_classical_transport:
     def test_electron_viscosity_wrapper(self):
         with pytest.warns(RelativityWarning):
             assert_quantity_allclose(electron_viscosity(T_e=self.T_e,
-                                                    n_e=self.n_e,
-                                                    T_i=self.T_i,
-                                                    n_i=self.n_i,
-                                                    ion_particle=self.ion_particle,
-                                                    Z=self.Z,
-                                                    B=self.B,
-                                                    model=self.model,
-                                                    field_orientation=self.field_orientation,
-                                                    mu=self.mu,
-                                                    theta=self.theta,
-                                                    ),
+                                                        n_e=self.n_e,
+                                                        T_i=self.T_i,
+                                                        n_i=self.n_i,
+                                                        ion_particle=self.ion_particle,
+                                                        Z=self.Z,
+                                                        B=self.B,
+                                                        model=self.model,
+                                                        field_orientation=self.field_orientation,
+                                                        mu=self.mu,
+                                                        theta=self.theta,
+                                                        ),
                                      self.ct_wrapper.electron_viscosity)
+
 
 @pytest.mark.parametrize(["particle"], ['e', 'p'])
 def test_nondim_thermal_conductivity_unrecognized_model(particle):


### PR DESCRIPTION
This PR is mostly changing things like

```Python
<Quantity 2.2347906415316helpimtrappedinafloatingpointnumber8795234896735489 MeV>
```
to 
```Python
<Quantity 2.234... MeV>
```
so that differences at the *n*th decimal point due to refined values for fundamental constants don't mess up our doctests.  