### PR TITLE
Drop pdf and epub form RTD doc build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,7 @@
 version: 2
 
-formats: htmlzip
+formats:
+  - htmlzip
 
 python:
   version: 3.7

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 
-formats: all
+formats: htmlzip
 
 python:
   version: 3.7

--- a/plasmapy/formulary/distribution.py
+++ b/plasmapy/formulary/distribution.py
@@ -711,7 +711,7 @@ def Maxwellian_speed_3D(v, T, particle="e", v_drift=0, vTh=np.nan, units="units"
 
     .. math::
 
-       f = 4 \pi \left v^{2} (\pi v_{Th}^2)^{-3/2} \exp(-v^{2} / v_{Th}^2)
+       f = 4 \pi v^{2} (\pi v_{Th}^2)^{-3/2} \exp(-v^{2} / v_{Th}^2)
 
     where :math:`v_{Th} = \sqrt{2 k_B T / m}` is the thermal speed.
 


### PR DESCRIPTION
This drops the pdf and epub builds from read the docs.  The current builders are not adequate enough to produce a readable product when the documentation is primarily designed for an html interface.  Additionally, it's too restrictive to have contributors design for both an html and pdf interface.  The documentation is still downloadable as an html zip file for offline use.

Also, remove the unpaired `\left` from the equation in `Maxwellian_speed_3D()` distribution function.