### PR TITLE
Implement `__eq__` for `AbstractParticle`

### DIFF
--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -169,6 +169,45 @@ class AbstractParticle(ABC):
         """
         raise AtomicError("The truth value of a particle is not defined.")
 
+    def __eq__(self, other) -> bool:
+        """
+        Determine if two objects correspond to the same particle.
+
+        This method will return `True` if ``other`` is an identical
+        `~plasmapy.particles.Particle`, `~plasmapy.particles.CustomParticle`
+        , `~plasmapy.particles.DimensionlessParticle` instance, and return
+        `False` if ``other`` is a different particle.
+
+        If ``other`` is not an instance amongst `~plasmapy.particles.Particle`,
+        `~plasmapy.particles.CustomParticle`, or
+        `~plasmapy.particles.DimensionlessParticle`,
+        then this method will raise a `TypeError`.
+
+        """
+        # other_particle = None
+        # if isinstance(other, str):
+        #     try:
+        #         other_particle = serialization.json_loads_particle(other)
+        #     except InvalidElementError as exc:
+        #         raise InvalidParticleError(
+        #             f"{other} is not a particle and cannot be compared to {self}."
+        #         )
+        # else:
+        #     other_particle = other
+
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"The equality of a {type(self)} object with a {type(other)} is undefined."
+            )
+
+        # Check properties mass and charge for equivalence
+        if u.isclose(self.mass, other.mass, equal_nan=True, rtol=1e-14) and u.isclose(
+            self.charge, other.charge, equal_nan=True, rtol=1e-14
+        ):
+            return True
+        else:
+            return False
+
     def json_dump(self, fp, **kwargs):
         """
         Writes the particle's `json_dict` to the `fp` file object using `json.dump`.

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1318,3 +1318,135 @@ def test_particle_to_json_file(cls, kwargs, expected_repr):
         f"expected_repr = {expected_repr['__init__']}.\n\n"
         f"json_repr: {test_dict['__init__']}"
     )
+
+
+data_equivalence_custom_dimensionless = [
+    (
+        CustomParticle,
+        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C},
+        CustomParticle,
+        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C},
+        True,
+        None,
+    ),
+    (
+        CustomParticle,
+        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C},
+        CustomParticle,
+        {"mass": 5.12 * u.kg, "charge": 6.3 * u.C},
+        False,
+        None,
+    ),
+    (
+        DimensionlessParticle,
+        {"mass": 5.2, "charge": 6.3},
+        DimensionlessParticle,
+        {"mass": 5.2, "charge": 6.3},
+        True,
+        None,
+    ),
+    (
+        DimensionlessParticle,
+        {"mass": 5.2, "charge": 6.3},
+        DimensionlessParticle,
+        {"mass": 5.1, "charge": 6.3},
+        False,
+        None,
+    ),
+    (
+        CustomParticle,
+        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C},
+        DimensionlessParticle,
+        {"mass": 5.12, "charge": 6.2},
+        False,
+        TypeError,
+    ),
+    # (
+    #     DimensionlessParticle,
+    #     {"mass": 5.2, "charge": 6.3},
+    #     DimensionlessParticle,
+    #     '{"plasmapy_particle": {"type": "DimensionlessParticle", \
+    #     "module": "plasmapy.particles.particle_class", \
+    #     "date_created": "...", "fake__init__": { \
+    #         "args": [], \
+    #         "kwargs": {"mass": 5.2, "charge": 6.3}}}}',
+    #     False,
+    #     InvalidElementError,
+    # ),
+    # (
+    #     CustomParticle,
+    #     {"mass": 5.12 * u.kg},
+    #     CustomParticle,
+    #     '{"plasmapy_particle": {"type": "CustomParticle", \
+    #     "module": "plasmapy.particles.particle_class", \
+    #     "date_created": "...", "fake__init__": { \
+    #         "args": [], \
+    #         "kwargs": {"mass": "5.12 kg", "charge": "nan C"}}}}',
+    #     False,
+    #     InvalidElementError,
+    # ),
+    # (
+    #     DimensionlessParticle,
+    #     {"mass": 5.2},
+    #     DimensionlessParticle,
+    #     '{"plasmapy_particle": {"type": "DimensionlessParticle", \
+    #     "module": "plasmapy.particles.particle_class", \
+    #     "date_created": "...", "__init__": { \
+    #         "args": [], \
+    #         "kwargs": {"mass": 5.2, "charge": NaN}}}}',
+    #     True,
+    #     None,
+    # ),
+    # (
+    #     CustomParticle,
+    #     {"mass": 5.12 * u.kg, "charge": 6.2 * u.C},
+    #     CustomParticle,
+    #     '{"plasmapy_particle": {"type": "CustomParticle", \
+    #     "module": "plasmapy.particles.particle_class", \
+    #     "date_created": "...", "__init__": { \
+    #         "args": [], \
+    #         "kwargs": {"mass": "5.12 kg", "charge": "6.2 C"}}}}',
+    #     True,
+    #     None,
+    # ),
+]
+
+
+@pytest.mark.parametrize(
+    "cls, kwargs, other_cls, other_kwargs, result, expected_exception",
+    data_equivalence_custom_dimensionless,
+)
+def test_equivalence_custom_dimensionless(
+    cls, kwargs, other_cls, other_kwargs, result, expected_exception
+):
+    """Test ``__eq__`` and ``__ne__`` in the AbstractParticle class for CustomParticle
+    and DimensionlessParticle."""
+    if expected_exception is None:
+        particle1 = cls(**kwargs)
+        # if isinstance(other_kwargs, str):
+        #     #Second argument is a string, use directly
+        #     comp_output = particle1 == other_kwargs
+        # else:
+        # Second argument is a particle, change to object before use
+        particle2 = other_cls(**other_kwargs)
+        comp_output = particle1 == particle2
+
+        assert comp_output == result, pytest.fail(
+            f"Given {cls} {kwargs} and {other_cls} {other_kwargs} "
+            f"expected {result}\n"
+            f"Got {comp_output}"
+        )
+    else:
+        with pytest.raises(expected_exception):
+            particle1 = cls(**kwargs)
+            # if isinstance(other_kwargs, str):
+            #     #Second argument is a string, use directly
+            #     comp_output = particle1 == other_kwargs
+            # else:
+            particle2 = other_cls(**other_kwargs)
+            comp_output = particle1 == particle2
+
+            pytest.fail(
+                f"Given {cls} {kwargs} and {other_cls} {other_kwargs} "
+                f"Did not raise {expected_exception}"
+            )


### PR DESCRIPTION
<!--
Thank you for contributing to PlasmaPy! Here's a bunch of pointers to
make things easier for all of us:

* If this PR will solve an issue tracked by GitHub, then please add
  "Closes #42" so the issue automatically closes once this pull request
  is merged.  In this example, issue #42 would have been closed.
  If your PR will not completely solve the issue, then please still reference
  still reference the issue like "issue #42".  (For more info see [GitHub's primer
  on linking issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)

* Remember to add some description of your changes in this text box.

* If your pull request is not yet ready for review - either because
  you're just looking for feedback on a change or because you're not
  perfectly satisfied with your change - submit it as a draft pull request.
  Remember to change its' status once it's ready.

* If this is your first contribution, please add your name to the author
  list in `docs/about/credits.rst`.

* Feel free to chat with other developers on our Matrix channel at:
   https://riot.im/app/#/room/#plasmapy:openastronomy.org

* We have a developer's guide to help answer some of your questions.
  http://docs.plasmapy.org/en/latest/development/index.html

Many thanks in advance for following these pointers and for being willing to contribute!

When submitting a pull request, please ensure that you can (eventually,
sometime before it is merged) check the following basic requirements:

-->

- [ ] I have added a changelog entry for this pull request.

<!--

In short: A changelog entry is a short description of your PR's changes.
Each entry is written in a `<PULL REQUEST>.<TYPE>.rst` file and stored in
the `changelog` directory,  where `<PULL REQUEST>` is a pull request
number and `<TYPE>` is one of:

* `breaking`: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
* `feature`: New user facing features and any new behavior.
* `bugfix`: Fixes a reported bug.
* `doc`: Documentation addition or improvement, like rewording an entire session or adding missing docs.
* `removal`: Feature deprecation and/or feature removal.
* `trivial`: A change which has no user facing effect or is tiny change.

A PR number is generated after you successfully submit a new PR, so the changelog
file can only be added after you open the PR.```

For more information, see:
https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst

--->

- [ ] If adding new functionality, I have added tests and
      docstrings.

<!--
(Tests pop up at the bottom, in the checks box.)
-->

- [ ] I have fixed any newly failing tests.

<!--
(If you're unsure why they're failing, ask!)
-->

Closes #806 
May close #848 

Implements `__eq__` into `AbstractParticle` class, allowing comparisons of `CustomParticle` and `DimensionlessParticle` using `==` operator.