### PR TITLE
[interoperability_tofu] Added tofu_import_error in optional_deps.py

### DIFF
--- a/plasmapy/optional_deps.py
+++ b/plasmapy/optional_deps.py
@@ -82,5 +82,5 @@ lmfit_import_error = _optional_import_error_template(
 tofu_import_error = _optional_import_error_template(
     "tofu",
     "https://tofuproject.github.io/tofu/installation.html",
-    conda_channel='conda-forge',
+    conda_channel="conda-forge",
 )

--- a/plasmapy/optional_deps.py
+++ b/plasmapy/optional_deps.py
@@ -6,6 +6,7 @@ __all__ = [
     "lmfit_import_error",
     "mpl_import_error",
     "mpmath_import_error",
+    "tofu_import_error",
 ]
 
 from typing import Optional
@@ -75,4 +76,11 @@ mpmath_import_error = _optional_import_error_template(
 #: Import error message for `lmfit`.
 lmfit_import_error = _optional_import_error_template(
     "lmfit", "https://lmfit.github.io/lmfit-py/installation.html"
+)
+
+#: Import error message for `tofu`.
+tofu_import_error = _optional_import_error_template(
+    "tofu",
+    "https://tofuproject.github.io/tofu/installation.html",
+    conda_channel='conda-forge',
 )


### PR DESCRIPTION
Motivations:
--------------
* First attempt at contributing to the interoperability between [tofu](https://github.com/ToFuProject/tofu) and [PlasmaPy](https://github.com/PlasmaPy/PlasmaPy), starting with the basics of how PlasmaPy can handle optional affiliated packages
* more a fisrt contact to agree on how I'll contribute than a significant contribution really

Main changes:
----------------
* Feature: Added `tofu_import_error `in optional_deps.py