### PR TITLE
Various administrative cleanups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,15 +33,6 @@ tox-conda-install: &tox-conda-install
   command: |
     pip install tox-conda
 
-image-run: &image-tests
-  name: Run image tests
-  environment:
-    MPLBACKEND: Agg
-  command: |
-    tox -e figure
-    pip install codecov
-    codecov
-
 version: 2
 jobs:
   egg-info-36:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,16 @@ repos:
     -   id: trailing-whitespace
     -   id: check-ast
     -   id: requirements-txt-fixer
+-   repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21-2
+    hooks:
+    -   id: isort
+        name: isort
+        entry: isort
+        require_serial: true
+        language: python
+        types: [python]
+        args: [-m=3, -tc]
 -   repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -5,7 +5,10 @@ try:
 except ImportError:
     pass
 else:
-    matplotlib.use("Agg")
+    import os
+
+    if "PLASMAPY_PLOT_TESTS" not in os.environ:
+        matplotlib.use("Agg")
 
 # coverage : ignore
 def pytest_configure(config):

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - mpmath
   - pillow
   - colorama
+  - pip
   - pip:
     - numpydoc
     - pytest

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,11 @@ setenv =
     PYTEST_COMMAND = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs -n=auto --dist=loadfile --ignore={toxinidir}/docs/conf.py
 extras = all,tests
 deps =
-    astropy31: astropy<3.2
-    astropydev: git+https://github.com/astropy/astropy
     numpydev: git+https://github.com/numpy/numpy
+    astropydev: git+https://github.com/astropy/astropy
     pytest-cov
     pytest-xdist
-    sphinx<=2.4.4
-
+    astropy31: astropy<3.2
 commands = {env:PYTEST_COMMAND} {posargs}
 
 [testenv:build_docs]
@@ -36,9 +34,6 @@ basepython = python3.6
 extras =
 deps =
   lmfit
-  sphinx-automodapi
-  sphinx-gallery
-  towncrier
   pytest-cov
   pytest-xdist
 conda_deps =
@@ -63,9 +58,6 @@ basepython = python3.6
 extras =
 deps =
   lmfit==0.9.7
-  sphinx-automodapi
-  sphinx-gallery
-  towncrier
   pytest-cov
   pytest-xdist
 conda_deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7}{,-astropydev,-numpydev,-astropy31},build_docs,py36-conda,py36-minimal-conda
+envlist = py37,build_docs
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
This PR:

* cleans tox.ini up a bit
* decreases the amount of test envs that get spun up when running simply `tox` to two from way too many
* adds isort to pre-commit hooks
* prevents conda from nagging us about lack of `pip` as a conda dep in `environment.yml`
* adds a neat PLASMAPY_PLOT_TEST env variable that can be set when running tests; this makes plots appear
* removes a reference to a sunpy tox-env we don't use from .circleci/config