### PR TITLE
Improve Package Exposure in Documentaiton

### DIFF
--- a/changelog/878.doc.rst
+++ b/changelog/878.doc.rst
@@ -1,0 +1,3 @@
+Add static stub files to `docs/api_static` so all modules of `plasmapy` are indexed.
+This is necessary to expose all of `plasmapy` since not all modules are indexed in
+the narrative documentation.

--- a/docs/api_static/plasmapy.conftest.rst
+++ b/docs/api_static/plasmapy.conftest.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.conftest`
+===================
+
+.. currentmodule:: plasmapy.conftest
+
+.. automodapi::  plasmapy.conftest
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.formulary.rst
+++ b/docs/api_static/plasmapy.formulary.rst
@@ -1,0 +1,32 @@
+:orphan:
+
+`plasmapy.formulary`
+====================
+
+.. currentmodule:: plasmapy.formulary
+
+.. automodule:: plasmapy.formulary
+
+Sub-Packages & Modules
+----------------------
+
+.. autosummary::
+
+   braginskii
+   collisions
+   dielectric
+   dimensionless
+   dispersionfunction
+   distribution
+   drifts
+   ionization
+   magnetostatics
+   mathematics
+   parameters
+   quantum
+   relativity
+
+.. automodapi:: plasmapy.formulary
+   :no-main-docstr:
+   :no-heading:
+   :include-all-objects:

--- a/docs/api_static/plasmapy.optional_deps.rst
+++ b/docs/api_static/plasmapy.optional_deps.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.optional_deps`
+========================
+
+.. currentmodule:: plasmapy.optional_deps
+
+.. automodapi::  plasmapy.optional_deps
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.atomic.rst
+++ b/docs/api_static/plasmapy.particles.atomic.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.atomic`
+===========================
+
+.. currentmodule:: plasmapy.particles.atomic
+
+.. automodapi:: plasmapy.particles.atomic
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.data.rst
+++ b/docs/api_static/plasmapy.particles.data.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.data`
+=========================
+
+.. currentmodule:: plasmapy.particles.data
+
+.. automodapi::  plasmapy.particles.data
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.decorators.rst
+++ b/docs/api_static/plasmapy.particles.decorators.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.decorators`
+===============================
+
+.. currentmodule:: plasmapy.particles.decorators
+
+.. automodapi::  plasmapy.particles.decorators
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.elements.rst
+++ b/docs/api_static/plasmapy.particles.elements.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.elements`
+=============================
+
+.. currentmodule:: plasmapy.particles.elements
+
+.. automodapi:: plasmapy.particles.elements
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.exceptions.rst
+++ b/docs/api_static/plasmapy.particles.exceptions.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.exceptions`
+===============================
+
+.. currentmodule:: plasmapy.particles.exceptions
+
+.. automodapi::  plasmapy.particles.exceptions
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.ionization_state.rst
+++ b/docs/api_static/plasmapy.particles.ionization_state.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.ionization_state`
+=====================================
+
+.. currentmodule:: plasmapy.particles.ionization_state
+
+.. automodapi::  plasmapy.particles.ionization_state
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.ionization_states.rst
+++ b/docs/api_static/plasmapy.particles.ionization_states.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.ionization_states`
+======================================
+
+.. currentmodule:: plasmapy.particles.ionization_states
+
+.. automodapi::  plasmapy.particles.ionization_states
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.isotopes.rst
+++ b/docs/api_static/plasmapy.particles.isotopes.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.isotopes`
+=============================
+
+.. currentmodule:: plasmapy.particles.isotopes
+
+.. automodapi::  plasmapy.particles.isotopes
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.nuclear.rst
+++ b/docs/api_static/plasmapy.particles.nuclear.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.nuclear`
+============================
+
+.. currentmodule:: plasmapy.particles.nuclear
+
+.. automodapi::  plasmapy.particles.nuclear
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.parsing.rst
+++ b/docs/api_static/plasmapy.particles.parsing.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.parsing`
+============================
+
+.. currentmodule:: plasmapy.particles.parsing
+
+.. automodapi::  plasmapy.particles.parsing
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.particle_class.rst
+++ b/docs/api_static/plasmapy.particles.particle_class.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.particle_class`
+===================================
+
+.. currentmodule:: plasmapy.particles.particle_class
+
+.. automodapi::  plasmapy.particles.particle_class
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.serialization.rst
+++ b/docs/api_static/plasmapy.particles.serialization.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.serialization`
+==================================
+
+.. currentmodule:: plasmapy.particles.serialization
+
+.. automodapi::  plasmapy.particles.serialization
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.special_particles.rst
+++ b/docs/api_static/plasmapy.particles.special_particles.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.special_particles`
+======================================
+
+.. currentmodule:: plasmapy.particles.special_particles
+
+.. automodapi::  plasmapy.particles.special_particles
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.particles.symbols.rst
+++ b/docs/api_static/plasmapy.particles.symbols.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.particles.symbols`
+============================
+
+.. currentmodule:: plasmapy.particles.symbols
+
+.. automodapi::  plasmapy.particles.symbols
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.plasma.exceptions.rst
+++ b/docs/api_static/plasmapy.plasma.exceptions.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.plasma.exceptions`
+============================
+
+.. currentmodule:: plasmapy.plasma.exceptions
+
+.. automodapi::  plasmapy.plasma.exceptions
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.plasma.plasma_base.rst
+++ b/docs/api_static/plasmapy.plasma.plasma_base.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.plasma.plasma_base`
+=============================
+
+.. currentmodule:: plasmapy.plasma.plasma_base
+
+.. automodapi::  plasmapy.plasma.plasma_base
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.plasma.plasma_factory.rst
+++ b/docs/api_static/plasmapy.plasma.plasma_factory.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.plasma.plasma_factor`
+===============================
+
+.. currentmodule:: plasmapy.plasma.plasma_factory
+
+.. automodapi::  plasmapy.plasma.plasma_factory
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.plasma.sources.openpmd_hdf5.rst
+++ b/docs/api_static/plasmapy.plasma.sources.openpmd_hdf5.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.plasma.sources.openpmd_hdf5`
+======================================
+
+.. currentmodule:: plasmapy.plasma.sources.openpmd_hdf5
+
+.. automodapi::  plasmapy.plasma.sources.openpmd_hdf5
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.plasma.sources.plasma3d.rst
+++ b/docs/api_static/plasmapy.plasma.sources.plasma3d.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.plasma.sources.plasma3d`
+==================================
+
+.. currentmodule:: plasmapy.plasma.sources.plasma3d
+
+.. automodapi::  plasmapy.plasma.sources.plasma3d
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.plasma.sources.plasmablob.rst
+++ b/docs/api_static/plasmapy.plasma.sources.plasmablob.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.plasma.sources.plasmablob`
+====================================
+
+.. currentmodule:: plasmapy.plasma.sources.plasmablob
+
+.. automodapi::  plasmapy.plasma.sources.plasmablob
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.rst
+++ b/docs/api_static/plasmapy.rst
@@ -1,0 +1,26 @@
+:orphan:
+
+PlasmaPy: A plasma physics Python package
+=========================================
+
+.. currentmodule:: plasmapy
+
+.. automodule:: plasmapy
+
+Sub-Packages & Modules
+----------------------
+
+.. autosummary::
+
+   diagnostics
+   formulary
+   particles
+   plasma
+   simulation
+   utils
+
+.. automodapi:: plasmapy
+   :no-main-docstr:
+   :no-heading:
+   :include-all-objects:
+   :headings: "-^"

--- a/docs/api_static/plasmapy.simulation.abstractions.rst
+++ b/docs/api_static/plasmapy.simulation.abstractions.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.simulation.abstractions`
+==================================
+
+.. currentmodule:: plasmapy.simulation.abstractions
+
+.. automodapi::  plasmapy.simulation.abstractions
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.simulation.particletracker.rst
+++ b/docs/api_static/plasmapy.simulation.particletracker.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.simulation.particletracker`
+=====================================
+
+.. currentmodule:: plasmapy.simulation.particletracker
+
+.. automodapi::  plasmapy.simulation.particletracker
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.simulation.rst
+++ b/docs/api_static/plasmapy.simulation.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.simulation`
+=====================
+
+.. currentmodule:: plasmapy.simulation
+
+.. automodapi::  plasmapy.simulation
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.simulation.rst
+++ b/docs/api_static/plasmapy.simulation.rst
@@ -5,6 +5,17 @@
 
 .. currentmodule:: plasmapy.simulation
 
+.. automodule:: plasmapy.simulation
+   :noindex:
+
+Sub-Packages & Modules
+----------------------
+
+.. autosummary::
+
+   abstractions
+   particletracker
+
 .. automodapi::  plasmapy.simulation
    :include-all-objects:
    :no-heading:

--- a/docs/api_static/plasmapy.utils.datatype_factory_base.rst
+++ b/docs/api_static/plasmapy.utils.datatype_factory_base.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.datatype_factory_base`
+======================================
+
+.. currentmodule:: plasmapy.utils.datatype_factory_base
+
+.. automodapi::  plasmapy.utils.datatype_factory_base
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.decorators.checks.rst
+++ b/docs/api_static/plasmapy.utils.decorators.checks.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.decorators.checks`
+==================================
+
+.. currentmodule:: plasmapy.utils.decorators.checks
+
+.. automodapi::  plasmapy.utils.decorators.checks
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.decorators.converter.rst
+++ b/docs/api_static/plasmapy.utils.decorators.converter.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.decorators.converter`
+=====================================
+
+.. currentmodule:: plasmapy.utils.decorators.converter
+
+.. automodapi::  plasmapy.utils.decorators.converter
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.decorators.helpers.rst
+++ b/docs/api_static/plasmapy.utils.decorators.helpers.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.decorators.helpers`
+===================================
+
+.. currentmodule:: plasmapy.utils.decorators.helpers
+
+.. automodapi::  plasmapy.utils.decorators.helpers
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.decorators.validators.rst
+++ b/docs/api_static/plasmapy.utils.decorators.validators.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.decorators.validators`
+======================================
+
+.. currentmodule:: plasmapy.utils.decorators.validators
+
+.. automodapi::  plasmapy.utils.decorators.validators
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.error_messages.rst
+++ b/docs/api_static/plasmapy.utils.error_messages.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.error_messages`
+===============================
+
+.. currentmodule:: plasmapy.utils.error_messages
+
+.. automodapi::  plasmapy.utils.error_messages
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.pytest_helpers.exceptions.rst
+++ b/docs/api_static/plasmapy.utils.pytest_helpers.exceptions.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.pytest_helpers.exceptions`
+==========================================
+
+.. currentmodule:: plasmapy.utils.pytest_helpers.exceptions
+
+.. automodapi::  plasmapy.utils.pytest_helpers.exceptions
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.pytest_helpers.pytest_helpers.rst
+++ b/docs/api_static/plasmapy.utils.pytest_helpers.pytest_helpers.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.pytest_helpers.pytest_helpers`
+==============================================
+
+.. currentmodule:: plasmapy.utils.pytest_helpers.pytest_helpers
+
+.. automodapi::  plasmapy.utils.pytest_helpers.pytest_helpers
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.roman.roman.rst
+++ b/docs/api_static/plasmapy.utils.roman.roman.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+`plasmapy.utils.roman.roman`
+============================
+
+.. currentmodule:: plasmapy.utils.roman.roman
+
+.. automodapi::  plasmapy.utils.roman.roman
+   :include-all-objects:
+   :no-heading:

--- a/docs/api_static/plasmapy.utils.roman.rst
+++ b/docs/api_static/plasmapy.utils.roman.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+`plasmapy.utils.roman`
+======================
+
+.. currentmodule:: plasmapy.utils.roman
+
+.. automodule:: plasmapy.utils.roman
+   :noindex:
+
+Sub-Packages & Modules
+----------------------
+
+.. autosummary::
+
+   roman
+
+.. automodapi::  plasmapy.utils.roman
+   :include-all-objects:
+   :no-heading:

--- a/docs/particles/index.rst
+++ b/docs/particles/index.rst
@@ -39,3 +39,4 @@ Reference/API
    :no-heading:
    :no-main-docstr:
    :inherited-members:
+   :include-all-objects:

--- a/docs/plasma/index.rst
+++ b/docs/plasma/index.rst
@@ -38,6 +38,7 @@ data, e.g. `~plasmapy.plasma.sources.PlasmaBlob` or
 a list of all of them).
 
 .. autoclass:: plasmapy.plasma.plasma_factory.PlasmaFactory
+   :noindex:
 
 Using Plasma Objects
 --------------------

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -47,6 +47,8 @@ try:
     #       as editable (e.g. `pip install -e {plasmapy_directory_root}`),
     #       but then __version__ will not be updated with each commit, it is
     #       frozen to the version at time of install.
+    #
+    #: PlasmaPy version string
     __version__ = pkg_resources.get_distribution("plasmapy").version
 except pkg_resources.DistributionNotFound:
     # package is not installed
@@ -79,8 +81,7 @@ except pkg_resources.DistributionNotFound:
     del fallback_version, warn_add
 
 # ----------------------------------------------------------------------------
-
-
+#: PlasmaPy citation instructions
 __citation__ = (
     "Instructions on how to cite and acknowledge PlasmaPy are provided in the "
     "online documentation at: http://docs.plasmapy.org/en/latest/about/citation.html"

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -28,7 +28,7 @@ if sys.version_info < tuple((int(val) for val in "3.6".split("."))):
 # ----------------------------------------------------------------------------
 import pkg_resources
 
-from . import (
+from plasmapy import (
     diagnostics,
     formulary,
     particles,

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -1,51 +1,43 @@
 """
-PlasmaPy: A plasma physics Python package
-================================================
-
-Documentation is available in the docstrings,
-online at https://docs.plasmapy.org (accessible also using
-the ``plasmapy.online_help`` function).
-
-Contents
---------
-PlasmaPy provides the following functionality:
-
-Subpackages
------------
-Each of these subpackages (except for `formulary` and `particles` requires an
-explicit import, for example, via ``import plasmapy.diagnostics``.
-
-::
-
- particles                         --- Database for atoms, isotopes, ions...
- plasma                            --- (WIP) `Plasma` class
- data                              --- Data used for testing and examples
- diagnostics                       --- Experimental research data analysis
- formulary                         --- Plasma theory analysis formulae
- utils                             --- Various utilities
-
-Utility tools
--------------
-::
-
- online_help       --- Search the online documentation
- __version__       --- PlasmaPy version string
- __citation__      --- PlasmaPy citation instructions
-
+Welcome to the `plasmapy` package, an open source community-developed Python
+package for the plasma community.  Documentation is available in the docstrings
+and online at https://docs.plasmapy.org (accessible also using the
+:func:`~plasmapy.online_help` function).
 """
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+__all__ = [
+    "online_help",
+    "diagnostics",
+    "formulary",
+    "particles",
+    "plasma",
+    "simulation",
+    "utils",
+    "__version__",
+    "__citation__",
+]
+
+import sys
+import pkg_resources
+
+from . import (
+    diagnostics,
+    formulary,
+    particles,
+    plasma,
+    simulation,
+    utils,
+)
 
 # Enforce Python version check during package import.
 # This is the same check as the one at the top of setup.py
-import sys
+if sys.version_info < tuple((int(val) for val in "3.6".split("."))):
+    raise Exception("PlasmaPy does not support Python < {}".format(3.6))
 
 # Packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
-import pkg_resources
 
-from . import formulary, particles
-
+# define version
 try:
     # this places a runtime dependency on setuptools
     #
@@ -86,7 +78,6 @@ except pkg_resources.DistributionNotFound:
         del warn
     del fallback_version, warn_add
 
-
 # ----------------------------------------------------------------------------
 
 
@@ -94,9 +85,6 @@ __citation__ = (
     "Instructions on how to cite and acknowledge PlasmaPy are provided in the "
     "online documentation at: http://docs.plasmapy.org/en/latest/about/citation.html"
 )
-
-if sys.version_info < tuple((int(val) for val in "3.6".split("."))):
-    raise Exception("PlasmaPy does not support Python < {}".format(3.6))
 
 
 def online_help(query):

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -16,7 +16,16 @@ __all__ = [
     "__citation__",
 ]
 
+# Enforce Python version check during package import.
+# This is the same check as the one at the top of setup.py
 import sys
+
+if sys.version_info < tuple((int(val) for val in "3.6".split("."))):
+    raise Exception("PlasmaPy does not support Python < {}".format(3.6))
+
+# Packages may add whatever they like to this file, but
+# should keep this content at the top.
+# ----------------------------------------------------------------------------
 import pkg_resources
 
 from . import (
@@ -27,15 +36,6 @@ from . import (
     simulation,
     utils,
 )
-
-# Enforce Python version check during package import.
-# This is the same check as the one at the top of setup.py
-if sys.version_info < tuple((int(val) for val in "3.6".split("."))):
-    raise Exception("PlasmaPy does not support Python < {}".format(3.6))
-
-# Packages may add whatever they like to this file, but
-# should keep this content at the top.
-# ----------------------------------------------------------------------------
 
 # define version
 try:

--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -18,11 +18,11 @@ __all__ = [
     "get_EEDF",
 ]
 
+import astropy.units as u
 import copy
-
-import astropy.constants.si as const
 import numpy as np
-from astropy import units as u
+
+from astropy.constants import si as const
 from astropy.visualization import quantity_support
 from scipy.optimize import curve_fit
 

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -2,6 +2,8 @@
 The `~plasmapy.formulary` subpackage contains commonly used formulae
 from plasma science.
 """
+# __all__ will be auto populated below
+__all__ = []
 
 from .braginskii import *
 from .collisions import *
@@ -16,3 +18,9 @@ from .parameters import *
 from .quantum import *
 from .relativity import *
 from .ionization import *
+
+# auto populate __all__
+for obj_name in list(globals()):
+    if not (obj_name.startswith("__") or obj_name.endswith("__")):
+        __all__.append(obj_name)
+__all__.sort()

--- a/plasmapy/formulary/dispersionfunction.py
+++ b/plasmapy/formulary/dispersionfunction.py
@@ -1,9 +1,11 @@
-import numbers
-from typing import Union
+__all__ = ["plasma_dispersion_func", "plasma_dispersion_func_deriv"]
 
+import astropy.units as u
+import numbers
 import numpy as np
-from astropy import units as u
+
 from scipy.special import wofz as Faddeeva_function
+from typing import Union
 
 
 def plasma_dispersion_func(

--- a/plasmapy/formulary/dispersionfunction.py
+++ b/plasmapy/formulary/dispersionfunction.py
@@ -48,7 +48,7 @@ def plasma_dispersion_func(
         Z(\zeta) = \pi^{-0.5} \int_{-\infty}^{+\infty}
         \frac{e^{-x^2}}{x-\zeta} dx
 
-    where the argument is a complex number [fried.conte-1961]_.
+    where the argument is a complex number [#]_.
 
     In plasma wave theory, the plasma dispersion function appears
     frequently when the background medium has a Maxwellian
@@ -57,9 +57,9 @@ def plasma_dispersion_func(
 
     References
     ----------
-    .. [fried.conte-1961] Fried, Burton D. and Samuel D. Conte. 1961.
+    .. [#] Fried, Burton D. and Samuel D. Conte. 1961.
        The Plasma Dispersion Function: The Hilbert Transformation of the
-       Gaussian. Academic Press (New York and London).
+       Gaussian. Academic Press (New York and London). ISBN 9781483261737
 
     Examples
     --------
@@ -137,7 +137,13 @@ def plasma_dispersion_func_deriv(
         Z'(\zeta) = \pi^{-1/2} \int_{-\infty}^{+\infty}
         \frac{e^{-x^2}}{(x-\zeta)^2} dx
 
-    where the argument is a complex number [fried.conte-1961]_.
+    where the argument is a complex number [#]_.
+
+    References
+    ----------
+    .. [#] Fried, Burton D. and Samuel D. Conte. 1961.
+       The Plasma Dispersion Function: The Hilbert Transformation of the
+       Gaussian. Academic Press (New York and London). ISBN 9781483261737
 
     Examples
     --------

--- a/plasmapy/formulary/distribution.py
+++ b/plasmapy/formulary/distribution.py
@@ -3,13 +3,6 @@ Common distribution functions for plasmas, such as the Maxwelian or
 Kappa distributions. Functionality is intended to include generation,
 fitting and calculation.
 """
-import astropy as astropy
-import numpy as np
-from astropy import units as u
-from scipy.special import gamma
-
-from plasmapy.formulary import parameters
-
 __all__ = [
     "Maxwellian_1D",
     "Maxwellian_velocity_2D",
@@ -20,6 +13,14 @@ __all__ = [
     "kappa_velocity_1D",
     "kappa_velocity_3D",
 ]
+
+import astropy as astropy
+import numpy as np
+
+from astropy import units as u
+from scipy.special import gamma
+
+from plasmapy.formulary import parameters
 
 
 def _v_drift_units(v_drift):

--- a/plasmapy/formulary/ionization.py
+++ b/plasmapy/formulary/ionization.py
@@ -1,4 +1,5 @@
-""" This module gathers functions relating to ionization states and the properties thereof.
+"""
+This module gathers functions relating to ionization states and the properties thereof.
 """
 __all__ = ["ionization_balance", "Saha", "Z_bal_"]
 
@@ -7,10 +8,7 @@ import astropy.units as u
 from astropy.constants import a0, k_B
 from numpy import pi, exp, sqrt, log
 
-from plasmapy.utils.decorators import (
-    check_relativistic,
-    validate_quantities,
-)
+from plasmapy.utils.decorators import validate_quantities
 
 
 @validate_quantities(

--- a/plasmapy/formulary/magnetostatics.py
+++ b/plasmapy/formulary/magnetostatics.py
@@ -2,14 +2,23 @@
 Define MagneticStatics class to calculate common static magnetic fields
 as first raised in issue #100.
 """
+__all__ = [
+    "CircularWire",
+    "FiniteStraightWire",
+    "GeneralWire",
+    "InfiniteStraightWire",
+    "MagneticDipole",
+    "MagnetoStatics",
+    "Wire",
+]
 
 import abc
+import astropy.units as u
 import numbers
-
 import numpy as np
 import scipy.special
+
 from astropy import constants
-from astropy import units as u
 
 from plasmapy.utils.decorators import validate_quantities
 

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -7,9 +7,9 @@ to be abstracted from the main function interface.
 __all__ = ["Fermi_integral"]
 
 import numbers
-from typing import Union
-
 import numpy as np
+
+from typing import Union
 
 
 def Fermi_integral(

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -43,13 +43,13 @@ __all__ = [
     "wuh_",
 ]
 
+import astropy.units as u
 import numbers
-import warnings
-from typing import Optional
-
 import numpy as np
-from astropy import units as u
+import warnings
+
 from astropy.constants.si import c, e, eps0, k_B, m_e, m_p, mu0
+from typing import Optional
 
 from plasmapy import particles
 from plasmapy.utils import PhysicsError

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -15,8 +15,9 @@ __all__ = [
     "Wigner_Seitz_radius",
 ]
 
+import astropy.units as u
 import numpy as np
-from astropy import units as u
+
 from astropy.constants.si import c, e, eps0, h, hbar, k_B, m_e
 
 from plasmapy import particles

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -1,8 +1,9 @@
 r"""Functionality for calculating relativistic quantities (:math:`v \to c`)."""
 __all__ = ["Lorentz_factor", "relativistic_energy"]
 
+import astropy.units as u
 import numpy as np
-from astropy import units as u
+
 from astropy.constants import c
 
 from plasmapy import utils

--- a/plasmapy/optional_deps.py
+++ b/plasmapy/optional_deps.py
@@ -1,4 +1,13 @@
-""" Useful error messages for optional dependencies that aren't found. """
+"""
+Useful error messages for optional dependencies that aren't found.
+"""
+__all__ = [
+    "h5py_import_error",
+    "lmfit_import_error",
+    "mpl_import_error",
+    "mpmath_import_error",
+]
+
 from typing import Optional
 
 
@@ -48,18 +57,22 @@ def _optional_import_error_template(
     return ImportError(template)
 
 
+#: Import error message for `h5py`.
 h5py_import_error = _optional_import_error_template(
     "h5py", "http://docs.h5py.org/en/latest/build.html"
 )
 
+#: Import error message for `matplotlib`.
 mpl_import_error = _optional_import_error_template(
     "matplotlib", "https://matplotlib.org/users/installing.html"
 )
 
+#: Import error message for `mpmath`.
 mpmath_import_error = _optional_import_error_template(
     "mpmath", "http://mpmath.org/doc/current/setup.html#download-and-installation"
 )
 
+#: Import error message for `lmfit`.
 lmfit_import_error = _optional_import_error_template(
     "lmfit", "https://lmfit.github.io/lmfit-py/installation.html"
 )

--- a/plasmapy/particles/__init__.py
+++ b/plasmapy/particles/__init__.py
@@ -53,10 +53,23 @@ from plasmapy.particles.symbols import (
 
 # Create instances of the most commonly used particles
 
+#: PlasmaPy particle object for a proton
 proton = Particle("p+")
+
+#: PlasmaPy particle object for an electron
 electron = Particle("e-")
+
+#: PlasmaPy particle object for a neutron
 neutron = Particle("n")
+
+#: PlasmaPy particle object for a positron
 positron = Particle("e+")
+
+#: PlasmaPy particle object for a deuteron
 deuteron = Particle("D 1+")
+
+#: PlasmaPy particle object for a triton
 triton = Particle("T 1+")
+
+#: PlasmaPy particle object for an alpha particle
 alpha = Particle("He-4 2+")

--- a/plasmapy/particles/__init__.py
+++ b/plasmapy/particles/__init__.py
@@ -2,15 +2,8 @@
 The `plasmapy.particles` subpackage provides access to information about
 atoms, isotopes, ions, and other particles.
 """
-__all__ = [
-    "json_load_particle",
-    "json_loads_particle",
-    "AbstractParticle",
-    "CustomParticle",
-    "DimensionlessParticle",
-    "Particle",
-    "ParticleJSONDecoder",
-]
+# __all__ will be auto populated below
+__all__ = []
 
 from plasmapy.particles.atomic import (
     atomic_number,
@@ -73,3 +66,9 @@ triton = Particle("T 1+")
 
 #: PlasmaPy particle object for an alpha particle
 alpha = Particle("He-4 2+")
+
+# auto populate __all__
+for obj_name in list(globals()):
+    if not (obj_name.startswith("__") or obj_name.endswith("__")):
+        __all__.append(obj_name)
+__all__.sort()

--- a/plasmapy/particles/data/__init__.py
+++ b/plasmapy/particles/data/__init__.py
@@ -1,6 +1,8 @@
-"""Data used for testing PlasmaPy, example datasets, etc.
+"""
+A collection of atomic data used in constructing PlasmaPy `~plasmapy.particles`.
 
-- test/data*.h5 files come from
-  https://github.com/openPMD/openPMD-example-datasets/tree/b4f87b817629b99a048026a2724a5b265810d8be
-
+There are currently two datasets, :file:`elements.json` and :file:`isotopes.json`.
+:file:`elements.json` contains element/atomic data that is loaded by the functionality
+contained in `plasmapy.particles.elements`.  :file:`isotopes.json` contains isotope
+data that is loaded by the functionality contained in `plasmapy.particles.isotopes`.
 """

--- a/plasmapy/particles/data/test/__init__.py
+++ b/plasmapy/particles/data/test/__init__.py
@@ -1,3 +1,7 @@
+"""
+Test`.h5` files came from
+https://github.com/openPMD/openPMD-example-datasets/tree/b4f87b817629b99a048026a2724a5b265810d8be
+"""
 import glob
 import os
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -1,7 +1,7 @@
 """
 Module used to define the framework needed for the `particle_input` decorator.
-The decorator to takes string and/or integer representations of particles
-as arguments and pass through the corresponding instance of the
+The decorator takes string and/or integer representations of particles
+as arguments and passes through the corresponding instance of the
 `~plasmapy.particles.Particle` class.
 """
 __all__ = ["particle_input"]

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -5,7 +5,7 @@ The periodic tabla data is from: http://periodic.lanl.gov/index.shtml
 
 .. attention::
     This module only contains non-public functionality.  To learn more about the
-    package functionality, then examine the code itself.
+    package functionality, examine the code itself.
 """
 __all__ = []
 

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -1,7 +1,11 @@
 """
-Dictionaries containing basic atomic data.
+Module for loading elemental data from :file:`plasmapy/particles/data/elements.json`.
 
 The periodic tabla data is from: http://periodic.lanl.gov/index.shtml
+
+.. attention::
+    This module only contains non-public functionality.  To learn more about the
+    package functionality, then examine the code itself.
 """
 __all__ = []
 

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -1,5 +1,6 @@
 """
-Module for loading elemental data from :file:`plasmapy/particles/data/elements.json`.
+Module for loading atomic data for elements from
+:file:`plasmapy/particles/data/elements.json`.
 
 The periodic tabla data is from: http://periodic.lanl.gov/index.shtml
 

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -3,12 +3,13 @@ Dictionaries containing basic atomic data.
 
 The periodic tabla data is from: http://periodic.lanl.gov/index.shtml
 """
+__all__ = []
 
+import astropy.units as u
 import collections
 import json
 import pkgutil
 
-import astropy.units as u
 
 _PeriodicTable = collections.namedtuple(
     "periodic_table", ["group", "category", "block", "period"]

--- a/plasmapy/particles/exceptions.py
+++ b/plasmapy/particles/exceptions.py
@@ -1,3 +1,19 @@
+"""
+Collection of `Exceptions` and `Warnings` for PlasmaPy particles.
+"""
+__all__ = [
+    "AtomicError",
+    "AtomicWarning",
+    "ChargeError",
+    "InvalidElementError",
+    "InvalidIonError",
+    "InvalidIsotopeError",
+    "InvalidParticleError",
+    "MissingAtomicDataError",
+    "MissingAtomicDataWarning",
+    "UnexpectedParticleError",
+]
+
 from plasmapy.utils import PlasmaPyError, PlasmaPyWarning
 
 

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -4,13 +4,13 @@ a single ionization level.
 """
 __all__ = ["IonizationState", "State"]
 
+import astropy.units as u
 import collections
+import numpy as np
 import warnings
+
 from numbers import Integral, Real
 from typing import List, Optional, Union
-
-import numpy as np
-from astropy import units as u
 
 from plasmapy.particles.exceptions import AtomicError, ChargeError, InvalidParticleError
 from plasmapy.particles.particle_class import Particle

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -24,6 +24,7 @@ _number_density_errmsg = (
 # TODO: Change `State` into a class with validations for all of the
 # TODO: attributes.
 
+#: Named tuple class for representing an ionization state (`collections.namedtuple`).
 State = collections.namedtuple(
     "State", ["integer_charge", "ionic_fraction", "ionic_symbol", "number_density"]
 )

--- a/plasmapy/particles/ionization_states.py
+++ b/plasmapy/particles/ionization_states.py
@@ -4,12 +4,12 @@ isotopes.
 """
 __all__ = ["IonizationStates"]
 
+import astropy.units as u
 import collections
+import numpy as np
+
 from numbers import Integral, Real
 from typing import Dict, List, Optional, Tuple, Union
-
-import numpy as np
-from astropy import units as u
 
 from plasmapy.particles.atomic import atomic_number
 from plasmapy.particles.exceptions import AtomicError, ChargeError, InvalidParticleError

--- a/plasmapy/particles/isotopes.py
+++ b/plasmapy/particles/isotopes.py
@@ -26,11 +26,13 @@ import pkgutil
 
 
 def _isotope_obj_hook(obj):
+    """An `object_hook` designed for `json.load` and `json.loads`."""
     if "unit" in obj:
         return obj["value"] * u.Unit(obj["unit"])
     return obj
 
 
+#: Dictionary of isotope data.
 _Isotopes = json.loads(
     pkgutil.get_data("plasmapy", "particles/data/isotopes.json"),
     object_hook=_isotope_obj_hook,

--- a/plasmapy/particles/isotopes.py
+++ b/plasmapy/particles/isotopes.py
@@ -2,11 +2,11 @@
 Create a dictionary containing basic information for isotopes and
 neutrons.
 """
-
-import json
-import pkgutil
+__all__ = []
 
 import astropy.units as u
+import json
+import pkgutil
 
 # this code was used to create the JSON file as per vn-ki on Riot:
 # https://matrix.to/#/!hkWCiyhQyxiYJlUtKF:matrix.org/

--- a/plasmapy/particles/isotopes.py
+++ b/plasmapy/particles/isotopes.py
@@ -1,6 +1,9 @@
 """
-Create a dictionary containing basic information for isotopes and
-neutrons.
+Module for loading isotope data from :file:`plasmapy/particles/data/isotopes.json`.
+
+.. attention::
+    This module only contains non-public functionality.  To learn more about the
+    package functionality, then examine the code itself.
 """
 __all__ = []
 

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -105,6 +105,9 @@ def mass_energy(particle: Particle, mass_numb: Optional[int] = None) -> u.Quanti
     `TypeError`
         If the inputs are not of the correct types.
 
+    Examples
+    --------
+
     >>> mass_energy('He-4')
     <Quantity 5.9719e-10 J>
 

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -1,10 +1,10 @@
 """Functions that are related to nuclear reactions."""
 __all__ = ["nuclear_binding_energy", "nuclear_reaction_energy", "mass_energy"]
 
+import astropy.units as u
 import re
-from typing import List, Optional, Union
 
-from astropy import units as u
+from typing import List, Optional, Union
 
 from plasmapy.particles.exceptions import AtomicError, InvalidParticleError
 from plasmapy.particles.particle_class import Particle

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -19,7 +19,7 @@ from plasmapy.particles.exceptions import (
 )
 from plasmapy.particles.isotopes import _Isotopes
 from plasmapy.particles.special_particles import ParticleZoo, _Particles
-from plasmapy.utils import call_string, roman
+from plasmapy.utils import roman
 
 
 def _create_alias_dicts(Particles: dict) -> (Dict[str, str], Dict[str, str]):

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -1,11 +1,11 @@
 """Functionality to parse representations of particles into standard form."""
 
 import re
-import warnings
-from numbers import Integral
-from typing import Dict, Optional, Union
-
 import numpy as np
+import warnings
+
+from numbers import Integral
+from typing import Dict, Union
 
 from plasmapy.particles.elements import (
     _atomic_numbers_to_symbols,

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -3,7 +3,7 @@ Functionality to parse representations of particles into standard form.
 
 .. attention::
     This module only contains non-public functionality.  To learn more about the
-    package functionality, then examine the code itself.
+    package functionality, examine the code itself.
 """
 __all__ = []
 

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -1,4 +1,11 @@
-"""Functionality to parse representations of particles into standard form."""
+"""
+Functionality to parse representations of particles into standard form.
+
+.. attention::
+    This module only contains non-public functionality.  To learn more about the
+    package functionality, then examine the code itself.
+"""
+__all__ = []
 
 import re
 import numpy as np

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -16,7 +16,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from datetime import datetime
-from numbers import Complex, Integral, Real
+from numbers import Integral, Real
 from typing import List, Optional, Set, Tuple, Union
 
 from plasmapy.particles.elements import _Elements, _PeriodicTable

--- a/plasmapy/particles/serialization.py
+++ b/plasmapy/particles/serialization.py
@@ -1,3 +1,6 @@
+"""
+Functionality for JSON deserialization of PlasmaPy particles.
+"""
 __all__ = [
     "json_load_particle",
     "json_loads_particle",

--- a/plasmapy/particles/serialization.py
+++ b/plasmapy/particles/serialization.py
@@ -8,6 +8,7 @@ __all__ = [
 ]
 
 import json
+
 from plasmapy.particles.exceptions import InvalidElementError
 from plasmapy.particles.particle_class import (
     AbstractParticle,

--- a/plasmapy/particles/special_particles.py
+++ b/plasmapy/particles/special_particles.py
@@ -124,6 +124,7 @@ class _ParticleZooClass:
         return self._taxonomy_dict["matter"] | self._taxonomy_dict["antimatter"]
 
 
+#: Instance of `_ParticleZooClass`.
 ParticleZoo = _ParticleZooClass()
 
 

--- a/plasmapy/particles/special_particles.py
+++ b/plasmapy/particles/special_particles.py
@@ -2,12 +2,13 @@
 Classes, sets, and dictionaries to store data and taxonomy
 information for special particles.
 """
+__all__ = ["ParticleZoo", "_ParticleZooClass"]
+
+import astropy.constants as const
+import astropy.units as u
+import numpy as np
 
 from typing import Dict, Set
-
-import numpy as np
-from astropy import constants as const
-from astropy import units as u
 
 from plasmapy.particles.elements import _PeriodicTable
 

--- a/plasmapy/particles/symbols.py
+++ b/plasmapy/particles/symbols.py
@@ -2,6 +2,12 @@
 Functions that deal with string representations of atomic symbols
 and numbers.
 """
+__all__ = [
+    "atomic_symbol",
+    "element_name",
+    "isotope_symbol",
+    "ionic_symbol",
+]
 
 from numbers import Integral
 from typing import Optional
@@ -17,14 +23,6 @@ from .decorators import particle_input
 # respectively.  The Particle class constructor will raise an
 # InvalidParticleError if the input does not correspond to a valid
 # particle.
-
-__all__ = [
-    "atomic_symbol",
-    "isotope_symbol",
-    "ionic_symbol",
-    "particle_input",
-    "element_name",
-]
 
 
 @particle_input

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -6,15 +6,15 @@ from plasmapy.particles.exceptions import (
     InvalidElementError,
     InvalidParticleError,
 )
-
-from ..parsing import (  # duplicate with utils.pytest_helpers.error_messages.call_string?
+from plasmapy.particles.parsing import (
+    # duplicate with utils.pytest_helpers.error_messages.call_string?
     _case_insensitive_aliases,
     _case_sensitive_aliases,
     _dealias_particle_aliases,
     _parse_and_check_atomic_input,
-    call_string,
 )
-from ..special_particles import ParticleZoo
+from plasmapy.particles.special_particles import ParticleZoo
+from plasmapy.utils import call_string
 
 
 def _particle_call_string(arg, kwargs=None) -> str:

--- a/plasmapy/plasma/exceptions.py
+++ b/plasmapy/plasma/exceptions.py
@@ -1,3 +1,9 @@
+"""
+Collection of `Exceptions` and `Warnings` for functionality defined in
+`plasmapy.plasma`.
+"""
+__all__ = ["DataStandardError"]
+
 from plasmapy.utils import PlasmaPyError
 
 

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -11,7 +11,7 @@ class BasePlasma(ABC):
     Registration class for `~plasmapy.plasma.GenericPlasma` and declares
     some abstract methods for data common in different kinds of plasmas.
 
-    This class checks for the existance of a method named ``is_datasource_for``
+    This class checks for the existence of a method named ``is_datasource_for``
     when a subclass of `GenericPlasma` is defined. If it exists it will add that
     class to the registry.
     """
@@ -67,7 +67,7 @@ class GenericPlasma(BasePlasma):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        pass
 
     # The definitions for the abstract methods declared in `BasePlasma`
     # goes here.

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -63,7 +63,7 @@ class BasePlasma(ABC):
 class GenericPlasma(BasePlasma):
     """
     A Generic Plasma class. This class contains definitions for abstract
-    methods declared in the `~plasmapy.plasma.plasma_base.BaseClass`.
+    methods declared in the `BasePlasma`.
     """
 
     def __init__(self, **kwargs):

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod, abstractproperty
 
 __all__ = ["BasePlasma", "GenericPlasma"]
 
+from abc import ABC, abstractmethod
+
 
 class BasePlasma(ABC):
     """
@@ -31,23 +33,28 @@ class BasePlasma(ABC):
     # For reference, see
     # https://github.com/sunpy/ndcube/blob/master/ndcube/ndcube.py#L26
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def electron_temperature(self):
         raise NotImplementedError
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def ion_temperature(self):
         raise NotImplementedError
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def electron_density(self):
         raise NotImplementedError
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def ion_density(self):
         raise NotImplementedError
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def average_ionization(self):
         raise NotImplementedError
 

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -1,5 +1,6 @@
-from abc import ABC, abstractmethod, abstractproperty
-
+"""
+Module for defining the base framework of the plasma classes.
+"""
 __all__ = ["BasePlasma", "GenericPlasma"]
 
 from abc import ABC, abstractmethod

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -67,7 +67,7 @@ class GenericPlasma(BasePlasma):
     """
 
     def __init__(self, **kwargs):
-        pass
+        super().__init__(**kwargs)
 
     # The definitions for the abstract methods declared in `BasePlasma`
     # goes here.

--- a/plasmapy/plasma/plasma_factory.py
+++ b/plasmapy/plasma/plasma_factory.py
@@ -4,14 +4,7 @@ Module for defining the frame work around the plasma factory.
 __all__ = ["PlasmaFactory", "Plasma"]
 
 from plasmapy.plasma.plasma_base import GenericPlasma
-from plasmapy.utils.datatype_factory_base import (
-    BasicRegistrationFactory,
-    MultipleMatchError,
-    NoMatchError,
-    ValidationFunctionError,
-)
-
-__all__ = ["PlasmaFactory", "Plasma"]
+from plasmapy.utils.datatype_factory_base import BasicRegistrationFactory
 
 
 class PlasmaFactory(BasicRegistrationFactory):

--- a/plasmapy/plasma/plasma_factory.py
+++ b/plasmapy/plasma/plasma_factory.py
@@ -1,3 +1,8 @@
+"""
+Module for defining the frame work around the plasma factory.
+"""
+__all__ = ["PlasmaFactory", "Plasma"]
+
 from plasmapy.plasma.plasma_base import GenericPlasma
 from plasmapy.utils.datatype_factory_base import (
     BasicRegistrationFactory,

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -1,8 +1,10 @@
-import os
-from distutils.version import StrictVersion
+__all__ = ["HDF5Reader"]
 
 import astropy.units as u
 import numpy as np
+import os
+
+from distutils.version import StrictVersion
 
 from plasmapy.plasma.exceptions import DataStandardError
 from plasmapy.plasma.plasma_base import GenericPlasma

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -56,6 +56,7 @@ class HDF5Reader(GenericPlasma):
         Any keyword accepted by `GenericPlasma`.
 
     """
+
     def __init__(self, hdf5, **kwargs):
         super().__init__(**kwargs)
 

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -41,28 +41,19 @@ def _valid_version(openPMD_version, outdated=_OUTDATED_VERSION, newer=_NEWER_VER
 
 
 class HDF5Reader(GenericPlasma):
-    def __init__(self, hdf5, **kwargs):
-        """
-        Core class for accessing various attributes on HDF5 files that
-        are based on OpenPMD standards.
+    """
+    .. _OpenPMD: http://openpmd.org/
 
-        Attributes
-        ----------
-        electric_field : `astropy.units.Quantity`
-            An (x, y, z) array containing electric field data.
-        charge_density : `astropy.units.Quantity`
-            An array containing charge density data.
+    Core class for accessing various attributes on HDF5 files that
+    are based on OpenPMD_ standards.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
         hdf5 : `str`
             Path to HDF5 file.
-
-        References
-        ----------
-        .. [1] http://openpmd.org/
-        """
-
+    """
+    def __init__(self, hdf5, **kwargs):
+        super().__init__(**kwargs)
         if not os.path.isfile(hdf5):
             raise FileNotFoundError(f"Could not find file: '{hdf5}'")
         try:
@@ -109,6 +100,10 @@ class HDF5Reader(GenericPlasma):
 
     @property
     def electric_field(self):
+        """
+        An (x, y, z) array containing electric field data.  (Returned as an astropy
+        `~astropy.units.Quantity`.)
+        """
         path = f"data/{self.subname}/fields/E"
         if path in self.h5:
             units = _fetch_units(self.h5[path].attrs["unitDimension"])
@@ -119,6 +114,10 @@ class HDF5Reader(GenericPlasma):
 
     @property
     def charge_density(self):
+        """
+        An array containing charge density data.  (Returned as an astropy
+        `~astropy.units.Quantity`.)
+        """
         path = f"data/{self.subname}/fields/rho"
         if path in self.h5:
             units = _fetch_units(self.h5[path].attrs["unitDimension"])

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -49,11 +49,16 @@ class HDF5Reader(GenericPlasma):
 
     Parameters
     ----------
-        hdf5 : `str`
-            Path to HDF5 file.
+    hdf5 : `str`
+        Path to HDF5 file.
+
+    **kwargs
+        Any keyword accepted by `GenericPlasma`.
+
     """
     def __init__(self, hdf5, **kwargs):
         super().__init__(**kwargs)
+
         if not os.path.isfile(hdf5):
             raise FileNotFoundError(f"Could not find file: '{hdf5}'")
         try:

--- a/plasmapy/plasma/sources/plasma3d.py
+++ b/plasmapy/plasma/sources/plasma3d.py
@@ -18,80 +18,155 @@ class Plasma3D(GenericPlasma):
     Core class for describing and calculating plasma parameters with
     spatial dimensions.
 
-    Attributes
-    ----------
-    x : `astropy.units.Quantity`
-        x-coordinates within the plasma domain. Equal to the
-        `domain_x` input parameter.
-    y : `astropy.units.Quantity`
-        y-coordinates within the plasma domain. Equal to the
-        `domain_y` input parameter.
-    z : `astropy.units.Quantity`
-        z-coordinates within the plasma domain. Equal to the
-        `domain_z` input parameter.
-    grid : `astropy.units.Quantity`
-        (3, x, y, z) array containing the values of each coordinate at
-        every point in the domain.
-    domain_shape : tuple
-        Shape of the plasma domain.
-    density : `astropy.units.Quantity`
-        (x, y, z) array of mass density at every point in the domain.
-    momentum : `astropy.units.Quantity`
-        (3, x, y, z) array of the momentum vector at every point in
-        the domain.
-    pressure : `astropy.units.Quantity`
-        (x, y, z) array of pressure at every point in the domain.
-    magnetic_field : `astropy.units.Quantity`
-        (3, x, y, z) array of the magnetic field vector at every point
-        in the domain.
-
     Parameters
     ----------
-    domain_x : `astropy.units.Quantity`
+    domain_x : `~astropy.units.Quantity`
         1D array of x-coordinates for the plasma domain. Must have
-        units convertable to length.
-    domain_y : `astropy.units.Quantity`
+        units convertible to length.
+    domain_y : `~astropy.units.Quantity`
         1D array of y-coordinates for the plasma domain. Must have
-        units convertable to length.
-    domain_z : `astropy.units.Quantity`
+        units convertible to length.
+    domain_z : `~astropy.units.Quantity`
         1D array of z-coordinates for the plasma domain. Must have
-        units convertable to length.
-
+        units convertible to length.
+    **kwargs:
+        Any keyword accepted by `~plasmapy.plasma.plasma_base.GenericPlasma`
     """
 
     @u.quantity_input(domain_x=u.m, domain_y=u.m, domain_z=u.m)
-    def __init__(self, domain_x, domain_y, domain_z):
-        # Define domain sizes
-        self.x = domain_x
-        self.y = domain_y
-        self.z = domain_z
+    def __init__(self, domain_x, domain_y, domain_z, **kwargs):
+        super().__init__(**kwargs)
 
-        self.grid = np.array(np.meshgrid(self.x, self.y, self.z, indexing="ij"))
-        self.domain_shape = (len(self.x), len(self.y), len(self.z))
+        # Define domain sizes
+        self._x = domain_x
+        self._y = domain_y
+        self._z = domain_z
+
+        self._grid = np.array(np.meshgrid(self._x, self._y, self._z, indexing="ij"))
+        self._domain_shape = (len(self._x), len(self._y), len(self._z))
 
         # Initiate core plasma variables
-        self.density = np.zeros(self.domain_shape) * u.kg / u.m ** 3
-        self.momentum = np.zeros((3, *self.domain_shape)) * u.kg / (u.m ** 2 * u.s)
-        self.pressure = np.zeros(self.domain_shape) * u.Pa
-        self.magnetic_field = np.zeros((3, *self.domain_shape)) * u.T
-        self.electric_field = np.zeros((3, *self.domain_shape)) * u.V / u.m
+        self._density = np.zeros(self.domain_shape) * u.kg / u.m ** 3
+        self._momentum = np.zeros((3, *self.domain_shape)) * u.kg / (u.m ** 2 * u.s)
+        self._pressure = np.zeros(self.domain_shape) * u.Pa
+        self._magnetic_field = np.zeros((3, *self.domain_shape)) * u.T
+        self._electric_field = np.zeros((3, *self.domain_shape)) * u.V / u.m
+
+    @property
+    def x(self):
+        """
+        (`~astropy.units.Quantity`) x-coordinates within the plasma domain. Equal to
+        the `domain_x` input parameter.
+        """
+        return self._x
+
+    @property
+    def y(self):
+        """
+        (`~astropy.units.Quantity`) y-coordinates within the plasma domain. Equal
+        to the `domain_y` input parameter.
+        """
+        return self._y
+
+    @property
+    def z(self):
+        """
+        (`~astropy.units.Quantity`) z-coordinates within the plasma domain. Equal
+        to the `domain_z` input parameter.
+        """
+        return self._z
+
+    @property
+    def grid(self):
+        """
+        (`~astropy.units.Quantity`) (3, x, y, z) array containing the values of each
+        coordinate at every point in the domain.
+        """
+        return self._grid
+
+    @property
+    def domain_shape(self) -> tuple:
+        """(`tuple`) Shape of the plasma domain."""
+        return self._domain_shape
+
+    @property
+    def density(self):
+        """
+        (`~astropy.units.Quantity`) (x, y, z) array of mass density at every
+        point in the domain.
+        """
+        return self._density
+
+    @property
+    def momentum(self):
+        """
+        (`~astropy.units.Quantity`) (3, x, y, z) array of the momentum vector at
+        every point in the domain.
+        """
+        return self._momentum
+
+    @property
+    def pressure(self):
+        """
+        (`~astropy.units.Quantity`) (x, y, z) array of pressure at every point
+        in the domain.
+        """
+        return self._pressure
+
+    @property
+    def magnetic_field(self):
+        """
+        (`~astropy.units.Quantity`) (3, x, y, z) array of the magnetic field vector
+        at every point in the domain.
+        """
+        return self._magnetic_field
+
+    @property
+    def electric_field(self):
+        """
+        (`~astropy.units.Quantity`) (3, x, y, z) array of the magnetic field vector
+        at every point in the domain.
+        """
+        return self._electric_field
 
     @property
     def velocity(self):
+        """
+        (`~astropy.units.Quantity`) (3, x, y, z) array of the fluid velocity vector at
+        every point in the domain.
+        """
         return self.momentum / self.density
 
     @property
     def magnetic_field_strength(self):
+        """
+        Total field strength.
+
+        .. math::
+            \\sqrt{ \\sum{ B^2 }}
+
+        """
         B = self.magnetic_field
         return np.sqrt(np.sum(B * B, axis=0))
 
     @property
     def electric_field_strength(self):
+        """
+        Total field strength.
+
+        .. math::
+            \\sqrt{ \\sum{ E^2 }}
+
+        """
         E = self.electric_field
         return np.sqrt(np.sum(E * E, axis=0))
 
     @property
     def alfven_speed(self):
+        """
+        (`~astropy.units.Quantity`) (x, y, z) array of the Alfvén speed at
+        every point in the domain.
+        """
         B = self.magnetic_field
         rho = self.density
         return np.sqrt(np.sum(B * B, axis=0) / (mu0 * rho))

--- a/plasmapy/plasma/sources/plasma3d.py
+++ b/plasmapy/plasma/sources/plasma3d.py
@@ -188,6 +188,5 @@ class Plasma3D(GenericPlasma):
                 # get coordinate
                 p = self.grid[(slice(None),) + point_index]  # function as [:, *index]
                 # calculate magnetic field at this point and add back
-                self.magnetic_field[
-                    (slice(None),) + point_index
-                ] += mstat.magnetic_field(p)
+                self.magnetic_field[(slice(None),) + point_index] += \
+                    mstat.magnetic_field(p)

--- a/plasmapy/plasma/sources/plasma3d.py
+++ b/plasmapy/plasma/sources/plasma3d.py
@@ -188,5 +188,6 @@ class Plasma3D(GenericPlasma):
                 # get coordinate
                 p = self.grid[(slice(None),) + point_index]  # function as [:, *index]
                 # calculate magnetic field at this point and add back
-                self.magnetic_field[(slice(None),) + point_index] += \
-                    mstat.magnetic_field(p)
+                self.magnetic_field[
+                    (slice(None),) + point_index
+                ] += mstat.magnetic_field(p)

--- a/plasmapy/plasma/sources/plasma3d.py
+++ b/plasmapy/plasma/sources/plasma3d.py
@@ -1,16 +1,16 @@
 """
 Defines the core Plasma class used by PlasmaPy to represent plasma properties.
 """
-
-import itertools
+__all__ = ["Plasma3D"]
 
 import astropy.units as u
+import itertools
 import numpy as np
+
 from astropy.constants import mu0
+
 from plasmapy.formulary.magnetostatics import MagnetoStatics
 from plasmapy.plasma.plasma_base import GenericPlasma
-
-__all__ = ["Plasma3D"]
 
 
 class Plasma3D(GenericPlasma):

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -1,17 +1,17 @@
 """
 Defines the core Plasma class used by PlasmaPy to represent plasma properties.
 """
-import warnings
+__all__ = ["PlasmaBlob"]
 
 import astropy.units as u
+import warnings
+
 from plasmapy.formulary.collisions import coupling_parameter
 from plasmapy.formulary.dimensionless import quantum_theta
 from plasmapy.formulary.parameters import _grab_charge
 from plasmapy.particles import particle_mass
 from plasmapy.plasma.plasma_base import GenericPlasma
 from plasmapy.utils import CouplingWarning, call_string
-
-__all__ = ["PlasmaBlob"]
 
 
 class PlasmaBlob(GenericPlasma):

--- a/plasmapy/simulation/__init__.py
+++ b/plasmapy/simulation/__init__.py
@@ -1,4 +1,9 @@
 """Module containing plasma simulation tools."""
+__all__ = [
+    "AbstractSimulation",
+    "AbstractTimeDependentSimulation",
+    "ParticleTracker",
+]
 
 from plasmapy.simulation.abstractions import (
     AbstractSimulation,

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -1,15 +1,15 @@
 """
 Class representing a group of particles.
 """
+__all__ = ["ParticleTracker"]
 
+import astropy.units as u
 import numpy as np
 import scipy.interpolate as interp
+
 from astropy import constants
-from astropy import units as u
 
 from plasmapy.particles import atomic
-
-__all__ = ["ParticleTracker"]
 
 
 class ParticleTracker:

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -29,14 +29,19 @@
 # Project     : https://github.com/sunpy/sunpy
 # File        : sunpy/util/datatype_factory_base.py
 # Commit hash : f6330eea602ea796b5b004dee283b8877b24da23
-
+__all__ = [
+    "BasicRegistrationFactory",
+    "MultipleMatchError",
+    "NoMatchError",
+    "ValidationFunctionError",
+]
 
 import inspect
 
 
 class BasicRegistrationFactory:
     """
-    Generalized registerable factory type.
+    Generalized registrable factory type.
 
     Widgets (classes) can be registered with an instance of this class.
     Arguments to the factory's `__call__` method are then passed to a function

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -1280,12 +1280,12 @@ def check_relativistic(func=None, betafrac=0.05):
     ValueError
         If `V` contains any `~numpy.nan` values.
 
-    ~plasmapy.utils.RelativityError
+    ~plasmapy.utils.exceptions.RelativityError
         If `V` is greater than or equal to the speed of light.
 
     Warns
     -----
-    ~plasmapy.utils.RelativityWarning
+    : `~plasmapy.utils.exceptions.RelativityWarning`
         If `V` is greater than or equal to `betafrac` times the speed of light,
         but less than the speed of light.
 

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -3,10 +3,9 @@ Decorator to convert units of functions in /physics methods
 """
 __all__ = ["angular_freq_to_hz"]
 
+import astropy.units as u
 import functools
 import inspect
-
-from astropy import units as u
 
 from plasmapy.utils.decorators.helpers import preserve_signature
 

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -3,12 +3,12 @@ Various decorators to validate input/output arguments to functions.
 """
 __all__ = ["validate_quantities", "ValidateQuantities"]
 
+import astropy.units as u
 import functools
 import inspect
 import warnings
-from typing import Any, Dict
 
-from astropy import units as u
+from typing import Any, Dict
 
 from plasmapy.utils.decorators.checks import CheckUnits, CheckValues
 from plasmapy.utils.decorators.helpers import preserve_signature

--- a/plasmapy/utils/error_messages.py
+++ b/plasmapy/utils/error_messages.py
@@ -1,9 +1,10 @@
+__all__ = ["call_string"]
+
+import astropy.units as u
+import colorama
+
 from typing import Any, Callable, Dict
 
-import colorama
-from astropy import units as u
-
-__all__ = ["call_string"]
 
 _bold = colorama.Style.BRIGHT
 _magenta = colorama.Fore.MAGENTA

--- a/plasmapy/utils/pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers/pytest_helpers.py
@@ -130,22 +130,22 @@ def run_test(
 
     Raises
     ------
-    UnexpectedResultError
+    ~plasmapy.utils.pytest_helpers.UnexpectedResultError
         If the test returns a result that is different from the expected
         result.
 
-    InconsistentTypeError
+    ~plasmapy.utils.pytest_helpers.InconsistentTypeError
         If the actual result is of a different type than the expected
         result.
 
-    UnexpectedExceptionError
+    ~plasmapy.utils.pytest_helpers.UnexpectedExceptionError
         If an exception occurs when no exception or a different
         exception is expected.
 
-    MissingExceptionError
+    ~plasmapy.utils.pytest_helpers.MissingExceptionError
         If no exception is raised when an exception is expected.
 
-    MissingWarningError
+    ~plasmapy.utils.pytest_helpers.MissingWarningError
         An expected warning is not issued.
 
     ~astropy.units.UnitsError
@@ -445,16 +445,16 @@ def run_test_equivalent_calls(*test_inputs, require_same_type: bool = True):
 
     Raises
     ------
-    ~plasmapy.utils.UnexpectedResultError
+    ~plasmapy.utils.pytest_helpers.UnexpectedResultError
         If not all of the results are equivalent, or not all of the
         results are of the same type and `require_same_type` evaluates
         to `True`.
 
-    ~plasmapy.utils.UnexpectedExceptionError
+    ~plasmapy.utils.pytest_helpers.UnexpectedExceptionError
         If an exception is raised whilst attempting to run one of the
         test cases.
 
-    ~plasmapy.utils.InvalidTestError
+    ~plasmapy.utils.pytest_helpers.InvalidTestError
         If there is an error associated with the inputs or the test is
         set up incorrectly.
 
@@ -669,7 +669,7 @@ def assert_can_handle_nparray(
 
     Raises
     ------
-    ~ValueError
+    ValueError
         If this function cannot interpret a parameter of function_to_test,
 
     Examples

--- a/plasmapy/utils/pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers/pytest_helpers.py
@@ -1,16 +1,22 @@
 """Test helper utilities."""
-import collections
-import functools
-import inspect
-import warnings
-from typing import Any, Callable, Dict
+__all__ = [
+    "assert_can_handle_nparray",
+    "run_test",
+    "run_test_equivalent_calls",
+]
 
 import astropy.constants as const
 import astropy.tests.helper as astrohelper
 import astropy.units as u
+import collections
 import colorama
+import functools
+import inspect
 import numpy as np
 import pytest
+import warnings
+
+from typing import Any, Callable, Dict
 
 from plasmapy.utils.error_messages import _exc_str, _represent_result, call_string
 from plasmapy.utils.exceptions import PlasmaPyWarning
@@ -37,8 +43,6 @@ _type_color = f"{_magenta}{_bold}"
 _func_color = f"{_cyan}{_bold}"
 _result_color = f"{_blue}{_bold}"
 _message_color = f"{_red}{_bold}"
-
-__all__ = ["run_test", "run_test_equivalent_calls", "assert_can_handle_nparray"]
 
 
 def _process_input(wrapped_function: Callable):

--- a/plasmapy/utils/roman/roman.py
+++ b/plasmapy/utils/roman/roman.py
@@ -11,13 +11,6 @@ it under the terms of the Python 2.1.1 license, available at
 https://www.python.org/download/releases/2.1.1/license/
 
 """
-
-import re
-from numbers import Integral
-from typing import Union
-
-import numpy as np
-
 __all__ = [
     "RomanError",
     "OutOfRangeError",
@@ -26,6 +19,12 @@ __all__ = [
     "from_roman",
     "is_roman_numeral",
 ]
+
+import numpy as np
+import re
+
+from numbers import Integral
+from typing import Union
 
 
 class RomanError(Exception):


### PR DESCRIPTION
This is a long needed update to the documentation that increases the document exposure of the `plamsapy` package.  Currently there is functionality in the package whose docstrings do not make it into the documentation build.  This is primarily due the fact that many package elements do not go through the `sphinx` `autodoc` directives during our narrative documentation.

This PR manually creates reST files for the package elements that are not `autodoc`-ed in our narrative documentation.  These reST files are placed in a newly created `/docs/api_static` directory (similar to the automatically generated `automodapi` stub files in the `api` directory).

This has no affect on our current narrative documentation, but improves the objects detected by `intersphinx` and exposes all package members in the `genindex` and/or `py-modindex` links.

I am also reviewing/adding docstrings to improve readability.