### PR TITLE
Remove xdist from minimal-conda test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,8 +58,8 @@ jobs:
       - linux: py37-numpydev
         name: py37_numpydev
 
-      - linux: py36-minimal-conda
-        name: py36_minimal_conda
+      - linux: py36-minimal
+        name: py36_minimal
         libraries: {}
 
       - linux: py36-minimal-pypi-import

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ changedir = tmp
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs -n=auto --dist=loadfile --ignore={toxinidir}/docs/conf.py
+    PYTEST_COMMAND = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs --ignore={toxinidir}/docs/conf.py
 extras = all,tests
 deps =
     numpydev: git+https://github.com/numpy/numpy
@@ -66,7 +66,6 @@ extras =
 deps =
   lmfit==1.0.1
   pytest-cov
-  pytest-xdist
 conda_deps =
   numpy=1.18.1
   scipy=1.2
@@ -77,6 +76,8 @@ conda_deps =
   pytest=5.1
   mpmath=1.0
   pillow
+setenv =
+  PYTEST_COMMAND = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs --ignore={toxinidir}/docs/conf.py
 commands = {env:PYTEST_COMMAND} {posargs}
 
 [testenv:py36-minimal-pypi-import]

--- a/tox.ini
+++ b/tox.ini
@@ -59,8 +59,8 @@ conda_deps =
   sphinx_rtd_theme
 commands = {env:PYTEST_COMMAND} {posargs}
 
-# This env requires tox-conda and tests minimal versions of each dependency.
-[testenv:py36-minimal-conda]
+# This env tests minimal versions of each dependency.
+[testenv:py36-minimal]
 basepython = python3.6
 extras =
 deps =
@@ -68,7 +68,6 @@ deps =
   pytest-cov
   pytest-xdist
   execnet==1.6
-conda_deps =
   numpy=1.18.1
   scipy=1.2
   astropy=4.0

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     astropydev: git+https://github.com/astropy/astropy
     pytest-cov
     pytest-xdist
+    pytest-pudb
     astropy31: astropy<3.2
 commands = {env:PYTEST_COMMAND} {posargs}
 
@@ -76,9 +77,7 @@ conda_deps =
   pytest=5.1
   mpmath=1.0
   pillow
-setenv =
-  PYTEST_COMMAND = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs --ignore={toxinidir}/docs/conf.py
-commands = {env:PYTEST_COMMAND} {posargs}
+commands = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs --ignore={toxinidir}/docs/conf.py {posargs}
 
 [testenv:py36-minimal-pypi-import]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
   pytest==5.1
   mpmath==1.0
   pillow
-commands = {env:PYTEST_COMMAND}
+commands = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs --ignore={toxinidir}/docs/conf.py
 
 [testenv:py36-minimal-pypi-import]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,6 @@ extras =
 deps =
   lmfit==1.0.1
   pytest-cov
-  pytest-xdist
-  execnet==1.6
   numpy==1.18.1
   scipy==1.2
   astropy==4.0
@@ -77,7 +75,7 @@ deps =
   pytest==5.1
   mpmath==1.0
   pillow
-commands = {env:PYTEST_COMMAND} {posargs}
+commands = {env:PYTEST_COMMAND}
 
 [testenv:py36-minimal-pypi-import]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps =
     astropydev: git+https://github.com/astropy/astropy
     pytest-cov
     pytest-xdist
-    pytest-pudb
     astropy31: astropy<3.2
 commands = {env:PYTEST_COMMAND} {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ conda_deps =
   pytest=5.1
   mpmath=1.0
   pillow
-commands = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs --ignore={toxinidir}/docs/conf.py {posargs}
+commands = {env:PYTEST_COMMAND} {posargs}
 
 [testenv:py36-minimal-pypi-import]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ extras =
 deps =
   lmfit==1.0.1
   pytest-cov
+  pytest-xdist
 conda_deps =
   numpy=1.18.1
   scipy=1.2

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,7 @@ deps =
   lmfit==1.0.1
   pytest-cov
   pytest-xdist
+  execnet==1.6
 conda_deps =
   numpy=1.18.1
   scipy=1.2

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ changedir = tmp
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs --ignore={toxinidir}/docs/conf.py
+    PYTEST_COMMAND = pytest -vvv --pyargs plasmapy --cov=plasmapy --cov-config={toxinidir}/setup.cfg --durations=25 {toxinidir}/docs -n=auto --dist=loadfile --ignore={toxinidir}/docs/conf.py
 extras = all,tests
 deps =
     numpydev: git+https://github.com/numpy/numpy

--- a/tox.ini
+++ b/tox.ini
@@ -68,14 +68,14 @@ deps =
   pytest-cov
   pytest-xdist
   execnet==1.6
-  numpy=1.18.1
-  scipy=1.2
-  astropy=4.0
-  colorama=0.3
-  h5py=2.8
-  matplotlib=2.0
-  pytest=5.1
-  mpmath=1.0
+  numpy==1.18.1
+  scipy==1.2
+  astropy==4.0
+  colorama==0.3
+  h5py==2.8
+  matplotlib==2.0
+  pytest==5.1
+  mpmath==1.0
   pillow
 commands = {env:PYTEST_COMMAND} {posargs}
 


### PR DESCRIPTION
Xdist seems to be breaking the minimal conda test now; I'm temporarily removing it from just that test.


<!--
Thank you for contributing to PlasmaPy! Here's a bunch of pointers to
make things easier for all of us:

* If this PR will solve an issue tracked by GitHub, then please add
  "Closes #42" so the issue automatically closes once this pull request
  is merged.  In this example, issue #42 would have been closed.
  If your PR will not completely solve the issue, then please still reference
  still reference the issue like "issue #42".  (For more info see [GitHub's primer
  on linking issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)

* Remember to add some description of your changes in this text box.

* If your pull request is not yet ready for review - either because
  you're just looking for feedback on a change or because you're not
  perfectly satisfied with your change - submit it as a draft pull request.
  Remember to change its' status once it's ready.

* If this is your first contribution, please add your name to the author
  list in `docs/about/credits.rst`.

* Feel free to chat with other developers on our Matrix channel at:
   https://riot.im/app/#/room/#plasmapy:openastronomy.org

* We have a developer's guide to help answer some of your questions.
  http://docs.plasmapy.org/en/latest/development/index.html

Many thanks in advance for following these pointers and for being willing to contribute!

When submitting a pull request, please ensure that you can (eventually,
sometime before it is merged) check the following basic requirements:

-->

- [ ] I have added a changelog entry for this pull request.

<!--

In short: A changelog entry is a short description of your PR's changes.
Each entry is written in a `<PULL REQUEST>.<TYPE>.rst` file and stored in
the `changelog` directory,  where `<PULL REQUEST>` is a pull request
number and `<TYPE>` is one of:

* `breaking`: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
* `feature`: New user facing features and any new behavior.
* `bugfix`: Fixes a reported bug.
* `doc`: Documentation addition or improvement, like rewording an entire session or adding missing docs.
* `removal`: Feature deprecation and/or feature removal.
* `trivial`: A change which has no user facing effect or is tiny change.

A PR number is generated after you successfully submit a new PR, so the changelog
file can only be added after you open the PR.```

For more information, see:
https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst

--->

- [ ] If adding new functionality, I have added tests and
      docstrings.

<!--
(Tests pop up at the bottom, in the checks box.)
-->

- [ ] I have fixed any newly failing tests.

<!--
(If you're unsure why they're failing, ask!)
-->