### PR TITLE
Restore isort to pre-commit check; apply to entire codebase

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,6 +7,5 @@
 8abf3d089c3046383651d0fd9eef4dc96e9f97b7
 39931da8cf1ab6a8f94e1b9490b7de096e409a72
 # Apply isort to entire codebase
-# TODO adjust to squashed commit
 86ce0fabe32f475688c6a389b632733f089a14f0
-4c94a5532aa57acd3bc32276e12518deeed8580f
+9602b5b780c71c3beb955c060d2ad4e5b24cf2cd

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# This file allows reasonable git blame's without looking at
+# black formatting changes.
+# For details see
+# https://github.com/psf/black/blob/d3cc63316b10c3ddc0e6a97a71130f30598ba5ef/README.md#migrating-your-code-style-without-ruining-git-blame
+
+# Apply black to entire codebase
+8abf3d089c3046383651d0fd9eef4dc96e9f97b7
+39931da8cf1ab6a8f94e1b9490b7de096e409a72
+# Apply isort to entire codebase
+# TODO adjust to squashed commit
+86ce0fabe32f475688c6a389b632733f089a14f0
+4c94a5532aa57acd3bc32276e12518deeed8580f

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,15 @@ repos:
     -   id: trailing-whitespace
     -   id: check-ast
     -   id: requirements-txt-fixer
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.2.2
+    hooks:
+    -   id: isort
+        name: isort
+        entry: isort
+        require_serial: true
+        language: python
+        types: [python]
 -   repo: https://github.com/psf/black
     rev: 19.10b0
     hooks:

--- a/changelog/857.trivial.rst
+++ b/changelog/857.trivial.rst
@@ -1,0 +1,1 @@
+Apply isort to entire codebase, bringing it back to the pre-commit hook suite.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,6 @@ sys.path.insert(0, os.path.abspath(".."))
 
 from plasmapy import __version__ as release
 
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -28,14 +28,7 @@ if sys.version_info < tuple((int(val) for val in "3.6".split("."))):
 # ----------------------------------------------------------------------------
 import pkg_resources
 
-from plasmapy import (
-    diagnostics,
-    formulary,
-    particles,
-    plasma,
-    simulation,
-    utils,
-)
+from plasmapy import diagnostics, formulary, particles, plasma, simulation, utils
 
 # define version
 try:
@@ -100,8 +93,9 @@ def online_help(query):
     query : str
         The search query.
     """
-    from urllib.parse import urlencode
     import webbrowser
+
+    from urllib.parse import urlencode
 
     url = (
         "http://docs.plasmapy.org/en/stable/search.html?"

--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -4,6 +4,7 @@
 import astropy.constants.si as const
 import numpy as np
 import pytest
+
 from astropy import units as u
 
 from plasmapy.diagnostics import langmuir

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -11,12 +11,12 @@ import astropy.constants as const
 import astropy.units as u
 import numpy as np
 
-from plasmapy.formulary.parameters import plasma_frequency, thermal_speed
-from plasmapy.formulary.dielectric import permittivity_1D_Maxwellian
-from plasmapy.particles import Particle
-from plasmapy.utils.decorators import validate_quantities
 from typing import List, Tuple, Union
 
+from plasmapy.formulary.dielectric import permittivity_1D_Maxwellian
+from plasmapy.formulary.parameters import plasma_frequency, thermal_speed
+from plasmapy.particles import Particle
+from plasmapy.utils.decorators import validate_quantities
 
 # TODO: interface for inputting a multi-species configuration could be
 # simplified using the plasmapy.classes.plasma_base class if that class

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -12,12 +12,12 @@ from .dimensionless import *
 from .dispersionfunction import *
 from .distribution import *
 from .drifts import *
+from .ionization import *
 from .magnetostatics import *
 from .mathematics import *
 from .parameters import *
 from .quantum import *
 from .relativity import *
-from .ionization import *
 
 # auto populate __all__
 for obj_name in list(globals()):

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -131,9 +131,9 @@ __all__ = [
     "electron_viscosity",
 ]
 
+import numpy as np
 import warnings
 
-import numpy as np
 from astropy import units as u
 from astropy.constants.si import e, k_B, m_e
 
@@ -143,7 +143,7 @@ from plasmapy.formulary.collisions import (
     fundamental_electron_collision_freq,
     fundamental_ion_collision_freq,
 )
-from plasmapy.formulary.parameters import Hall_parameter, _grab_charge
+from plasmapy.formulary.parameters import _grab_charge, Hall_parameter
 from plasmapy.particles.atomic import _is_electron
 from plasmapy.utils import PhysicsError
 from plasmapy.utils.decorators import validate_quantities

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -55,9 +55,9 @@ __all__ = [
     "coupling_parameter",
 ]
 
+import numpy as np
 import warnings
 
-import numpy as np
 from astropy import units as u
 from astropy.constants.si import c, e, eps0, hbar, k_B, m_e
 from numpy import pi
@@ -66,9 +66,9 @@ from plasmapy import particles, utils
 from plasmapy.formulary import parameters
 from plasmapy.formulary.mathematics import Fermi_integral
 from plasmapy.formulary.quantum import (
-    Wigner_Seitz_radius,
     chemical_potential,
     thermal_deBroglie_wavelength,
+    Wigner_Seitz_radius,
 )
 from plasmapy.utils.decorators import validate_quantities
 from plasmapy.utils.decorators.checks import _check_relativistic

--- a/plasmapy/formulary/dielectric.py
+++ b/plasmapy/formulary/dielectric.py
@@ -5,10 +5,10 @@ __all__ = [
     "permittivity_1D_Maxwellian",
 ]
 
-from collections import namedtuple
-
 import numpy as np
+
 from astropy import units as u
+from collections import namedtuple
 from numpy import pi
 
 from plasmapy.formulary import parameters

--- a/plasmapy/formulary/ionization.py
+++ b/plasmapy/formulary/ionization.py
@@ -6,7 +6,7 @@ __all__ = ["ionization_balance", "Saha", "Z_bal_"]
 import astropy.units as u
 
 from astropy.constants import a0, k_B
-from numpy import pi, exp, sqrt, log
+from numpy import exp, log, pi, sqrt
 
 from plasmapy.utils.decorators import validate_quantities
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -832,8 +832,8 @@ def Hall_parameter(
 
     """
     from plasmapy.formulary.collisions import (
-        fundamental_ion_collision_freq,
         fundamental_electron_collision_freq,
+        fundamental_ion_collision_freq,
     )
 
     gyro_frequency = gyrofrequency(B, particle)

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1,22 +1,24 @@
 import numpy as np
 import pytest
+
 from astropy import units as u
 from astropy.constants import c
 from astropy.tests.helper import assert_quantity_allclose
 
 import plasmapy.particles.exceptions
+
 from plasmapy.formulary.braginskii import Coulomb_logarithm
 from plasmapy.formulary.collisions import (
-    Knudsen_number,
-    Spitzer_resistivity,
     collision_frequency,
     coupling_parameter,
     fundamental_electron_collision_freq,
     fundamental_ion_collision_freq,
     impact_parameter,
     impact_parameter_perp,
+    Knudsen_number,
     mean_free_path,
     mobility,
+    Spitzer_resistivity,
 )
 from plasmapy.utils import exceptions
 from plasmapy.utils.exceptions import CouplingWarning

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -2,14 +2,15 @@
 dielectry.py"""
 
 import numpy as np
+
 from astropy import units as u
 
 from ..dielectric import (
-    RotatingTensorElements,
-    StixTensorElements,
     cold_plasma_permittivity_LRP,
     cold_plasma_permittivity_SDP,
     permittivity_1D_Maxwellian,
+    RotatingTensorElements,
+    StixTensorElements,
 )
 from ..parameters import gyrofrequency, plasma_frequency, thermal_speed
 

--- a/plasmapy/formulary/tests/test_dimensionless.py
+++ b/plasmapy/formulary/tests/test_dimensionless.py
@@ -1,14 +1,15 @@
 import astropy.units as u
 import numpy as np
 import pytest
+
 from astropy.constants import c
 
 from plasmapy.formulary.dimensionless import (
-    Mag_Reynolds,
-    Reynolds_number,
     beta,
+    Mag_Reynolds,
     quantum_theta,
     Re_,
+    Reynolds_number,
     Rm_,
 )
 from plasmapy.utils import RelativityError

--- a/plasmapy/formulary/tests/test_dispersion.py
+++ b/plasmapy/formulary/tests/test_dispersion.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+
 from astropy import units as u
 from numpy import pi as π
 from scipy.special import gamma as Γ

--- a/plasmapy/formulary/tests/test_distribution.py
+++ b/plasmapy/formulary/tests/test_distribution.py
@@ -3,18 +3,19 @@
 import numpy as np
 import pytest
 import scipy.integrate as spint
+
 from astropy import units as u
 from astropy.constants import c, e, eps0, k_B, m_e, m_p, mu0
 
 from ..distribution import (
+    kappa_velocity_1D,
+    kappa_velocity_3D,
     Maxwellian_1D,
     Maxwellian_speed_1D,
     Maxwellian_speed_2D,
     Maxwellian_speed_3D,
     Maxwellian_velocity_2D,
     Maxwellian_velocity_3D,
-    kappa_velocity_1D,
-    kappa_velocity_3D,
 )
 from ..parameters import kappa_thermal_speed, thermal_speed
 

--- a/plasmapy/formulary/tests/test_drifts.py
+++ b/plasmapy/formulary/tests/test_drifts.py
@@ -1,5 +1,6 @@
 import astropy.units as u
 import pytest
+
 from astropy.tests.helper import assert_quantity_allclose
 
 from plasmapy.formulary import drifts

--- a/plasmapy/formulary/tests/test_ionization.py
+++ b/plasmapy/formulary/tests/test_ionization.py
@@ -2,7 +2,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 
-from plasmapy.formulary.ionization import Saha, ionization_balance, Z_bal_
+from plasmapy.formulary.ionization import ionization_balance, Saha, Z_bal_
 
 
 def test_ionization_balance():

--- a/plasmapy/formulary/tests/test_magnetostatics.py
+++ b/plasmapy/formulary/tests/test_magnetostatics.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from astropy import constants
 from astropy import units as u
 

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -2,14 +2,15 @@
 
 import numpy as np
 import pytest
+
 from astropy import units as u
 from astropy.constants import c, e, m_e, m_p, mu0
 from astropy.tests.helper import assert_quantity_allclose
 
 from plasmapy.formulary.parameters import (
     Alfven_speed,
-    Bohm_diffusion,
     betaH_,
+    Bohm_diffusion,
     cs_,
     cwp_,
     DB_,
@@ -42,8 +43,8 @@ from plasmapy.formulary.parameters import (
     vth_,
     vth_kappa_,
     wc_,
-    wp_,
     wlh_,
+    wp_,
     wuh_,
 )
 from plasmapy.particles.exceptions import InvalidParticleError

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -1,21 +1,22 @@
 import astropy.units as u
 import numpy as np
 import pytest
+
 from astropy.constants import c, h
 
 from plasmapy.utils.exceptions import RelativityError
 
 from ..quantum import (
-    Fermi_energy,
-    Thomas_Fermi_length,
-    Wigner_Seitz_radius,
     _chemical_potential_interp,
     chemical_potential,
     deBroglie_wavelength,
-    thermal_deBroglie_wavelength,
     Ef_,
+    Fermi_energy,
     lambdaDB_,
     lambdaDB_th_,
+    thermal_deBroglie_wavelength,
+    Thomas_Fermi_length,
+    Wigner_Seitz_radius,
 )
 
 

--- a/plasmapy/formulary/tests/test_relativity.py
+++ b/plasmapy/formulary/tests/test_relativity.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+
 from astropy import units as u
 from astropy.constants import c
 

--- a/plasmapy/formulary/tests/test_transport.py
+++ b/plasmapy/formulary/tests/test_transport.py
@@ -2,12 +2,12 @@
 
 import numpy as np
 import pytest
+
 from astropy import units as u
 from astropy.constants import m_e, m_p
 from astropy.tests.helper import assert_quantity_allclose
 
 from plasmapy.formulary.braginskii import (
-    ClassicalTransport,
     _check_Z,
     _nondim_resist_braginskii,
     _nondim_resist_ji_held,
@@ -28,6 +28,7 @@ from plasmapy.formulary.braginskii import (
     _nondim_visc_i_braginskii,
     _nondim_visc_i_ji_held,
     _nondim_viscosity,
+    ClassicalTransport,
     electron_thermal_conductivity,
     electron_viscosity,
     ion_thermal_conductivity,

--- a/plasmapy/particles/__init__.py
+++ b/plasmapy/particles/__init__.py
@@ -20,6 +20,7 @@ from plasmapy.particles.atomic import (
     stable_isotopes,
     standard_atomic_weight,
 )
+from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.ionization_state import IonizationState, State
 from plasmapy.particles.ionization_states import IonizationStates
 from plasmapy.particles.nuclear import nuclear_binding_energy, nuclear_reaction_energy
@@ -29,7 +30,6 @@ from plasmapy.particles.particle_class import (
     DimensionlessParticle,
     Particle,
 )
-from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.serialization import (
     json_load_particle,
     json_loads_particle,

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -25,6 +25,7 @@ import astropy.units as u
 from numbers import Integral, Real
 from typing import Any, List, Optional, Union
 
+from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.elements import _Elements
 from plasmapy.particles.exceptions import (
     InvalidElementError,
@@ -34,9 +35,7 @@ from plasmapy.particles.exceptions import (
 )
 from plasmapy.particles.isotopes import _Isotopes
 from plasmapy.particles.particle_class import Particle
-from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.symbols import atomic_symbol
-
 
 __all__.sort()
 

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -15,7 +15,6 @@ import collections
 import json
 import pkgutil
 
-
 _PeriodicTable = collections.namedtuple(
     "periodic_table", ["group", "category", "block", "period"]
 )

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -12,9 +12,9 @@ import warnings
 from numbers import Integral, Real
 from typing import List, Optional, Union
 
+from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.exceptions import AtomicError, ChargeError, InvalidParticleError
 from plasmapy.particles.particle_class import Particle
-from plasmapy.particles.decorators import particle_input
 from plasmapy.utils.decorators import validate_quantities
 
 _number_density_errmsg = (

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -6,9 +6,9 @@ import re
 
 from typing import List, Optional, Union
 
+from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.exceptions import AtomicError, InvalidParticleError
 from plasmapy.particles.particle_class import Particle
-from plasmapy.particles.decorators import particle_input
 
 
 @particle_input(any_of={"isotope", "baryon"})

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -7,8 +7,8 @@ Functionality to parse representations of particles into standard form.
 """
 __all__ = []
 
-import re
 import numpy as np
+import re
 import warnings
 
 from numbers import Integral
@@ -25,7 +25,7 @@ from plasmapy.particles.exceptions import (
     InvalidParticleError,
 )
 from plasmapy.particles.isotopes import _Isotopes
-from plasmapy.particles.special_particles import ParticleZoo, _Particles
+from plasmapy.particles.special_particles import _Particles, ParticleZoo
 from plasmapy.utils import roman
 
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -38,10 +38,10 @@ from plasmapy.particles.parsing import (
     _parse_and_check_atomic_input,
 )
 from plasmapy.particles.special_particles import (
-    ParticleZoo,
     _antiparticles,
     _Particles,
     _special_ion_masses,
+    ParticleZoo,
 )
 from plasmapy.utils import roman
 

--- a/plasmapy/particles/symbols.py
+++ b/plasmapy/particles/symbols.py
@@ -12,8 +12,8 @@ __all__ = [
 from numbers import Integral
 from typing import Optional
 
-from .particle_class import Particle
 from .decorators import particle_input
+from .particle_class import Particle
 
 # The @particle_input decorator takes the inputs for a function or
 # method and passes through the corresponding instance of the Particle

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from astropy import constants as const
 from astropy import units as u
 

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -1,6 +1,6 @@
-from typing import List, Optional, Tuple, Union
-
 import pytest
+
+from typing import List, Optional, Tuple, Union
 
 from plasmapy.particles.exceptions import (
     AtomicError,
@@ -11,8 +11,8 @@ from plasmapy.particles.exceptions import (
     InvalidParticleError,
 )
 
-from ..particle_class import Particle
 from ..decorators import particle_input
+from ..particle_class import Particle
 
 
 @particle_input

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -1,14 +1,13 @@
-import collections
-
 import astropy.units as u
+import collections
 import numpy as np
 import pytest
 
 from plasmapy.particles import (
-    Particle,
     atomic_number,
     atomic_symbol,
     isotope_symbol,
+    Particle,
     particle_symbol,
 )
 from plasmapy.particles.exceptions import AtomicError, InvalidIsotopeError

--- a/plasmapy/particles/tests/test_ionization_states.py
+++ b/plasmapy/particles/tests/test_ionization_states.py
@@ -1,20 +1,20 @@
+import astropy.units as u
 import collections
 import itertools
-from numbers import Real
-from typing import Dict
-
-import astropy.units as u
 import numpy as np
 import pytest
 
+from numbers import Real
+from typing import Dict
+
 from plasmapy.particles import (
+    atomic_number,
     IonizationState,
     IonizationStates,
-    Particle,
-    State,
-    atomic_number,
     mass_number,
+    Particle,
     particle_symbol,
+    State,
 )
 from plasmapy.particles.exceptions import AtomicError, InvalidIsotopeError
 from plasmapy.utils.pytest_helpers import run_test

--- a/plasmapy/particles/tests/test_nuclear.py
+++ b/plasmapy/particles/tests/test_nuclear.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from astropy import constants as const
 from astropy import units as u
 

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -6,8 +6,7 @@ from plasmapy.particles.exceptions import (
     InvalidElementError,
     InvalidParticleError,
 )
-from plasmapy.particles.parsing import (
-    # duplicate with utils.pytest_helpers.error_messages.call_string?
+from plasmapy.particles.parsing import (  # duplicate with utils.pytest_helpers.error_messages.call_string?
     _case_insensitive_aliases,
     _case_sensitive_aliases,
     _dealias_particle_aliases,

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -9,6 +9,7 @@ from astropy import constants as const
 from astropy import units as u
 from astropy.constants import c, e, m_e, m_n, m_p
 
+from plasmapy.particles import json_load_particle, json_loads_particle
 from plasmapy.particles.atomic import known_isotopes
 from plasmapy.particles.exceptions import (
     AtomicError,
@@ -30,8 +31,6 @@ from plasmapy.particles.particle_class import (
 from plasmapy.particles.special_particles import ParticleZoo
 from plasmapy.utils import call_string, roman
 from plasmapy.utils.pytest_helpers import run_test_equivalent_calls
-
-from plasmapy.particles import json_load_particle, json_loads_particle
 
 # (arg, kwargs, results_dict)
 test_Particle_table = [

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -1,6 +1,6 @@
 import pytest
 
-from plasmapy.particles.special_particles import ParticleZoo, _Particles
+from plasmapy.particles.special_particles import _Particles, ParticleZoo
 
 particle_antiparticle_pairs = [
     ("e-", "e+"),

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -11,7 +11,7 @@ from plasmapy.formulary.dimensionless import quantum_theta
 from plasmapy.formulary.parameters import _grab_charge
 from plasmapy.particles import particle_mass
 from plasmapy.plasma.plasma_base import GenericPlasma
-from plasmapy.utils import CouplingWarning, call_string
+from plasmapy.utils import call_string, CouplingWarning
 
 
 class PlasmaBlob(GenericPlasma):

--- a/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
@@ -1,13 +1,14 @@
-from astropy import units as u
-from typing import Union, Tuple, List
 import os
-from typing import List, Tuple, Union
 import pytest
 
-from plasmapy.plasma.sources import openpmd_hdf5
-from plasmapy.plasma.exceptions import DataStandardError
-from plasmapy.particles.data.test import data_dir
+from astropy import units as u
+from typing import List, Tuple, Union
+
 import plasmapy.plasma
+
+from plasmapy.particles.data.test import data_dir
+from plasmapy.plasma.exceptions import DataStandardError
+from plasmapy.plasma.sources import openpmd_hdf5
 
 
 @pytest.fixture(scope="module")

--- a/plasmapy/plasma/tests/test_plasma_factory.py
+++ b/plasmapy/plasma/tests/test_plasma_factory.py
@@ -1,9 +1,10 @@
-import os
-
 import astropy.units as u
 import numpy as np
-import plasmapy.plasma
+import os
 import pytest
+
+import plasmapy.plasma
+
 from plasmapy.particles.data.test import data_dir
 
 

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -206,8 +206,9 @@ class ParticleTracker:
 
     def plot_trajectories(self):  # coverage: ignore
         r"""Draws trajectory history."""
-        from astropy.visualization import quantity_support
         import matplotlib.pyplot as plt
+
+        from astropy.visualization import quantity_support
         from mpl_toolkits.mplot3d import Axes3D
 
         quantity_support()
@@ -233,8 +234,9 @@ class ParticleTracker:
             Enable plotting of position component x, y, z for each of these
             letters included in `plot`.
         """
-        from astropy.visualization import quantity_support
         import matplotlib.pyplot as plt
+
+        from astropy.visualization import quantity_support
         from mpl_toolkits.mplot3d import Axes3D
 
         quantity_support()

--- a/plasmapy/simulation/tests/test_particletracker.py
+++ b/plasmapy/simulation/tests/test_particletracker.py
@@ -1,8 +1,9 @@
 import astropy.units as u
 import numpy as np
 import pytest
+
 from astropy import units as u
-from astropy.modeling import models, fitting
+from astropy.modeling import fitting, models
 from scipy.optimize import curve_fit
 
 from plasmapy.plasma.sources import Plasma3D

--- a/plasmapy/utils/decorators/__init__.py
+++ b/plasmapy/utils/decorators/__init__.py
@@ -15,13 +15,13 @@ __all__ = [
 ]
 
 from plasmapy.utils.decorators.checks import (
-    CheckBase,
-    CheckUnits,
-    CheckValues,
     check_relativistic,
     check_units,
     check_values,
+    CheckBase,
+    CheckUnits,
+    CheckValues,
 )
 from plasmapy.utils.decorators.converter import angular_freq_to_hz
 from plasmapy.utils.decorators.helpers import preserve_signature
-from plasmapy.utils.decorators.validators import ValidateQuantities, validate_quantities
+from plasmapy.utils.decorators.validators import validate_quantities, ValidateQuantities

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -13,13 +13,13 @@ __all__ = [
 import collections
 import functools
 import inspect
-import warnings
-from functools import reduce
-from typing import Any, Dict, List, Tuple, Union
-
 import numpy as np
+import warnings
+
 from astropy import units as u
 from astropy.constants import c
+from functools import reduce
+from typing import Any, Dict, List, Tuple, Union
 
 from plasmapy.utils.decorators.helpers import preserve_signature
 from plasmapy.utils.exceptions import (

--- a/plasmapy/utils/decorators/tests/test_checks.py
+++ b/plasmapy/utils/decorators/tests/test_checks.py
@@ -3,23 +3,23 @@ Tests for 'check` decorators (i.e. decorators that only check objects but do not
 change them).
 """
 import inspect
+import numpy as np
+import pytest
+
+from astropy import units as u
+from astropy.constants import c
 from types import LambdaType
 from typing import Any, Dict
 from unittest import mock
 
-import numpy as np
-import pytest
-from astropy import units as u
-from astropy.constants import c
-
 from plasmapy.utils.decorators.checks import (
-    CheckBase,
-    CheckUnits,
-    CheckValues,
     _check_relativistic,
     check_relativistic,
     check_units,
     check_values,
+    CheckBase,
+    CheckUnits,
+    CheckValues,
 )
 from plasmapy.utils.exceptions import (
     PlasmaPyWarning,

--- a/plasmapy/utils/decorators/tests/test_helpers.py
+++ b/plasmapy/utils/decorators/tests/test_helpers.py
@@ -1,5 +1,6 @@
 """Tests for module :mod:`plasmapy.utils.decorators`."""
 import inspect
+
 from unittest import mock
 
 from ..helpers import preserve_signature

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -3,15 +3,15 @@ Tests for 'validate` decorators (i.e. decorators that check objects and change t
 when possible).
 """
 import inspect
+import pytest
 import warnings
+
+from astropy import units as u
 from typing import Any, Dict, List
 from unittest import mock
 
-import pytest
-from astropy import units as u
-
 from plasmapy.utils.decorators.checks import CheckUnits, CheckValues
-from plasmapy.utils.decorators.validators import ValidateQuantities, validate_quantities
+from plasmapy.utils.decorators.validators import validate_quantities, ValidateQuantities
 from plasmapy.utils.exceptions import ImplicitUnitConversionWarning
 
 

--- a/plasmapy/utils/error_messages.py
+++ b/plasmapy/utils/error_messages.py
@@ -5,7 +5,6 @@ import colorama
 
 from typing import Any, Callable, Dict
 
-
 _bold = colorama.Style.BRIGHT
 _magenta = colorama.Fore.MAGENTA
 _blue = colorama.Fore.BLUE

--- a/plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py
@@ -1,8 +1,8 @@
-import warnings
-from typing import Any
-
 import astropy.units as u
 import pytest
+import warnings
+
+from typing import Any
 
 from plasmapy.particles import Particle
 from plasmapy.utils import call_string
@@ -11,10 +11,10 @@ from plasmapy.utils.pytest_helpers import (
     InconsistentTypeError,
     MissingExceptionError,
     MissingWarningError,
-    UnexpectedExceptionError,
-    UnexpectedResultError,
     run_test,
     run_test_equivalent_calls,
+    UnexpectedExceptionError,
+    UnexpectedResultError,
 )
 
 

--- a/plasmapy/utils/roman/__init__.py
+++ b/plasmapy/utils/roman/__init__.py
@@ -1,10 +1,10 @@
 """Utilities to convert integers to Roman numerals and vice versa."""
 
 from .roman import (
+    from_roman,
     InvalidRomanNumeralError,
+    is_roman_numeral,
     OutOfRangeError,
     RomanError,
-    from_roman,
-    is_roman_numeral,
     to_roman,
 )

--- a/plasmapy/utils/roman/tests/test_roman.py
+++ b/plasmapy/utils/roman/tests/test_roman.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import plasmapy.utils.roman as roman
+
 from plasmapy.utils.pytest_helpers import run_test
 
 ints_and_roman_numerals = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,15 @@ build-backend = "setuptools.build_meta"
       number_incorrect_long = "The changelog entry's number does not match this pull request's number."
       type_incorrect = "Incorrect changelog entry type (see list in changelog README)"
       type_incorrect_long = "The changelog entry for this PR must have one of the types (as in NUMBER.TYPE.rst) as described in the changelog README)."
+
+[tool.isort]
+line_length = 88
+wrap_length = 80
+sections = ["FUTURE", "STDLIB", "FIRSTPARTY", "LOCALFOLDER"]
+known_first_party = ["plasmapy", ]
+default_section = "STDLIB"
+multi_line_output = 3
+use_parentheses = true
+include_trailing_comma = true
+force_alphabetical_sort_within_sections = true
+lines_between_types = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ addopts = --doctest-modules --doctest-continue-on-failure --ignore=docs/conf.py
 # E902 - IOError
 # select = E226,E241,E242,E704,W504
 exclude = version.py,build
-max-line-length = 90
+max-line-length = 88
 
 [pydocstyle]
 # D302 is unnecessary as we are using Python 3.6+. Ignoring D202 allows blank
@@ -115,7 +115,7 @@ convention = numpy
 select = D402,D413
 ignore = D202,D205,D302,D400,D105,D107,F401
 exclude = extern,sphinx,*parsetab.py,conftest.py,docs/conf.py,setup.py
-max-line-length = 90
+max-line-length = 88
 
 [coverage:run]
 omit =
@@ -129,9 +129,3 @@ exclude_lines =
     coverage: ignore
     ImportError
     ModuleNotFoundError
-
-[isort]
-# Set sorting of imports to be consistent with black formatting
-line_length=90
-multi_line_output=3
-include_trailing_comma: True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from itertools import chain
-
 from setuptools import setup
 from setuptools.config import read_configuration
 


### PR DESCRIPTION
#846 removed isort from the pre-commit suite because it didn't play nicely
with CI. Well, according to
https://github.com/timothycrosley/isort/issues/1147#issuecomment-646905036
isort will work well now. Let's see if that works.

- [x] This should probably not get merged yet; let's give isort a few days to put
a release out.

I also brought back the 88 line limit for consistency between the two
(it got the suite stuck in a permanent 2-cycle of 2 character line length
changes) - it turns out it's the default
in `black`, and I figure if Łukasz Langa believes in that default,
it's a sane default.

I also added a file that lets you ignore isort/black commits in git blame locally.

- [ ] make sure the commit hash for this PR is correct upon squashing; this will take a manual local merge.