### PR TITLE
Added more description to hall_parameter signature in parameters.py

### DIFF
--- a/changelog/934.doc.rst
+++ b/changelog/934.doc.rst
@@ -1,1 +1,2 @@
-Added description to Hall_parameter signature and equation in docstrings.
+Added description to :func:`~plasmapy.formulary.parameters.Hall_parameter`
+signature and equation in docstrings.

--- a/changelog/934.doc.rst
+++ b/changelog/934.doc.rst
@@ -1,0 +1,1 @@
+Added description to Hall_parameter signature and equation in docstrings.

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -816,7 +816,7 @@ def Hall_parameter(
     B : `~astropy.units.quantity.Quantity`
         The magnetic field.
     ion : `~plasmapy.particles.Particle`
-        The type of ion ``particle`` is colliding.
+        The type of ion ``particle`` is colliding with.
     particle : `~plasmapy.particles.Particle`
         The particle species for which the Hall parameter is calculated for.
         Representation of the particle species (e.g., 'p' for protons, 'D+' for

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -819,10 +819,10 @@ def Hall_parameter(
         The type of ion ``particle`` is colliding with.
     particle : `~plasmapy.particles.Particle`
         The particle species for which the Hall parameter is calculated for.
-        Representation of the particle species (e.g., 'p' for protons, 'D+' for
-        deuterium, or 'He-4 +1' for singly ionized helium-4). If no charge state
-        information is provided, then the particles are assumed to be singly
-        charged.
+        Representation of the particle species (e.g., ``'p'`` for protons,
+        ``'D+'`` for deuterium, or ``'He-4 +1'`` for singly ionized helium-4).
+        If no charge state information is provided, then the particles are
+        assumed to be singly charged.
     coulomb_log : `float`, optional
         Preset value for the Coulomb logarithm. Used mostly for testing purposes.
     V : `~astropy.units.quantity.Quantity`

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -809,8 +809,8 @@ def Hall_parameter(
     ion : ~plasmapy.particles.Particle
         The type of ion ``particle`` is colliding with in the ionized gas.
     particle : ~plasmapy.particles.Particle
-        The charged particle species of interest in plasma.Representation of the
-        particle species (e.g., 'p' for protons, 'D+'for deuterium, or 'He-4 +1'
+        The charged particle species of interest in the plasma. Representation of the
+        particle species (e.g., 'p' for protons, 'D+' for deuterium, or 'He-4 +1'
         for singly ionized helium-4). If no charge state information is provided,
         then the particles are assumed to be singly charged.
     coulomb_log : float, optional

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -791,58 +791,69 @@ def Hall_parameter(
     V=None,
     coulomb_log_method="classical",
 ):
-    r"""Calculate the ratio between the particle gyrofrequency and the
-    particle-ion particle collision rate.
+    r"""
+    Calculate the ``particle`` Hall parameter for a plasma.
 
-    All parameters apply to `particle`.
+    The Hall parameter for plasma species :math:`s` (``particle``) is given by:
+
+    .. math::
+
+        \beta_{s} = \frac{\Omega_{c s}}{\nu_{s s^{\prime}}}
+
+    where :math:`\Omega_{c s}` is the gyrofrequncy for plasma species :math:`s`
+    (``particle``) and :math:`\nu_{s s^{\prime}}` is the collison frequency
+    between plasma species :math:`s` (``particle``) and species
+    :math:`s^{\prime}` (``ion``).
 
     **Aliases:** `betaH_`
 
     Parameters
     ----------
-    n : ~astropy.units.quantity.Quantity
-        The density of charged particle species s
-    T : ~astropy.units.quantity.Quantity
-        The temperature of particles
-    B : ~astropy.units.quantity.Quantity
-        The magnetic field
-    ion : ~plasmapy.particles.Particle
-        The type of ion ``particle`` is colliding with in the ionized gas.
-    particle : ~plasmapy.particles.Particle
-        The charged particle species of interest in the plasma. Representation of the
-        particle species (e.g., 'p' for protons, 'D+' for deuterium, or 'He-4 +1'
-        for singly ionized helium-4). If no charge state information is provided,
-        then the particles are assumed to be singly charged.
-    coulomb_log : float, optional
+    n : `~astropy.units.quantity.Quantity`
+        The number density associated with ``particle``.
+    T : `~astropy.units.quantity.Quantity`
+        The temperature of associated with ``particle``.
+    B : `~astropy.units.quantity.Quantity`
+        The magnetic field.
+    ion : `~plasmapy.particles.Particle`
+        The type of ion ``particle`` is colliding.
+    particle : `~plasmapy.particles.Particle`
+        The particle species for which the Hall parameter is calculated for.
+        Representation of the particle species (e.g., 'p' for protons, 'D+' for
+        deuterium, or 'He-4 +1' for singly ionized helium-4). If no charge state
+        information is provided, then the particles are assumed to be singly
+        charged.
+    coulomb_log : `float`, optional
         Preset value for the Coulomb logarithm. Used mostly for testing purposes.
-    V : ~astropy.units.quantity.Quantity
-        The relative velocity between `particle` and ion particles.
-    coulomb_log_method : str, optional
-        Method used for Coulomb logarithm calculation. Refer to its documentation.
+    V : `~astropy.units.quantity.Quantity`
+        The relative velocity between ``particle`` and ``ion``.  If not provided,
+        then the ``particle`` thermal velocity is assumed
+        (`~plasmapy.formulary.parameters.thermal_speed`).
+    coulomb_log_method : `str`, optional
+        Method used for Coulomb logarithm calculation. (see
+        `~plasmapy.formulary.collisions.Coulomb_logarithm`)
 
     See Also
     --------
     plasmapy.formulary.parameters.gyrofrequency
-    plasmapy.formulary.parameters.fundamental_electron_collision_freq
+    plasmapy.formulary.collisions.fundamental_electron_collision_freq
+    plasmapy.formulary.collisions.fundamental_ion_collision_freq
     plasmapy.formulary.collisions.Coulomb_logarithm
 
     Returns
     -------
-    astropy.units.quantity.Quantity
+    `~astropy.units.quantity.Quantity`
+        Hall parameter for ``particle``.
 
     Notes
     -----
-    The Hall Parameter is the ratio between the gyrofrequency and the ion-particle
-    collision rate (also known as collision frequency).
-
-    .. math::
-        \beta = \frac{\omega_c}{\nu}
-
-    where :math:`\omega_c` is the particle's gyrofrequency and :math:`\nu` is
-    the collision frequency between ``particle`` and ``ion``.
-
-    The collision frequencies are calculated assuming a slowly moving
-    Maxwellian distribution.
+    * For calculating the collision frequency,
+      `~plamsapy.formulary.colisions.fundamental_electron_collision_freq` is used
+      when ``particle`` is an electron and
+      `~plamsapy.formulary.colisions.fundamental_ion_collision_freq` when
+      ``particle`` is an ion.
+    * The collision frequencies are calculated assuming a slowly moving
+      Maxwellian distribution.
 
     Examples
     --------
@@ -851,7 +862,6 @@ def Hall_parameter(
     <Quantity 7.26446...e+16>
     >>> Hall_parameter(1e10 * u.m**-3, 5.8e3 * u.eV, 2.3 * u.T, 'He-4 +1', 'e-')
     <Quantity 2.11158...e+17>
-
     """
     from plasmapy.formulary.collisions import (
         fundamental_electron_collision_freq,

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -847,7 +847,7 @@ def Hall_parameter(
 
     Notes
     -----
-    * For calculating the collision frequency,
+    * For calculating the collision frequency
       `~plamsapy.formulary.colisions.fundamental_electron_collision_freq` is used
       when ``particle`` is an electron and
       `~plamsapy.formulary.colisions.fundamental_ion_collision_freq` when

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -786,7 +786,7 @@ def Hall_parameter(
     T: u.K,
     B: u.T,
     ion: Particle,
-    charged_particle: Particle,
+    particle: Particle,
     coulomb_log=None,
     V=None,
     coulomb_log_method="classical",
@@ -808,7 +808,7 @@ def Hall_parameter(
         The magnetic field
     ion : ~plasmapy.particles.Particle
         The type of ion ``particle`` is colliding with in the ionized gas.
-    charged_particle : ~plasmapy.particles.Particle
+    particle : ~plasmapy.particles.Particle
         The charged particle species of interest in plasma.Representation of the
         particle species (e.g., 'p' for protons, 'D+'for deuterium, or 'He-4 +1'
         for singly ionized helium-4). If no charge state information is provided,

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -838,6 +838,12 @@ def Hall_parameter(
     .. math::
         \beta = \frac{\omega_c}{\nu}
 
+    where :math:`\omega_c` is the particle's gyrofrequency and :math:`\nu` is
+    the collision frequency between ``particle`` and ``ion``.
+
+    The collision frequencies are calculated assuming a slowly moving
+    Maxwellian distribution.
+
     Examples
     --------
     >>> from astropy import units as u

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -833,7 +833,7 @@ def Hall_parameter(
     Notes
     -----
     The Hall Parameter is the ratio between the gyrofrequency and the ion-particle
-    collision rate(also known as collision frequency)
+    collision rate (also known as collision frequency).
 
     .. math::
         \beta = \frac{\omega_c}{\nu}

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -786,7 +786,7 @@ def Hall_parameter(
     T: u.K,
     B: u.T,
     ion: Particle,
-    particle: Particle,
+    charged_particle: Particle,
     coulomb_log=None,
     V=None,
     coulomb_log_method="classical",
@@ -801,15 +801,18 @@ def Hall_parameter(
     Parameters
     ----------
     n : ~astropy.units.quantity.Quantity
-        The density of particle s
+        The density of charged particle species s
     T : ~astropy.units.quantity.Quantity
         The temperature of particles
     B : ~astropy.units.quantity.Quantity
         The magnetic field
     ion : ~plasmapy.particles.Particle
-        The type of ion ``particle`` is colliding with.
-    particle : ~plasmapy.particles.Particle
-        The particle of interest.
+        The type of ion ``particle`` is colliding with in the ionized gas.
+    charged_particle : ~plasmapy.particles.Particle
+        The charged particle species of interest in plasma.Representation of the
+        particle species (e.g., 'p' for protons, 'D+'for deuterium, or 'He-4 +1'
+        for singly ionized helium-4). If no charge state information is provided,
+        then the particles are assumed to be singly charged.
     coulomb_log : float, optional
         Preset value for the Coulomb logarithm. Used mostly for testing purposes.
     V : ~astropy.units.quantity.Quantity
@@ -826,6 +829,14 @@ def Hall_parameter(
     Returns
     -------
     astropy.units.quantity.Quantity
+
+    Notes
+    -----
+    The Hall Parameter is the ratio between the gyrofrequency and the ion-particle
+    collision rate(also known as collision frequency)
+
+    .. math::
+        \beta = \frac{\omega_c}{\nu}
 
     Examples
     --------


### PR DESCRIPTION
For issue #915 
I have added some docstrings for `hall_parameter`. Copied `particle` docstring from existing docstring of `kappa_thermal_speed`. .Wasn't sure with what to do with `ion` and `particle`. Also added `hall_parameter` equation.