### PR TITLE
Decorator @modify_docstring

### DIFF
--- a/changelog/943.feature.rst
+++ b/changelog/943.feature.rst
@@ -1,0 +1,2 @@
+Create decorator `~plasmapy.utils.decorators.helpers.modify_docstring`, which allows
+for programmatically prepending and/or appending a docstring.

--- a/plasmapy/utils/decorators/__init__.py
+++ b/plasmapy/utils/decorators/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "check_relativistic",
     "check_values",
     "check_units",
+    "modify_docstring",
     "preserve_signature",
     "validate_quantities",
     "CheckBase",
@@ -23,5 +24,5 @@ from plasmapy.utils.decorators.checks import (
     CheckValues,
 )
 from plasmapy.utils.decorators.converter import angular_freq_to_hz
-from plasmapy.utils.decorators.helpers import preserve_signature
+from plasmapy.utils.decorators.helpers import modify_docstring, preserve_signature
 from plasmapy.utils.decorators.validators import validate_quantities, ValidateQuantities

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -37,9 +37,9 @@ def modify_docstring(func=None, prepend: str = None, append: str = None):
         ...     '''Beautiful'''
         ...     pass
         >>> foo.__original_doc__
-        "Beautiful"
+        'Beautiful'
         >>> foo.__doc__
-        "Hello\\n\\nBeautiful\\n\\nWorld"
+        'Hello\\n\\nBeautiful\\n\\nWorld'
 
     """
 

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -87,6 +87,7 @@ def modify_docstring(func=None, prepend: str = None, append: str = None):
                 f"Expected type str for argument 'append', got {type(append)}."
             )
 
+        # define new docstring
         wrapper.__doc__ = "\n".join(prependlines + doclines + appendlines)
 
         return wrapper

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -7,7 +7,7 @@ import functools
 import inspect
 
 
-def modify_docstring(func=None, prepend=None, append=None):
+def modify_docstring(func=None, prepend: str = None, append: str = None):
     """
     A decorator which programmatically prepends and/or appends the docstring
     of the decorated method/function.  The unmodified/original docstring is

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -32,15 +32,17 @@ def modify_docstring(func=None, prepend: str = None, append: str = None):
     Examples
     --------
 
-    >>> @modify_docstring(prepend='''Hello''', append='''World''')
-    ... def foo():
-    ...     '''Beautiful'''
-    ...     pass
-    >>> foo.__original_doc__
-    'Beautiful'
-    >>> foo.__doc__
-    'Hello\n\nBeautiful\n\nWorld'
+        >>> @modify_docstring(prepend='''Hello''', append='''World''')
+        ... def foo():
+        ...     '''Beautiful'''
+        ...     pass
+        >>> foo.__original_doc__
+        "Beautiful"
+        >>> foo.__doc__
+        "Hello\\n\\nBeautiful\\n\\nWorld"
+
     """
+
     def decorator(f):
         sig = inspect.signature(f)
 

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -1,10 +1,100 @@
 """
 Miscellaneous decorators for various package uses.
 """
-__all__ = ["preserve_signature"]
+__all__ = ["modify_docstring", "preserve_signature"]
 
 import functools
 import inspect
+
+
+def modify_docstring(func=None, prepend=None, append=None):
+    """
+    A decorator which programmatically prepends and/or appends the docstring
+    of the decorated method/function.  The unmodified/original docstring is
+    saved as the ``__original_doc__`` attribute.
+
+    Parameters
+    ----------
+    func: callable
+        The method/function to be decorated
+
+    prepend: `str`
+        The string to be prepended to the ``func``'s docstring.
+
+    append: `str`
+        The string to be appended to the ``func``'s docstring.
+
+    Returns
+    -------
+    callable
+        Wrapped version of the function.
+
+    Examples
+    --------
+
+    >>> @modify_docstring(prepend='''Hello''', append='''World''')
+    ... def foo():
+    ...     '''Beautiful'''
+    ...     pass
+    >>> foo.__original_doc__
+    'Beautiful'
+    >>> foo.__doc__
+    'Hello\n\nBeautiful\n\nWorld'
+    """
+    def decorator(f):
+        sig = inspect.signature(f)
+
+        @preserve_signature
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            # combine args and kwargs into dictionary
+            bound_args = sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+
+            return f(*bound_args.args, **bound_args.kwargs)
+
+        if prepend is None and append is None:
+            raise TypeError(
+                "Decorator @modify_docstring() missing argument 'prepend' and/or"
+                " 'append', at least one argument is required."
+            )
+
+        # save the original docstring
+        setattr(wrapper, "__original_doc__", wrapper.__doc__)
+        doclines = inspect.cleandoc(wrapper.__doc__).splitlines()
+
+        # prepend docstring lines
+        if isinstance(prepend, str):
+            prependlines = inspect.cleandoc(prepend).splitlines()
+            prependlines.append("")
+        elif prepend is None:
+            prependlines = []
+        else:
+            raise TypeError(
+                f"Expected type str for argument 'prepend', got {type(prepend)}."
+            )
+
+        # append docstring lines
+        if isinstance(append, str):
+            appendlines = inspect.cleandoc(append).splitlines()
+            appendlines = [""] + appendlines
+        elif append is None:
+            appendlines = []
+        else:
+            raise TypeError(
+                f"Expected type str for argument 'append', got {type(append)}."
+            )
+
+        wrapper.__doc__ = "\n".join(prependlines + doclines + appendlines)
+
+        return wrapper
+
+    if func is not None:
+        # `modify_docstring` called as a function
+        return decorator(func)
+    else:
+        # `modify_docstring` called as a decorator "sugar-syntax"
+        return decorator
 
 
 def preserve_signature(f):

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -16,7 +16,7 @@ def modify_docstring(func=None, prepend: str = None, append: str = None):
     Parameters
     ----------
     func: callable
-        The method/function to be decorated
+        The method/function to be decorated.
 
     prepend: `str`
         The string to be prepended to the ``func``'s docstring.

--- a/plasmapy/utils/decorators/tests/test_helpers.py
+++ b/plasmapy/utils/decorators/tests/test_helpers.py
@@ -13,7 +13,7 @@ from ..helpers import modify_docstring, preserve_signature
 class TestModifyDocstring:
     # create function to test on
     @staticmethod
-    def foo_simple(x: float, y: float) -> float:
+    def func_simple_docstring(x: float, y: float) -> float:
         """A simple docstring."""
         return x + y
 
@@ -40,11 +40,11 @@ class TestModifyDocstring:
     def test_no_arg_exception(self):
         """Raise exception if decorator is used without modifying docstring."""
         with pytest.raises(TypeError):
-            modify_docstring(self.foo_simple)
+            modify_docstring(self.func_simple_docstring)
 
     def test_save_original_doc(self):
-        original_doc = self.foo_simple.__doc__
-        wfoo = modify_docstring(prepend="Hello")(self.foo_simple)
+        original_doc = self.func_simple_docstring.__doc__
+        wfoo = modify_docstring(prepend="Hello")(self.func_simple_docstring)
         assert hasattr(wfoo, "__original_doc__")
         assert wfoo.__original_doc__ == original_doc
 
@@ -53,26 +53,26 @@ class TestModifyDocstring:
     )
     def test_raises(self, prepend, append, expected):
         with pytest.raises(expected):
-            modify_docstring(prepend=prepend, append=append, func=self.foo_simple)
+            modify_docstring(prepend=prepend, append=append, func=self.func_simple_docstring)
 
     def test_preserve_signature(self):
-        wfoo = modify_docstring(prepend="Hello")(self.foo_simple)
+        wfoo = modify_docstring(prepend="Hello")(self.func_simple_docstring)
         assert hasattr(wfoo, "__signature__")
-        assert wfoo.__signature__ == inspect.signature(self.foo_simple)
+        assert wfoo.__signature__ == inspect.signature(self.func_simple_docstring)
 
     @pytest.mark.parametrize(
         "prepend, append, func_name, additions",
         [
-            ("Hello", "Goodbye", "foo_simple", (["Hello", ""], ["", "Goodbye"])),
+            ("Hello", "Goodbye", "func_simple_docstring", (["Hello", ""], ["", "Goodbye"])),
             ("Hello", "Goodbye", "foo_complex", (["Hello", ""], ["", "Goodbye"])),
-            ("Hello", None, "foo_simple", (["Hello", ""], [])),
-            (None, "Goodbye", "foo_simple", ([], ["", "Goodbye"])),
+            ("Hello", None, "func_simple_docstring", (["Hello", ""], [])),
+            (None, "Goodbye", "func_simple_docstring", ([], ["", "Goodbye"])),
             (
                 "\n".join(
                     ["    Hello", "    ", "        * item 1", "            * item 2"]
                 ),
                 None,
-                "foo_simple",
+                "func_simple_docstring",
                 (["Hello", "", "* item 1", "    * item 2", ""], []),
             ),
             (
@@ -86,7 +86,7 @@ class TestModifyDocstring:
                         "            * item 2",
                     ]
                 ),
-                "foo_simple",
+                "func_simple_docstring",
                 ([], ["", "Notes", "-----", "", "    * item 1", "        * item 2"]),
             ),
         ],
@@ -102,7 +102,7 @@ class TestModifyDocstring:
         assert wfunc.__doc__ == expected
 
     def test_arguments_passed(self):
-        wfunc = modify_docstring(prepend="Hello")(self.foo_simple)
+        wfunc = modify_docstring(prepend="Hello")(self.func_simple_docstring)
         assert wfunc(5, 4) == 9
 
 

--- a/plasmapy/utils/decorators/tests/test_helpers.py
+++ b/plasmapy/utils/decorators/tests/test_helpers.py
@@ -53,7 +53,9 @@ class TestModifyDocstring:
     )
     def test_raises(self, prepend, append, expected):
         with pytest.raises(expected):
-            modify_docstring(prepend=prepend, append=append, func=self.func_simple_docstring)
+            modify_docstring(
+                prepend=prepend, append=append, func=self.func_simple_docstring
+            )
 
     def test_preserve_signature(self):
         wfoo = modify_docstring(prepend="Hello")(self.func_simple_docstring)
@@ -63,8 +65,18 @@ class TestModifyDocstring:
     @pytest.mark.parametrize(
         "prepend, append, func_name, additions",
         [
-            ("Hello", "Goodbye", "func_simple_docstring", (["Hello", ""], ["", "Goodbye"])),
-            ("Hello", "Goodbye", "func_complex_docstring", (["Hello", ""], ["", "Goodbye"])),
+            (
+                "Hello",
+                "Goodbye",
+                "func_simple_docstring",
+                (["Hello", ""], ["", "Goodbye"]),
+            ),
+            (
+                "Hello",
+                "Goodbye",
+                "func_complex_docstring",
+                (["Hello", ""], ["", "Goodbye"]),
+            ),
             ("Hello", None, "func_simple_docstring", (["Hello", ""], [])),
             (None, "Goodbye", "func_simple_docstring", ([], ["", "Goodbye"])),
             (

--- a/plasmapy/utils/decorators/tests/test_helpers.py
+++ b/plasmapy/utils/decorators/tests/test_helpers.py
@@ -49,11 +49,7 @@ class TestModifyDocstring:
         assert wfoo.__original_doc__ == original_doc
 
     @pytest.mark.parametrize(
-        "prepend, append, expected",
-        [
-            (5, None, TypeError),
-            (None, 5, TypeError),
-        ],
+        "prepend, append, expected", [(5, None, TypeError), (None, 5, TypeError)],
     )
     def test_raises(self, prepend, append, expected):
         with pytest.raises(expected):
@@ -72,33 +68,35 @@ class TestModifyDocstring:
             ("Hello", None, "foo_simple", (["Hello", ""], [])),
             (None, "Goodbye", "foo_simple", ([], ["", "Goodbye"])),
             (
-                "\n".join(["    Hello",
-                           "    ",
-                           "        * item 1",
-                           "            * item 2"]),
+                "\n".join(
+                    ["    Hello", "    ", "        * item 1", "            * item 2"]
+                ),
                 None,
                 "foo_simple",
-                (["Hello", "", "* item 1", "    * item 2", ""], [])
+                (["Hello", "", "* item 1", "    * item 2", ""], []),
             ),
             (
                 None,
-                "\n".join(["    Notes",
-                           "    -----",
-                           "    ",
-                           "        * item 1",
-                           "            * item 2"]),
-
+                "\n".join(
+                    [
+                        "    Notes",
+                        "    -----",
+                        "    ",
+                        "        * item 1",
+                        "            * item 2",
+                    ]
+                ),
                 "foo_simple",
-                ([], ["", "Notes", "-----", "", "    * item 1", "        * item 2"])
+                ([], ["", "Notes", "-----", "", "    * item 1", "        * item 2"]),
             ),
         ],
     )
     def test_modification(self, prepend, append, func_name, additions):
         func = getattr(self, func_name)
 
-        expected = "\n".join(additions[0]
-                             + inspect.cleandoc(func.__doc__).splitlines()
-                             + additions[1])
+        expected = "\n".join(
+            additions[0] + inspect.cleandoc(func.__doc__).splitlines() + additions[1]
+        )
 
         wfunc = modify_docstring(prepend=prepend, append=append)(func)
         assert wfunc.__doc__ == expected

--- a/plasmapy/utils/decorators/tests/test_helpers.py
+++ b/plasmapy/utils/decorators/tests/test_helpers.py
@@ -18,7 +18,7 @@ class TestModifyDocstring:
         return x + y
 
     @staticmethod
-    def foo_complex(x: float, y: float) -> float:
+    def func_complex_docstring(x: float, y: float) -> float:
         """
         A simple docstring.
 
@@ -64,7 +64,7 @@ class TestModifyDocstring:
         "prepend, append, func_name, additions",
         [
             ("Hello", "Goodbye", "func_simple_docstring", (["Hello", ""], ["", "Goodbye"])),
-            ("Hello", "Goodbye", "foo_complex", (["Hello", ""], ["", "Goodbye"])),
+            ("Hello", "Goodbye", "func_complex_docstring", (["Hello", ""], ["", "Goodbye"])),
             ("Hello", None, "func_simple_docstring", (["Hello", ""], [])),
             (None, "Goodbye", "func_simple_docstring", ([], ["", "Goodbye"])),
             (
@@ -86,7 +86,7 @@ class TestModifyDocstring:
                         "            * item 2",
                     ]
                 ),
-                "func_simple_docstring",
+                "func_complex_docstring",
                 ([], ["", "Notes", "-----", "", "    * item 1", "        * item 2"]),
             ),
         ],


### PR DESCRIPTION
This is a simple decorator that allows for the programmatic prepending and/or appending of docstrings.  The original docstring is stored in a new `__original_doc__` attribute so it can still be retrieved.

This is useful in a scenario where you are overriding a method and the signature does not change, but you want add a little more info to the original docstring.