### PR TITLE
Fit Function documentation patch

### DIFF
--- a/docs/notebooks/analysis/fit_functions.ipynb
+++ b/docs/notebooks/analysis/fit_functions.ipynb
@@ -11,7 +11,7 @@
     "[curve_fit()]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html\n",
     "[fsolve()]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fsolve.html\n",
     "\n",
-    "**[Fit functions]** are a set of callable classes designed to aid in fitting analytical functions to data.  A fit function class combines the following functionality:\n",
+    "[Fit functions] are a set of callable classes designed to aid in fitting analytical functions to data.  A fit function class combines the following functionality:\n",
     "\n",
     "1. An analytical function that is callable with given parameters or fitted parameters.\n",
     "1. Curve fitting functionality (usually SciPy's [curve_fit()] or [linregress()]), which stores the fit statistics and parameters into the class.  This makes the function easily callable with the fitted parameters.\n",


### PR DESCRIPTION
Removing bold highlighting on a link in the fit function jupyter notebook.  This syntax works in local builds, but it appears RTD can not handle it.