### PR TITLE
Fix building of documentaiton using tox

### DIFF
--- a/changelog/780.doc.rst
+++ b/changelog/780.doc.rst
@@ -1,0 +1,3 @@
+Fix failing documentation build due to duplicate docstrings for
+`ParticleTracker.kinetic_energy_history` and incompatibility of `sphinx-automodapi`
+with `sphinx` `v3.0.0`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,12 +32,16 @@ sys.path.insert(0, os.path.abspath('..'))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.mathjax',
-              'sphinx.ext.napoleon', 'sphinx.ext.intersphinx',
-              'sphinx_automodapi.automodapi',
-              'sphinx_automodapi.smart_resolver',
-              'sphinx_gallery.gen_gallery',
-              'sphinx.ext.graphviz']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.graphviz',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
+    'sphinx_automodapi.automodapi',
+    'sphinx_automodapi.smart_resolver',
+    'sphinx_gallery.gen_gallery',
+]
 
 
 intersphinx_mapping = {

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -49,8 +49,6 @@ class ParticleTracker:
     eff_q : `astropy.units.Quantity`
     eff_m : `astropy.units.Quantity`
         Total charge and mass of macroparticle.
-    kinetic_energy
-        calculated from `v`, as in, current velocity.
 
     Examples
     ----------

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -51,8 +51,6 @@ class ParticleTracker:
         Total charge and mass of macroparticle.
     kinetic_energy
         calculated from `v`, as in, current velocity.
-    kinetic_energy_history
-        calculated from `velocity_history`.
 
     Examples
     ----------

--- a/requirements/automated-documentation-tests.txt
+++ b/requirements/automated-documentation-tests.txt
@@ -2,7 +2,7 @@
 
 numpydoc
 pillow
-sphinx
+sphinx <= 2.4.4
 sphinx-automodapi
 sphinx-gallery
 sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ theory =
 docs =
   numpydoc
   pillow
-  sphinx
+  sphinx<=2.4.4
   sphinx-automodapi
   sphinx-gallery
   sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,13 @@ setenv =
     PYTEST_COMMAND = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs -n=auto --dist=loadfile --ignore={toxinidir}/docs/conf.py
 extras = all,tests
 deps =
-    numpydev: git+https://github.com/numpy/numpy
+    astropy31: astropy<3.2
     astropydev: git+https://github.com/astropy/astropy
+    numpydev: git+https://github.com/numpy/numpy
     pytest-cov
     pytest-xdist
-    astropy31: astropy<3.2
+    sphinx<=2.4.4
+
 commands = {env:PYTEST_COMMAND} {posargs}
 
 [testenv:build_docs]


### PR DESCRIPTION
This is an attempt to fix the documentation build errors via `tox` as seen on CircleCI (see #778)

1. Removed duplicate docstrings for `ParticleTracker.kinetic_energy_history`.  Docstrings were defined both in the method definition and class level docstrings. 
1. Added dependency `sphinx <= 2.4.4`, since [`sphinx-automodapi` is currently failing with `sphinx` `v3.0.0`](https://github.com/astropy/sphinx-automodapi/issues/99).

Closes #778 