### PR TITLE
Cleanup quantum.py docstrings

### DIFF
--- a/changelog/951.doc.rst
+++ b/changelog/951.doc.rst
@@ -1,0 +1,1 @@
+Improves the documentation of quantum.py.

--- a/changelog/951.doc.rst
+++ b/changelog/951.doc.rst
@@ -1,1 +1,1 @@
-Improves the documentation of quantum.py.
+Improves documentation of `plasmapy/formulary/quantum.py` by cleaning up docstrings of contained functionality.

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -77,7 +77,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
 
     Warns
     -----
-    : ~astropy.units.UnitsWarning
+    : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
     Notes
@@ -161,12 +161,12 @@ def thermal_deBroglie_wavelength(T_e: u.K) -> u.m:
 
     Parameters
     ----------
-    T_e : ~astropy.units.Quantity
+    T_e : `~astropy.units.Quantity`
         Electron temperature.
 
     Returns
     -------
-    lambda_dbTh : ~astropy.units.Quantity
+    lambda_dbTh : `~astropy.units.Quantity`
         The thermal de Broglie wavelength for electrons in meters.
 
     Raises
@@ -285,12 +285,12 @@ def Thomas_Fermi_length(n_e: u.m ** -3) -> u.m:
 
     Parameters
     ----------
-    n_e : ~astropy.units.Quantity
+    n_e : `~astropy.units.Quantity`
         Electron number density.
 
     Returns
     -------
-    lambda_TF : ~astropy.units.Quantity
+    lambda_TF : `~astropy.units.Quantity`
         The Thomas-Fermi screening length in meters.
 
     Raises
@@ -361,12 +361,12 @@ def Wigner_Seitz_radius(n: u.m ** -3) -> u.m:
 
     Parameters
     ----------
-    n : ~astropy.units.Quantity
+    n : `~astropy.units.Quantity`
         Particle number density.
 
     Returns
     -------
-    radius : ~astropy.units.Quantity
+    radius : `~astropy.units.Quantity`
         The Wigner-Seitz radius in meters.
 
     Raises
@@ -422,7 +422,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
 
     Parameters
     ----------
-    n_e : ~astropy.units.Quantity
+    n_e : `~astropy.units.Quantity`
         Electron number density.
 
     T : ~astropy.units.Quantity
@@ -430,7 +430,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
 
     Returns
     -------
-    beta_mu : ~astropy.units.Quantity
+    beta_mu : `~astropy.units.Quantity`
         The dimensionless ideal chemical potential. That is the ratio of
         the ideal chemical potential to the thermal energy.
 
@@ -541,7 +541,7 @@ def _chemical_potential_interp(n_e, T):
 
     Parameters
     ----------
-    n_e : ~astropy.units.Quantity
+    n_e : `~astropy.units.Quantity`
         Electron number density.
 
     T : ~astropy.units.Quantity
@@ -549,7 +549,7 @@ def _chemical_potential_interp(n_e, T):
 
     Returns
     -------
-    beta_mu : ~astropy.units.Quantity
+    beta_mu : `~astropy.units.Quantity`
         The dimensionless chemical potential, which is a ratio of
         chemical potential energy to thermal kinetic energy.
 

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -33,12 +33,9 @@ from plasmapy.utils.decorators import validate_quantities
 )
 def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     r"""
-    Calculates the de Broglie wavelength.
+    Returns the de Broglie wavelength.
 
-    Formula
-    -------
-
-    The de Broglie wavelength is defined by
+    Formula: The de Broglie wavelength is defined by
 
     .. math::
 
@@ -46,8 +43,8 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
 
     where :math:`h` is the Planck constant, :math:`p` is the
     relativistic momentum of the particle, :math:`\gamma` is the
-    Lorentz factor, :math:`m` is the particle's mass, and :math:`V` is the
-    particle's velocity.
+    Lorentz factor, :math:`m` is the mass of the particle, and
+    :math:`V` is the velocity of the particle.
 
     **Aliases:** `lambdaDB_`
 

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -35,10 +35,6 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     r"""
     Calculates the de Broglie wavelength.
 
-    **Aliases:** `lambdaDB_`
-    
-    Formula
-    -------
     The de Broglie wavelength is given by
 
     .. math::
@@ -50,6 +46,8 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     Lorentz factor, :math:`m` is the particle's mass, and :math:`V` is the
     particle's velocity.
 
+    **Aliases:** `lambdaDB_`
+
     Parameters
     ----------
     V : ~astropy.units.Quantity
@@ -57,7 +55,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
 
     particle : str or ~astropy.units.Quantity
         Representation of the particle species (e.g., `'e'`, `'p'`, `'D+'`,
-        or `'He-4 1+'`, or the particle mass in units convertible to
+        or `'He-4 1+'`) or the particle mass in units convertible to
         kilograms.
 
     Returns
@@ -76,7 +74,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
 
     ~plasmapy.utils.RelativityError
         If the magnitude of `V` is faster than the speed of light.
-
+    
     Warns
     -----
     ~astropy.units.UnitsWarning
@@ -157,19 +155,19 @@ lambdaDB_ = deBroglie_wavelength
 )
 def thermal_deBroglie_wavelength(T_e: u.K) -> u.m:
     r"""
-    Calculate the thermal deBroglie wavelength for electrons.
+    Calculate the thermal de Broglie wavelength for electrons.
 
     **Aliases:** `lambdaDB_th_`
 
     Parameters
     ----------
-    T_e: ~astropy.units.Quantity
+    T_e : ~astropy.units.Quantity
         Electron temperature.
 
     Returns
     -------
-    lambda_dbTh: ~astropy.units.Quantity
-        The thermal deBroglie wavelength for electrons in meters.
+    lambda_dbTh : ~astropy.units.Quantity
+        The thermal de Broglie wavelength for electrons in meters.
 
     Raises
     ------
@@ -189,7 +187,7 @@ def thermal_deBroglie_wavelength(T_e: u.K) -> u.m:
 
     Notes
     -----
-    The thermal deBroglie wavelength is approximately the average deBroglie
+    The thermal de Broglie wavelength is approximately the average deBroglie
     wavelength for electrons in an ideal gas and is given by
 
     .. math::
@@ -287,12 +285,12 @@ def Thomas_Fermi_length(n_e: u.m ** -3) -> u.m:
 
     Parameters
     ----------
-    n_e: ~astropy.units.Quantity
+    n_e : ~astropy.units.Quantity
         Electron number density.
 
     Returns
     -------
-    lambda_TF: ~astropy.units.Quantity
+    lambda_TF : ~astropy.units.Quantity
         The Thomas-Fermi screening length in meters.
 
     Raises
@@ -363,12 +361,12 @@ def Wigner_Seitz_radius(n: u.m ** -3) -> u.m:
 
     Parameters
     ----------
-    n: ~astropy.units.Quantity
+    n : ~astropy.units.Quantity
         Particle number density.
 
     Returns
     -------
-    radius: ~astropy.units.Quantity
+    radius : ~astropy.units.Quantity
         The Wigner-Seitz radius in meters.
 
     Raises
@@ -424,7 +422,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
 
     Parameters
     ----------
-    n_e: ~astropy.units.Quantity
+    n_e : ~astropy.units.Quantity
         Electron number density.
 
     T : ~astropy.units.Quantity
@@ -432,7 +430,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
 
     Returns
     -------
-    beta_mu: ~astropy.units.Quantity
+    beta_mu : ~astropy.units.Quantity
         The dimensionless ideal chemical potential. That is the ratio of
         the ideal chemical potential to the thermal energy.
 
@@ -543,7 +541,7 @@ def _chemical_potential_interp(n_e, T):
 
     Parameters
     ----------
-    n_e: ~astropy.units.Quantity
+    n_e : ~astropy.units.Quantity
         Electron number density.
 
     T : ~astropy.units.Quantity
@@ -551,7 +549,7 @@ def _chemical_potential_interp(n_e, T):
 
     Returns
     -------
-    beta_mu: ~astropy.units.Quantity
+    beta_mu : ~astropy.units.Quantity
         The dimensionless chemical potential, which is a ratio of
         chemical potential energy to thermal kinetic energy.
 

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -53,10 +53,13 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     V : ~astropy.units.Quantity
         Particle velocity in units convertible to meters per second.
 
-    particle : str or ~astropy.units.Quantity
-        Representation of the particle species (e.g., ``'e'``, ``'p'``, ``'D+'``,
-        or ``'He-4 1+'``) or the particle mass in units convertible to
-        kilograms.
+    particle : `str`, `~plasmapy.particles.Particle`, or `~astropy.units.Quantity`
+        An instance of `~plasmapy.particles.particle_class.Particle`, or
+        an equvalent representation (e.g., ``'e'``, ``'p'``, ``'D+'``, or
+        ``'He-4 1+'``), for the particle of interest, or the particle
+        mass in units convertible to kg.  If a `plasmapy`
+        `~plasmapy.particles.particle_class.Particle` instance is given, then the
+        particle mass is retrieved from the object.
 
     Returns
     -------
@@ -66,14 +69,14 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     Raises
     ------
     TypeError
-        The velocity is not a `~astropy.units.Quantity` and cannot be
-        converted into a ~astropy.units.Quantity.
+        If the velocity is not a `~astropy.units.Quantity` and cannot be
+        converted into a `~astropy.units.Quantity`.
 
     ~astropy.units.UnitConversionError
         If the velocity is not in appropriate units.
 
     ~plasmapy.utils.RelativityError
-        If the magnitude of `V` is faster than the speed of light.
+        If the magnitude of `V` is higher than the speed of light.
 
     Warns
     -----

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -36,6 +36,19 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     Calculates the de Broglie wavelength.
 
     **Aliases:** `lambdaDB_`
+    
+    Formula
+    -------
+    The de Broglie wavelength is given by
+
+    .. math::
+
+        \lambda_{dB} = \frac{h}{p} = \frac{h}{\gamma m V}
+
+    where :math:`h` is the Planck constant, :math:`p` is the
+    relativistic momentum of the particle, :math:`gamma` is the
+    Lorentz factor, :math:`m` is the particle's mass, and :math:`V` is the
+    particle's velocity.
 
     Parameters
     ----------

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -35,7 +35,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     r"""
     Returns the de Broglie wavelength.
 
-    Formula: The de Broglie wavelength (:math:`\lambda_{dB}`) of a particle is defined by
+    The de Broglie wavelength (:math:`\lambda_{dB}`) of a particle is defined by
 
     .. math::
 

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -54,8 +54,8 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
         Particle velocity in units convertible to meters per second.
 
     particle : str or ~astropy.units.Quantity
-        Representation of the particle species (e.g., `'e'`, `'p'`, `'D+'`,
-        or `'He-4 1+'`) or the particle mass in units convertible to
+        Representation of the particle species (e.g., ``'e'``, ``'p'``, ``'D+'``,
+        or ``'He-4 1+'``) or the particle mass in units convertible to
         kilograms.
 
     Returns
@@ -77,8 +77,8 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
-        If units are not provided, SI units are assumed
+    : ~astropy.units.UnitsWarning
+        If units are not provided, SI units are assumed.
 
     Notes
     -----

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -57,7 +57,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
         An instance of `~plasmapy.particles.particle_class.Particle`, or
         an equvalent representation (e.g., ``'e'``, ``'p'``, ``'D+'``, or
         ``'He-4 1+'``), for the particle of interest, or the particle
-        mass in units convertible to kg.  If a plasmapy
+        mass in units convertible to kg.  If a PlasmaPy
         `~plasmapy.particles.particle_class.Particle` instance is given, then the
         particle mass is retrieved from the object.
 
@@ -176,7 +176,7 @@ def thermal_deBroglie_wavelength(T_e: u.K) -> u.m:
 
     Notes
     -----
-    The thermal de Broglie wavelength is approximately the average deBroglie
+    The thermal de Broglie wavelength is approximately the average de Broglie
     wavelength for electrons in an ideal gas and is given by
 
     .. math::

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -35,14 +35,17 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     r"""
     Calculates the de Broglie wavelength.
 
-    The de Broglie wavelength is given by
+    Formula
+    -------
+
+    The de Broglie wavelength is defined by
 
     .. math::
 
         \lambda_{dB} = \frac{h}{p} = \frac{h}{\gamma m V}
 
     where :math:`h` is the Planck constant, :math:`p` is the
-    relativistic momentum of the particle, :math:`gamma` is the
+    relativistic momentum of the particle, :math:`\gamma` is the
     Lorentz factor, :math:`m` is the particle's mass, and :math:`V` is the
     particle's velocity.
 
@@ -80,19 +83,6 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
-    Notes
-    -----
-    The de Broglie wavelength is given by
-
-    .. math::
-
-        \lambda_{dB} = \frac{h}{p} = \frac{h}{\gamma m V}
-
-    where :math:`h` is the Planck constant, :math:`p` is the
-    relativistic momentum of the particle, :math:`gamma` is the
-    Lorentz factor, :math:`m` is the particle's mass, and :math:`V` is the
-    particle's velocity.
-
     Examples
     --------
     >>> from astropy import units as u
@@ -123,8 +113,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
             m = particle.to(u.kg)
         except Exception:
             raise u.UnitConversionError(
-                "The second argument for deBroglie"
-                " wavelength must be either a "
+                "The second argument for deBroglie_wavelength must be either a "
                 "representation of a particle or a"
                 " Quantity with units of mass."
             )

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -74,7 +74,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
 
     ~plasmapy.utils.RelativityError
         If the magnitude of `V` is faster than the speed of light.
-    
+
     Warns
     -----
     ~astropy.units.UnitsWarning

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -35,7 +35,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     r"""
     Returns the de Broglie wavelength.
 
-    Formula: The de Broglie wavelength (:math:'\lambda_{dB}') of a particle is defined by
+    Formula: The de Broglie wavelength (:math:`\lambda_{dB}`) of a particle is defined by
 
     .. math::
 
@@ -75,8 +75,8 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     ~astropy.units.UnitConversionError
         If the velocity is not in appropriate units.
 
-    ~plasmapy.utils.RelativityError
-        If the magnitude of `V` is higher than the speed of light.
+    ~plasmapy.utils.exceptions.RelativityError
+        If the magnitude of `V` is larger than the speed of light.
 
     Warns
     -----
@@ -171,7 +171,7 @@ def thermal_deBroglie_wavelength(T_e: u.K) -> u.m:
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
     Notes
@@ -229,7 +229,7 @@ def Fermi_energy(n_e: u.m ** -3) -> u.J:
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
     Notes
@@ -295,7 +295,7 @@ def Thomas_Fermi_length(n_e: u.m ** -3) -> u.m:
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
     Notes
@@ -371,7 +371,7 @@ def Wigner_Seitz_radius(n: u.m ** -3) -> u.m:
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
     Notes
@@ -436,7 +436,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
     Notes

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -35,7 +35,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     r"""
     Returns the de Broglie wavelength.
 
-    Formula: The de Broglie wavelength is defined by
+    Formula: The de Broglie wavelength (:math:'\lambda_{dB}') of a particle is defined by
 
     .. math::
 
@@ -50,20 +50,20 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
 
     Parameters
     ----------
-    V : ~astropy.units.Quantity
+    V : `~astropy.units.Quantity`
         Particle velocity in units convertible to meters per second.
 
     particle : `str`, `~plasmapy.particles.Particle`, or `~astropy.units.Quantity`
         An instance of `~plasmapy.particles.particle_class.Particle`, or
         an equvalent representation (e.g., ``'e'``, ``'p'``, ``'D+'``, or
         ``'He-4 1+'``), for the particle of interest, or the particle
-        mass in units convertible to kg.  If a `plasmapy`
+        mass in units convertible to kg.  If a plasmapy
         `~plasmapy.particles.particle_class.Particle` instance is given, then the
         particle mass is retrieved from the object.
 
     Returns
     -------
-    lambda_dB : ~astropy.units.Quantity
+    lambda_dB : `~astropy.units.Quantity`
         The de Broglie wavelength in units of meters.
 
     Raises


### PR DESCRIPTION
- [x] I have added a changelog entry for this pull request.

<!--

In short: A changelog entry is a short description of your PR's changes.
Each entry is written in a `<PULL REQUEST>.<TYPE>.rst` file and stored in
the `changelog` directory,  where `<PULL REQUEST>` is a pull request
number and `<TYPE>` is one of:

* `breaking`: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
* `feature`: New user facing features and any new behavior.
* `bugfix`: Fixes a reported bug.
* `doc`: Documentation addition or improvement, like rewording an entire session or adding missing docs.
* `removal`: Feature deprecation and/or feature removal.
* `trivial`: A change which has no user facing effect or is tiny change.

A PR number is generated after you successfully submit a new PR, so the changelog
file can only be added after you open the PR.```

For more information, see:
https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst

--->

- [ ] If adding new functionality, I have added tests and
      docstrings.

<!--
(Tests pop up at the bottom, in the checks box.)
-->

- [ ] I have fixed any newly failing tests.

<!--
(If you're unsure why they're failing, ask!)
-->


