### PR TITLE
Set isort settings to be consistent with black

### DIFF
--- a/changelog/773.trivial.rst
+++ b/changelog/773.trivial.rst
@@ -1,0 +1,1 @@
+Default settings for isort were set to be consistent with default settings for black.

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,16 +113,21 @@ ignore = D202,D205,D302,D400,D105,D107,F401
 exclude = extern,sphinx,*parsetab.py,conftest.py,docs/conf.py,setup.py
 max-line-length = 99
 
-
-
 [coverage:run]
 omit =
     ci-helpers/*
     */tests/*
     plasmapy/setup_package.py
     plasmapy/version.py
+
 [coverage:report]
 exclude_lines =
     coverage: ignore
     ImportError
     ModuleNotFoundError
+
+[isort]
+# Set sorting of imports to be consistent with black formatting
+line_length=88
+multi_line_output=3
+include_trailing_comma: True

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ addopts = --doctest-modules --doctest-continue-on-failure --ignore=docs/conf.py
 # E902 - IOError
 # select = E226,E241,E242,E704,W504
 exclude = version.py,build
-max-line-length = 99
+max-line-length = 88
 
 [pydocstyle]
 # D302 is unnecessary as we are using Python 3.6+. Ignoring D202 allows blank
@@ -111,7 +111,7 @@ convention = numpy
 select = D402,D413
 ignore = D202,D205,D302,D400,D105,D107,F401
 exclude = extern,sphinx,*parsetab.py,conftest.py,docs/conf.py,setup.py
-max-line-length = 99
+max-line-length = 88
 
 [coverage:run]
 omit =


### PR DESCRIPTION
The default settings for [isort](https://readthedocs.org/projects/isort/) (which sorts imports) and [black](https://black.readthedocs.io/en/stable/) (which strictly formats code) are not consistent with each other.  This sets the default settings for isort to be consistent with black.  If you run black and isort once, then switching between them afterward will lead to no changes.