### PR TITLE
[RTD build repair] set dependency pygments >= 2.4.1

### DIFF
--- a/changelog/898.feature.rst
+++ b/changelog/898.feature.rst
@@ -1,0 +1,1 @@
+Add dependency `pygments >= 2.4.1`.

--- a/requirements/automated-documentation-tests.txt
+++ b/requirements/automated-documentation-tests.txt
@@ -5,6 +5,7 @@ nbsphinx
 
 numpydoc
 pillow
+pygments >= 2.4.1
 pytest
 setuptools-scm
 sphinx <= 2.4.4

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -19,6 +19,7 @@ dependencies:
     - numpydoc
     - pytest
     - lmfit
+    - pygments>=2.4.1
     - sphinx>2
     - sphinx-gallery
     - sphinx-automodapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ theory =
 docs =
   numpydoc
   pillow
+  pygments>=2.4.1
   sphinx<=2.4.4
   sphinx-automodapi
   sphinx-gallery


### PR DESCRIPTION
`nbconvert` recently (9/10/2020) released `v6.0.0` which puts a dependency on `pygments` of `2.4.1 <= pygments < 3.0.0`.  However, RTD was still installing `pygments==2.3.1`.  This PR places a `pygments >= 2.4.1` dependency on our pkg.