### PR TITLE
Fix npsphinx-thumbnail for ./docs/notebooks/langmuir_analysis.ipynb

### DIFF
--- a/docs/notebooks/langmuir_analysis.ipynb
+++ b/docs/notebooks/langmuir_analysis.ipynb
@@ -94,7 +94,7 @@
      "outputs_hidden": false
     },
     "nbsphinx-thumbnail": {
-     "output-index": 1
+     "output-index": 2
     }
    },
    "outputs": [],

--- a/docs/notebooks/langmuir_analysis.ipynb
+++ b/docs/notebooks/langmuir_analysis.ipynb
@@ -1,20 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%matplotlib inline"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -38,12 +24,16 @@
    },
    "outputs": [],
    "source": [
-    "from plasmapy.diagnostics.langmuir import Characteristic, swept_probe_analysis\n",
-    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
     "import astropy.units as u\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import os\n",
-    "from pprint import pprint"
+    "\n",
+    "from pprint import pprint\n",
+    "\n",
+    "from plasmapy.diagnostics.langmuir import Characteristic, swept_probe_analysis"
    ]
   },
   {
@@ -56,8 +46,7 @@
     "a low (ion) temperature, low density plasma with a cylindrical probe. This\n",
     "allows us to utilize OML theory implemented in :func:`~plasmapy.diagnostics.langmuir.swept_probe_analysis`.\n",
     "The data has been preprocessed with some smoothing, which allows us to obtain\n",
-    "a Electron Energy Distribution Function (EEDF) as well.\n",
-    "\n"
+    "a Electron Energy Distribution Function (EEDF) as well."
    ]
   },
   {


### PR DESCRIPTION
The original "output-index" (1) for "nbsphinx-thumbnail" was pointing to an invalid MIME (a python dictionary instead of an image).  I changed the "output-index" to 2, so the first image is take as the thumbnail.

The documentation build failure was first noted by @StanczakDominik ([comment](https://github.com/PlasmaPy/PlasmaPy/pull/864#issuecomment-660463536)).