### PR TITLE
Formatting fixes such as for when multiple strings are on one line

### DIFF
--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests for Langmuir probe analysis functions."""
 
 import astropy.constants.si as const
@@ -53,7 +52,7 @@ class Test__fitting_functions:
 
     def test_fit_func_double_lin_inverse(self):
         r"""Test double linear fitting function with inverse slope and an offset
-            for use in fitting a bi-Maxwellian electron current growth region"""
+        for use in fitting a bi-Maxwellian electron current growth region"""
 
         value = langmuir._fit_func_double_lin_inverse(
             self.x, self.x0, self.y0, self.T0, self.Delta_T
@@ -119,7 +118,7 @@ class Test__characteristic_errors:
 
         ab_sum = a + b
 
-        errStr = f"Addition of characteristic objects is not behaving as it " f"should."
+        errStr = f"Addition of characteristic objects is not behaving as it should."
         assert (a.current + b.current == ab_sum.current).all(), errStr
 
     def test_subtraction(self):
@@ -130,9 +129,7 @@ class Test__characteristic_errors:
 
         ab_sub = a - b
 
-        errStr = (
-            f"Subtraction of characteristic objects is not behaving as " f"it should."
-        )
+        errStr = f"Subtraction of characteristic objects is not behaving as it should."
         assert (a.current - b.current == ab_sub.current).all(), errStr
 
 
@@ -296,7 +293,7 @@ class Test__swept_probe_analysis:
             bimaxwellian=bimaxwellian,
         )
 
-        errStr = f"Analysis should be invariant to the ordering of the " f"input data."
+        errStr = f"Analysis should be invariant to the ordering of the input data."
         for key in sim_result:
             assert (sim_result[key] == sim_result_shuffled[key]).all(), errStr
 

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -202,7 +202,7 @@ def test_collective_spectrum():
 
     # Check that alpha is correct
     assert np.isclose(alpha.value, 1.801, atol=0.01), (
-        "Collective case alpha " f"returns {alpha} instead of " "expected 1.801"
+        "Collective case alpha returns {alpha} instead of " "expected 1.801"
     )
 
     i_width = width_at_value(wavelength.value, Skw.value, 2e-13)
@@ -230,7 +230,7 @@ def test_non_collective_spectrum():
 
     # Check that alpha is correct
     assert np.isclose(alpha.value, 0.05707, atol=0.01), (
-        "Non-collective case alpha " f"returns {alpha} instead of " "expected 0.05707"
+        "Non-collective case alpha returns {alpha} instead of " "expected 0.05707"
     )
 
     e_width = width_at_value(wavelength.value, Skw.value, 0.2e-13)

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -202,7 +202,7 @@ def test_collective_spectrum():
 
     # Check that alpha is correct
     assert np.isclose(alpha.value, 1.801, atol=0.01), (
-        "Collective case alpha returns {alpha} instead of " "expected 1.801"
+        "Collective case alpha returns {alpha} instead of expected 1.801"
     )
 
     i_width = width_at_value(wavelength.value, Skw.value, 2e-13)
@@ -230,7 +230,7 @@ def test_non_collective_spectrum():
 
     # Check that alpha is correct
     assert np.isclose(alpha.value, 0.05707, atol=0.01), (
-        "Non-collective case alpha returns {alpha} instead of " "expected 0.05707"
+        "Non-collective case alpha returns {alpha} instead of expected 0.05707"
     )
 
     e_width = width_at_value(wavelength.value, Skw.value, 0.2e-13)

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -201,9 +201,9 @@ def test_collective_spectrum():
     alpha, wavelength, Skw = gen_collective_spectrum()
 
     # Check that alpha is correct
-    assert np.isclose(alpha.value, 1.801, atol=0.01), (
-        "Collective case alpha returns {alpha} instead of expected 1.801"
-    )
+    assert np.isclose(
+        alpha.value, 1.801, atol=0.01
+    ), "Collective case alpha returns {alpha} instead of expected 1.801"
 
     i_width = width_at_value(wavelength.value, Skw.value, 2e-13)
     e_width = width_at_value(wavelength.value, Skw.value, 0.2e-13)
@@ -229,9 +229,9 @@ def test_non_collective_spectrum():
     alpha, wavelength, Skw = gen_non_collective_spectrum()
 
     # Check that alpha is correct
-    assert np.isclose(alpha.value, 0.05707, atol=0.01), (
-        "Non-collective case alpha returns {alpha} instead of expected 0.05707"
-    )
+    assert np.isclose(
+        alpha.value, 0.05707, atol=0.01
+    ), "Non-collective case alpha returns {alpha} instead of expected 0.05707"
 
     e_width = width_at_value(wavelength.value, Skw.value, 0.2e-13)
 

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -189,7 +189,7 @@ def spectral_density(
         Te = np.repeat(Te, len(efract))
     elif Te.size != len(efract):
         raise ValueError(
-            f"Got {Te.size} electron temperatures and expected " f"{len(efract)}."
+            f"Got {Te.size} electron temperatures and expected {len(efract)}."
         )
 
     # Condition Ti
@@ -199,7 +199,7 @@ def spectral_density(
         Ti = [Ti.value] * len(ion_species) * Ti.unit
     elif Ti.size != len(ion_species):
         raise ValueError(
-            f"Got {Ti.size} ion temperatures and expected " f"{len(ion_species)}."
+            f"Got {Ti.size} ion temperatures and expected {len(ion_species)}."
         )
 
     # Make sure the sizes of ion_species, ifract, ion_vel, and Ti all match

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -336,9 +336,7 @@ class ClassicalTransport:
         valid_fields = ["parallel", "par", "perpendicular", "perp", "cross", "all"]
         is_valid_field = self.field_orientation in valid_fields
         if not is_valid_field:
-            raise ValueError(
-                f"Unknown field orientation " f"'{self.field_orientation}'"
-            )
+            raise ValueError(f"Unknown field orientation '{self.field_orientation}'")
 
         # values and units have already been checked by decorator
         self.T_e = T_e
@@ -352,7 +350,7 @@ class ClassicalTransport:
                 self.m_i = particles.particle_mass(ion)
             except Exception:
                 raise ValueError(
-                    f"Unable to find mass of particle: " f"{ion} in ClassicalTransport"
+                    f"Unable to find mass of particle: {ion} in ClassicalTransport"
                 )
         else:
             self.m_i = m_i

--- a/plasmapy/formulary/magnetostatics.py
+++ b/plasmapy/formulary/magnetostatics.py
@@ -228,14 +228,16 @@ class FiniteStraightWire(Wire):
         self._current_u = current.unit
 
     def __repr__(self):
-        return "{name}(p1={p1}{p1_u}, p2={p2}{p2_u}, current={current}{current_u})".format(
-            name=self.__class__.__name__,
-            p1=self.p1,
-            p2=self.p2,
-            current=self.current,
-            p1_u=self._p1_u,
-            p2_u=self._p2_u,
-            current_u=self._current_u,
+        return (
+            "{name}(p1={p1}{p1_u}, p2={p2}{p2_u}, current={current}{current_u})".format(
+                name=self.__class__.__name__,
+                p1=self.p1,
+                p2=self.p2,
+                current=self.current,
+                p1_u=self._p1_u,
+                p2_u=self._p2_u,
+                current_u=self._current_u,
+            )
         )
 
     def magnetic_field(self, p) -> u.T:

--- a/plasmapy/formulary/magnetostatics.py
+++ b/plasmapy/formulary/magnetostatics.py
@@ -233,7 +233,7 @@ class FiniteStraightWire(Wire):
         p2 = self.p2
         current = self.current
         p1_u = self._p1_u
-        p2_2 = self._p2_u
+        p2_u = self._p2_u
         current_u = self._current_u
         return f"{name}(p1={p1}{p1_u}, p2={p2}{p2_u}, current={current}{current_u})"
 

--- a/plasmapy/formulary/magnetostatics.py
+++ b/plasmapy/formulary/magnetostatics.py
@@ -228,17 +228,14 @@ class FiniteStraightWire(Wire):
         self._current_u = current.unit
 
     def __repr__(self):
-        return (
-            "{name}(p1={p1}{p1_u}, p2={p2}{p2_u}, current={current}{current_u})".format(
-                name=self.__class__.__name__,
-                p1=self.p1,
-                p2=self.p2,
-                current=self.current,
-                p1_u=self._p1_u,
-                p2_u=self._p2_u,
-                current_u=self._current_u,
-            )
-        )
+        name = self.__class__.__name__
+        p1 = self.p1
+        p2 = self.p2
+        current = self.current
+        p1_u = self._p1_u
+        p2_2 = self._p2_u
+        current_u = self._current_u
+        return f"{name}(p1={p1}{p1_u}, p2={p2}{p2_u}, current={current}{current_u})"
 
     def magnetic_field(self, p) -> u.T:
         r"""

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -694,7 +694,7 @@ class Test_impact_parameter:
         bmin, bmax = methodVal
         methodVal = bmin.si.value, bmax.si.value
         testTrue = np.allclose(self.True1, methodVal, rtol=1e-1, atol=0.0)
-        errStr = f"Impact parameters should be {self.True1} and " f"not {methodVal}."
+        errStr = f"Impact parameters should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):
@@ -797,7 +797,7 @@ class Test_collision_frequency:
                 method="classical",
             )
         testTrue = np.isclose(self.True1, methodVal.si.value, rtol=1e-1, atol=0.0)
-        errStr = f"Collision frequency should be {self.True1} and " f"not {methodVal}."
+        errStr = f"Collision frequency should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):
@@ -896,9 +896,7 @@ class Test_collision_frequency:
                 method="classical",
             )
         testTrue = np.isclose(self.True_zmean, methodVal.si.value, rtol=1e-1, atol=0.0)
-        errStr = (
-            f"Collision frequency should be {self.True_zmean} and " f"not {methodVal}."
-        )
+        errStr = f"Collision frequency should be {self.True_zmean} and not {methodVal}."
         assert testTrue, errStr
 
 
@@ -971,7 +969,7 @@ class Test_mean_free_path:
                 method="classical",
             )
         testTrue = np.isclose(self.True1, methodVal.si.value, rtol=1e-1, atol=0.0)
-        errStr = f"Mean free path should be {self.True1} and " f"not {methodVal}."
+        errStr = f"Mean free path should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):
@@ -1033,7 +1031,7 @@ class Test_Spitzer_resistivity:
             method="classical",
         )
         testTrue = np.isclose(self.True1, methodVal.si.value, rtol=1e-1, atol=0.0)
-        errStr = f"Spitzer resistivity should be {self.True1} and " f"not {methodVal}."
+        errStr = f"Spitzer resistivity should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):
@@ -1068,9 +1066,7 @@ class Test_Spitzer_resistivity:
             method="classical",
         )
         testTrue = np.isclose(self.True_zmean, methodVal.si.value, rtol=1e-1, atol=0.0)
-        errStr = (
-            f"Spitzer resistivity should be {self.True_zmean} and " f"not {methodVal}."
-        )
+        errStr = f"Spitzer resistivity should be {self.True_zmean} and not {methodVal}."
         assert testTrue, errStr
 
     # TODO vector z_mean
@@ -1115,7 +1111,7 @@ class Test_mobility:
                 method="classical",
             )
         testTrue = np.isclose(self.True1, methodVal.si.value, rtol=1e-1, atol=0.0)
-        errStr = f"Mobility should be {self.True1} and " f"not {methodVal}."
+        errStr = f"Mobility should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):
@@ -1152,7 +1148,7 @@ class Test_mobility:
                 method="classical",
             )
         testTrue = np.isclose(self.True_zmean, methodVal.si.value, rtol=1e-1, atol=0.0)
-        errStr = f"Mobility should be {self.True_zmean} and " f"not {methodVal}."
+        errStr = f"Mobility should be {self.True_zmean} and not {methodVal}."
         assert testTrue, errStr
 
     # TODO vector z_mean
@@ -1198,7 +1194,7 @@ class Test_Knudsen_number:
                 method="classical",
             )
         testTrue = np.isclose(self.True1, methodVal, rtol=1e-1, atol=0.0)
-        errStr = f"Knudsen number should be {self.True1} and " f"not {methodVal}."
+        errStr = f"Knudsen number should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):
@@ -1262,7 +1258,7 @@ class Test_coupling_parameter:
             method="classical",
         )
         testTrue = np.isclose(self.True1, methodVal, rtol=1e-1, atol=0.0)
-        errStr = f"Coupling parameter should be {self.True1} and " f"not {methodVal}."
+        errStr = f"Coupling parameter should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):
@@ -1299,9 +1295,7 @@ class Test_coupling_parameter:
             method="classical",
         )
         testTrue = np.isclose(self.True_zmean, methodVal, rtol=1e-1, atol=0.0)
-        errStr = (
-            f"Coupling parameter should be {self.True_zmean} and " f"not {methodVal}."
-        )
+        errStr = f"Coupling parameter should be {self.True_zmean} and not {methodVal}."
         assert testTrue, errStr
 
     # TODO vector z_mean
@@ -1327,7 +1321,7 @@ class Test_coupling_parameter:
         )
         testTrue = np.isclose(self.True_quantum, methodVal, rtol=1e-1, atol=0.0)
         errStr = (
-            f"Coupling parameter should be {self.True_quantum} and " f"not {methodVal}."
+            f"Coupling parameter should be {self.True_quantum} and not {methodVal}."
         )
         assert testTrue, errStr
 

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -1,5 +1,5 @@
 """Tests for functions that calculate plasma dielectric parameters in
-dielectry.py"""
+dielectric.py"""
 
 import numpy as np
 
@@ -134,7 +134,7 @@ class Test_permittivity_1D_Maxwellian:
             self.omega, self.kWave, self.T, self.n, self.particle, self.z_mean
         )
         testTrue = np.isclose(methodVal, self.True1, rtol=1e-6, atol=0.0)
-        errStr = f"Permittivity value should be {self.True1} and not " f"{methodVal}."
+        errStr = f"Permittivity value should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):

--- a/plasmapy/formulary/tests/test_distribution.py
+++ b/plasmapy/formulary/tests/test_distribution.py
@@ -81,9 +81,7 @@ class Test_Maxwellian_1D(object):
         # value returned from quad is (integral, error), we just need
         # the 1st
         integVal = integ[0]
-        exceptStr = (
-            "Integral of distribution function should be 1 " f"and not {integVal}."
-        )
+        exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_std(self):
@@ -197,7 +195,7 @@ class Test_Maxwellian_1D(object):
             v_drift=self.v_drift3,
             units="units",
         )
-        errStr = f"Distribution function should be {testVal} " f"and not {distFunc}."
+        errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
 
@@ -325,7 +323,7 @@ class Test_Maxwellian_speed_1D(object):
             v_drift=self.v_drift2,
             units="units",
         )
-        errStr = f"Distribution function should be 0.0 " f"and not {distFunc}."
+        errStr = f"Distribution function should be 0.0 and not {distFunc}."
         assert np.isclose(
             distFunc.value, self.distFuncDrift.value, rtol=1e-5, atol=0.0
         ), errStr
@@ -370,9 +368,7 @@ class Test_Maxwellian_velocity_2D(object):
         # value returned from dblquad is (integral, error), we just need
         # the 1st
         integVal = integ[0]
-        exceptStr = (
-            "Integral of distribution function should be 1 " f"and not {integVal}."
-        )
+        exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_units_no_vTh(self):
@@ -487,7 +483,7 @@ class Test_Maxwellian_velocity_2D(object):
             vy_drift=self.vy_drift2,
             units="units",
         )
-        errStr = f"Distribution function should be {testVal} " f"and not {distFunc}."
+        errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
 
@@ -669,9 +665,7 @@ class Test_Maxwellian_velocity_3D(object):
         # value returned from tplquad is (integral, error), we just need
         # the 1st
         integVal = integ[0]
-        exceptStr = (
-            "Integral of distribution function should be 1 " f"and not {integVal}."
-        )
+        exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_units_no_vTh(self):
@@ -798,7 +792,7 @@ class Test_Maxwellian_velocity_3D(object):
             vz_drift=self.vz_drift2,
             units="units",
         )
-        errStr = f"Distribution function should be {testVal} " f"and not {distFunc}."
+        errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
 
@@ -1029,9 +1023,7 @@ class Test_kappa_velocity_1D(object):
         # value returned from quad is (integral, error), we just need
         # the 1st
         integVal = integ[0]
-        exceptStr = (
-            "Integral of distribution function should be 1 " f"and not {integVal}."
-        )
+        exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_std(self):
@@ -1163,7 +1155,7 @@ class Test_kappa_velocity_1D(object):
             v_drift=self.v_drift3,
             units="units",
         )
-        errStr = f"Distribution function should be {testVal} " f"and not {distFunc}."
+        errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
 
@@ -1264,9 +1256,7 @@ class Test_kappa_velocity_3D(object):
         # value returned from tplquad is (integral, error), we just need
         # the 1st
         integVal = integ[0]
-        exceptStr = (
-            "Integral of distribution function should be 1 " f"and not {integVal}."
-        )
+        exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_units_no_vTh(self):
@@ -1399,5 +1389,5 @@ class Test_kappa_velocity_3D(object):
             vz_drift=self.vz_drift2,
             units="units",
         )
-        errStr = f"Distribution function should be {testVal} " f"and not {distFunc}."
+        errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -221,8 +221,7 @@ def test_ion_sound_speed():
 
     # Test that function call without keyword argument works correctly
     assert np.isclose(
-        ion_sound_speed(1.831 * u.MK, 1.3232 * u.MK, "p").value,
-        218816.06086407552,
+        ion_sound_speed(1.831 * u.MK, 1.3232 * u.MK, "p").value, 218816.06086407552,
     )
 
     assert np.isclose(

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -221,7 +221,8 @@ def test_ion_sound_speed():
 
     # Test that function call without keyword argument works correctly
     assert np.isclose(
-        ion_sound_speed(1.831 * u.MK, 1.3232 * u.MK, "p").value, 218816.06086407552,
+        ion_sound_speed(1.831 * u.MK, 1.3232 * u.MK, "p").value,
+        218816.06086407552,
     )
 
     assert np.isclose(

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -105,7 +105,7 @@ def test_Fermi_energy():
     energy_F_true = 1.2586761116196002e-18
     # test a simple case for expected value
     expectStr = (
-        "Fermi energy at 1e23 cm^-3 should be " f"{energy_F_true} and not {energy_F}."
+        "Fermi energy at 1e23 cm^-3 should be {energy_F_true} and not {energy_F}."
     )
     assert np.isclose(energy_F.value, energy_F_true, rtol=1e-5, atol=0.0), expectStr
     # testing returned units
@@ -145,9 +145,7 @@ def test_Wigner_Seitz_radius():
     radiusTrue = 1.3365046175719772e-10 * u.m
     radiusMeth = Wigner_Seitz_radius(n_e)
     testTrue = u.isclose(radiusMeth, radiusTrue, rtol=1e-5)
-    errStr = (
-        f"Error in Wigner_Seitz_radius(), got {radiusMeth}, " f"should be {radiusTrue}"
-    )
+    errStr = f"Error in Wigner_Seitz_radius(), got {radiusMeth}, should be {radiusTrue}"
     assert testTrue, errStr
 
 
@@ -169,9 +167,7 @@ class Test_chemical_potential:
         """
         methodVal = chemical_potential(self.n_e, self.T)
         testTrue = u.isclose(methodVal, self.True1, rtol=1e-16, atol=0.0)
-        errStr = (
-            f"Chemical potential value should be {self.True1} and not " f"{methodVal}."
-        )
+        errStr = f"Chemical potential value should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     @pytest.mark.xfail(
@@ -209,9 +205,7 @@ class Test__chemical_potential_interp:
         """
         methodVal = _chemical_potential_interp(self.n_e, self.T)
         testTrue = u.isclose(methodVal, self.True1, rtol=1e-16, atol=0.0)
-        errStr = (
-            f"Chemical potential value should be {self.True1} and not " f"{methodVal}."
-        )
+        errStr = f"Chemical potential value should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     @pytest.mark.xfail(

--- a/plasmapy/formulary/tests/test_transport.py
+++ b/plasmapy/formulary/tests/test_transport.py
@@ -319,10 +319,10 @@ class Test_classical_transport:
                 ct2.V_ei,
             )
             testTrue = hall_i == ct2.hall_i
-            errStr = f"Ion hall parameter should be {hall_i} " f"and not {ct2.hall_i}."
+            errStr = f"Ion hall parameter should be {hall_i} and not {ct2.hall_i}."
         assert testTrue, errStr
         testTrue = hall_e == ct2.hall_e
-        errStr = f"Electron hall parameter should be {hall_e} " f"and not {ct2.hall_e}."
+        errStr = f"Electron hall parameter should be {hall_e} and not {ct2.hall_e}."
         assert testTrue, errStr
 
     def test_invalid_model(self):
@@ -604,7 +604,7 @@ class Test_classical_transport:
         calculated = self.all_variables[key]
         testTrue = np.allclose(expected, calculated.si.value)
         errStr = (
-            f"Expected values of {key} are {expected} and not" f"{calculated.si.value}."
+            f"Expected values of {key} are {expected} and not{calculated.si.value}."
         )
         assert testTrue, errStr
 
@@ -1075,7 +1075,7 @@ def test__nondim_tc_e_ji_held(hall, Z, field_orientation, expected):
     kappa_hat = _nondim_tc_e_ji_held(hall, Z, field_orientation)
     kappa_check = expected
     testTrue = np.isclose(kappa_hat, kappa_check, rtol=2e-2)
-    errStr = f"Kappa hat from ji-held should be {kappa_check} " f"and not {kappa_hat}."
+    errStr = f"Kappa hat from ji-held should be {kappa_check} and not {kappa_hat}."
     assert testTrue, errStr
 
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -66,7 +66,7 @@ def _category_errmsg(particle, require, exclude, any_of, funcname) -> str:
     for condition, phrase in errmsg_table:
         if condition:
             category_errmsg += (
-                f"The particle {phrase} of the following categories: " f"{condition}. "
+                f"The particle {phrase} of the following categories: {condition}. "
             )
 
     return category_errmsg

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -291,7 +291,7 @@ def _parse_and_check_atomic_input(
                 mass_numb = int(mass_numb_str)
             except ValueError:
                 raise InvalidParticleError(
-                    f"Invalid mass number in isotope string " f"'{isotope_info}'."
+                    f"Invalid mass number in isotope string '{isotope_info}'."
                 ) from None
 
         return element_info, mass_numb

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -362,7 +362,7 @@ atomic_warnings_table = [
 @pytest.mark.parametrize("arg, kwargs, num_warnings", atomic_warnings_table)
 def test_parse_AtomicWarnings(arg, kwargs, num_warnings):
     r"""Tests that _parse_and_check_atomic_input issues an AtomicWarning
-    under the required conditions.  """
+    under the required conditions."""
 
     with pytest.warns(AtomicWarning) as record:
         _parse_and_check_atomic_input(arg, **kwargs)

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -835,9 +835,9 @@ def test_particleing_a_particle(arg):
     """
     particle = Particle(arg)
 
-    assert particle == Particle(particle), (
-        f"Particle({repr(arg)}) does not equal " f"Particle(Particle({repr(arg)})."
-    )
+    assert particle == Particle(
+        particle
+    ), f"Particle({repr(arg)}) does not equal Particle(Particle({repr(arg)})."
 
     assert particle == Particle(Particle(Particle(particle))), (
         f"Particle({repr(arg)}) does not equal "
@@ -1201,7 +1201,7 @@ def test_particles_from_json_string(cls, kwargs, json_string, expected_exception
         expected_particle = instance.particle
         actual_particle = instance_from_json.particle
         assert expected_particle == actual_particle, pytest.fail(
-            f"Expected {expected_particle}\n" f"Got {actual_particle}"
+            f"Expected {expected_particle}\nGot {actual_particle}"
         )
     else:
         with pytest.raises(expected_exception):
@@ -1225,7 +1225,7 @@ def test_particles_from_json_file(cls, kwargs, json_string, expected_exception):
         expected_particle = instance.particle
         actual_particle = instance_from_json.particle
         assert expected_particle == actual_particle, pytest.fail(
-            f"Expected {expected_particle}\n" f"Got {actual_particle}"
+            f"Expected {expected_particle}\nGot {actual_particle}"
         )
     else:
         with pytest.raises(expected_exception):

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -111,17 +111,17 @@ class PlasmaBlob(GenericPlasma):
         if quantum_theta <= 0.01:
             # Fermi energy dominant
             quantum_theta_str = (
-                f"Fermi quantum energy dominant: Theta = " f"{quantum_theta}"
+                f"Fermi quantum energy dominant: Theta = {quantum_theta}"
             )
         elif quantum_theta >= 100:
             # thermal kinetic energy dominant
             quantum_theta_str = (
-                f"Thermal kinetic energy dominant: Theta = " f"{quantum_theta}"
+                f"Thermal kinetic energy dominant: Theta = {quantum_theta}"
             )
         else:
             # intermediate regime
             quantum_theta_str = (
-                f"Both Fermi and thermal energy important: " f"Theta = {quantum_theta}"
+                f"Both Fermi and thermal energy important: Theta = {quantum_theta}"
             )
 
         # summarizing and printing/returning regimes

--- a/plasmapy/plasma/sources/tests/test_plasmablob.py
+++ b/plasmapy/plasma/sources/tests/test_plasmablob.py
@@ -113,8 +113,7 @@ def test_Plasma3D_derived_vars():
 
 @pytest.mark.slow
 def test_Plasma3D_add_magnetostatics():
-    r"""Function to test add_magnetostatic function
-    """
+    r"""Function to test add_magnetostatic function"""
     dipole = magnetostatics.MagneticDipole(
         np.array([0, 0, 1]) * u.A * u.m * u.m, np.array([0, 0, 0]) * u.m
     )

--- a/plasmapy/simulation/tests/test_particletracker.py
+++ b/plasmapy/simulation/tests/test_particletracker.py
@@ -104,13 +104,13 @@ def fit_sine_curve(position, t, expected_gyrofrequency, phase=0):
 @pytest.mark.slow
 def test_particle_exb_drift(uniform_magnetic_field):
     r"""
-        Tests the particle stepper for a field with magnetic field in the Z
-        direction, electric field in the y direction. This should produce a
-        drift in the negative X direction, with the drift velocity
+    Tests the particle stepper for a field with magnetic field in the Z
+    direction, electric field in the y direction. This should produce a
+    drift in the negative X direction, with the drift velocity
 
-        v_e = ExB / B^2
+    v_e = ExB / B^2
 
-        which is independent of ion charge.
+    which is independent of ion charge.
     """
     test_plasma = uniform_magnetic_field
     test_plasma.electric_field[1] = 1 * u.V / u.m

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -99,7 +99,7 @@ class BasicRegistrationFactory:
         ] + additional_validation_functions
 
     def __call__(self, *args, **kwargs):
-        """ Method for running the factory.
+        """Method for running the factory.
 
         Arguments args and kwargs are passed through to the validation
         function and to the constructor for the final type.
@@ -142,7 +142,7 @@ class BasicRegistrationFactory:
         return WidgetType(*args, **kwargs)
 
     def register(self, WidgetType, validation_function=None, is_default=False):
-        """ Register a widget with the factory.
+        """Register a widget with the factory.
 
         If `validation_function` is not specified, tests `WidgetType` for
         existence of any function in in the list `self.validation_functions`,


### PR DESCRIPTION
We use [black](https://black.readthedocs.io/en/stable/) as a code formatter.  One of black's idiosyncrasies is that it sometimes puts multiple strings on one line if they'll both fit.  This PR mostly includes formatting fixes, such as the change below:
```Python
        f"Unknown field orientation " f"'{self.field_orientation}'"   # two strings
        f"Unknown field orientation '{self.field_orientation}'"  # replace with one string
 ```
I'm skipping `ionization_state.py`, etc. because I'm doing these fixes in #796 for those files.