### PR TITLE
Update naming of methods for Coulomb logarithms

### DIFF
--- a/changelog/962.breaking.rst
+++ b/changelog/962.breaking.rst
@@ -1,0 +1,1 @@
+Changed the names of the supported methods of computing the Coulomb logarithm to improve readability. Expanded the documentation of these methods.

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -257,7 +257,7 @@ class ClassicalTransport:
     coulomb_log_method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -254,6 +254,16 @@ class ClassicalTransport:
         on the ion transport coefficients. Defaults to T_e / T_i. Only
         has effect if mu is non-zero.
 
+    coulomb_log_method : str, optional
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of
+        `~plasmapy.formulary.collisions.Coulomb_logarithm` for more
+        information about these methods.
+
     Raises
     ------
     ValueError

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -168,7 +168,7 @@ def Coulomb_logarithm(
     impact parameters for Coulomb collisions [1]_.
 
     The outer impact parameter is given by the Debye length:
-    :math:`b_{min} = \lambda_D` which is a function of electron
+    :math:`b_{max} = \lambda_D` which is a function of electron
     temperature and electron density.  At distances greater than the
     Debye length, electric fields from other particles will be
     screened out due to electrons rearranging themselves.
@@ -208,7 +208,13 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
-        This method is not valid if :math:`\lambda < 0`, which may be true if the 
+        .. math::
+            b_{min} = \max\left( \Lambda_{deBroglie}, \rho_{\perp} \right)
+        
+        .. math::
+            b_{max} = \lambda_D
+        
+        This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
     Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer with interpolation of :math:`b_{min}`)
         A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated 
@@ -218,7 +224,7 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
-        This method is not valid if :math:`\lambda < 0`, which may be true if the coupling 
+        This method is not valid if :math:`\Lambda < 0`, which may be true if the coupling 
         parameter is high (such as for dense, cold plasmas).
         This is the first method in Table 1 of Reference [4].
     Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
@@ -231,7 +237,7 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
-        This method is not valid if :math:`\lambda < 0`, which may be true if the coupling 
+        This method is not valid if :math:`\Lambda < 0`, which may be true if the coupling 
         parameter is high (such as for dense, cold plasmas).
         This is the second method in Table 1 of Reference [4].
     Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
@@ -242,9 +248,9 @@ def Coulomb_logarithm(
         approach.
         
         .. math::
-        \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+            \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
-        This method cannot fail because it is impossible for :math:`\lambda < 0` in this 
+        This method cannot fail because it is impossible for :math:`\Lambda < 0` in this 
         method, even for a large coupling parameter.
         This is the third method in Table 1 of Reference [4].
     Option 5: `"hyperls"` or `"hls"` (Hyperbolic Landau-Spitzer)
@@ -257,7 +263,7 @@ def Coulomb_logarithm(
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\lambda < 0` in this method, even for a high coupling parameter.
+        impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
         This is the fourth method in Table 1 of Reference [4].
     Option 6: `"hlsmaxinterp"` or `"hlsmi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{max}`)
         A modified hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated 
@@ -270,7 +276,7 @@ def Coulomb_logarithm(
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\lambda < 0` in this method, even for a high coupling parameter.
+        impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
         This is the fifth method in Table 1 of Reference [4].
     Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
@@ -284,7 +290,7 @@ def Coulomb_logarithm(
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\lambda < 0` in this method, even for a high coupling parameter.
+        impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
         This is the sixth method in Table 1 of Reference [4].
 
     Examples
@@ -330,7 +336,8 @@ def Coulomb_logarithm(
         ln_Lambda = 0.5 * np.log(1 + bmax ** 2 / bmin ** 2)
     else:
         raise ValueError(
-            "Unknown method! Choose from 'ls', 'lsmini', 'lsfulli', 'lsclamp', 'hls', 'hlsmaxi', and 'hlsfulli'."
+            "Unknown method! Choose from \"ls\", \"lsmini\", \"lsfulli\", \"lsclamp\", \"hyperls\", \"hlsmaxi\", 
+            \"hlsfulli\", or their aliases. Please refer to the documentation of this function for more information."
         )
     # applying dimensionless units
     ln_Lambda = ln_Lambda.to(u.dimensionless_unscaled).value

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -121,8 +121,8 @@ def Coulomb_logarithm(
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer method
         (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and 
-        ``"hls_full_interp"``. Please refer to the Notes section of this 
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the Notes section of this
         docstring for more information, including about abbreviated aliases of these names.
 
     Returns
@@ -156,13 +156,13 @@ def Coulomb_logarithm(
     : `~plasmapy.utils.exceptions.RelativityWarning`
         If the input velocity is greater than 5% of the speed of
         light.
-    
+
     Notes
     -----
     **Overview of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
-    
+
     PlasmaPy supports 7 methods of computing the Coulomb logarithm:
-    
+
     1. ``"classical"`` or ``"LS"``
     2. ``"ls_min_interp"`` or ``"GMS-1"``
     3. ``"ls_full_interp"`` or ``"GMS-2"``
@@ -170,197 +170,197 @@ def Coulomb_logarithm(
     5. ``"hls_min_interp"`` or ``"GMS-4"``
     6. ``"hls_max_interp"`` or ``"GMS-5"``
     7. ``"hls_full_interp"`` or ``"GMS-6"``
-    
-    Options 1–4 are straight-line Landau-Spitzer (``"ls..."``) methods in which the trajectory of a 
-    Coulomb collision is modeled as a straight line. For the straight-line Landau-Spitzer methods, the Coulomb 
+
+    Options 1–4 are straight-line Landau-Spitzer (``"ls..."``) methods in which the trajectory of a
+    Coulomb collision is modeled as a straight line. For the straight-line Landau-Spitzer methods, the Coulomb
     logarithm (:math:`\ln{\Lambda}`) is defined to be:
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
-    
-    Options 5–7 are hyperbolic Landau-Spitzer (``"hls..."``) methods in which the trajectory of a 
-    Coulomb collision is modeled as a hyperbola. For the hyperbolic Landau-Spitzer methods, the Coulomb 
+
+    Options 5–7 are hyperbolic Landau-Spitzer (``"hls..."``) methods in which the trajectory of a
+    Coulomb collision is modeled as a hyperbola. For the hyperbolic Landau-Spitzer methods, the Coulomb
     logarithm (:math:`\ln{\Lambda}`) is defined to be:
-    
+
     .. math::
         \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
 
     For all 7 methods, :math:`b_{min}` and :math:`b_{max}` are the inner impact parameter and the outer
-    impact parameter for Coulomb collisions [1]_; :math:`b_{min}` and :math:`b_{max}` are each computed 
+    impact parameter for Coulomb collisions [1]_; :math:`b_{min}` and :math:`b_{max}` are each computed
     by `impact_parameter`, another function.
 
-    .. note:: 
+    .. note::
         For strongly-coupled plasma, PlasmaPy recommends Option 7, ``"hls_full_interp"`` or ``"GMS-6"``,
         because of its high accuracy regardless of a plasma's strength of coupling.
-    
+
     **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
-    
-    In this section, further information about each method, such as about interpolation and other special 
+
+    In this section, further information about each method, such as about interpolation and other special
     features, is documented. Please refer to Reference [4]_ for additional information about these methods.
-    
+
     Option 1: ``"classical"`` or ``"LS"`` (Landau-Spitzer)
-        The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 
-        higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest 
-        approach (:math:`\rho_{\perp}`) if they are not equal (and either of the two if they are equal) and 
+        The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the
+        higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest
+        approach (:math:`\rho_{\perp}`) if they are not equal (and either of the two if they are equal) and
         :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
-        
+
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
-            
+
         .. math::
-            b_{min} \equiv 
+            b_{min} \equiv
             \left\{
                 \begin{array}{ll}
                            \lambda_{de Broglie} & \mbox{if } \lambda_{de Broglie} \geq \rho_{\perp} \\
                            \rho_{\perp}         & \mbox{if } \rho_{\perp} \geq \lambda_{de Broglie}
                 \end{array}
             \right.
-        
+
         .. math::
             b_{max} \equiv \lambda_{Debye}
-        
-        The inner impact parameter (:math:`b_{min}`) is the higher of :math:`\lambda_{de Broglie}` 
-        and :math:`\rho_{\perp}` because for impact parameters lower than :math:`\lambda_{de Broglie}`, 
+
+        The inner impact parameter (:math:`b_{min}`) is the higher of :math:`\lambda_{de Broglie}`
+        and :math:`\rho_{\perp}` because for impact parameters lower than :math:`\lambda_{de Broglie}`,
         quantum effects cause the collision to be non-Coulombic [2]_ [3]_.
-        
-        The outer impact parameter (:math:`b_{max}`) is defined to be the Debye length 
+
+        The outer impact parameter (:math:`b_{max}`) is defined to be the Debye length
         (:math:`\lambda_{Debye}`) because at distances higher than the
         Debye length, the electric fields created by other particles are
         screened out by the electrons rearranging themselves.
 
         The uncertainty of the classical straight-line Landau-Spitzer method is on the order
         of its reciprocal.
-        
+
         This method is invalid if :math:`\ln{\Lambda} < 2` because of the uncertainty of the classical
-        straight-line Landau-Spitzer method and if :math:`\ln{\Lambda} < 0`, which may be true if the 
+        straight-line Landau-Spitzer method and if :math:`\ln{\Lambda} < 0`, which may be true if the
         coupling parameter is high (such as for nonideal, dense, cold plasmas).
-        
+
         Please refer to Reference [1]_ for additional information about this method.
-        
+
     Option 2: ``"ls_min_interp"`` or ``"GMS-1"`` (Landau-Spitzer, interpolation of :math:`b_{min}`)
-        A straight-line Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
-        de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        A straight-line Landau-Spitzer method in which :math:`b_{min}` is interpolated between the
+        de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach
         (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
-        
+
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
-            
+
         .. math::
             b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
-        
+
         .. math::
             b_{max} \equiv \lambda_{Debye}
-        
-        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the coupling 
+
+        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the coupling
         parameter is high (such as for nonideal, dense, cold plasmas).
-        
+
         Note: This is the first method in Table 1 of Reference [4]_.
-        
+
     Option 3: ``"ls_full_interp"`` or ``"GMS-2"`` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
-        (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
-        :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
+        (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`).
+        :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`)
         and the ion sphere radius (:math:`a_i`).
-        
+
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
-        
+
         .. math::
             b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
-            
+
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
-       
-        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the coupling 
+
+        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the coupling
         parameter is high (such as for nonideal, dense, cold plasmas).
-        
+
         Note: This is the second method in Table 1 of Reference [4]_.
-        
+
     Option 4: ``"ls_clamp_mininterp"`` or ``"GMS-3"`` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
-        A straight-line Landau-Spitzer method in which the value of :math:`\ln{\Lambda}` is clamped at 
-        a minimum of :math:`2` so that it is impossible for :math:`\ln{\Lambda} < 0`, unlike by the 
-        classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
-        wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        A straight-line Landau-Spitzer method in which the value of :math:`\ln{\Lambda}` is clamped at
+        a minimum of :math:`2` so that it is impossible for :math:`\ln{\Lambda} < 0`, unlike by the
+        classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie
+        wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach
         (:math:`\rho_{\perp}`). :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
-        
+
         .. math::
-            \ln{\Lambda} \equiv 
+            \ln{\Lambda} \equiv
             \left\{
                 \begin{array}{ll}
                            \ln\left( \frac{b_{max}}{b_{min}} \right) & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}} \right) \geq 2 \\
                            2                                         & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}} \right) \leq 2
                 \end{array}
             \right.
-            
+
         .. math::
             b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
-        
+
         .. math::
             b_{max} \equiv \lambda_{Debye}
-        
-        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
+
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this
         method, even if the coupling parameter is high (such as for nonideal, dense, cold plasmas).
-        
+
         Note: This is the third method in Table 1 of Reference [4]_.
-        
+
     Option 5: ``"hls_min_interp"`` or ``"GMS-4"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}`)
-        A hyperbolic Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
-        de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        A hyperbolic Landau-Spitzer method in which :math:`b_{min}` is interpolated between the
+        de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach
         (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
-        
+
         .. math::
             \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
-        
+
         .. math::
             b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
-            
+
         .. math::
             b_{max} \equiv \lambda_{Debye}
-        
-        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
+
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this
         method, even if the coupling parameter is high (such as for nonideal, dense, cold plasmas).
-        
+
         Note: This is the fourth method in Table 1 of Reference [4]_.
-        
+
     Option 6: ``"hls_max_interp"`` or ``"GMS-5"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
-        A hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated between 
+        A hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated between
         the Debye length (:math:`\lambda_{Debye}`) and the ion sphere radius (:math:`a_i`)
         and :math:`b_{min}` is defined to be the distance of closest approach (:math:`\rho_{\perp}`).
-        
+
         .. math::
             \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
-        
+
         .. math::
             b_{min} \equiv \rho_{\perp}
-        
+
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
-        
-        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
+
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this
         method, even if the coupling parameter is high (such as for nonideal, dense, cold plasmas).
-        
+
         Caution: This method overestimates :math:`\ln{\Lambda}` at high temperatures.
-        
+
         Note: This is the fifth method in Table 1 of Reference [4]_.
-        
+
     Option 7: ``"hls_full_interp"`` or ``"GMS-6"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
-        (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
-        :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
+        (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`).
+        :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`)
         and the ion sphere radius (:math:`a_i`).
-        
+
         .. math::
             \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
-        
+
         .. math::
             b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
-            
+
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
-        
-        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
+
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this
         method, even if the coupling parameter is high (such as for nonideal, dense, cold plasmas).
 
         Note: This is the sixth method in Table 1 of Reference [4]_.
@@ -390,7 +390,7 @@ def Coulomb_logarithm(
     .. [4] Dense plasma temperature equilibration in the binary collision
        approximation. D. O. Gericke et. al. PRE,  65, 036418 (2002).
        DOI: 10.1103/PhysRevE.65.036418
-    
+
     See Also
     --------
     impact_parameter : Computes :math:`b_{min}` and :math:`b_{max}`.

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -735,7 +735,7 @@ def impact_parameter(
 
     # obtaining minimum and maximum impact parameters depending on which
     # method is requested
-    if method == "classical":
+    if method == "classical" or method == "LS":
         bmax = lambdaDe
         # Coulomb-style collisions will not happen for impact parameters
         # shorter than either of these two impact parameters, so we choose

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -163,6 +163,8 @@ def Coulomb_logarithm(
 
     Notes
     -----
+    ** Overview of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm
+    
     PlasmaPy supports 7 methods of computing the Coulomb logarithm:
     
     1. `"classical"` or `"ls"`
@@ -173,36 +175,39 @@ def Coulomb_logarithm(
     6. `"hlsmaxinterp"` or `"hlsmaxi"`
     7. `"hlsfullinterp"` or `"hlsfi"`
     
-    The first 4 methods are straight-line Landau-Spitzer methods in which the trajectory of a Coulomb collision 
-    is modeled as a straight line. The last 3 methods are hyperbolic Landau-Spitzer methods in which
-    the trajectory of a Coulomb collision is modeled as a hyperbola.
-    
-    The Coulomb logarithm is defined for straight-line Landau-Spitzer methods by
+    Method 1 - Method 4 are straight-line Landau-Spitzer ("ls...") methods in which the trajectory of a 
+    Coulomb collision is modeled as a straight line. For the straight-line Landau-Spitzer methods, the Coulomb 
+    logarithm is defined to be:
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
     
-    and for hyperbolic Landau-Spitzer methods by
+    Method 5 - Method 7 are hyperbolic Landau-Spitzer ("hls...") methods in which the trajectory of a 
+    Coulomb collision is modeled as a hyperbola. For the hyperbolic Landau-Spitzer methods, the Coulomb 
+    logarithm is defined to be:
     
     .. math::
         \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
 
-    where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
-    impact parameters for Coulomb collisions [1]_; :math:`b_{min}` and :math:`b_{max}` are each computed by `impact_parameter`.
-
-    The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
-    the straight-line Landau-Spitzer methods fail if :math:`\Lambda < 0`.
-
-    .. note:: PlasmaPy recommends Option 7, `"hlsfulli"` or `hlsfi"`, for most users.
-
-    Further information about these methods is in Reference [4]_.
+    For all 7 methods, :math:`b_{min}` and :math:`b_{max}` are the inner impact parameter and the outer
+    impact parameter for Coulomb collisions [1]_; :math:`b_{min}` and :math:`b_{max}` are each computed 
+    by `impact_parameter`.
     
-    **Supported Methods of Computing the Coulomb Logarithm**
+    In "Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm" below, further 
+    information about each method, such as about interpolation and other special features, is documented. 
+    Please refer to in Reference [4]_ for additional information about these methods.
+
+    .. note:: 
+        PlasmaPy recommends Option 7, `"hlsfulli"` or `hlsfi"`, for most users. The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
+        the straight-line Landau-Spitzer methods fail if :math:`\Lambda < 0`.
+    
+    **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
     
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
-        The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the higher of 
-        the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
-        (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
+        The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 
+        higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest 
+        approach (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length 
+        (:math:`\lambda_{Debye}`).
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -121,7 +121,7 @@ def Coulomb_logarithm(
         The default method is the classical straight-line Landau-Spitzer method
         (`"classical"` or `"ls"`). The other 6 supported methods are `"lsmininterp"`,
         `"lsfullinterp"`, `"lsclampmininterp"`, `"hlsmininterp"`, `"hlsmaxinterp"`, and 
-        `"hlsfullinterp"`. Please refer to the :ref:`reference-to-Notes` section of this 
+        `"hlsfullinterp"`. Please refer to the `Notes <#Notes>`_ section of this 
         docstring for more information, including about abbreviated aliases of these names.
 
     Returns
@@ -155,8 +155,6 @@ def Coulomb_logarithm(
     : `~plasmapy.utils.exceptions.RelativityWarning`
         If the input velocity is greater than 5% of the speed of
         light.
-
-    .. _reference-to-Notes:
     
     Notes
     -----
@@ -191,7 +189,8 @@ def Coulomb_logarithm(
     by `impact_parameter`, another function.
 
     .. note:: 
-        PlasmaPy recommends Option 7, `"hlsfullinterp"` or `"hlsfi"`, for most users because it is the most accurate for all plasmas, regardless of the strength of coupling.
+        PlasmaPy recommends Option 7, `"hlsfullinterp"` or `"hlsfi"`, for most users because it is the most accurate overall, 
+        regardless of a plasma's strength of coupling.
     
     **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
     
@@ -201,7 +200,7 @@ def Coulomb_logarithm(
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 
         higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest 
-        approach (:math:`\rho_{\perp}`) if they are not equal and either of the two if they are equal and 
+        approach (:math:`\rho_{\perp}`) if they are not equal (and either of the two if they are equal) and 
         :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
@@ -252,9 +251,9 @@ def Coulomb_logarithm(
             b_{max} \equiv \lambda_{Debye}
         
         This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the coupling 
-        parameter is high such as for nonideal, dense, cold plasmas.
+        parameter is high (such as for nonideal, dense, cold plasmas).
         
-        Note: This is the first method in Table 1 of Reference [4].
+        Note: This is the first method in Table 1 of Reference [4]_.
         
     Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
@@ -273,13 +272,13 @@ def Coulomb_logarithm(
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
        
         This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the coupling 
-        parameter is high such as for nonideal, dense, cold plasmas.
+        parameter is high (such as for nonideal, dense, cold plasmas).
         
-        Note: This is the second method in Table 1 of Reference [4].
+        Note: This is the second method in Table 1 of Reference [4]_.
         
     Option 4: `"lsclampmininterp"` or `"lscmini"` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which the value of :math:`\ln{\Lambda}` is clamped at 
-        a minimum of :math:`2` so that this method  for Coulomb logarithm < 0, unlike the 
+        a minimum of :math:`2` so that it is impossible for :math:`\ln{\Lambda} < 0`, unlike by the 
         classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
         wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`). :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
@@ -302,7 +301,7 @@ def Coulomb_logarithm(
         This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
         method, even if the coupling parameter is high.
         
-        Note: This is the third method in Table 1 of Reference [4].
+        Note: This is the third method in Table 1 of Reference [4]_.
         
     Option 5: `"hlsmininterp"` or `"hlsmini"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
@@ -321,11 +320,11 @@ def Coulomb_logarithm(
         This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
         method, even if the coupling parameter is high.
         
-        Note: This is the fourth method in Table 1 of Reference [4].
+        Note: This is the fourth method in Table 1 of Reference [4]_.
         
     Option 6: `"hlsmaxinterp"` or `"hlsmaxi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
-        A hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated 
-        between the Debye length (:math:`\lambda_{Debye}`) and the ion sphere radius (:math:`a_i`)
+        A hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated between 
+        the Debye length (:math:`\lambda_{Debye}`) and the ion sphere radius (:math:`a_i`)
         and :math:`b_{min}` is defined to be the distance of closest approach (:math:`\rho_{\perp}`).
         
         .. math::
@@ -342,7 +341,7 @@ def Coulomb_logarithm(
         
         Caution: This method overestimates :math:`\ln{\Lambda}` at high temperatures.
         
-        Note: This is the fifth method in Table 1 of Reference [4].
+        Note: This is the fifth method in Table 1 of Reference [4]_.
         
     Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
@@ -363,7 +362,7 @@ def Coulomb_logarithm(
         This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
         method, even if the coupling parameter is high.
 
-        Note: This is the sixth method in Table 1 of Reference [4].
+        Note: This is the sixth method in Table 1 of Reference [4]_.
 
     Examples
     --------

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -120,9 +120,9 @@ def Coulomb_logarithm(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical Landau-Spitzer method
-        ("classical"). The other 6 supported methods are "GMS-1",
-        "GMS-2", "GMS-3", "GMS-4", "GMS-5", and "GMS-6". Please refer to
-        the "Notes" section of this docstring for more information.
+        (`"classical"`). The other 6 supported methods are `"lsmininterp"`,
+        `"lsfullinterp"`, `"lsclamp"`, `"hyperls"`, "hlsmaxinterp", and "hlsfullinterp". Please refer to
+        the "Notes" section of this docstring for more information, including about abbreviated aliases of these names.
 
     Returns
     -------
@@ -222,7 +222,7 @@ def Coulomb_logarithm(
         A clamp is placed at Lambda_min = 2 because the classical
         Landau-Spitzer method fails for a Coulomb logarithm < 0.
         The third method in Table 1 of Reference [4].
-    Option 5: `"hls"` (Hyperbolic Landau-Spitzer)
+    Option 5: `"hyperls"` or `"hls"` (Hyperbolic Landau-Spitzer)
         Spitzer-like extension to Coulomb logarithm by noting that
         Coulomb collisions take hyperbolic trajectories. Removes
         divergence for small bmin issue in classical Landau-Spitzer

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -214,11 +214,11 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
-        #.. math::
-            #b_{min} \equiv \max\left( \Lambda_{deBroglie}, \rho_{\perp} \right)
+        .. math::
+            \b_{min} \equiv \Lambda_{de Broglie}
         
         .. math::
-            b_{max} \equiv \lambda_D
+            \b_{max} \equiv \lambda_D
         
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -173,22 +173,22 @@ def Coulomb_logarithm(
     6. `"hlsmaxinterp"` or `"hlsmaxi"`
     7. `"hlsfullinterp"` or `"hlsfi"`
     
-    The first 4 methods are straight-line methods in which the trajectory of a Coulomb collision 
-    is modeled as a straight line. The last 3 methods are hyperbolic methods in which
+    The first 4 methods are straight-line Landau-Spitzer methods in which the trajectory of a Coulomb collision 
+    is modeled as a straight line. The last 3 methods are hyperbolic Landau-Spitzer methods in which
     the trajectory of a Coulomb collision is modeled as a hyperbola.
     
-    For straight-line Landau-Spitzer methods, the Coulomb logarithm is defined by
+    The Coulomb logarithm is defined for straight-line Landau-Spitzer methods by
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
-
-    where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
-    impact parameters for Coulomb collisions [1]_. They are computed by `impact_parameter`.
     
-    For hyperbolic Landau-Spitzer methods, the Coulomb logarithm is defined by
+    and for hyperbolic Landau-Spitzer methods by
     
     .. math::
         \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+
+    where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
+    impact parameters for Coulomb collisions [1]_; :math:`b_{min}` and :math:`b_{max}` are each computed by `impact_parameter`.
 
     The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
     the straight-line Landau-Spitzer methods fail if :math:`\Lambda < 0`.
@@ -213,6 +213,7 @@ def Coulomb_logarithm(
                 \begin{array}{ll}
                            \lambda_{de Broglie} & \mbox{if } \lambda_{de Broglie} > \rho_{\perp}
                            \rho_{\perp}         & \mbox{if } \rho_{\perp} > \lambda_{de Broglie}
+                \end{array}
             \right.
         
         .. math::

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -177,7 +177,7 @@ def Coulomb_logarithm(
     is modeled as a straight line. The last 3 methods are hyperbolic methods in which
     the trajectory of a Coulomb collision is modeled as a hyperbola.
     
-    For **straight-line** Landau-Spitzer methods, the Coulomb logarithm is defined by
+    For straight-line Landau-Spitzer methods, the Coulomb logarithm is defined by
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
@@ -185,10 +185,10 @@ def Coulomb_logarithm(
     where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
     impact parameters for Coulomb collisions [1]_. They are computed by `impact_parameter`.
     
-    For **hyperbolic** Landau-Spitzer methods, the Coulomb logarithm is defined by
+    For hyperbolic Landau-Spitzer methods, the Coulomb logarithm is defined by
     
     .. math::
-        \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+        \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
 
     The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
     the straight-line Landau-Spitzer methods fail if :math:`\Lambda < 0`.
@@ -211,8 +211,8 @@ def Coulomb_logarithm(
             b_{min} \equiv 
             \left\{
                 \begin{array}{ll}
-                           \lambda_{de Broglie} & mbox(if) \lambda_{de Broglie} > \rho_{\perp}
-                           \rho_{\perp}         & mbox(if) \rho_{\perp} > \lambda_{de Broglie}
+                           \lambda_{de Broglie} & \mbox{if } \lambda_{de Broglie} > \rho_{\perp}
+                           \rho_{\perp}         & \mbox{if } \rho_{\perp} > \lambda_{de Broglie}
             \right.
         
         .. math::
@@ -266,10 +266,10 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
         .. math::
-            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
             
         .. math::
-            b_{max} \equiv \left(\lambda_{Debye}^2 + a_i^2\right)^{1/2}
+            b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
         This method is not valid if :math:`\Lambda < 0`, which may be true if the coupling 
         parameter is high (such as for dense, cold plasmas).
@@ -285,7 +285,7 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
         .. math::
-            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
         
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -302,7 +302,7 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
         
         .. math::
-            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
             
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -324,7 +324,7 @@ def Coulomb_logarithm(
             b_{min} \equiv \rho_{\perp}
         
         .. math::
-            b_{max} \equiv \left(\lambda_{Debye}^2 + a_i^2\right)^{1/2}
+            b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
@@ -342,10 +342,10 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
         
         .. math::
-            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
             
         .. math::
-            b_{max} \equiv \left(\lambda_{Debye}^2 + a_i^2\right)^{1/2}
+            b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -163,49 +163,30 @@ def Coulomb_logarithm(
 
     Notes
     -----
-    PlasmaPy recommends Option 7, `"hlsfulli"` or `hlsfi"`, for most users.
+    PlasmaPy supports 7 methods of computing the Coulomb logarithm, 4 methods in which
+    the trajectory of a Coulomb collision is modeled as a straight line and 3 methods in which
+    the trajectory of a Coulomb collision is modeled as a hyperbola.
     
-    The classical Landau-Spitzer Coulomb logarithm is given by
+    For straight-line Landau-Spitzer methods, the Coulomb logarithm is defined by
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
 
     where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
     impact parameters for Coulomb collisions [1]_.
-
-    The outer impact parameter is given by the Debye length:
-    :math:`b_{max} = \lambda_D` which is a function of electron
-    temperature and electron density.  At distances greater than the
-    Debye length, electric fields from other particles will be
-    screened out due to electrons rearranging themselves.
-
-    The choice of inner impact parameter is either the distance of closest
-    approach for a 90 degree Coulomb collision or the thermal deBroglie
-    wavelength, whichever is larger. This is because Coulomb-style collisions
-    cannot occur for impact parameters shorter than the deBroglie
-    wavelength because quantum effects will change the fundamental
-    nature of the collision [2]_, [3]_.
-
-    Errors associated with the classical Coulomb logarithm are of order its
-    reciprocal. If the Coulomb logarithm is of order unity, then the
-    assumptions made in the standard analysis of Coulomb collisions
-    are invalid.
-
-    For dense plasmas where the classical Coulomb logarithm breaks
-    down there are various extended methods. These can be found
-    in D.O. Gericke et al's paper, which has a table summarizing
-    the methods [4]_. The GMS-1 through GMS-6 methods correspond
-    to the methods found it that table.
-
-    It should be noted that GMS-4 thru GMS-6 modify the Coulomb
-    logarithm to the form:
-
+    
+    For hyperbolic Landau-Spitzer methods, the Coulomb logarithm is defined by
+    
     .. math::
         \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
 
-    This means the Coulomb logarithm will not break down for Lambda < 0,
-    which occurs for dense, cold plasmas.
+    The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
+    the straight-line Landau-Spitzer methods fail if :math:`\Lambda < 0`.
 
+    .. note:: PlasmaPy recommends Option 7, `"hlsfulli"` or `hlsfi"`, for most users.
+
+    Further information about these methods is in Reference [4].
+    
     **Supported Methods of Computing the Coulomb Logarithm**
     
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
@@ -218,6 +199,24 @@ def Coulomb_logarithm(
             
             b_{max} \equiv \lambda_{Debye}
         
+        The outer impact parameter is given by the Debye length:
+        :math:`b_{max} = \lambda_D` which is a function of electron
+        temperature and electron density.  At distances greater than the
+        Debye length, electric fields from other particles will be
+        screened out due to electrons rearranging themselves.
+
+        The choice of inner impact parameter is either the distance of closest
+        approach for a 90 degree Coulomb collision or the thermal deBroglie
+        wavelength, whichever is larger. This is because Coulomb-style collisions
+        cannot occur for impact parameters shorter than the deBroglie
+        wavelength because quantum effects will change the fundamental
+        nature of the collision [2]_, [3]_.
+
+        Errors associated with the classical Coulomb logarithm are of order its
+        reciprocal. If the Coulomb logarithm is of order unity, then the
+        assumptions made in the standard analysis of Coulomb collisions
+        are invalid.
+        
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
     Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
@@ -227,6 +226,12 @@ def Coulomb_logarithm(
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+            
+        .. math::
+            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+        
+        .. math::
+            b_{max} \equiv \lambda_{Debye}
         
         This method is not valid if :math:`\Lambda < 0`, which may be true if the coupling 
         parameter is high (such as for dense, cold plasmas).
@@ -241,6 +246,12 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
+        .. math::
+            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            
+        .. math::
+            b_{max} \equiv \left(\lambda_{Debye}^2 + a_i^2\right)^{1/2}
+        
         This method is not valid if :math:`\Lambda < 0`, which may be true if the coupling 
         parameter is high (such as for dense, cold plasmas).
         This is the second method in Table 1 of Reference [4].
@@ -253,6 +264,12 @@ def Coulomb_logarithm(
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+            
+        .. math::
+            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+        
+        .. math::
+            b_{max} \equiv \lambda_{Debye}
         
         This method cannot fail because it is impossible for :math:`\Lambda < 0` in this 
         method, even for a large coupling parameter.
@@ -263,6 +280,12 @@ def Coulomb_logarithm(
         
         .. math::
             \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+        
+        .. math::
+            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            
+        .. math::
+            b_{max} \equiv \lambda_{Debye}
         
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
@@ -277,6 +300,12 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
         
+        .. math::
+            b_{min} \equiv \rho_{\perp}
+        
+        .. math::
+            b_{max} \equiv \left(\lambda_{Debye}^2 + a_i^2\right)^{1/2}
+        
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
@@ -290,6 +319,12 @@ def Coulomb_logarithm(
         
         .. math::
             \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+        
+        .. math::
+            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            
+        .. math::
+            b_{max} \equiv \left(\lambda_{Debye}^2 + a_i^2\right)^{1/2}
         
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -214,15 +214,15 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
-        .. math::
-            b_{min} \equiv \max\left( \Lambda_{deBroglie}, \rho_{\perp} \right)
+        #.. math::
+            #b_{min} \equiv \max\left( \Lambda_{deBroglie}, \rho_{\perp} \right)
         
         .. math::
             b_{max} \equiv \lambda_D
         
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
-    Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer with interpolation of :math:`b_{min}`)
+    Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
         A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated 
         between the deBroglie wavelength and the distance of closest approach rather 
         than being the larger of the deBroglie wavelength and the distance of closest approach.
@@ -233,7 +233,7 @@ def Coulomb_logarithm(
         This method is not valid if :math:`\Lambda < 0`, which may be true if the coupling 
         parameter is high (such as for dense, cold plasmas).
         This is the first method in Table 1 of Reference [4].
-    Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
+    Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the deBroglie 
         wavelength and the distance of closest approach. :math:`b_{max}` is interpolated 
@@ -271,7 +271,7 @@ def Coulomb_logarithm(
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
         impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
         This is the fourth method in Table 1 of Reference [4].
-    Option 6: `"hlsmaxinterp"` or `"hlsmi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{max}`)
+    Option 6: `"hlsmaxinterp"` or `"hlsmi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
         A modified hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated 
         between the Debye length and the ion sphere radius and :math:`b_{min}` is the distance 
         of closest approach.
@@ -284,7 +284,7 @@ def Coulomb_logarithm(
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
         impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
         This is the fifth method in Table 1 of Reference [4].
-    Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
+    Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the deBroglie wavelength 
         and the distance of closest approach. :math:`b_{max}` is interpolated between the Debye

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -16,9 +16,8 @@ into account the cumulative effects of many such collisions.
 Coulomb logarithms
 ==================
 
-Please see the documentation for the `Coulomb_logarithm`
-for a review of the many ways in which one can define and calculate
-that quantity.
+Please read the documentation of `Coulomb_logarithm` below for an explanation of the
+7 PlasmaPy-supported methods of computing the Coulomb logarithm.
 
 Collision rates
 ===============
@@ -120,7 +119,7 @@ def Coulomb_logarithm(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical Landau-Spitzer method
-        (`"classical"`). The other 6 supported methods are `"lsmininterp"`,
+        (`"classical"` or `"ls"`). The other 6 supported methods are `"lsmininterp"`,
         `"lsfullinterp"`, `"lsclamp"`, `"hyperls"`, `"hlsmaxinterp"`, and 
         `"hlsfullinterp"`. Please refer to the "Notes" section of this docstring
         for more information, including about abbreviated aliases of these names.
@@ -137,7 +136,7 @@ def Coulomb_logarithm(
         If the mass or charge of either particle cannot be found, or
         any of the inputs contain incorrect values.
 
-    `UnitConversionError`
+    `~astropy.units.UnitConversionError`
         If the units on any of the inputs are incorrect.
 
         If the n_e, T, or V are not Quantities.
@@ -201,44 +200,54 @@ def Coulomb_logarithm(
     This means the Coulomb logarithm will not break down for Lambda < 0,
     which occurs for dense, cold plasmas.
 
-    Methods
+    **Supported Methods of Computing the Coulomb Logarithm**
     
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
         The classical Landau-Spitzer method. Fails for large coupling
         parameter where Lambda can become less than zero.
     Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer with interpolation of :math:`b_{min}`)
-        Landau-Spitzer, but with interpolated bmin instead of bmin
-        selected between deBroglie wavelength and distance of closest
-        approach. Fails for large coupling parameter where Lambda can
-        become less than zero.
-        The first method in Table 1 of Reference [4].
+        A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated rather than
+        the larger of the deBroglie wavelength and the distance of closest
+        approach.
+        
+        This method fails if :math:`\lambda < 0`, which may be true if the coupling parameter is high.
+        This is the first method in Table 1 of Reference [4].
     Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
-        Another Landau-Spitzer like approach, but now bmax is also
-        being interpolated. The interpolation is between the Debye
+        A modified Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
+        are each interpolated. The interpolation is between the Debye
         length and the ion sphere radius, allowing for descriptions
-        of dilute plasmas. Fails for large coupling
-        parameter where Lambda can become less than zero.
-        The second method in Table 1 of Reference [4].
+        of dilute plasmas.
+        
+        This method fails if :math:`\lambda < 0`, which may be true if the coupling parameter is high.
+        This is the second method in Table 1 of Reference [4].
     Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
-        A clamp is placed at Lambda_min = 2 because the classical
+        A modified Landau-Spitzer method in which the value of :math:`\lambda < 0` is clamped at a minimum of :math:`2` because the classical
         Landau-Spitzer method fails for a Coulomb logarithm < 0.
-        The third method in Table 1 of Reference [4].
+        This is the third method in Table 1 of Reference [4].
     Option 5: `"hyperls"` or `"hls"` (Hyperbolic Landau-Spitzer)
-        Spitzer-like extension to Coulomb logarithm by noting that
-        Coulomb collisions take hyperbolic trajectories. Removes
-        divergence for small bmin issue in classical Landau-Spitzer
-        approach, so bmin can be zero. Also doesn't break down as
-        Lambda < 0 is now impossible, even when coupling parameter is large.
-        The fourth method in Table 1 of Reference [4].
+        A modified Landau-Spitzer method in which the trajectories of Coulomb collisions are modeled as hyperbolic
+        rather than straight.
+        
+        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic Landau-Spitzer
+        methods because these methods do not diverge for small :math:`b_{min}`, unlike the non-hyperbolic Landau-Spitzer methods.
+        This method cannot fail because it is impossible for :math:`\lambda < 0` in this method, even for a large coupling parameter.
+        This is the fourth method in Table 1 of Reference [4].
     Option 6: `"hlsmaxinterp"` or `"hlsmi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{max}`)
-        Similar to GMS-4, but setting bmin as distance of closest approach
-        and bmax interpolated between Debye length and ion sphere radius.
-        Lambda < 0 impossible.
-        The fifth method in Table 1 of Reference [4].
-    Option 7: `"hlsfullinterp`" or `"hlsfi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
-        Similar to GMS-4 and GMS-5, but using interpolation methods
-        for both bmin and bmax.
-        The sixth method in Table 1 of Reference [4].
+        A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` is the distance of closest approach
+        and :math:`b_{max}` is interpolated between the Debye length and the ion sphere radius.
+        
+        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic Landau-Spitzer
+        methods because these methods do not diverge for small :math:`b_{min}`, unlike the non-hyperbolic Landau-Spitzer methods.
+        This method cannot fail because it is impossible for :math:`\lambda < 0` in this method, even for a large coupling parameter.
+        This is the fifth method in Table 1 of Reference [4].
+    Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
+        A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
+        are each interpolated.
+        
+        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic Landau-Spitzer
+        methods because these methods do not diverge for small :math:`b_{min}`, unlike the non-hyperbolic Landau-Spitzer methods.
+        This method cannot fail because it is impossible for :math:`\lambda < 0` in this method, even for a large coupling parameter.
+        This is the sixth method in Table 1 of Reference [4].
 
     Examples
     --------

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -157,8 +157,14 @@ def Coulomb_logarithm(
         If the input velocity is greater than 5% of the speed of
         light.
 
+    See Also
+    --------
+    impact_parameter : Computes :math:`b_{min}` and :math:`b_{max}`.
+
     Notes
     -----
+    PlasmaPy recommends Option 7, `"hlsfulli"` or `hlsfi"`, for most users.
+    
     The classical Landau-Spitzer Coulomb logarithm is given by
 
     .. math::
@@ -209,10 +215,10 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
         .. math::
-            b_{min} = \max\left( \Lambda_{deBroglie}, \rho_{\perp} \right)
+            b_{min} \equiv \max\left( \Lambda_{deBroglie}, \rho_{\perp} \right)
         
         .. math::
-            b_{max} = \lambda_D
+            b_{max} \equiv \lambda_D
         
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -214,10 +214,6 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
-            b_{min} \equiv \lambda_{de Broglie}
-            
-            b_{max} \equiv \lambda_D
-        
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
     Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer, interpolation of :math:`b_{min}`)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -120,7 +120,7 @@ def Coulomb_logarithm(
         The method by which to compute the Coulomb logarithm.
         The default method is the classical Landau-Spitzer method
         (`"classical"` or `"ls"`). The other 6 supported methods are `"lsmininterp"`,
-        `"lsfullinterp"`, `"lsclamp"`, `"hyperls"`, `"hlsmaxinterp"`, and 
+        `"lsfullinterp"`, `"lsclamp"`, `"hlsmininterp"`, `"hlsmaxinterp"`, and 
         `"hlsfullinterp"`. Please refer to the "Notes" section of this docstring
         for more information, including about abbreviated aliases of these names.
 
@@ -163,8 +163,18 @@ def Coulomb_logarithm(
 
     Notes
     -----
-    PlasmaPy supports 7 methods of computing the Coulomb logarithm, 4 methods in which
-    the trajectory of a Coulomb collision is modeled as a straight line and 3 methods in which
+    PlasmaPy supports 7 methods of computing the Coulomb logarithm:
+    
+    1. `"classical"` or `"ls"`
+    2. `"lsmininterp"` or `"lsmini"`
+    3. `"lsfullinterp"` or `"lsfi"`
+    4. `"lsclamp"` or `"lsc"`
+    5. `"hlsmininterp"` or `"hlsmini"`
+    6. `"hlsmaxinterp"` or `"hlsmaxi"`
+    7. `"hlsfullinterp"` or `"hlsfi"`
+    
+    The first 4 methods are straight-line methods in which the trajectory of a Coulomb collision 
+    is modeled as a straight line. The last 3 methods are hyperbolic methods in which
     the trajectory of a Coulomb collision is modeled as a hyperbola.
     
     For **straight-line** Landau-Spitzer methods, the Coulomb logarithm is defined by
@@ -198,7 +208,12 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
         .. math::
-            b_{min} \equiv \lambda_{de Broglie}
+            b_{min} \equiv 
+            \left\{
+                \begin{array}{ll}
+                           \lambda_{de Broglie} & mbox(if) \lambda_{de Broglie} > \rho_{\perp}
+                           \rho_{\perp}         & mbox(if) \rho_{\perp} > \lambda_{de Broglie}
+            \right.
         
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -223,7 +238,7 @@ def Coulomb_logarithm(
         
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
-    Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
+    Option 2: `"lsmininterp"` or `"lsmini"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
@@ -232,7 +247,7 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
         .. math::
-            b_{min} \equiv \sqrt\lambda_{de Broglie}^2 + \rho_{\perp}^2
+            b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
         
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -278,7 +293,7 @@ def Coulomb_logarithm(
         This method cannot fail because it is impossible for :math:`\Lambda < 0` in this 
         method, even for a large coupling parameter.
         This is the third method in Table 1 of Reference [4].
-    Option 5: `"hlsmininterp"` or `"hlsmini"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{in}`)
+    Option 5: `"hlsmininterp"` or `"hlsmini"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -399,8 +399,15 @@ def Coulomb_logarithm(
     bmin, bmax = impact_parameter(
         T=T, n_e=n_e, species=species, z_mean=z_mean, V=V, method=method
     )
-    
-    if method in ("classical", "LS", "ls_min_interp", "GMS-1", "ls_full_interp", "GMS-2"):
+
+    if method in (
+        "classical",
+        "LS",
+        "ls_min_interp",
+        "GMS-1",
+        "ls_full_interp",
+        "GMS-2",
+    ):
         ln_Lambda = np.log(bmax / bmin)
     elif method in ("ls_clamp_mininterp", "GMS-3"):
         ln_Lambda = np.log(bmax / bmin)
@@ -409,23 +416,37 @@ def Coulomb_logarithm(
                 ln_Lambda = 2 * u.dimensionless_unscaled
             else:
                 ln_Lambda[ln_Lambda < 2] = 2 * u.dimensionless_unscaled
-    elif method in ("hls_min_interp", "GMS-4", "hls_max_interp", "GMS-5", "hls_full_interp", "GMS-6"):
+    elif method in (
+        "hls_min_interp",
+        "GMS-4",
+        "hls_max_interp",
+        "GMS-5",
+        "hls_full_interp",
+        "GMS-6",
+    ):
         ln_Lambda = 0.5 * np.log(1 + bmax ** 2 / bmin ** 2)
     else:
         raise ValueError(
-            "Unknown method. Choose from \"classical\", \"ls_min_interp\", \"ls_full_interp\", "
-            "\"ls_clamp_mininterp\", \"hls_min_interp\", \"hls_max_interp\", \"hls_full_interp\", "
+            'Unknown method. Choose from "classical", "ls_min_interp", "ls_full_interp", '
+            '"ls_clamp_mininterp", "hls_min_interp", "hls_max_interp", "hls_full_interp", '
             "and their aliases. Please refer to the documentation of this function for more information."
         )
-    
+
     # applying dimensionless units
     ln_Lambda = ln_Lambda.to(u.dimensionless_unscaled).value
-    
-    #Allow NaNs through the < checks without warning
+
+    # Allow NaNs through the < checks without warning
     with np.errstate(invalid="ignore"):
-        if np.any(ln_Lambda < 2) and method in ["classical", "LS", "ls_min_interp", "GMS-1", "ls_full_interp", "GMS-2"]:
+        if np.any(ln_Lambda < 2) and method in [
+            "classical",
+            "LS",
+            "ls_min_interp",
+            "GMS-1",
+            "ls_full_interp",
+            "GMS-2",
+        ]:
             warnings.warn(
-                f"The Coulomb logarithm is {ln_Lambda}, and the specified method, \"{method}\", depends on "
+                f'The Coulomb logarithm is {ln_Lambda}, and the specified method, "{method}", depends on '
                 "weak coupling.",
                 utils.CouplingWarning,
             )
@@ -435,7 +456,7 @@ def Coulomb_logarithm(
                 "coupling effects may exist for the plasma.",
                 utils.CouplingWarning,
             )
-    
+
     return ln_Lambda
 
 
@@ -469,7 +490,7 @@ def _replaceNanVwithThermalV(V, T, m):
     if np.any(V == 0):
         raise utils.PhysicsError("You cannot have a collision for zero velocity!")
     # getting thermal velocity of system if no velocity is given
-    
+
     if V is None:
         V = parameters.thermal_speed(T, "e-", mass=m)
     elif np.any(np.isnan(V)):
@@ -481,7 +502,7 @@ def _replaceNanVwithThermalV(V, T, m):
         else:
             V = V.copy()
             V[np.isnan(V)] = parameters.thermal_speed(T[np.isnan(V)], "e-", mass=m)
-    
+
     return V
 
 
@@ -707,7 +728,7 @@ def impact_parameter(
     lambdaBroglie = hbar / (2 * reduced_mass * V)
     # distance of closest approach in 90 degree Coulomb collision
     bPerp = impact_parameter_perp(T=T, species=species, V=V)
-    
+
     # obtaining minimum and maximum impact parameters depending on which
     # method is requested
     if method == "classical":
@@ -776,7 +797,7 @@ def impact_parameter(
         bmin = (lambdaBroglie ** 2 + bPerp ** 2) ** (1 / 2)
     else:
         raise ValueError(f"Method {method} not found!")
-   
+
     # ARRAY NOTES
     # it could be that bmin and bmax have different sizes. If Te is a scalar,
     # T and V will be scalar from _boilerplate, so bmin will scalar.  However
@@ -784,7 +805,7 @@ def impact_parameter(
     # do we want to extend the scalar bmin to equal the length of bmax? Sure.
     if np.isscalar(bmin.value) and not np.isscalar(bmax.value):
         bmin = np.repeat(bmin, len(bmax))
-    
+
     return bmin.to(u.m), bmax.to(u.m)
 
 
@@ -904,7 +925,7 @@ def collision_frequency(
     # using a more descriptive name for the thermal velocity using
     # reduced mass
     V_reduced = V_r
-    
+
     if species[0] in ("e", "e-") and species[1] in ("e", "e-"):
         # electron-electron collision
         # if a velocity was passed, we use that instead of the reduced
@@ -937,7 +958,7 @@ def collision_frequency(
         bPerp = impact_parameter_perp(T=T, species=species, V=V)
         # Coulomb logarithm
         cou_log = Coulomb_logarithm(T, n, species, z_mean, V=V, method=method)
-   
+
     # collisional cross section
     sigma = Coulomb_cross_section(bPerp)
     # collision frequency where Coulomb logarithm accounts for
@@ -1906,7 +1927,7 @@ def coupling_parameter(
     """
     # boiler plate checks
     T, masses, charges, reduced_mass, V = _boilerPlate(T=T, species=species, V=V)
-    
+
     if np.isnan(z_mean):
         # using mean charge to get average ion density.
         # If you are running this, you should strongly consider giving
@@ -1923,13 +1944,13 @@ def coupling_parameter(
         n_i = n_e / z_mean
         # getting Wigner-Seitz radius based on ion density
         radius = Wigner_Seitz_radius(n_i)
-    
+
     # Coulomb potential energy between particles
     if np.isnan(z_mean):
         coulombEnergy = charges[0] * charges[1] / (4 * np.pi * eps0 * radius)
     else:
         coulombEnergy = (z_mean * e) ** 2 / (4 * np.pi * eps0 * radius)
-    
+
     if method == "classical":
         # classical thermal kinetic energy
         kineticEnergy = k_B * T

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -157,10 +157,6 @@ def Coulomb_logarithm(
         If the input velocity is greater than 5% of the speed of
         light.
 
-    See Also
-    --------
-    impact_parameter : Computes :math:`b_{min}` and :math:`b_{max}`.
-
     Notes
     -----
     **Overview of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
@@ -191,11 +187,11 @@ def Coulomb_logarithm(
 
     For all 7 methods, :math:`b_{min}` and :math:`b_{max}` are the inner impact parameter and the outer
     impact parameter for Coulomb collisions [1]_; :math:`b_{min}` and :math:`b_{max}` are each computed 
-    by `impact_parameter`.
+    by `impact_parameter`, another function.
 
     .. note:: 
-        PlasmaPy recommends Method 7, `"hlsfulli"` or `hlsfi"`, for most users. The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
-        the straight-line Landau-Spitzer methods fail if :math:`\Lambda < 0`.
+        PlasmaPy recommends Method 7, `"hlsfullinterp"` or `hlsfi"`, for most users. The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
+        the straight-line Landau-Spitzer methods fail if :math:`\ln{\Lambda} < 0`.
     
     **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
     
@@ -241,7 +237,9 @@ def Coulomb_logarithm(
         assumptions made in the standard analysis of Coulomb collisions
         are invalid.
         
-        This method is not valid if :math:`\Lambda < 0`, which may be true if the 
+        Valid For: Only dilute, weakly coupled plasmas.
+        
+        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
     Option 2: `"lsmininterp"` or `"lsmini"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
@@ -257,15 +255,17 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        This method is not valid if :math:`\Lambda < 0`, which may be true if the coupling 
+        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true for nonideal plasmas and if the coupling 
         parameter is high (such as for dense, cold plasmas).
-        This is the first method in Table 1 of Reference [4].
+        
+        Note: This is the first method in Table 1 of Reference [4].
+        
     Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
         :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
-        and the ion sphere radius (:math:`a_i`), allowing for descriptions of dilute plasmas.
+        and the ion sphere radius (:math:`a_i`).
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
@@ -276,9 +276,13 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
-        This method is not valid if :math:`\Lambda < 0`, which may be true if the coupling 
+        Valid For: Dilute plasmas
+        
+        Invalid For: This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true for nonideal plasmas and if the coupling 
         parameter is high (such as for dense, cold plasmas).
-        This is the second method in Table 1 of Reference [4].
+        
+        Note: This is the second method in Table 1 of Reference [4].
+        
     Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
         A straight-line Landau-Spitzer method in which the value of :math:`\Lambda` is clamped at 
         a minimum of :math:`2` so that it does not fail for Coulomb logarithm < 0, unlike the 
@@ -288,6 +292,15 @@ def Coulomb_logarithm(
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+        
+         .. math::
+            \ln{\Lambda} \equiv 
+            \left\{
+                \begin{array}{ll}
+                           \ln\left( \frac{b_{max}}{b_{min}} \right) & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}} \right) > 2 \\
+                           2                                         & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}} \right) \leq 2
+                \end{array}
+            \right.
             
         .. math::
             b_{min} \equiv \sqrt{\lambda_{de Broglie}^2 + \rho_{\perp}^2}
@@ -295,9 +308,11 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        This method cannot fail because it is impossible for :math:`\Lambda < 0` in this 
+        Invalid For: N/A. This method cannot fail because it is impossible for :math:`\ln{\Lambda} < 0` in this 
         method, even for a large coupling parameter.
-        This is the third method in Table 1 of Reference [4].
+        
+        Note: This is the third method in Table 1 of Reference [4].
+        
     Option 5: `"hlsmininterp"` or `"hlsmini"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
@@ -315,8 +330,10 @@ def Coulomb_logarithm(
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
-        This is the fourth method in Table 1 of Reference [4].
+        impossible for :math:`\ln{\Lambda} < 0` in this method, even for a high coupling parameter.
+        
+        Note: This is the fourth method in Table 1 of Reference [4].
+        
     Option 6: `"hlsmaxinterp"` or `"hlsmaxi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated 
         between the Debye length (:math:`\lambda_{Debye}`) and the ion sphere radius (:math:`a_i`)
@@ -334,14 +351,16 @@ def Coulomb_logarithm(
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
-        This is the fifth method in Table 1 of Reference [4].
+        impossible for :math:`\ln{\Lambda} < 0` in this method, even for a high coupling parameter.
+        
+        Note: This is the fifth method in Table 1 of Reference [4].
+        
     Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
         :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
-        and the ion sphere radius (:math:`a_i`), allowing for descriptions of dilute plasmas.
+        and the ion sphere radius (:math:`a_i`).
         
         .. math::
             \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
@@ -355,8 +374,11 @@ def Coulomb_logarithm(
         A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
         Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
-        This is the sixth method in Table 1 of Reference [4].
+        impossible for :math:`\ln{\Lambda} < 0` in this method, even for a high coupling parameter.
+        
+        Valid For: Dilute plasmas
+        
+        Note: This is the sixth method in Table 1 of Reference [4].
 
     Examples
     --------
@@ -383,6 +405,10 @@ def Coulomb_logarithm(
     .. [4] Dense plasma temperature equilibration in the binary collision
        approximation. D. O. Gericke et. al. PRE,  65, 036418 (2002).
        DOI: 10.1103/PhysRevE.65.036418
+    
+    See Also
+    --------
+    impact_parameter : Computes :math:`b_{min}` and :math:`b_{max}`.
     """
     # fetching impact min and max impact parameters
     bmin, bmax = impact_parameter(

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -185,7 +185,7 @@ def Coulomb_logarithm(
 
     .. note:: PlasmaPy recommends Option 7, `"hlsfulli"` or `hlsfi"`, for most users.
 
-    Further information about these methods is in Reference [4].
+    Further information about these methods is in Reference [4]_.
     
     **Supported Methods of Computing the Coulomb Logarithm**
     
@@ -195,8 +195,10 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
+        .. math::
             b_{min} \equiv \lambda_{de Broglie}
-            
+        
+        .. math::
             b_{max} \equiv \lambda_{Debye}
         
         The outer impact parameter is defined to be the Debye length:
@@ -206,9 +208,9 @@ def Coulomb_logarithm(
         screened out due to electrons rearranging themselves.
 
         The choice of inner impact parameter is either the distance of closest
-        approach for a 90 degree Coulomb collision or the thermal deBroglie
+        approach for a 90 degree Coulomb collision or the thermal de Broglie
         wavelength, whichever is larger. This is because Coulomb-style collisions
-        cannot occur for impact parameters shorter than the deBroglie
+        cannot occur for impact parameters shorter than the de Broglie
         wavelength because quantum effects will change the fundamental
         nature of the collision [2]_, [3]_.
 
@@ -221,14 +223,14 @@ def Coulomb_logarithm(
         coupling parameter is high (such as for dense, cold plasmas).
     Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
         A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
-        deBroglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`) rather than being the larger of the two.
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
         .. math::
-            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \sqrt(\left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right))
         
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -238,7 +240,7 @@ def Coulomb_logarithm(
         This is the first method in Table 1 of Reference [4].
     Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
-        are each interpolated. :math:`b_{min}` is interpolated between the deBroglie wavelength
+        are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
         :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
         and the ion sphere radius (:math:`a_i`), allowing for descriptions of dilute plasmas.
@@ -258,7 +260,7 @@ def Coulomb_logarithm(
     Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
         A modified Landau-Spitzer method in which the value of :math:`\lambda` is clamped at 
         a minimum of :math:`2` so that it does not fail for Coulomb logarithm < 0, unlike the 
-        classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the deBroglie 
+        classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
         wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`). :math:`b_{max}` is the Debye length (:math:`\lambda_{Debye}`).
         
@@ -277,7 +279,7 @@ def Coulomb_logarithm(
     Option 5: `"hyperls"` or `"hls"` (Hyperbolic Landau-Spitzer)
         A modified Landau-Spitzer method in which the trajectories of Coulomb collisions are 
         modeled as hyperbolic rather than straight. :math:`b_{min}` is interpolated between the 
-        deBroglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`). :math:`b_{max}` is the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
@@ -315,7 +317,7 @@ def Coulomb_logarithm(
         This is the fifth method in Table 1 of Reference [4].
     Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
-        are each interpolated. :math:`b_{min}` is interpolated between the deBroglie wavelength
+        are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
         :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
         and the ion sphere radius (:math:`a_i`), allowing for descriptions of dilute plasmas.
@@ -625,13 +627,13 @@ def impact_parameter(
         b_{max} = \left(\lambda_{De}^2 + a_i^2\right)^{1/2}
 
     The minimum impact parameter is typically some combination of the
-    thermal deBroglie wavelength and the distance of closest approach
+    thermal de Broglie wavelength and the distance of closest approach
     for a 90 degree Coulomb collision. A quadratic sum is used for
     all GMS methods, except for GMS-5, where b_min is simply set to
     the distance of closest approach [1]_.
 
     .. math::
-        b_{min} = \left(\Lambda_{deBroglie}^2 + \rho_{\perp}^2\right)^{1/2}
+        b_{min} = \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
 
     Examples
     --------
@@ -661,7 +663,7 @@ def impact_parameter(
             )
     # Debye length
     lambdaDe = parameters.Debye_length(T, n_e)
-    # deBroglie wavelength
+    # de Broglie wavelength
     lambdaBroglie = hbar / (2 * reduced_mass * V)
     # distance of closest approach in 90 degree Coulomb collision
     bPerp = impact_parameter_perp(T=T, species=species, V=V)
@@ -672,7 +674,7 @@ def impact_parameter(
         # Coulomb-style collisions will not happen for impact parameters
         # shorter than either of these two impact parameters, so we choose
         # the larger of these two possibilities. That is, between the
-        # deBroglie wavelength and the distance of closest approach.
+        # de Broglie wavelength and the distance of closest approach.
         # ARRAY NOTES
         # T and V should be guaranteed to be same size inputs from _boilerplate
         # therefore, lambdaBroglie and bPerp are either both scalar or both array
@@ -689,7 +691,7 @@ def impact_parameter(
     elif method == "GMS-1":
         # 1st method listed in Table 1 of reference [1]
         # This is just another form of the classical Landau-Spitzer
-        # approach, but bmin is interpolated between the deBroglie
+        # approach, but bmin is interpolated between the de Broglie
         # wavelength and distance of closest approach.
         bmax = lambdaDe
         bmin = (lambdaBroglie ** 2 + bPerp ** 2) ** (1 / 2)
@@ -1802,10 +1804,10 @@ def coupling_parameter(
     The degeneracy parameter is given by
 
     .. math::
-        \chi = n_e \Lambda_{deBroglie} ^ 3
+        \chi = n_e \Lambda_{de Broglie} ^ 3
 
-    where :math:`n_e` is the electron density and :math:`\Lambda_{deBroglie}`
-    is the thermal deBroglie wavelength.
+    where :math:`n_e` is the electron density and :math:`\Lambda_{de Broglie}`
+    is the thermal de Broglie wavelength.
 
     See equations 1.2, 1.3 and footnote 5 in [2]_ for details on the ideal
     chemical potential.

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -714,10 +714,17 @@ def impact_parameter(
     T, masses, charges, reduced_mass, V = _boilerPlate(T=T, species=species, V=V)
     # catching error where mean charge state is not given for non-classical
     # methods that require the ion density
-    if method in ("GMS-2", "GMS-5", "GMS-6"):
+    if method in (
+        "ls_full_interp",
+        "GMS-2",
+        "hls_max_interp",
+        "GMS-5",
+        "hls_full_interp",
+        "GMS-6",
+    ):
         if np.isnan(z_mean):
             raise ValueError(
-                "Must provide a z_mean for GMS-2, GMS-5, and GMS-6 methods."
+                'Must provide a z_mean for "ls_full_interp", "hls_max_interp", and "hls_full_interp" methods.'
             )
     # Debye length
     lambdaDe = parameters.Debye_length(T, n_e)
@@ -747,14 +754,14 @@ def impact_parameter(
         except ValueError:  # both lambdaBroglie and bPerp are arrays
             bmin = lambdaBroglie
             bmin[bPerp > lambdaBroglie] = bPerp[bPerp > lambdaBroglie]
-    elif method == "GMS-1":
+    elif method == "ls_min_interp" or method == "GMS-1":
         # 1st method listed in Table 1 of reference [1]
         # This is just another form of the classical Landau-Spitzer
         # approach, but bmin is interpolated between the de Broglie
         # wavelength and distance of closest approach.
         bmax = lambdaDe
         bmin = (lambdaBroglie ** 2 + bPerp ** 2) ** (1 / 2)
-    elif method == "GMS-2":
+    elif method == "ls_full_interp" or method == "GMS-2":
         # 2nd method listed in Table 1 of reference [1]
         # Another Landau-Spitzer like approach, but now bmax is also
         # being interpolated. The interpolation is between the Debye
@@ -766,17 +773,17 @@ def impact_parameter(
         ionRadius = Wigner_Seitz_radius(n_i)
         bmax = (lambdaDe ** 2 + ionRadius ** 2) ** (1 / 2)
         bmin = (lambdaBroglie ** 2 + bPerp ** 2) ** (1 / 2)
-    elif method == "GMS-3":
+    elif method == "ls_clamp_mininterp" or method == "GMS-3":
         # 3rd method listed in Table 1 of reference [1]
         # same as GMS-1, but not Lambda has a clamp at Lambda_min = 2
         # where Lambda is the argument to the Coulomb logarithm.
         bmax = lambdaDe
         bmin = (lambdaBroglie ** 2 + bPerp ** 2) ** (1 / 2)
-    elif method == "GMS-4":
+    elif method == "hls_min_interp" or method == "GMS-4":
         # 4th method listed in Table 1 of reference [1]
         bmax = lambdaDe
         bmin = (lambdaBroglie ** 2 + bPerp ** 2) ** (1 / 2)
-    elif method == "GMS-5":
+    elif method == "hls_max_interp" or method == "GMS-5":
         # 5th method listed in Table 1 of reference [1]
         # Mean ion density.
         n_i = n_e / z_mean
@@ -784,7 +791,7 @@ def impact_parameter(
         ionRadius = Wigner_Seitz_radius(n_i)
         bmax = (lambdaDe ** 2 + ionRadius ** 2) ** (1 / 2)
         bmin = bPerp
-    elif method == "GMS-6":
+    elif method == "hls_full_interp" or method == "GMS-6":
         # 6th method listed in Table 1 of reference [1]
         # Mean ion density.
         n_i = n_e / z_mean

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -213,6 +213,10 @@ def Coulomb_logarithm(
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+            
+            b_{min} \equiv \lambda_{de Broglie}
+            
+            b_{max} \equiv \lambda_{Debye}
         
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
@@ -336,8 +340,7 @@ def Coulomb_logarithm(
         ln_Lambda = 0.5 * np.log(1 + bmax ** 2 / bmin ** 2)
     else:
         raise ValueError(
-            "Unknown method! Choose from \"ls\", \"lsmini\", \"lsfulli\", \"lsclamp\", \"hyperls\", \"hlsmaxi\", 
-            \"hlsfulli\", or their aliases. Please refer to the documentation of this function for more information."
+            "Unknown method! Choose from \"ls\", \"lsmini\", \"lsfulli\", \"lsclamp\", \"hyperls\", \"hlsmaxi\", \"hlsfulli\", or their aliases. Please refer to the documentation of this function for more information."
         )
     # applying dimensionless units
     ln_Lambda = ln_Lambda.to(u.dimensionless_unscaled).value

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -121,8 +121,9 @@ def Coulomb_logarithm(
         The method by which to compute the Coulomb logarithm.
         The default method is the classical Landau-Spitzer method
         (`"classical"`). The other 6 supported methods are `"lsmininterp"`,
-        `"lsfullinterp"`, `"lsclamp"`, `"hyperls"`, "hlsmaxinterp", and "hlsfullinterp". Please refer to
-        the "Notes" section of this docstring for more information, including about abbreviated aliases of these names.
+        `"lsfullinterp"`, `"lsclamp"`, `"hyperls"`, `"hlsmaxinterp"`, and 
+        `"hlsfullinterp"`. Please refer to the "Notes" section of this docstring
+        for more information, including about abbreviated aliases of these names.
 
     Returns
     -------
@@ -132,19 +133,19 @@ def Coulomb_logarithm(
 
     Raises
     ------
-    ValueError
+    `ValueError`
         If the mass or charge of either particle cannot be found, or
         any of the inputs contain incorrect values.
 
-    UnitConversionError
+    `UnitConversionError`
         If the units on any of the inputs are incorrect.
 
         If the n_e, T, or V are not Quantities.
 
-    PhysicsError
+    `~plasmapy.utils.exceptions.PhysicsError`
         If the result is smaller than 1.
 
-    RelativityError
+    `~plasmapy.utils.exceptions.RelativityError`
         If the input velocity is same or greater than the speed
         of light.
 
@@ -153,7 +154,7 @@ def Coulomb_logarithm(
     : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
-    : `~plasmapy.utils.RelativityWarning`
+    : `~plasmapy.utils.exceptions.RelativityWarning`
         If the input velocity is greater than 5% of the speed of
         light.
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -287,7 +287,7 @@ def Coulomb_logarithm(
         Note: This is the second method in Table 1 of Reference [4].
         
     Option 4: `"lsclampmininterp"` or `"lscmini"` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
-        A straight-line Landau-Spitzer method in which the value of :math:`\Lambda` is clamped at 
+        A straight-line Landau-Spitzer method in which the value of :math:`\ln{\Lambda}` is clamped at 
         a minimum of :math:`2` so that it does not fail for Coulomb logarithm < 0, unlike the 
         classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
         wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -121,7 +121,7 @@ def Coulomb_logarithm(
         The default method is the classical straight-line Landau-Spitzer method
         (`"classical"` or `"ls"`). The other 6 supported methods are `"lsmininterp"`,
         `"lsfullinterp"`, `"lsclampmininterp"`, `"hlsmininterp"`, `"hlsmaxinterp"`, and 
-        `"hlsfullinterp"`. Please refer to the `Notes <#Notes>`_ section of this 
+        `"hlsfullinterp"`. Please refer to the :ref:`Notes` section of this 
         docstring for more information, including about abbreviated aliases of these names.
 
     Returns

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -199,9 +199,9 @@ def Coulomb_logarithm(
             
             b_{max} \equiv \lambda_{Debye}
         
-        The outer impact parameter is given by the Debye length:
-        :math:`b_{max} = \lambda_D` which is a function of electron
-        temperature and electron density.  At distances greater than the
+        The outer impact parameter is defined to be the Debye length:
+        :math:`b_{max} = \lambda_D`, which is a function of electron
+        temperature and electron density. At distances greater than the
         Debye length, electric fields from other particles will be
         screened out due to electrons rearranging themselves.
 
@@ -220,15 +220,15 @@ def Coulomb_logarithm(
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
     Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
-        A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated 
-        between the deBroglie wavelength and the distance of closest approach rather 
-        than being the larger of the deBroglie wavelength and the distance of closest approach.
+        A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
+        deBroglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        (:math:`\rho_{\perp}`) rather than being the larger of the two.
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
         .. math::
-            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
         
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -238,16 +238,16 @@ def Coulomb_logarithm(
         This is the first method in Table 1 of Reference [4].
     Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
-        are each interpolated. :math:`b_{min}` is interpolated between the deBroglie 
-        wavelength and the distance of closest approach. :math:`b_{max}` is interpolated 
-        between the Debye length and the ion sphere radius, allowing for descriptions
-        of dilute plasmas.
+        are each interpolated. :math:`b_{min}` is interpolated between the deBroglie wavelength
+        (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
+        :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
+        and the ion sphere radius (:math:`a_i`), allowing for descriptions of dilute plasmas.
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
         .. math::
-            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
             
         .. math::
             b_{max} \equiv \left(\lambda_{Debye}^2 + a_i^2\right)^{1/2}
@@ -258,15 +258,15 @@ def Coulomb_logarithm(
     Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
         A modified Landau-Spitzer method in which the value of :math:`\lambda` is clamped at 
         a minimum of :math:`2` so that it does not fail for Coulomb logarithm < 0, unlike the 
-        classical Landau-Spitzer method. :math:`b_{min}` is interpolated between
-        the deBroglie wavelength and the distance of closest
-        approach.
+        classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the deBroglie 
+        wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        (:math:`\rho_{\perp}`). :math:`b_{max}` is the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
         .. math::
-            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
         
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -276,13 +276,15 @@ def Coulomb_logarithm(
         This is the third method in Table 1 of Reference [4].
     Option 5: `"hyperls"` or `"hls"` (Hyperbolic Landau-Spitzer)
         A modified Landau-Spitzer method in which the trajectories of Coulomb collisions are 
-        modeled as hyperbolic rather than straight.
+        modeled as hyperbolic rather than straight. :math:`b_{min}` is interpolated between the 
+        deBroglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        (:math:`\rho_{\perp}`). :math:`b_{max}` is the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
             \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
         
         .. math::
-            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
             
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -294,8 +296,8 @@ def Coulomb_logarithm(
         This is the fourth method in Table 1 of Reference [4].
     Option 6: `"hlsmaxinterp"` or `"hlsmi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
         A modified hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated 
-        between the Debye length and the ion sphere radius and :math:`b_{min}` is the distance 
-        of closest approach.
+        between the Debye length (:math:`\lambda_{Debye}`) and the ion sphere radius (:math:`a_i`)
+        and :math:`b_{min}` is the distance of closest approach (:math:`\rho_{\perp}`).
         
         .. math::
             \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
@@ -313,15 +315,16 @@ def Coulomb_logarithm(
         This is the fifth method in Table 1 of Reference [4].
     Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
-        are each interpolated. :math:`b_{min}` is interpolated between the deBroglie wavelength 
-        and the distance of closest approach. :math:`b_{max}` is interpolated between the Debye
-        length and the ion sphere radius, allowing for descriptions of dilute plasmas.
+        are each interpolated. :math:`b_{min}` is interpolated between the deBroglie wavelength
+        (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
+        :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
+        and the ion sphere radius (:math:`a_i`), allowing for descriptions of dilute plasmas.
         
         .. math::
             \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
         
         .. math::
-            b_{min} \equiv \left(\Lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
+            b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
             
         .. math::
             b_{max} \equiv \left(\lambda_{Debye}^2 + a_i^2\right)^{1/2}

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -86,7 +86,7 @@ def Coulomb_logarithm(
     species: (particles.Particle, particles.Particle),
     z_mean: u.dimensionless_unscaled = np.nan * u.dimensionless_unscaled,
     V: u.m / u.s = np.nan * u.m / u.s,
-    method="LS",
+    method="classical",
 ):
     r"""
     Computes the Coulomb logarithm.
@@ -288,7 +288,7 @@ def Coulomb_logarithm(
     ln_Lambda = ln_Lambda.to(u.dimensionless_unscaled).value
     # Allow NaNs through the < checks without warning
     with np.errstate(invalid="ignore"):
-        if np.any(ln_Lambda < 2) and method in ["classical", "LS", "GMS-1", "LS_min_I", "GMS-2", "LS_full_I"]:
+        if np.any(ln_Lambda < 2) and method in ["classical", "ls", "GMS-1", "lsmini", "GMS-2", "lsfulli"]:
             warnings.warn(
                 f"Coulomb logarithm is {ln_Lambda} and {method} relies on "
                 "weak coupling.",

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -120,7 +120,7 @@ def Coulomb_logarithm(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the Notes section of this docstring for more
@@ -160,11 +160,11 @@ def Coulomb_logarithm(
 
     Notes
     -----
-    **Overview of Supported Methods of Computing the Coulomb Logarithm**
+    **Summary of Supported Methods of Computing the Coulomb Logarithm**
 
     PlasmaPy supports 7 methods of computing the Coulomb logarithm:
 
-    1. ``"classical"`` or ``"LS"``
+    1. ``"classical"`` or ``"ls"``
     2. ``"ls_min_interp"`` or ``"GMS-1"``
     3. ``"ls_full_interp"`` or ``"GMS-2"``
     4. ``"ls_clamp_mininterp"`` or ``"GMS-3"``
@@ -187,8 +187,11 @@ def Coulomb_logarithm(
         \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
 
     For all 7 methods, :math:`b_{min}` and :math:`b_{max}` are the inner impact parameter and the outer
-    impact parameter for Coulomb collisions [1]_; :math:`b_{min}` and :math:`b_{max}` are each computed
-    by `impact_parameter`, another function.
+    impact parameter, respectively, for Coulomb collisions [1]_;
+    :math:`b_{min}` and :math:`b_{max}` are each computed by `impact_parameter`, another function.
+
+    The abbreviations of Options 2-7 (``"GMS-..."``) refer to the first initials of the three authors
+    of Reference [4]_.
 
     .. note::
         For strongly-coupled plasma, PlasmaPy recommends Option 7, ``"hls_full_interp"`` or ``"GMS-6"``,
@@ -198,9 +201,10 @@ def Coulomb_logarithm(
 
     In this section, further information about each method, such as about
     interpolation and other special features, is documented. Please refer
-    to Reference [4]_ for additional information about these methods.
+    to Reference [1]_ and Reference [4]_ for additional information about
+    these methods.
 
-    Option 1: ``"classical"`` or ``"LS"`` (Landau-Spitzer)
+    Option 1: ``"classical"`` or ``"ls"`` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the
         higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest
         approach (:math:`\rho_{\perp}`) if they are not equal (and either of the two if they are equal) and
@@ -233,8 +237,8 @@ def Coulomb_logarithm(
         The uncertainty of the classical straight-line Landau-Spitzer method is on the order
         of its reciprocal.
 
-        This method is invalid if :math:`\ln{\Lambda} < 2` because of the uncertainty of the classical
-        straight-line Landau-Spitzer method and if :math:`\ln{\Lambda} < 0`, which may be true if the
+        This method is invalid if :math:`\ln{\Lambda} < 2` because of the uncertainty of this method
+        and is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the
         coupling parameter is high (such as for nonideal, dense, cold plasmas).
 
         Please refer to Reference [1]_ for additional information about this method.
@@ -281,8 +285,8 @@ def Coulomb_logarithm(
 
     Option 4: ``"ls_clamp_mininterp"`` or ``"GMS-3"`` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which the value of :math:`\ln{\Lambda}` is clamped at
-        a minimum of :math:`2` so that it is impossible for :math:`\ln{\Lambda} < 0`, unlike by the
-        classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie
+        a minimum of :math:`2` so that it is impossible for :math:`\ln{\Lambda} < 0` (which is possible by the
+        classical Landau-Spitzer method). :math:`b_{min}` is interpolated between the de Broglie
         wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach
         (:math:`\rho_{\perp}`). :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
 
@@ -404,7 +408,7 @@ def Coulomb_logarithm(
 
     if method in (
         "classical",
-        "LS",
+        "ls",
         "ls_min_interp",
         "GMS-1",
         "ls_full_interp",
@@ -439,7 +443,7 @@ def Coulomb_logarithm(
     with np.errstate(invalid="ignore"):
         if np.any(ln_Lambda < 2) and method in [
             "classical",
-            "LS",
+            "ls",
             "ls_min_interp",
             "GMS-1",
             "ls_full_interp",
@@ -638,7 +642,7 @@ def impact_parameter(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
@@ -738,7 +742,7 @@ def impact_parameter(
 
     # obtaining minimum and maximum impact parameters depending on which
     # method is requested
-    if method == "classical" or method == "LS":
+    if method == "classical" or method == "ls":
         bmax = lambdaDe
         # Coulomb-style collisions will not happen for impact parameters
         # shorter than either of these two impact parameters, so we choose
@@ -864,7 +868,7 @@ def collision_frequency(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
@@ -1065,7 +1069,7 @@ def fundamental_electron_collision_freq(
     coulomb_log_method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
@@ -1195,7 +1199,7 @@ def fundamental_ion_collision_freq(
     coulomb_log_method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
@@ -1337,7 +1341,7 @@ def mean_free_path(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
@@ -1461,7 +1465,7 @@ def Spitzer_resistivity(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
@@ -1592,7 +1596,7 @@ def mobility(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
@@ -1724,7 +1728,7 @@ def Knudsen_number(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
@@ -1847,7 +1851,7 @@ def coupling_parameter(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -127,7 +127,7 @@ def Coulomb_logarithm(
     Returns
     -------
     ln_Lambda : float or numpy.ndarray
-        The Coulomb logarithm, the uncertainty of which is on the order
+        The dimensionless Coulomb logarithm, the uncertainty of which is on the order
         of its reciprocal.
 
     Raises
@@ -150,10 +150,10 @@ def Coulomb_logarithm(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : `~astropy.units.UnitsWarning`
         If units are not provided, SI units are assumed.
 
-    ~plasmapy.utils.RelativityWarning
+    : `~plasmapy.utils.RelativityWarning`
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -202,39 +202,39 @@ def Coulomb_logarithm(
 
     Methods
     
-    Option 1: "classical" or "ls" (Landau-Spitzer)
-        The classical Landau-Spitzer approach. Fails for large coupling
+    Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
+        The classical Landau-Spitzer method. Fails for large coupling
         parameter where Lambda can become less than zero.
-    Option 2: "GMS-1" or "lsmini" (Landau-Spitzer with interpolation of :math:`b_{min}`)
+    Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer with interpolation of :math:`b_{min}`)
         Landau-Spitzer, but with interpolated bmin instead of bmin
         selected between deBroglie wavelength and distance of closest
         approach. Fails for large coupling parameter where Lambda can
         become less than zero.
         The first method in Table 1 of Reference [4].
-    Option 3: "GMS-2" or "lsfulli" (Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
+    Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
         Another Landau-Spitzer like approach, but now bmax is also
         being interpolated. The interpolation is between the Debye
         length and the ion sphere radius, allowing for descriptions
         of dilute plasmas. Fails for large coupling
         parameter where Lambda can become less than zero.
         The second method in Table 1 of Reference [4].
-    Option 4: "GMS-3" or "lsclamp" (Landau-Spitzer with a clamp)
+    Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
         A clamp is placed at Lambda_min = 2 because the classical
         Landau-Spitzer method fails for a Coulomb logarithm < 0.
         The third method in Table 1 of Reference [4].
-    Option 5: "GMS-4" or "hls" (Hyperbolic Landau-Spitzer)
+    Option 5: `"hls"` (Hyperbolic Landau-Spitzer)
         Spitzer-like extension to Coulomb logarithm by noting that
         Coulomb collisions take hyperbolic trajectories. Removes
         divergence for small bmin issue in classical Landau-Spitzer
         approach, so bmin can be zero. Also doesn't break down as
         Lambda < 0 is now impossible, even when coupling parameter is large.
         The fourth method in Table 1 of Reference [4].
-    Option 6: "GMS-5" or "hlsmaxi" (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{max}`)
+    Option 6: `"hlsmaxinterp"` or `"hlsmi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{max}`)
         Similar to GMS-4, but setting bmin as distance of closest approach
         and bmax interpolated between Debye length and ion sphere radius.
         Lambda < 0 impossible.
         The fifth method in Table 1 of Reference [4].
-    Option 7: "GMS-6" or "hlsfulli" (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
+    Option 7: `"hlsfullinterp`" or `"hlsfi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
         Similar to GMS-4 and GMS-5, but using interpolation methods
         for both bmin and bmax.
         The sixth method in Table 1 of Reference [4].

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -163,7 +163,7 @@ def Coulomb_logarithm(
 
     Notes
     -----
-    ** Overview of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm
+    **Overview of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
     
     PlasmaPy supports 7 methods of computing the Coulomb logarithm:
     
@@ -175,16 +175,16 @@ def Coulomb_logarithm(
     6. `"hlsmaxinterp"` or `"hlsmaxi"`
     7. `"hlsfullinterp"` or `"hlsfi"`
     
-    Method 1 - Method 4 are straight-line Landau-Spitzer ("ls...") methods in which the trajectory of a 
+    Method 1 through Method 4 are straight-line Landau-Spitzer ("ls...") methods in which the trajectory of a 
     Coulomb collision is modeled as a straight line. For the straight-line Landau-Spitzer methods, the Coulomb 
-    logarithm is defined to be:
+    logarithm (:math:`\ln{\Lambda}`) is defined to be:
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
     
-    Method 5 - Method 7 are hyperbolic Landau-Spitzer ("hls...") methods in which the trajectory of a 
+    Method 5 through Method 7 are hyperbolic Landau-Spitzer ("hls...") methods in which the trajectory of a 
     Coulomb collision is modeled as a hyperbola. For the hyperbolic Landau-Spitzer methods, the Coulomb 
-    logarithm is defined to be:
+    logarithm (:math:`\ln{\Lambda}`) is defined to be:
     
     .. math::
         \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
@@ -192,16 +192,15 @@ def Coulomb_logarithm(
     For all 7 methods, :math:`b_{min}` and :math:`b_{max}` are the inner impact parameter and the outer
     impact parameter for Coulomb collisions [1]_; :math:`b_{min}` and :math:`b_{max}` are each computed 
     by `impact_parameter`.
-    
-    In "Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm" below, further 
-    information about each method, such as about interpolation and other special features, is documented. 
-    Please refer to in Reference [4]_ for additional information about these methods.
 
     .. note:: 
-        PlasmaPy recommends Option 7, `"hlsfulli"` or `hlsfi"`, for most users. The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
+        PlasmaPy recommends Method 7, `"hlsfulli"` or `hlsfi"`, for most users. The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
         the straight-line Landau-Spitzer methods fail if :math:`\Lambda < 0`.
     
     **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
+    
+    In this section, further information about each method, such as about interpolation and other special 
+    features, is documented. Please refer to Reference [4]_ for additional information about these methods.
     
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -109,8 +109,8 @@ def Coulomb_logarithm(
         a macroscopic description is valid. This is used to recover the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters. `z_mean` is a required parameter if `method` is
-        `"lsfullinterp"`, `"hlsmaxinterp"`, or `"hlsfullinterp"`.
+        impact parameters. ``z_mean`` is a required parameter if ``method`` is
+        ``"lsfullinterp"``, ``"hlsmaxinterp"``, or ``"hlsfullinterp"``.
 
     V : ~astropy.units.Quantity, optional
         The relative velocity between particles.  If not provided,
@@ -120,9 +120,9 @@ def Coulomb_logarithm(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer method
-        (`"classical"` or `"ls"`). The other 6 supported methods are `"lsmininterp"`,
-        `"lsfullinterp"`, `"lsclampmininterp"`, `"hlsmininterp"`, `"hlsmaxinterp"`, and 
-        `"hlsfullinterp"`. Please refer to the Notes section of this 
+        (``"classical"`` or ``"ls"``). The other 6 supported methods are ``"lsmininterp"``,
+        ``"lsfullinterp"``, ``"lsclampmininterp"``, ``"hlsmininterp"``, ``"hlsmaxinterp"``, and 
+        ``"hlsfullinterp"``. Please refer to the Notes section of this 
         docstring for more information, including about abbreviated aliases of these names.
 
     Returns
@@ -163,22 +163,22 @@ def Coulomb_logarithm(
     
     PlasmaPy supports 7 methods of computing the Coulomb logarithm:
     
-    1. `"classical"` or `"ls"`
-    2. `"lsmininterp"` or `"lsmini"`
-    3. `"lsfullinterp"` or `"lsfi"`
-    4. `"lsclampmininterp"` or `"lscmini"`
-    5. `"hlsmininterp"` or `"hlsmini"`
-    6. `"hlsmaxinterp"` or `"hlsmaxi"`
-    7. `"hlsfullinterp"` or `"hlsfi"`
+    1. ``"classical"`` or ``"ls"``
+    2. ``"lsmininterp"`` or ``"lsmini"``
+    3. ``"lsfullinterp"`` or ``"lsfi"``
+    4. ``"lsclampmininterp"`` or ``"lscmini"``
+    5. ``"hlsmininterp"`` or ``"hlsmini"``
+    6. ``"hlsmaxinterp"`` or ``"hlsmaxi"``
+    7. ``"hlsfullinterp"`` or ``"hlsfi"``
     
-    Option 1 through Option 4 are straight-line Landau-Spitzer (`"ls..."`) methods in which the trajectory of a 
+    Options 1–4 are straight-line Landau-Spitzer (``"ls..."``) methods in which the trajectory of a 
     Coulomb collision is modeled as a straight line. For the straight-line Landau-Spitzer methods, the Coulomb 
     logarithm (:math:`\ln{\Lambda}`) is defined to be:
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
     
-    Option 5 through Option 7 are hyperbolic Landau-Spitzer (`"hls..."`) methods in which the trajectory of a 
+    Options 5–7 are hyperbolic Landau-Spitzer (``"hls..."``) methods in which the trajectory of a 
     Coulomb collision is modeled as a hyperbola. For the hyperbolic Landau-Spitzer methods, the Coulomb 
     logarithm (:math:`\ln{\Lambda}`) is defined to be:
     
@@ -190,15 +190,15 @@ def Coulomb_logarithm(
     by `impact_parameter`, another function.
 
     .. note:: 
-        PlasmaPy recommends Option 7, `"hlsfullinterp"` or `"hlsfi"`, for most users because it is the most accurate overall, 
-        regardless of a plasma's strength of coupling.
+        For strongly-coupled plasma, PlasmaPy recommends Option 7, ``"hlsfullinterp"`` or ``"hlsfi"``,
+        because it provides high accuracy regardless of a plasma's strength of coupling.
     
     **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
     
     In this section, further information about each method, such as about interpolation and other special 
     features, is documented. Please refer to Reference [4]_ for additional information about these methods.
     
-    Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
+    Option 1: ``"classical"`` or ``"ls"`` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 
         higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest 
         approach (:math:`\rho_{\perp}`) if they are not equal (and either of the two if they are equal) and 
@@ -237,7 +237,7 @@ def Coulomb_logarithm(
         
         Please refer to Reference [1]_ for additional information about this method.
         
-    Option 2: `"lsmininterp"` or `"lsmini"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
+    Option 2: ``"lsmininterp"`` or ``"lsmini"`` (Landau-Spitzer, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
@@ -256,7 +256,7 @@ def Coulomb_logarithm(
         
         Note: This is the first method in Table 1 of Reference [4]_.
         
-    Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
+    Option 3: ``"lsfullinterp"`` or ``"lsfi"`` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
@@ -277,7 +277,7 @@ def Coulomb_logarithm(
         
         Note: This is the second method in Table 1 of Reference [4]_.
         
-    Option 4: `"lsclampmininterp"` or `"lscmini"` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
+    Option 4: ``"lsclampmininterp"`` or ``"lscmini"`` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which the value of :math:`\ln{\Lambda}` is clamped at 
         a minimum of :math:`2` so that it is impossible for :math:`\ln{\Lambda} < 0`, unlike by the 
         classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
@@ -304,7 +304,7 @@ def Coulomb_logarithm(
         
         Note: This is the third method in Table 1 of Reference [4]_.
         
-    Option 5: `"hlsmininterp"` or `"hlsmini"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}`)
+    Option 5: ``"hlsmininterp"`` or ``"hlsmini"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
@@ -323,7 +323,7 @@ def Coulomb_logarithm(
         
         Note: This is the fourth method in Table 1 of Reference [4]_.
         
-    Option 6: `"hlsmaxinterp"` or `"hlsmaxi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
+    Option 6: ``"hlsmaxinterp"`` or ``"hlsmaxi"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated between 
         the Debye length (:math:`\lambda_{Debye}`) and the ion sphere radius (:math:`a_i`)
         and :math:`b_{min}` is defined to be the distance of closest approach (:math:`\rho_{\perp}`).
@@ -344,7 +344,7 @@ def Coulomb_logarithm(
         
         Note: This is the fifth method in Table 1 of Reference [4]_.
         
-    Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
+    Option 7: ``"hlsfullinterp"`` or ``"hlsfi"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
@@ -605,8 +605,8 @@ def impact_parameter(
         a macroscopic description is valid. This is used to recover the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters. `z_mean` is a required parameter if `method` is
-        `"lsfullinterp"`, `"hlsmaxinterp"`, or `"hlsfullinterp"`.
+        impact parameters. ``z_mean`` is a required parameter if ``method`` is
+        ``"lsfullinterp"``, ``"hlsmaxinterp"``, or ``"hlsfullinterp"``.
 
     V : ~astropy.units.Quantity, optional
         The relative velocity between particles.  If not provided,

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -190,7 +190,9 @@ def Coulomb_logarithm(
     **Supported Methods of Computing the Coulomb Logarithm**
     
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
-        The classical Landau-Spitzer method.
+        The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the higher of 
+        the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
+        (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
@@ -222,15 +224,15 @@ def Coulomb_logarithm(
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).
     Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer, interpolation of :math:`b_{min}`)
-        A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
+        A straight-line Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
-        (:math:`\rho_{\perp}`) rather than being the larger of the two.
+        (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
         .. math::
-            b_{min} \equiv \sqrt(\left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right))
+            b_{min} \equiv \sqrt(\lambda_{de Broglie}^2 + \rho_{\perp}^2)
         
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -239,7 +241,7 @@ def Coulomb_logarithm(
         parameter is high (such as for dense, cold plasmas).
         This is the first method in Table 1 of Reference [4].
     Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
-        A modified Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
+        A straight-line Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
         :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 
@@ -258,11 +260,11 @@ def Coulomb_logarithm(
         parameter is high (such as for dense, cold plasmas).
         This is the second method in Table 1 of Reference [4].
     Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
-        A modified Landau-Spitzer method in which the value of :math:`\lambda` is clamped at 
+        A straight-line Landau-Spitzer method in which the value of :math:`\lambda` is clamped at 
         a minimum of :math:`2` so that it does not fail for Coulomb logarithm < 0, unlike the 
         classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
         wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
-        (:math:`\rho_{\perp}`). :math:`b_{max}` is the Debye length (:math:`\lambda_{Debye}`).
+        (:math:`\rho_{\perp}`). :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
@@ -276,14 +278,13 @@ def Coulomb_logarithm(
         This method cannot fail because it is impossible for :math:`\Lambda < 0` in this 
         method, even for a large coupling parameter.
         This is the third method in Table 1 of Reference [4].
-    Option 5: `"hyperls"` or `"hls"` (Hyperbolic Landau-Spitzer)
-        A modified Landau-Spitzer method in which the trajectories of Coulomb collisions are 
-        modeled as hyperbolic rather than straight. :math:`b_{min}` is interpolated between the 
+    Option 5: `"hlsmininterp"` or `"hlsmini"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{in}`)
+        A hyperbolic Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
-        (:math:`\rho_{\perp}`). :math:`b_{max}` is the Debye length (:math:`\lambda_{Debye}`).
+        (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
-            \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+            \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
         
         .. math::
             b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
@@ -296,10 +297,10 @@ def Coulomb_logarithm(
         unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
         impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
         This is the fourth method in Table 1 of Reference [4].
-    Option 6: `"hlsmaxinterp"` or `"hlsmi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
-        A modified hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated 
+    Option 6: `"hlsmaxinterp"` or `"hlsmaxi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
+        A hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated 
         between the Debye length (:math:`\lambda_{Debye}`) and the ion sphere radius (:math:`a_i`)
-        and :math:`b_{min}` is the distance of closest approach (:math:`\rho_{\perp}`).
+        and :math:`b_{min}` is defined to be the distance of closest approach (:math:`\rho_{\perp}`).
         
         .. math::
             \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
@@ -316,7 +317,7 @@ def Coulomb_logarithm(
         impossible for :math:`\Lambda < 0` in this method, even for a high coupling parameter.
         This is the fifth method in Table 1 of Reference [4].
     Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
-        A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
+        A hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
         :math:`b_{max}` is interpolated between the Debye length (:math:`\lambda_{Debye}`) 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -203,50 +203,88 @@ def Coulomb_logarithm(
     **Supported Methods of Computing the Coulomb Logarithm**
     
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
-        The classical Landau-Spitzer method. Fails for large coupling
-        parameter where Lambda can become less than zero.
-    Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer with interpolation of :math:`b_{min}`)
-        A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated rather than
-        the larger of the deBroglie wavelength and the distance of closest
-        approach.
+        The classical Landau-Spitzer method.
         
-        This method fails if :math:`\lambda < 0`, which may be true if the coupling parameter is high.
+        .. math::
+            \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+        
+        This method is not valid if :math:`\lambda < 0`, which may be true if the 
+        coupling parameter is high (such as for dense, cold plasmas).
+    Option 2: `"lsmininterp"` or `"lsmi"` (Landau-Spitzer with interpolation of :math:`b_{min}`)
+        A modified Landau-Spitzer method in which :math:`b_{min}` is interpolated 
+        between the deBroglie wavelength and the distance of closest approach rather 
+        than being the larger of the deBroglie wavelength and the distance of closest approach.
+        
+        .. math::
+            \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+        
+        This method is not valid if :math:`\lambda < 0`, which may be true if the coupling 
+        parameter is high (such as for dense, cold plasmas).
         This is the first method in Table 1 of Reference [4].
     Option 3: `"lsfullinterp"` or `"lsfi"` (Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
-        are each interpolated. The interpolation is between the Debye
-        length and the ion sphere radius, allowing for descriptions
+        are each interpolated. :math:`b_{min}` is interpolated between the deBroglie 
+        wavelength and the distance of closest approach. :math:`b_{max}` is interpolated 
+        between the Debye length and the ion sphere radius, allowing for descriptions
         of dilute plasmas.
         
-        This method fails if :math:`\lambda < 0`, which may be true if the coupling parameter is high.
+        .. math::
+            \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+        
+        This method is not valid if :math:`\lambda < 0`, which may be true if the coupling 
+        parameter is high (such as for dense, cold plasmas).
         This is the second method in Table 1 of Reference [4].
     Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
-        A modified Landau-Spitzer method in which the value of :math:`\lambda < 0` is clamped at a minimum of :math:`2` because the classical
-        Landau-Spitzer method fails for a Coulomb logarithm < 0.
+        A modified Landau-Spitzer method in which the value of :math:`\lambda` is clamped at 
+        a minimum of :math:`2` so that it does not fail for Coulomb logarithm < 0, unlike the 
+        classical Landau-Spitzer method. :math:`b_{min}` is interpolated between
+        the deBroglie wavelength and the distance of closest
+        approach.
+        
+        .. math::
+        \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+        
+        This method cannot fail because it is impossible for :math:`\lambda < 0` in this 
+        method, even for a large coupling parameter.
         This is the third method in Table 1 of Reference [4].
     Option 5: `"hyperls"` or `"hls"` (Hyperbolic Landau-Spitzer)
-        A modified Landau-Spitzer method in which the trajectories of Coulomb collisions are modeled as hyperbolic
-        rather than straight.
+        A modified Landau-Spitzer method in which the trajectories of Coulomb collisions are 
+        modeled as hyperbolic rather than straight.
         
-        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic Landau-Spitzer
-        methods because these methods do not diverge for small :math:`b_{min}`, unlike the non-hyperbolic Landau-Spitzer methods.
-        This method cannot fail because it is impossible for :math:`\lambda < 0` in this method, even for a large coupling parameter.
+        .. math::
+            \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+        
+        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
+        Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
+        unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
+        impossible for :math:`\lambda < 0` in this method, even for a high coupling parameter.
         This is the fourth method in Table 1 of Reference [4].
     Option 6: `"hlsmaxinterp"` or `"hlsmi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{max}`)
-        A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` is the distance of closest approach
-        and :math:`b_{max}` is interpolated between the Debye length and the ion sphere radius.
+        A modified hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated 
+        between the Debye length and the ion sphere radius and :math:`b_{min}` is the distance 
+        of closest approach.
         
-        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic Landau-Spitzer
-        methods because these methods do not diverge for small :math:`b_{min}`, unlike the non-hyperbolic Landau-Spitzer methods.
-        This method cannot fail because it is impossible for :math:`\lambda < 0` in this method, even for a large coupling parameter.
+        .. math::
+            \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+        
+        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
+        Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
+        unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
+        impossible for :math:`\lambda < 0` in this method, even for a high coupling parameter.
         This is the fifth method in Table 1 of Reference [4].
     Option 7: `"hlsfullinterp"` or `"hlsfi"` (Hyperbolic Landau-Spitzer with interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A modified hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
-        are each interpolated.
+        are each interpolated. :math:`b_{min}` is interpolated between the deBroglie wavelength 
+        and the distance of closest approach. :math:`b_{max}` is interpolated between the Debye
+        length and the ion sphere radius, allowing for descriptions of dilute plasmas.
         
-        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic Landau-Spitzer
-        methods because these methods do not diverge for small :math:`b_{min}`, unlike the non-hyperbolic Landau-Spitzer methods.
-        This method cannot fail because it is impossible for :math:`\lambda < 0` in this method, even for a large coupling parameter.
+        .. math::
+            \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+        
+        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
+        Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
+        unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
+        impossible for :math:`\lambda < 0` in this method, even for a high coupling parameter.
         This is the sixth method in Table 1 of Reference [4].
 
     Examples

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -121,7 +121,7 @@ def Coulomb_logarithm(
         The default method is the classical straight-line Landau-Spitzer method
         (`"classical"` or `"ls"`). The other 6 supported methods are `"lsmininterp"`,
         `"lsfullinterp"`, `"lsclampmininterp"`, `"hlsmininterp"`, `"hlsmaxinterp"`, and 
-        `"hlsfullinterp"`. Please refer to the :ref:`Notes` section of this 
+        `"hlsfullinterp"`. Please refer to the Notes section of this 
         docstring for more information, including about abbreviated aliases of these names.
 
     Returns
@@ -398,6 +398,7 @@ def Coulomb_logarithm(
     bmin, bmax = impact_parameter(
         T=T, n_e=n_e, species=species, z_mean=z_mean, V=V, method=method
     )
+    
     if method in ("classical", "ls", "GMS-1", "lsmininterp", "lsmini", "GMS-2", "lsfullinterp", "lsfulli"):
         ln_Lambda = np.log(bmax / bmin)
     elif method in ("GMS-3", "lsclampmininterp", "lscmini"):
@@ -413,9 +414,11 @@ def Coulomb_logarithm(
         raise ValueError(
             "Unknown method. Choose from \"classical\", \"lsmininterp\", \"lsfullinterp\", \"lsclampmininterp\", \"hlsmininterp\", \"hlsmaxinterp\", \"hlsfullinterp\", and their aliases. Please refer to the documentation of this function for more information."
         )
+    
     # applying dimensionless units
     ln_Lambda = ln_Lambda.to(u.dimensionless_unscaled).value
-    # Allow NaNs through the < checks without warning
+    
+    #Allow NaNs through the < checks without warning
     with np.errstate(invalid="ignore"):
         if np.any(ln_Lambda < 2) and method in ["classical", "ls", "GMS-1", "lsmininterp", "lsmini", "GMS-2", "lsfullinterp", "lsfulli"]:
             warnings.warn(
@@ -429,6 +432,7 @@ def Coulomb_logarithm(
                 "coupling effects",
                 utils.CouplingWarning,
             )
+    
     return ln_Lambda
 
 
@@ -462,6 +466,7 @@ def _replaceNanVwithThermalV(V, T, m):
     if np.any(V == 0):
         raise utils.PhysicsError("You cannot have a collision for zero velocity!")
     # getting thermal velocity of system if no velocity is given
+    
     if V is None:
         V = parameters.thermal_speed(T, "e-", mass=m)
     elif np.any(np.isnan(V)):
@@ -473,6 +478,7 @@ def _replaceNanVwithThermalV(V, T, m):
         else:
             V = V.copy()
             V[np.isnan(V)] = parameters.thermal_speed(T[np.isnan(V)], "e-", mass=m)
+    
     return V
 
 
@@ -489,7 +495,6 @@ def impact_parameter_perp(
 
     Parameters
     ----------
-
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
@@ -527,10 +532,10 @@ def impact_parameter_perp(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed
 
-    ~plasmapy.utils.RelativityWarning
+    : ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -541,7 +546,6 @@ def impact_parameter_perp(
     .. math::
         b_{\perp} = \frac{Z_1 Z_2}{4 \pi \epsilon_0 m v^2}
 
-
     Examples
     --------
     >>> from astropy import units as u
@@ -550,12 +554,10 @@ def impact_parameter_perp(
     >>> impact_parameter_perp(T, species)
     <Quantity 8.3550...e-12 m>
 
-
     References
     ----------
     .. [1] Francis, F. Chen. Introduction to plasma physics and controlled
        fusion 3rd edition. Ch 5 (Springer 2015).
-
     """
     # boiler plate checks
     T, masses, charges, reduced_mass, V = _boilerPlate(T=T, species=species, V=V)
@@ -585,7 +587,6 @@ def impact_parameter(
 
     Parameters
     ----------
-
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
@@ -610,7 +611,7 @@ def impact_parameter(
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
-    method: str, optional
+    method : str, optional
         Selects which theory to use when calculating the Coulomb
         logarithm. Defaults to classical method.
 
@@ -638,10 +639,10 @@ def impact_parameter(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed
 
-    ~plasmapy.utils.RelativityWarning
+    : ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -698,6 +699,7 @@ def impact_parameter(
     lambdaBroglie = hbar / (2 * reduced_mass * V)
     # distance of closest approach in 90 degree Coulomb collision
     bPerp = impact_parameter_perp(T=T, species=species, V=V)
+    
     # obtaining minimum and maximum impact parameters depending on which
     # method is requested
     if method == "classical":
@@ -766,6 +768,7 @@ def impact_parameter(
         bmin = (lambdaBroglie ** 2 + bPerp ** 2) ** (1 / 2)
     else:
         raise ValueError(f"Method {method} not found!")
+   
     # ARRAY NOTES
     # it could be that bmin and bmax have different sizes. If Te is a scalar,
     # T and V will be scalar from _boilerplate, so bmin will scalar.  However
@@ -773,6 +776,7 @@ def impact_parameter(
     # do we want to extend the scalar bmin to equal the length of bmax? Sure.
     if np.isscalar(bmin.value) and not np.isscalar(bmax.value):
         bmin = np.repeat(bmin, len(bmax))
+    
     return bmin.to(u.m), bmax.to(u.m)
 
 
@@ -793,13 +797,11 @@ def collision_frequency(
 
     Parameters
     ----------
-
     T : ~astropy.units.Quantity
         Temperature in units of temperature.
         This should be the electron temperature for electron-electron
         and electron-ion collisions, and the ion temperature for
         ion-ion collisions.
-
 
     n : ~astropy.units.Quantity
         The density in units convertible to per cubic meter.
@@ -822,7 +824,7 @@ def collision_frequency(
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
-    method: str, optional
+    method : str, optional
         Selects which theory to use when calculating the Coulomb
         logarithm. Defaults to classical method.
 
@@ -849,10 +851,10 @@ def collision_frequency(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed
 
-    ~plasmapy.utils.RelativityWarning
+    : ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -884,7 +886,6 @@ def collision_frequency(
     .. [1] Francis, F. Chen. Introduction to plasma physics and controlled
        fusion 3rd edition. Ch 5 (Springer 2015).
     .. [2] http://homepages.cae.wisc.edu/~callen/chap2.pdf
-
     """
     # boiler plate checks
     T, masses, charges, reduced_mass, V_r = _boilerPlate(T=T, species=species, V=V)
@@ -941,12 +942,10 @@ def Coulomb_cross_section(impact_param: u.m) -> u.m ** 2:
     impact_param : ~astropy.units.Quantity
         Impact parameter for the collision.
 
-    Examples
-    --------
-    >>> Coulomb_cross_section(7e-10*u.m)
-    <Quantity 6.157...e-18 m2>
-    >>> Coulomb_cross_section(0.5*u.m)
-    <Quantity 3.141... m2>
+    Returns
+    -------
+    sigma : ~astropy.units.Quantity
+        The Coulomb collision cross section area.
 
     Notes
     -----
@@ -961,10 +960,12 @@ def Coulomb_cross_section(impact_param: u.m) -> u.m ** 2:
     calculation. Please note that it is not guaranteed to return the correct
     results for small angle collisions.
 
-    Returns
-    -------
-    ~astropy.units.Quantity
-        The Coulomb collision cross section area.
+    Examples
+    --------
+    >>> Coulomb_cross_section(7e-10*u.m)
+    <Quantity 6.157...e-18 m2>
+    >>> Coulomb_cross_section(0.5*u.m)
+    <Quantity 3.141... m2>
 
     References
     ----------
@@ -1003,7 +1004,7 @@ def fundamental_electron_collision_freq(
     n_e : ~astropy.units.Quantity
         The number density of the Maxwellian test electrons
 
-    ion: str
+    ion : str
         String signifying a particle type of the field ions, including charge
         state information.
 
@@ -1017,9 +1018,13 @@ def fundamental_electron_collision_freq(
         If not specified, the Coulomb log will is calculated using the
         `~plasmapy.formulary.Coulomb_logarithm` function.
 
-    coulomb_log_method : string, optional
+    coulomb_log_method : str, optional
         Method used for Coulomb logarithm calculation (see that function
         for more documentation). Choose from "classical" or "GMS-1" to "GMS-6".
+
+    Returns
+    -------
+    nu_e : ~astropy.units.Quantity
 
     Notes
     -----
@@ -1123,7 +1128,7 @@ def fundamental_ion_collision_freq(
     n_i : ~astropy.units.Quantity
         The number density of the Maxwellian test ions
 
-    ion: str
+    ion : str
         String signifying a particle type of the test and field ions,
         including charge state information. This function assumes the test
         and field ions are the same species.
@@ -1141,6 +1146,10 @@ def fundamental_ion_collision_freq(
     coulomb_log_method : str, optional
         Method used for Coulomb logarithm calculation (see that function
         for more documentation). Choose from "classical" or "GMS-1" to "GMS-6".
+
+    Returns
+    -------
+    nu_i : ~astropy.units.Quantity
 
     Notes
     -----
@@ -1164,7 +1173,6 @@ def fundamental_ion_collision_freq(
     classical transport expressions. It is equivalent to:
     * 1/tau_i from ref [1]_, equation (2.5i) pp. 215,
     * nu_i from ref [2]_ pp. 33,
-
 
     References
     ----------
@@ -1247,14 +1255,13 @@ def mean_free_path(
 
     Parameters
     ----------
-
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
         the target particle
 
     n_e : ~astropy.units.Quantity
-        The electron density in units convertible to per cubic meter.
+        The electron number density in units convertible to per cubic meter.
 
     species : tuple
         A tuple containing string representations of the test particle
@@ -1272,7 +1279,7 @@ def mean_free_path(
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
-    method: str, optional
+    method : str, optional
         Selects which theory to use when calculating the Coulomb
         logarithm. Defaults to classical method.
 
@@ -1299,10 +1306,10 @@ def mean_free_path(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed
 
-    ~plasmapy.utils.RelativityWarning
+    : ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -1363,7 +1370,6 @@ def Spitzer_resistivity(
 
     Parameters
     ----------
-
     T : ~astropy.units.Quantity
         Temperature in units of temperature.
         This should be the electron temperature for electron-electron
@@ -1391,7 +1397,7 @@ def Spitzer_resistivity(
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
-    method: str, optional
+    method : str, optional
         Selects which theory to use when calculating the Coulomb
         logarithm. Defaults to classical method.
 
@@ -1418,10 +1424,10 @@ def Spitzer_resistivity(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed
 
-    ~plasmapy.utils.RelativityWarning
+    : ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -1490,14 +1496,13 @@ def mobility(
 
     Parameters
     ----------
-
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
         the target particle
 
     n_e : ~astropy.units.Quantity
-        The electron density in units convertible to per cubic meter.
+        The electron number density in units convertible to per cubic meter.
 
     species : tuple
         A tuple containing string representations of the test particle
@@ -1518,7 +1523,7 @@ def mobility(
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
-    method: str, optional
+    method : str, optional
         Selects which theory to use when calculating the Coulomb
         logarithm. Defaults to classical method.
 
@@ -1545,10 +1550,10 @@ def mobility(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed
 
-    ~plasmapy.utils.RelativityWarning
+    : ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -1617,7 +1622,6 @@ def Knudsen_number(
 
     Parameters
     ----------
-
     characteristic_length : ~astropy.units.Quantity
         Rough order-of-magnitude estimate of the relevant size of the system.
 
@@ -1645,7 +1649,7 @@ def Knudsen_number(
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
-    method: str, optional
+    method : str, optional
         Selects which theory to use when calculating the Coulomb
         logarithm. Defaults to classical method.
 
@@ -1672,10 +1676,10 @@ def Knudsen_number(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed
 
-    ~plasmapy.utils.RelativityWarning
+    : ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -1739,7 +1743,6 @@ def coupling_parameter(
 
     Parameters
     ----------
-
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
@@ -1764,7 +1767,7 @@ def coupling_parameter(
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
-    method: str, optional
+    method : str, optional
         Selects which theory to use when calculating the Coulomb
         logarithm. Defaults to classical method.
 
@@ -1791,10 +1794,10 @@ def coupling_parameter(
 
     Warns
     -----
-    ~astropy.units.UnitsWarning
+    : ~astropy.units.UnitsWarning
         If units are not provided, SI units are assumed
 
-    ~plasmapy.utils.RelativityWarning
+    : ~plasmapy.utils.RelativityWarning
         If the input velocity is greater than 5% of the speed of
         light.
 
@@ -1860,11 +1863,10 @@ def coupling_parameter(
        approximation. D. O. Gericke et. al. PRE,  65, 036418 (2002).
        DOI: 10.1103/PhysRevE.65.036418
     .. [2] Bonitz, Michael. Quantum kinetic theory. Stuttgart: Teubner, 1998.
-
-
     """
     # boiler plate checks
     T, masses, charges, reduced_mass, V = _boilerPlate(T=T, species=species, V=V)
+    
     if np.isnan(z_mean):
         # using mean charge to get average ion density.
         # If you are running this, you should strongly consider giving
@@ -1881,11 +1883,13 @@ def coupling_parameter(
         n_i = n_e / z_mean
         # getting Wigner-Seitz radius based on ion density
         radius = Wigner_Seitz_radius(n_i)
+    
     # Coulomb potential energy between particles
     if np.isnan(z_mean):
         coulombEnergy = charges[0] * charges[1] / (4 * np.pi * eps0 * radius)
     else:
         coulombEnergy = (z_mean * e) ** 2 / (4 * np.pi * eps0 * radius)
+    
     if method == "classical":
         # classical thermal kinetic energy
         kineticEnergy = k_B * T

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -119,11 +119,12 @@ def Coulomb_logarithm(
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the Notes section of this
-        docstring for more information, including about abbreviated aliases of these names.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the Notes section of this docstring for more
+        information, including about abbreviated aliases of these names.
 
     Returns
     -------
@@ -612,33 +613,33 @@ def impact_parameter(
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
-        the target particle
+        the target particle.
 
     n_e : ~astropy.units.Quantity
-        The electron density in units convertible to per cubic meter.
+        The electron number density in units convertible to per cubic meter.
 
     species : tuple
         A tuple containing string representations of the test particle
-        (listed first) and the target particle (listed second)
+        (listed first) and the target particle (listed second).
 
     z_mean : ~astropy.units.Quantity, optional
-        The average ionization (arithmetic mean) for a plasma where the
-        a macroscopic description is valid. This is used to recover the
+        The average ionization (arithmetic mean) of a plasma for which
+        a macroscopic description is valid. This parameter is used to compute the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
         impact parameters. ``z_mean`` is a required parameter if ``method`` is
-        ``"lsfullinterp"``, ``"hlsmaxinterp"``, or ``"hlsfullinterp"``.
+        ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     V : ~astropy.units.Quantity, optional
-        The relative velocity between particles.  If not provided,
+        The relative velocity between particles. If not provided,
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are 
-        ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, 
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
         information about these methods.
@@ -845,27 +846,29 @@ def collision_frequency(
 
     species : tuple
         A tuple containing string representations of the test particle
-        (listed first) and the target particle (listed second)
+        (listed first) and the target particle (listed second).
 
     z_mean : ~astropy.units.Quantity, optional
-        The average ionization (arithmetic mean) for a plasma where the
-        a macroscopic description is valid. This is used to recover the
+        The average ionization (arithmetic mean) of a plasma for which
+        a macroscopic description is valid. This parameter is used to compute the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters.
+        impact parameters. ``z_mean`` is a required parameter if ``method`` is
+        ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     V : ~astropy.units.Quantity, optional
-        The relative velocity between particles.  If not provided,
+        The relative velocity between particles. If not provided,
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
-        about these methods.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
 
     Returns
     -------
@@ -1309,24 +1312,25 @@ def mean_free_path(
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
-        the target particle
+        the target particle.
 
     n_e : ~astropy.units.Quantity
         The electron number density in units convertible to per cubic meter.
 
     species : tuple
         A tuple containing string representations of the test particle
-        (listed first) and the target particle (listed second)
+        (listed first) and the target particle (listed second).
 
     z_mean : ~astropy.units.Quantity, optional
-        The average ionization (arithmetic mean) for a plasma where the
-        a macroscopic description is valid. This is used to recover the
+        The average ionization (arithmetic mean) of a plasma for which
+        a macroscopic description is valid. This parameter is used to compute the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters.
+        impact parameters. ``z_mean`` is a required parameter if ``method`` is
+        ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     V : ~astropy.units.Quantity, optional
-        The relative velocity between particles.  If not provided,
+        The relative velocity between particles. If not provided,
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
@@ -1438,18 +1442,19 @@ def Spitzer_resistivity(
         and the ion density for electron-ion and ion-ion collisions.
 
     z_mean : ~astropy.units.Quantity, optional
-        The average ionization (arithmetic mean) for a plasma where the
-        a macroscopic description is valid. This is used to recover the
+        The average ionization (arithmetic mean) of a plasma for which
+        a macroscopic description is valid. This parameter is used to compute the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters.
+        impact parameters. ``z_mean`` is a required parameter if ``method`` is
+        ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     species : tuple
         A tuple containing string representations of the test particle
-        (listed first) and the target particle (listed second)
+        (listed first) and the target particle (listed second).
 
     V : ~astropy.units.Quantity, optional
-        The relative velocity between particles.  If not provided,
+        The relative velocity between particles. If not provided,
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
@@ -1461,7 +1466,6 @@ def Spitzer_resistivity(
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of `Coulomb_logarithm` for more
         information about these methods.
-        about these methods.
 
     Returns
     -------
@@ -1560,27 +1564,28 @@ def mobility(
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
-        the target particle
+        the target particle.
 
     n_e : ~astropy.units.Quantity
         The electron number density in units convertible to per cubic meter.
 
     species : tuple
         A tuple containing string representations of the test particle
-        (listed first) and the target particle (listed second)
+        (listed first) and the target particle (listed second).
 
     z_mean : ~astropy.units.Quantity, optional
-        The average ionization (arithmetic mean) for a plasma where the
-        a macroscopic description is valid. This is used to recover the
+        The average ionization (arithmetic mean) of a plasma for which
+        a macroscopic description is valid. This parameter is used to compute the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
         impact parameters. It is also used the obtain the average mobility
         of a plasma with multiple charge state species. When z_mean
         is not given, the average charge between the two particles is
-        used instead.
+        used instead. ``z_mean`` is a required parameter if ``method`` is
+        ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     V : ~astropy.units.Quantity, optional
-        The relative velocity between particles.  If not provided,
+        The relative velocity between particles. If not provided,
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
@@ -1694,24 +1699,25 @@ def Knudsen_number(
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
-        the target particle
+        the target particle.
 
     n_e : ~astropy.units.Quantity
-        The electron density in units convertible to per cubic meter.
+        The electron number density in units convertible to per cubic meter.
 
     species : tuple
         A tuple containing string representations of the test particle
-        (listed first) and the target particle (listed second)
+        (listed first) and the target particle (listed second).
 
     z_mean : ~astropy.units.Quantity, optional
-        The average ionization (arithmetic mean) for a plasma where the
-        a macroscopic description is valid. This is used to recover the
+        The average ionization (arithmetic mean) of a plasma for which
+        a macroscopic description is valid. This parameter is used to compute the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters.
+        impact parameters. ``z_mean`` is a required parameter if ``method`` is
+        ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     V : ~astropy.units.Quantity, optional
-        The relative velocity between particles.  If not provided,
+        The relative velocity between particles. If not provided,
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
@@ -1816,24 +1822,25 @@ def coupling_parameter(
     T : ~astropy.units.Quantity
         Temperature in units of temperature or energy per particle,
         which is assumed to be equal for both the test particle and
-        the target particle
+        the target particle.
 
     n_e : ~astropy.units.Quantity
-        The electron density in units convertible to per cubic meter.
+        The electron number density in units convertible to per cubic meter.
 
     species : tuple
         A tuple containing string representations of the test particle
         (listed first) and the target particle (listed second).
 
     z_mean : ~astropy.units.Quantity, optional
-        The average ionization (arithmetic mean) for a plasma where the
-        a macroscopic description is valid. This is used to recover the
+        The average ionization (arithmetic mean) of a plasma for which
+        a macroscopic description is valid. This parameter is used to compute the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters.
+        impact parameters. ``z_mean`` is a required parameter if ``method`` is
+        ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     V : ~astropy.units.Quantity, optional
-        The relative velocity between particles.  If not provided,
+        The relative velocity between particles. If not provided,
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -211,7 +211,7 @@ def Coulomb_logarithm(
             b_{min} \equiv 
             \left\{
                 \begin{array}{ll}
-                           \lambda_{de Broglie} & \mbox{if } \lambda_{de Broglie} > \rho_{\perp}
+                           \lambda_{de Broglie} & \mbox{if } \lambda_{de Broglie} > \rho_{\perp} \\
                            \rho_{\perp}         & \mbox{if } \rho_{\perp} > \lambda_{de Broglie}
                 \end{array}
             \right.

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -110,7 +110,7 @@ def Coulomb_logarithm(
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
         impact parameters. ``z_mean`` is a required parameter if ``method`` is
-        ``"lsfullinterp"``, ``"hlsmaxinterp"``, or ``"hlsfullinterp"``.
+        ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     V : ~astropy.units.Quantity, optional
         The relative velocity between particles.  If not provided,
@@ -120,9 +120,9 @@ def Coulomb_logarithm(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"ls"``). The other 6 supported methods are ``"lsmininterp"``,
-        ``"lsfullinterp"``, ``"lsclampmininterp"``, ``"hlsmininterp"``, ``"hlsmaxinterp"``, and 
-        ``"hlsfullinterp"``. Please refer to the Notes section of this 
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and 
+        ``"hls_full_interp"``. Please refer to the Notes section of this 
         docstring for more information, including about abbreviated aliases of these names.
 
     Returns
@@ -163,13 +163,13 @@ def Coulomb_logarithm(
     
     PlasmaPy supports 7 methods of computing the Coulomb logarithm:
     
-    1. ``"classical"`` or ``"ls"``
-    2. ``"lsmininterp"`` or ``"lsmini"``
-    3. ``"lsfullinterp"`` or ``"lsfi"``
-    4. ``"lsclampmininterp"`` or ``"lscmini"``
-    5. ``"hlsmininterp"`` or ``"hlsmini"``
-    6. ``"hlsmaxinterp"`` or ``"hlsmaxi"``
-    7. ``"hlsfullinterp"`` or ``"hlsfi"``
+    1. ``"classical"`` or ``"LS"``
+    2. ``"ls_min_interp"`` or ``"GMS-1"``
+    3. ``"ls_full_interp"`` or ``"GMS-2"``
+    4. ``"ls_clamp_mininterp"`` or ``"GMS-3"``
+    5. ``"hls_min_interp"`` or ``"GMS-4"``
+    6. ``"hls_max_interp"`` or ``"GMS-5"``
+    7. ``"hls_full_interp"`` or ``"GMS-6"``
     
     Options 1–4 are straight-line Landau-Spitzer (``"ls..."``) methods in which the trajectory of a 
     Coulomb collision is modeled as a straight line. For the straight-line Landau-Spitzer methods, the Coulomb 
@@ -190,15 +190,15 @@ def Coulomb_logarithm(
     by `impact_parameter`, another function.
 
     .. note:: 
-        For strongly-coupled plasma, PlasmaPy recommends Option 7, ``"hlsfullinterp"`` or ``"hlsfi"``,
-        because it provides high accuracy regardless of a plasma's strength of coupling.
+        For strongly-coupled plasma, PlasmaPy recommends Option 7, ``"hls_full_interp"`` or ``"GMS-6"``,
+        because of its high accuracy regardless of a plasma's strength of coupling.
     
     **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
     
     In this section, further information about each method, such as about interpolation and other special 
     features, is documented. Please refer to Reference [4]_ for additional information about these methods.
     
-    Option 1: ``"classical"`` or ``"ls"`` (Landau-Spitzer)
+    Option 1: ``"classical"`` or ``"LS"`` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 
         higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest 
         approach (:math:`\rho_{\perp}`) if they are not equal (and either of the two if they are equal) and 
@@ -237,7 +237,7 @@ def Coulomb_logarithm(
         
         Please refer to Reference [1]_ for additional information about this method.
         
-    Option 2: ``"lsmininterp"`` or ``"lsmini"`` (Landau-Spitzer, interpolation of :math:`b_{min}`)
+    Option 2: ``"ls_min_interp"`` or ``"GMS-1"`` (Landau-Spitzer, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
@@ -256,7 +256,7 @@ def Coulomb_logarithm(
         
         Note: This is the first method in Table 1 of Reference [4]_.
         
-    Option 3: ``"lsfullinterp"`` or ``"lsfi"`` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
+    Option 3: ``"ls_full_interp"`` or ``"GMS-2"`` (Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A straight-line Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
@@ -277,7 +277,7 @@ def Coulomb_logarithm(
         
         Note: This is the second method in Table 1 of Reference [4]_.
         
-    Option 4: ``"lsclampmininterp"`` or ``"lscmini"`` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
+    Option 4: ``"ls_clamp_mininterp"`` or ``"GMS-3"`` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which the value of :math:`\ln{\Lambda}` is clamped at 
         a minimum of :math:`2` so that it is impossible for :math:`\ln{\Lambda} < 0`, unlike by the 
         classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
@@ -300,11 +300,11 @@ def Coulomb_logarithm(
             b_{max} \equiv \lambda_{Debye}
         
         This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
-        method, even if the coupling parameter is high.
+        method, even if the coupling parameter is high (such as for nonideal, dense, cold plasmas).
         
         Note: This is the third method in Table 1 of Reference [4]_.
         
-    Option 5: ``"hlsmininterp"`` or ``"hlsmini"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}`)
+    Option 5: ``"hls_min_interp"`` or ``"GMS-4"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` is interpolated between the 
         de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
@@ -319,11 +319,11 @@ def Coulomb_logarithm(
             b_{max} \equiv \lambda_{Debye}
         
         This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
-        method, even if the coupling parameter is high.
+        method, even if the coupling parameter is high (such as for nonideal, dense, cold plasmas).
         
         Note: This is the fourth method in Table 1 of Reference [4]_.
         
-    Option 6: ``"hlsmaxinterp"`` or ``"hlsmaxi"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
+    Option 6: ``"hls_max_interp"`` or ``"GMS-5"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{max}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{max}` is interpolated between 
         the Debye length (:math:`\lambda_{Debye}`) and the ion sphere radius (:math:`a_i`)
         and :math:`b_{min}` is defined to be the distance of closest approach (:math:`\rho_{\perp}`).
@@ -338,13 +338,13 @@ def Coulomb_logarithm(
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
         This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
-        method, even if the coupling parameter is high.
+        method, even if the coupling parameter is high (such as for nonideal, dense, cold plasmas).
         
         Caution: This method overestimates :math:`\ln{\Lambda}` at high temperatures.
         
         Note: This is the fifth method in Table 1 of Reference [4]_.
         
-    Option 7: ``"hlsfullinterp"`` or ``"hlsfi"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
+    Option 7: ``"hls_full_interp"`` or ``"GMS-6"`` (Hyperbolic Landau-Spitzer, interpolation of :math:`b_{min}` and :math:`b_{max}`)
         A hyperbolic Landau-Spitzer method in which :math:`b_{min}` and :math:`b_{max}`
         are each interpolated. :math:`b_{min}` is interpolated between the de Broglie wavelength
         (:math:`\lambda_{de Broglie}`) and the distance of closest approach (:math:`\rho_{\perp}`). 
@@ -361,7 +361,7 @@ def Coulomb_logarithm(
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
         This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
-        method, even if the coupling parameter is high.
+        method, even if the coupling parameter is high (such as for nonideal, dense, cold plasmas).
 
         Note: This is the sixth method in Table 1 of Reference [4]_.
 
@@ -400,20 +400,22 @@ def Coulomb_logarithm(
         T=T, n_e=n_e, species=species, z_mean=z_mean, V=V, method=method
     )
     
-    if method in ("classical", "ls", "GMS-1", "lsmininterp", "lsmini", "GMS-2", "lsfullinterp", "lsfulli"):
+    if method in ("classical", "LS", "ls_min_interp", "GMS-1", "ls_full_interp", "GMS-2"):
         ln_Lambda = np.log(bmax / bmin)
-    elif method in ("GMS-3", "lsclampmininterp", "lscmini"):
+    elif method in ("ls_clamp_mininterp", "GMS-3"):
         ln_Lambda = np.log(bmax / bmin)
         if np.any(ln_Lambda < 2):
             if np.isscalar(ln_Lambda.value):
                 ln_Lambda = 2 * u.dimensionless_unscaled
             else:
                 ln_Lambda[ln_Lambda < 2] = 2 * u.dimensionless_unscaled
-    elif method in ("GMS-4", "hlsminterp", "hlsmini", "GMS-5", "hlsmaxinterp", "hlsmaxi", "GMS-6", "hlsfullinterp", "hlsfulli"):
+    elif method in ("hls_min_interp", "GMS-4", "hls_max_interp", "GMS-5", "hls_full_interp", "GMS-6"):
         ln_Lambda = 0.5 * np.log(1 + bmax ** 2 / bmin ** 2)
     else:
         raise ValueError(
-            "Unknown method. Choose from \"classical\", \"lsmininterp\", \"lsfullinterp\", \"lsclampmininterp\", \"hlsmininterp\", \"hlsmaxinterp\", \"hlsfullinterp\", and their aliases. Please refer to the documentation of this function for more information."
+            "Unknown method. Choose from \"classical\", \"ls_min_interp\", \"ls_full_interp\", "
+            "\"ls_clamp_mininterp\", \"hls_min_interp\", \"hls_max_interp\", \"hls_full_interp\", "
+            "and their aliases. Please refer to the documentation of this function for more information."
         )
     
     # applying dimensionless units
@@ -421,16 +423,16 @@ def Coulomb_logarithm(
     
     #Allow NaNs through the < checks without warning
     with np.errstate(invalid="ignore"):
-        if np.any(ln_Lambda < 2) and method in ["classical", "ls", "GMS-1", "lsmininterp", "lsmini", "GMS-2", "lsfullinterp", "lsfulli"]:
+        if np.any(ln_Lambda < 2) and method in ["classical", "LS", "ls_min_interp", "GMS-1", "ls_full_interp", "GMS-2"]:
             warnings.warn(
-                f"Coulomb logarithm is {ln_Lambda} and {method} relies on "
+                f"The Coulomb logarithm is {ln_Lambda}, and the specified method, \"{method}\", depends on "
                 "weak coupling.",
                 utils.CouplingWarning,
             )
         elif np.any(ln_Lambda < 4):
             warnings.warn(
-                f"Coulomb logarithm is {ln_Lambda}, you might have strong "
-                "coupling effects",
+                f"The Coulomb logarithm is {ln_Lambda}, so strong "
+                "coupling effects may exist for the plasma.",
                 utils.CouplingWarning,
             )
     
@@ -614,8 +616,12 @@ def impact_parameter(
         where `mu` is the reduced mass.
 
     method : str, optional
-        Selects which theory to use when calculating the Coulomb
-        logarithm. Defaults to classical method.
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------
@@ -827,8 +833,12 @@ def collision_frequency(
         where `mu` is the reduced mass.
 
     method : str, optional
-        Selects which theory to use when calculating the Coulomb
-        logarithm. Defaults to classical method.
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------
@@ -872,7 +882,7 @@ def collision_frequency(
     taken as the thermal velocity), and :math:`\ln{\Lambda}` is the Coulomb
     logarithm accounting for small angle collisions.
 
-    See eq (2.14) in [2]_.
+    See Equation (2.14) in [2]_.
 
     Examples
     --------
@@ -894,6 +904,7 @@ def collision_frequency(
     # using a more descriptive name for the thermal velocity using
     # reduced mass
     V_reduced = V_r
+    
     if species[0] in ("e", "e-") and species[1] in ("e", "e-"):
         # electron-electron collision
         # if a velocity was passed, we use that instead of the reduced
@@ -926,6 +937,7 @@ def collision_frequency(
         bPerp = impact_parameter_perp(T=T, species=species, V=V)
         # Coulomb logarithm
         cou_log = Coulomb_logarithm(T, n, species, z_mean, V=V, method=method)
+   
     # collisional cross section
     sigma = Coulomb_cross_section(bPerp)
     # collision frequency where Coulomb logarithm accounts for
@@ -1021,8 +1033,12 @@ def fundamental_electron_collision_freq(
         `~plasmapy.formulary.Coulomb_logarithm` function.
 
     coulomb_log_method : str, optional
-        Method used for Coulomb logarithm calculation (see that function
-        for more documentation). Choose from "classical" or "GMS-1" to "GMS-6".
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------
@@ -1146,8 +1162,12 @@ def fundamental_ion_collision_freq(
         ~plasmapy.formulary.Coulomb_logarithm function.
 
     coulomb_log_method : str, optional
-        Method used for Coulomb logarithm calculation (see that function
-        for more documentation). Choose from "classical" or "GMS-1" to "GMS-6".
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------
@@ -1282,8 +1302,12 @@ def mean_free_path(
         where `mu` is the reduced mass.
 
     method : str, optional
-        Selects which theory to use when calculating the Coulomb
-        logarithm. Defaults to classical method.
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------
@@ -1400,8 +1424,12 @@ def Spitzer_resistivity(
         where `mu` is the reduced mass.
 
     method : str, optional
-        Selects which theory to use when calculating the Coulomb
-        logarithm. Defaults to classical method.
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------
@@ -1465,7 +1493,6 @@ def Spitzer_resistivity(
     .. [1] Francis, F. Chen. Introduction to plasma physics and controlled
        fusion 3rd edition. Ch 5 (Springer 2015).
     .. [2] http://homepages.cae.wisc.edu/~callen/chap2.pdf
-
     """
     # collisional frequency
     freq = collision_frequency(
@@ -1526,8 +1553,12 @@ def mobility(
         where `mu` is the reduced mass.
 
     method : str, optional
-        Selects which theory to use when calculating the Coulomb
-        logarithm. Defaults to classical method.
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------
@@ -1652,8 +1683,12 @@ def Knudsen_number(
         where `mu` is the reduced mass.
 
     method : str, optional
-        Selects which theory to use when calculating the Coulomb
-        logarithm. Defaults to classical method.
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------
@@ -1716,7 +1751,6 @@ def Knudsen_number(
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Knudsen_number
-
     """
     path_length = mean_free_path(
         T=T, n_e=n_e, species=species, z_mean=z_mean, V=V, method=method
@@ -1770,8 +1804,12 @@ def coupling_parameter(
         where `mu` is the reduced mass.
 
     method : str, optional
-        Selects which theory to use when calculating the Coulomb
-        logarithm. Defaults to classical method.
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer method
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
+        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
+        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        about these methods.
 
     Returns
     -------

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -444,8 +444,7 @@ def Coulomb_logarithm(
             "GMS-2",
         ]:
             warnings.warn(
-                f'The Coulomb logarithm is {ln_Lambda}, and the specified method, "{method}", depends on '
-                'weak coupling.',
+                f'The Coulomb logarithm is {ln_Lambda}, and the specified method, "{method}", depends on weak coupling.',
                 utils.CouplingWarning,
             )
         elif np.any(ln_Lambda < 4):

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -282,7 +282,7 @@ def Coulomb_logarithm(
         ln_Lambda = 0.5 * np.log(1 + bmax ** 2 / bmin ** 2)
     else:
         raise ValueError(
-            "Unknown method! Choose from 'ls', 'lsmini', 'lsfulli', 'lsclamp', 'hls'. 'hlsmaxi', and 'hlsfulli'."
+            "Unknown method! Choose from 'ls', 'lsmini', 'lsfulli', 'lsclamp', 'hls', 'hlsmaxi', and 'hlsfulli'."
         )
     # applying dimensionless units
     ln_Lambda = ln_Lambda.to(u.dimensionless_unscaled).value

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -118,17 +118,16 @@ def Coulomb_logarithm(
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical Landau-Spitzer method
+        The default method is the classical straight-line Landau-Spitzer method
         (`"classical"` or `"ls"`). The other 6 supported methods are `"lsmininterp"`,
         `"lsfullinterp"`, `"lsclampmininterp"`, `"hlsmininterp"`, `"hlsmaxinterp"`, and 
-        `"hlsfullinterp"`. Please refer to the "Notes" section of this docstring
-        for more information, including about abbreviated aliases of these names.
+        `"hlsfullinterp"`. Please refer to the :ref:`reference-to-Notes` section of this 
+        docstring for more information, including about abbreviated aliases of these names.
 
     Returns
     -------
     ln_Lambda : float or numpy.ndarray
-        The dimensionless Coulomb logarithm, the uncertainty of which is on the order
-        of its reciprocal.
+        The dimensionless Coulomb logarithm.
 
     Raises
     ------
@@ -157,6 +156,8 @@ def Coulomb_logarithm(
         If the input velocity is greater than 5% of the speed of
         light.
 
+    .. _reference-to-Notes:
+    
     Notes
     -----
     **Overview of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
@@ -171,14 +172,14 @@ def Coulomb_logarithm(
     6. `"hlsmaxinterp"` or `"hlsmaxi"`
     7. `"hlsfullinterp"` or `"hlsfi"`
     
-    Method 1 through Method 4 are straight-line Landau-Spitzer ("ls...") methods in which the trajectory of a 
+    Option 1 through Option 4 are straight-line Landau-Spitzer (`"ls..."`) methods in which the trajectory of a 
     Coulomb collision is modeled as a straight line. For the straight-line Landau-Spitzer methods, the Coulomb 
     logarithm (:math:`\ln{\Lambda}`) is defined to be:
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
     
-    Method 5 through Method 7 are hyperbolic Landau-Spitzer ("hls...") methods in which the trajectory of a 
+    Option 5 through Option 7 are hyperbolic Landau-Spitzer (`"hls..."`) methods in which the trajectory of a 
     Coulomb collision is modeled as a hyperbola. For the hyperbolic Landau-Spitzer methods, the Coulomb 
     logarithm (:math:`\ln{\Lambda}`) is defined to be:
     
@@ -190,8 +191,7 @@ def Coulomb_logarithm(
     by `impact_parameter`, another function.
 
     .. note:: 
-        PlasmaPy recommends Method 7, `"hlsfullinterp"` or `hlsfi"`, for most users. The hyperbolic Landau-Spitzer methods are accurate for dense, cold plasmas for which 
-        the straight-line Landau-Spitzer methods fail if :math:`\ln{\Lambda} < 0`.
+        PlasmaPy recommends Option 7, `"hlsfullinterp"` or `"hlsfi"`, for most users because it is the most accurate for all plasmas, regardless of the strength of coupling.
     
     **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
     
@@ -201,8 +201,8 @@ def Coulomb_logarithm(
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 
         higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest 
-        approach (:math:`\rho_{\perp}`) and either if they are equal and :math:`b_{max}` is defined to 
-        be the Debye length (:math:`\lambda_{Debye}`).
+        approach (:math:`\rho_{\perp}`) if they are not equal and either if they are equal and 
+        :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
@@ -219,28 +219,21 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        The outer impact parameter is defined to be the Debye length:
-        :math:`b_{max} = \lambda_D`, which is a function of electron
-        temperature and electron density. At distances greater than the
-        Debye length, electric fields from other particles will be
-        screened out due to electrons rearranging themselves.
-
-        The choice of inner impact parameter is either the distance of closest
-        approach for a 90 degree Coulomb collision or the thermal de Broglie
-        wavelength, whichever is larger. This is because Coulomb-style collisions
-        cannot occur for impact parameters shorter than the de Broglie
-        wavelength because quantum effects will change the fundamental
-        nature of the collision [2]_, [3]_.
-
-        Errors associated with the classical Coulomb logarithm are of order its
-        reciprocal. If the Coulomb logarithm is of order unity, then the
-        assumptions made in the standard analysis of Coulomb collisions
-        are invalid.
+        The inner impact parameter (:math:`b_{min}`) is the higher of (:math:`\lambda_{de Broglie}`) 
+        and (:math:`\rho_{\perp}`) because for impact parameters lower than (:math:`\lambda_{de Broglie}`), 
+        quantum effects cause the collision to be non-Coulombic [2]_[3]_.
         
-        Valid For: Only dilute, weakly coupled plasmas.
+        The outer impact parameter (:math:`b_{max}`) is defined to be the Debye length 
+        (:math:`\lambda_{Debye}`) because at distances higher than the
+        Debye length, the electric fields created by other particles are
+        screened out by the electrons rearranging themselves.
+
+        The uncertainty of the classical straight-line Landau-Spitzer method is on the order
+        of its reciprocal.
         
-        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the 
-        coupling parameter is high (such as for dense, cold plasmas).
+        This method is invalid if :math:`\ln{\Lambda} < 2` because of the uncertainty of the classical
+        straight-line Landau-Spitzer method and if :math:`\ln{\Lambda} < 0`, which may be true if the 
+        coupling parameter is high (such as for nonideal, dense, cold plasmas).
         
         Please refer to Reference [1]_ for additional information about this method.
         
@@ -258,8 +251,8 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true for nonideal plasmas and if the coupling 
-        parameter is high (such as for dense, cold plasmas).
+        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the coupling 
+        parameter is high such as for nonideal, dense, cold plasmas.
         
         Note: This is the first method in Table 1 of Reference [4].
         
@@ -278,17 +271,15 @@ def Coulomb_logarithm(
             
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
-        
-        Valid For: Dilute plasmas
-        
-        Invalid For: This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true for nonideal plasmas and if the coupling 
-        parameter is high (such as for dense, cold plasmas).
+       
+        This method is invalid if :math:`\ln{\Lambda} < 0`, which may be true if the coupling 
+        parameter is high such as for nonideal, dense, cold plasmas.
         
         Note: This is the second method in Table 1 of Reference [4].
         
     Option 4: `"lsclampmininterp"` or `"lscmini"` (Landau-Spitzer with a clamp, interpolation of :math:`b_{min}`)
         A straight-line Landau-Spitzer method in which the value of :math:`\ln{\Lambda}` is clamped at 
-        a minimum of :math:`2` so that it does not fail for Coulomb logarithm < 0, unlike the 
+        a minimum of :math:`2` so that this method  for Coulomb logarithm < 0, unlike the 
         classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
         wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
         (:math:`\rho_{\perp}`). :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
@@ -308,8 +299,8 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        Invalid For: N/A. This method cannot fail because it is impossible for :math:`\ln{\Lambda} < 0` in this 
-        method, even for a large coupling parameter.
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` in this 
+        method, even if the coupling parameter is high.
         
         Note: This is the third method in Table 1 of Reference [4].
         
@@ -327,10 +318,8 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
-        Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
-        unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\ln{\Lambda} < 0` in this method, even for a high coupling parameter.
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` in this 
+        method, even if the coupling parameter is high.
         
         Note: This is the fourth method in Table 1 of Reference [4].
         
@@ -348,10 +337,10 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
-        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
-        Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
-        unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\ln{\Lambda} < 0` in this method, even for a high coupling parameter.
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` in this 
+        method, even if the coupling parameter is high.
+        
+        This method overestimates :math:`\ln{\Lambda}` at high temperatures.
         
         Note: This is the fifth method in Table 1 of Reference [4].
         
@@ -371,13 +360,9 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
-        A value of :math:`0` of :math:`b_{min}` is valid in this method and other hyperbolic 
-        Landau-Spitzer methods because these methods do not diverge for small :math:`b_{min}`, 
-        unlike the non-hyperbolic Landau-Spitzer methods. This method cannot fail because it is 
-        impossible for :math:`\ln{\Lambda} < 0` in this method, even for a high coupling parameter.
-        
-        Valid For: Dilute plasmas
-        
+        This method is valid for any because it is impossible for :math:`\ln{\Lambda} < 0` in this 
+        method, even if the coupling parameter is high.
+
         Note: This is the sixth method in Table 1 of Reference [4].
 
     Examples

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -427,9 +427,7 @@ def Coulomb_logarithm(
         ln_Lambda = 0.5 * np.log(1 + bmax ** 2 / bmin ** 2)
     else:
         raise ValueError(
-            'Unknown method. Choose from "classical", "ls_min_interp", "ls_full_interp", '
-            '"ls_clamp_mininterp", "hls_min_interp", "hls_max_interp", "hls_full_interp", '
-            "and their aliases. Please refer to the documentation of this function for more information."
+            'Unknown method. Choose from "classical", "ls_min_interp", "ls_full_interp", "ls_clamp_mininterp", "hls_min_interp", "hls_max_interp", "hls_full_interp", and their aliases. Please refer to the documentation of this function for more information.'
         )
 
     # applying dimensionless units
@@ -447,7 +445,7 @@ def Coulomb_logarithm(
         ]:
             warnings.warn(
                 f'The Coulomb logarithm is {ln_Lambda}, and the specified method, "{method}", depends on '
-                "weak coupling.",
+                'weak coupling.',
                 utils.CouplingWarning,
             )
         elif np.any(ln_Lambda < 4):

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -109,7 +109,8 @@ def Coulomb_logarithm(
         a macroscopic description is valid. This is used to recover the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters.
+        impact parameters. `z_mean` is a required parameter if `method` is
+        `"lsfullinterp"`, `"hlsmaxinterp"`, or `"hlsfullinterp"`.
 
     V : ~astropy.units.Quantity, optional
         The relative velocity between particles.  If not provided,
@@ -604,7 +605,8 @@ def impact_parameter(
         a macroscopic description is valid. This is used to recover the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
-        impact parameters.
+        impact parameters. `z_mean` is a required parameter if `method` is
+        `"lsfullinterp"`, `"hlsmaxinterp"`, or `"hlsfullinterp"`.
 
     V : ~astropy.units.Quantity, optional
         The relative velocity between particles.  If not provided,

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -105,15 +105,15 @@ def Coulomb_logarithm(
         (listed first) and the target particle (listed second).
 
     z_mean : ~astropy.units.Quantity, optional
-        The average ionization (arithmetic mean) for a plasma where the
-        a macroscopic description is valid. This is used to recover the
+        The average ionization (arithmetic mean) of a plasma for which
+        a macroscopic description is valid. This parameter is used to compute the
         average ion density (given the average ionization and electron
         density) for calculating the ion sphere radius for non-classical
         impact parameters. ``z_mean`` is a required parameter if ``method`` is
         ``"ls_full_interp"``, ``"hls_max_interp"``, or ``"hls_full_interp"``.
 
     V : ~astropy.units.Quantity, optional
-        The relative velocity between particles.  If not provided,
+        The relative velocity between particles. If not provided,
         thermal velocity is assumed: :math:`\mu V^2 \sim 2 k_B T`
         where `mu` is the reduced mass.
 
@@ -195,8 +195,9 @@ def Coulomb_logarithm(
 
     **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
 
-    In this section, further information about each method, such as about interpolation and other special
-    features, is documented. Please refer to Reference [4]_ for additional information about these methods.
+    In this section, further information about each method, such as about
+    interpolation and other special features, is documented. Please refer
+    to Reference [4]_ for additional information about these methods.
 
     Option 1: ``"classical"`` or ``"LS"`` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the
@@ -1814,7 +1815,7 @@ def coupling_parameter(
 
     species : tuple
         A tuple containing string representations of the test particle
-        (listed first) and the target particle (listed second)
+        (listed first) and the target particle (listed second).
 
     z_mean : ~astropy.units.Quantity, optional
         The average ionization (arithmetic mean) for a plasma where the

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -159,7 +159,7 @@ def Coulomb_logarithm(
 
     Notes
     -----
-    **Overview of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
+    **Overview of Supported Methods of Computing the Coulomb Logarithm**
 
     PlasmaPy supports 7 methods of computing the Coulomb logarithm:
 
@@ -637,10 +637,11 @@ def impact_parameter(
     method : str, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
-        about these methods.
+        (``"classical"`` or ``"LS"``). The other 6 supported methods are 
+        ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, 
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
 
     Returns
     -------
@@ -688,7 +689,7 @@ def impact_parameter(
     The minimum impact parameter is typically some combination of the
     thermal de Broglie wavelength and the distance of closest approach
     for a 90 degree Coulomb collision. A quadratic sum is used for
-    all GMS methods, except for GMS-5, where b_min is simply set to
+    all GMS methods, except for GMS-5, where ``b_min`` is simply set to
     the distance of closest approach [1]_.
 
     .. math::
@@ -1060,11 +1061,12 @@ def fundamental_electron_collision_freq(
 
     coulomb_log_method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
-        about these methods.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
 
     Returns
     -------
@@ -1189,11 +1191,12 @@ def fundamental_ion_collision_freq(
 
     coulomb_log_method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
-        about these methods.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
 
     Returns
     -------
@@ -1329,11 +1332,12 @@ def mean_free_path(
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
-        about these methods.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
 
     Returns
     -------
@@ -1451,10 +1455,12 @@ def Spitzer_resistivity(
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
         about these methods.
 
     Returns
@@ -1580,11 +1586,12 @@ def mobility(
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
-        about these methods.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
 
     Returns
     -------
@@ -1710,11 +1717,12 @@ def Knudsen_number(
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
-        about these methods.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
 
     Returns
     -------
@@ -1831,11 +1839,12 @@ def coupling_parameter(
 
     method : str, optional
         The method by which to compute the Coulomb logarithm.
-        The default method is the classical straight-line Landau-Spitzer method
-        (``"classical"`` or ``"LS"``). The other 6 supported methods are ``"ls_min_interp"``,
-        ``"ls_full_interp"``, ``"ls_clamp_mininterp"``, ``"hls_min_interp"``, ``"hls_max_interp"``, and
-        ``"hls_full_interp"``. Please refer to the docstring of `Coulomb_logarithm` for more information
-        about these methods.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of `Coulomb_logarithm` for more
+        information about these methods.
 
     Returns
     -------

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -201,7 +201,7 @@ def Coulomb_logarithm(
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 
         higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest 
-        approach (:math:`\rho_{\perp}`) if they are not equal and either if they are equal and 
+        approach (:math:`\rho_{\perp}`) if they are not equal and either of the two if they are equal and 
         :math:`b_{max}` is defined to be the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
@@ -219,9 +219,9 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        The inner impact parameter (:math:`b_{min}`) is the higher of (:math:`\lambda_{de Broglie}`) 
-        and (:math:`\rho_{\perp}`) because for impact parameters lower than (:math:`\lambda_{de Broglie}`), 
-        quantum effects cause the collision to be non-Coulombic [2]_[3]_.
+        The inner impact parameter (:math:`b_{min}`) is the higher of :math:`\lambda_{de Broglie}` 
+        and :math:`\rho_{\perp}` because for impact parameters lower than :math:`\lambda_{de Broglie}`, 
+        quantum effects cause the collision to be non-Coulombic [2]_ [3]_.
         
         The outer impact parameter (:math:`b_{max}`) is defined to be the Debye length 
         (:math:`\lambda_{Debye}`) because at distances higher than the
@@ -299,7 +299,7 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` in this 
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
         method, even if the coupling parameter is high.
         
         Note: This is the third method in Table 1 of Reference [4].
@@ -318,7 +318,7 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \lambda_{Debye}
         
-        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` in this 
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
         method, even if the coupling parameter is high.
         
         Note: This is the fourth method in Table 1 of Reference [4].
@@ -337,10 +337,10 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
-        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` in this 
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
         method, even if the coupling parameter is high.
         
-        This method overestimates :math:`\ln{\Lambda}` at high temperatures.
+        Caution: This method overestimates :math:`\ln{\Lambda}` at high temperatures.
         
         Note: This is the fifth method in Table 1 of Reference [4].
         
@@ -360,7 +360,7 @@ def Coulomb_logarithm(
         .. math::
             b_{max} \equiv \sqrt{\lambda_{Debye}^2 + a_i^2}
         
-        This method is valid for any because it is impossible for :math:`\ln{\Lambda} < 0` in this 
+        This method is valid for any plasma because it is impossible for :math:`\ln{\Lambda} < 0` by this 
         method, even if the coupling parameter is high.
 
         Note: This is the sixth method in Table 1 of Reference [4].

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -167,15 +167,15 @@ def Coulomb_logarithm(
     the trajectory of a Coulomb collision is modeled as a straight line and 3 methods in which
     the trajectory of a Coulomb collision is modeled as a hyperbola.
     
-    For straight-line Landau-Spitzer methods, the Coulomb logarithm is defined by
+    For **straight-line** Landau-Spitzer methods, the Coulomb logarithm is defined by
 
     .. math::
         \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
 
     where :math:`b_{min}` and :math:`b_{max}` are the inner and outer
-    impact parameters for Coulomb collisions [1]_.
+    impact parameters for Coulomb collisions [1]_. They are computed by `impact_parameter`.
     
-    For hyperbolic Landau-Spitzer methods, the Coulomb logarithm is defined by
+    For **hyperbolic** Landau-Spitzer methods, the Coulomb logarithm is defined by
     
     .. math::
         \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
@@ -232,7 +232,7 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
             
         .. math::
-            b_{min} \equiv \sqrt(\lambda_{de Broglie}^2 + \rho_{\perp}^2)
+            b_{min} \equiv \sqrt\lambda_{de Broglie}^2 + \rho_{\perp}^2
         
         .. math::
             b_{max} \equiv \lambda_{Debye}
@@ -260,7 +260,7 @@ def Coulomb_logarithm(
         parameter is high (such as for dense, cold plasmas).
         This is the second method in Table 1 of Reference [4].
     Option 4: `"lsclamp"` or `"lsc"` (Landau-Spitzer with a clamp)
-        A straight-line Landau-Spitzer method in which the value of :math:`\lambda` is clamped at 
+        A straight-line Landau-Spitzer method in which the value of :math:`\Lambda` is clamped at 
         a minimum of :math:`2` so that it does not fail for Coulomb logarithm < 0, unlike the 
         classical Landau-Spitzer method. :math:`b_{min}` is interpolated between the de Broglie 
         wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest approach 
@@ -303,7 +303,7 @@ def Coulomb_logarithm(
         and :math:`b_{min}` is defined to be the distance of closest approach (:math:`\rho_{\perp}`).
         
         .. math::
-            \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+            \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
         
         .. math::
             b_{min} \equiv \rho_{\perp}
@@ -324,7 +324,7 @@ def Coulomb_logarithm(
         and the ion sphere radius (:math:`a_i`), allowing for descriptions of dilute plasmas.
         
         .. math::
-            \ln{\Lambda} \equiv 0.5 \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+            \ln{\Lambda} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
         
         .. math::
             b_{min} \equiv \left(\lambda_{de Broglie}^2 + \rho_{\perp}^2\right)^{1/2}
@@ -377,11 +377,11 @@ def Coulomb_logarithm(
                 ln_Lambda = 2 * u.dimensionless_unscaled
             else:
                 ln_Lambda[ln_Lambda < 2] = 2 * u.dimensionless_unscaled
-    elif method in ("GMS-4", "hls", "GMS-5", "hlsmaxi", "GMS-6", "hlsfulli"):
+    elif method in ("GMS-4", "hlsmini", "GMS-5", "hlsmaxi", "GMS-6", "hlsfulli"):
         ln_Lambda = 0.5 * np.log(1 + bmax ** 2 / bmin ** 2)
     else:
         raise ValueError(
-            "Unknown method! Choose from \"ls\", \"lsmini\", \"lsfulli\", \"lsclamp\", \"hyperls\", \"hlsmaxi\", \"hlsfulli\", or their aliases. Please refer to the documentation of this function for more information."
+            "Unknown method! Choose from \"classical\", \"lsmini\", \"lsfulli\", \"lsclamp\", \"hlsmini\", \"hlsmaxi\", \"hlsfulli\", or their aliases. Please refer to the documentation of this function for more information."
         )
     # applying dimensionless units
     ln_Lambda = ln_Lambda.to(u.dimensionless_unscaled).value

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -201,8 +201,8 @@ def Coulomb_logarithm(
     Option 1: `"classical"` or `"ls"` (Landau-Spitzer)
         The classical straight-line Landau-Spitzer method in which :math:`b_{min}` is defined to be the 
         higher of the de Broglie wavelength (:math:`\lambda_{de Broglie}`) and the distance of closest 
-        approach (:math:`\rho_{\perp}`) and :math:`b_{max}` is defined to be the Debye length 
-        (:math:`\lambda_{Debye}`).
+        approach (:math:`\rho_{\perp}`) and either if they are equal and :math:`b_{max}` is defined to 
+        be the Debye length (:math:`\lambda_{Debye}`).
         
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
@@ -211,8 +211,8 @@ def Coulomb_logarithm(
             b_{min} \equiv 
             \left\{
                 \begin{array}{ll}
-                           \lambda_{de Broglie} & \mbox{if } \lambda_{de Broglie} > \rho_{\perp} \\
-                           \rho_{\perp}         & \mbox{if } \rho_{\perp} > \lambda_{de Broglie}
+                           \lambda_{de Broglie} & \mbox{if } \lambda_{de Broglie} \geq \rho_{\perp} \\
+                           \rho_{\perp}         & \mbox{if } \rho_{\perp} \geq \lambda_{de Broglie}
                 \end{array}
             \right.
         
@@ -297,7 +297,7 @@ def Coulomb_logarithm(
             \ln{\Lambda} \equiv 
             \left\{
                 \begin{array}{ll}
-                           \ln\left( \frac{b_{max}}{b_{min}} \right) & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}} \right) > 2 \\
+                           \ln\left( \frac{b_{max}}{b_{min}} \right) & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}} \right) \geq 2 \\
                            2                                         & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}} \right) \leq 2
                 \end{array}
             \right.

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -214,11 +214,9 @@ def Coulomb_logarithm(
         .. math::
             \ln{\Lambda} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
         
-        .. math::
-            \b_{min} \equiv \Lambda_{de Broglie}
-        
-        .. math::
-            \b_{max} \equiv \lambda_D
+            b_{min} \equiv \lambda_{de Broglie}
+            
+            b_{max} \equiv \lambda_D
         
         This method is not valid if :math:`\Lambda < 0`, which may be true if the 
         coupling parameter is high (such as for dense, cold plasmas).

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -194,7 +194,7 @@ def Coulomb_logarithm(
         For strongly-coupled plasma, PlasmaPy recommends Option 7, ``"hls_full_interp"`` or ``"GMS-6"``,
         because of its high accuracy regardless of a plasma's strength of coupling.
 
-    **Explanation of PlasmaPy-Supported Methods of Computing the Coulomb Logarithm**
+    **Explanation of Supported Methods of Computing the Coulomb Logarithm**
 
     In this section, further information about each method, such as about
     interpolation and other special features, is documented. Please refer

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -908,7 +908,7 @@ def Hall_parameter(
     coulomb_log_method : `str`, optional
         The method by which to compute the Coulomb logarithm.
         The default method is the classical straight-line Landau-Spitzer
-        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        method (``"classical"`` or ``"ls"``). The other 6 supported methods
         are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
         ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
         Please refer to the docstring of

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -906,8 +906,14 @@ def Hall_parameter(
         then the ``particle`` thermal velocity is assumed
         (`~plasmapy.formulary.parameters.thermal_speed`).
     coulomb_log_method : `str`, optional
-        Method used for Coulomb logarithm calculation. (see
-        `~plasmapy.formulary.collisions.Coulomb_logarithm`)
+        The method by which to compute the Coulomb logarithm.
+        The default method is the classical straight-line Landau-Spitzer
+        method (``"classical"`` or ``"LS"``). The other 6 supported methods
+        are ``"ls_min_interp"``, ``"ls_full_interp"``, ``"ls_clamp_mininterp"``,
+        ``"hls_min_interp"``, ``"hls_max_interp"``, and ``"hls_full_interp"``.
+        Please refer to the docstring of
+        `~plasmapy.formulary.collisions.Coulomb_logarithm` for more
+        information about these methods.
 
     See Also
     --------

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -289,7 +289,7 @@ class Test_Coulomb_logarithm:
         Murillo, and Schlanges PRE (2002). This checks for when
         a negative (invalid) Coulomb logarithm is returned.
         """
-        with pytest.warns(exceptions.CouplingWarning, match="relies on weak coupling"):
+        with pytest.warns(exceptions.CouplingWarning, match="depends on weak coupling"):
             Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -326,7 +326,7 @@ class Test_Coulomb_logarithm:
         Murillo, and Schlanges PRE (2002). This checks for when
         a negative (invalid) Coulomb logarithm is returned.
         """
-        with pytest.warns(exceptions.CouplingWarning, match="relies on weak coupling"):
+        with pytest.warns(exceptions.CouplingWarning, match="depends on weak coupling"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -37,18 +37,31 @@ class Test_Coulomb_logarithm:
         self.density2 = 1e23 * u.cm ** -3
         self.z_mean = 2.5
         self.particles = ("e", "p")
+        self.ls_min_interp = 3.4014290066940966
         self.gms1 = 3.4014290066940966
+        self.ls_min_interp_negative = -3.4310536971592493
         self.gms1_negative = -3.4310536971592493
+        self.ls_full_interp = 3.6349941014645157
         self.gms2 = 3.6349941014645157
+        self.ls_full_interp_negative = -1.379394033464292
         self.gms2_negative = -1.379394033464292
+        self.ls_clamp_mininterp = 3.4014290066940966
         self.gms3 = 3.4014290066940966
+        self.ls_clamp_mininterp_negative = 2
         self.gms3_negative = 2
+        self.ls_clamp_mininterp_non_scalar = (2, 2)
         self.gms3_non_scalar = (2, 2)
+        self.hls_min_interp = 3.401983996820073
         self.gms4 = 3.401983996820073
+        self.hls_min_interp_negative = 0.0005230791851781715
         self.gms4_negative = 0.0005230791851781715
+        self.hls_max_interp = 3.7196690506837693
         self.gms5 = 3.7196690506837693
+        self.hls_max_interp_negative = 0.03126832674323108
         self.gms5_negative = 0.03126832674323108
+        self.hls_full_interp = 3.635342040477818 
         self.gms6 = 3.635342040477818
+        self.hls_full_interp_negative = 0.030720859361047514
         self.gms6_negative = 0.030720859361047514
 
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
@@ -57,11 +70,18 @@ class Test_Coulomb_logarithm:
         "kwargs",
         [
             {"method": "classical"},
+            {"method": "LS"},
+            {"method": "ls_min_interp"},
             {"method": "GMS-1"},
+            {"method": "ls_full_interp", "z_mean": 1.0},
             {"method": "GMS-2", "z_mean": 1.0},
+            {"method": "ls_clamp_mininterp"},
             {"method": "GMS-3"},
+            {"method": "hls_min_interp"},
             {"method": "GMS-4"},
+            {"method": "hls_max_interp", "z_mean": 1.0},
             {"method": "GMS-5", "z_mean": 1.0},
+            {"method": "hls_full_interp", "z_mean": 1.0},
             {"method": "GMS-6", "z_mean": 1.0},
         ],
     )
@@ -262,6 +282,27 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
+    def test_ls_min_interp(self):
+        """
+        Test for first version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002).
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature1,
+                self.density1,
+                self.particles,
+                z_mean=np.nan * u.dimensionless_unscaled,
+                V=np.nan * u.m / u.s,
+                method="ls_min_interp",
+            )
+        testTrue = np.isclose(methodVal, self.ls_min_interp, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for ls_min_interp should be "
+            f"{self.ls_min_interp} and not {methodVal}."
+        )
+        assert testTrue, errStr
+
     def test_GMS1(self):
         """
         Test for first version of Coulomb logarithm from Gericke,
@@ -283,6 +324,22 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
+    def test_ls_min_interp_negative(self):
+        """
+        Test for first version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002). This checks for when
+        a negative (invalid) Coulomb logarithm is returned.
+        """
+        with pytest.warns(exceptions.CouplingWarning, match="depends on weak coupling"):
+            Coulomb_logarithm(
+                self.temperature2,
+                self.density2,
+                self.particles,
+                z_mean=np.nan * u.dimensionless_unscaled,
+                V=np.nan * u.m / u.s,
+                method="ls_min_interp",
+            )
+
     def test_GMS1_negative(self):
         """
         Test for first version of Coulomb logarithm from Gericke,
@@ -298,6 +355,27 @@ class Test_Coulomb_logarithm:
                 V=np.nan * u.m / u.s,
                 method="GMS-1",
             )
+
+    def test_ls_full_interp(self):
+        """
+        Test for second version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002).
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature1,
+                self.density1,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="ls_full_interp",
+            )
+        testTrue = np.isclose(methodVal, self.ls_full_interp, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-2 should be "
+            f"{self.ls_full_interp} and not {methodVal}."
+        )
+        assert testTrue, errStr
 
     def test_GMS2(self):
         """
@@ -320,6 +398,22 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
+    def test_ls_full_interp_negative(self):
+        """
+        Test for second version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002). This checks for when
+        a negative (invalid) Coulomb logarithm is returned.
+        """
+        with pytest.warns(exceptions.CouplingWarning, match="depends on weak coupling"):
+            methodVal = Coulomb_logarithm(
+                self.temperature2,
+                self.density2,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="ls_full_interp",
+            )
+
     def test_GMS2_negative(self):
         """
         Test for second version of Coulomb logarithm from Gericke,
@@ -335,6 +429,27 @@ class Test_Coulomb_logarithm:
                 V=np.nan * u.m / u.s,
                 method="GMS-2",
             )
+
+    def test_ls_clamp_mininterp(self):
+        """
+        Test for third version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002).
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature1,
+                self.density1,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="ls_clamp_mininterp",
+            )
+        testTrue = np.isclose(methodVal, self.ls_clamp_mininterp, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for ls_clamp_minterp should be "
+            f"{self.ls_clamp_mininterp} and not {methodVal}."
+        )
+        assert testTrue, errStr
 
     def test_GMS3(self):
         """
@@ -354,6 +469,29 @@ class Test_Coulomb_logarithm:
         errStr = (
             f"Coulomb logarithm for GMS-3 should be "
             f"{self.gms3} and not {methodVal}."
+        )
+        assert testTrue, errStr
+
+    def test_ls_clamp_mininterp_negative(self):
+        """
+        Test for third version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002). This checks whether
+        a positive value is returned whereas the classical Coulomb
+        logarithm would return a negative value.
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature2,
+                self.density2,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="ls_clamp_mininterp",
+            )
+        testTrue = np.isclose(methodVal, self.ls_clamp_mininterp_negative, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-3 should be "
+            f"{self.ls_clamp_mininterp_negative} and not {methodVal}."
         )
         assert testTrue, errStr
 
@@ -380,6 +518,29 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
+    def test_ls_clamp_mininterp_non_scalar_density(self):
+        """
+        Test for third version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002). This checks whether
+        passing in a collection of density values returns a
+        collection of Coulomb logarithm values.
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                10 * 1160 * u.K,
+                (1e23 * u.cm ** -3, 1e20 * u.cm ** -3),
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="ls_clamp_mininterp",
+            )
+        testTrue = np.isclose(methodVal, self.ls_clamp_mininterp_non_scalar, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-3 should be "
+            f"{self.ls_clamp_mininterp_non_scalar} and not {methodVal}."
+        )
+        assert testTrue.all(), errStr
+
     def test_GMS3_non_scalar_density(self):
         """
         Test for third version of Coulomb logarithm from Gericke,
@@ -403,6 +564,27 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue.all(), errStr
 
+    def test_hls_min_interp(self):
+        """
+        Test for fourth version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002).
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature1,
+                self.density1,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="hls_min_interp",
+            )
+        testTrue = np.isclose(methodVal, self.hls_min_interp, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-4 should be "
+            f"{self.hls_min_interp} and not {methodVal}."
+        )
+        assert testTrue, errStr
+
     def test_GMS4(self):
         """
         Test for fourth version of Coulomb logarithm from Gericke,
@@ -421,6 +603,29 @@ class Test_Coulomb_logarithm:
         errStr = (
             f"Coulomb logarithm for GMS-4 should be "
             f"{self.gms4} and not {methodVal}."
+        )
+        assert testTrue, errStr
+
+    def test_hls_min_interp_negative(self):
+        """
+        Test for fourth version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002). This checks whether
+        a positive value is returned whereas the classical Coulomb
+        logarithm would return a negative value.
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature2,
+                self.density2,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="hls_min_interp",
+            )
+        testTrue = np.isclose(methodVal, self.hls_min_interp_negative, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-4 should be "
+            f"{self.hls_min_interp_negative} and not {methodVal}."
         )
         assert testTrue, errStr
 
@@ -447,6 +652,27 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
+    def test_hls_max_interp(self):
+        """
+        Test for fifth version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002).
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature1,
+                self.density1,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="hls_max_interp",
+            )
+        testTrue = np.isclose(methodVal, self.hls_max_interp, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-5 should be "
+            f"{self.hls_max_interp} and not {methodVal}."
+        )
+        assert testTrue, errStr
+
     def test_GMS5(self):
         """
         Test for fifth version of Coulomb logarithm from Gericke,
@@ -465,6 +691,29 @@ class Test_Coulomb_logarithm:
         errStr = (
             f"Coulomb logarithm for GMS-5 should be "
             f"{self.gms5} and not {methodVal}."
+        )
+        assert testTrue, errStr
+
+    def test_hls_max_interp_negative(self):
+        """
+        Test for fifth version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002). This checks whether
+        a positive value is returned whereas the classical Coulomb
+        logarithm would return a negative value.
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature2,
+                self.density2,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="hls_max_interp",
+            )
+        testTrue = np.isclose(methodVal, self.hls_max_interp_negative, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-5 should be "
+            f"{self.hls_max_interp_negative} and not {methodVal}."
         )
         assert testTrue, errStr
 
@@ -491,6 +740,27 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
+    def test_hls_full_interp(self):
+        """
+        Test for sixth version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002).
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature1,
+                self.density1,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="hls_full_interp",
+            )
+        testTrue = np.isclose(methodVal, self.hls_full_interp, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-6 should be "
+            f"{self.hls_full_interp} and not {methodVal}."
+        )
+        assert testTrue, errStr
+
     def test_GMS6(self):
         """
         Test for sixth version of Coulomb logarithm from Gericke,
@@ -509,6 +779,29 @@ class Test_Coulomb_logarithm:
         errStr = (
             f"Coulomb logarithm for GMS-6 should be "
             f"{self.gms6} and not {methodVal}."
+        )
+        assert testTrue, errStr
+
+    def test_hls_full_interp_negative(self):
+        """
+        Test for sixth version of Coulomb logarithm from Gericke,
+        Murillo, and Schlanges PRE (2002). This checks whether
+        a positive value is returned whereas the classical Coulomb
+        logarithm would return a negative value.
+        """
+        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+            methodVal = Coulomb_logarithm(
+                self.temperature2,
+                self.density2,
+                self.particles,
+                z_mean=self.z_mean,
+                V=np.nan * u.m / u.s,
+                method="hls_full_interp",
+            )
+        testTrue = np.isclose(methodVal, self.hls_full_interp_negative, rtol=1e-6, atol=0.0)
+        errStr = (
+            f"Coulomb logarithm for GMS-6 should be "
+            f"{self.hls_full_interp_negative} and not {methodVal}."
         )
         assert testTrue, errStr
 
@@ -535,6 +828,16 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
+    def test_ls_full_interp_zmean_error(self):
+        """
+        Tests whether ls_full_interp raises z_mean error when a z_mean is not
+        provided.
+        """
+        with pytest.raises(ValueError):
+            methodVal = Coulomb_logarithm(
+                self.temperature2, self.density2, self.particles, method="ls_full_interp"
+            )
+
     def test_GMS2_zmean_error(self):
         """
         Tests whether GMS-2 raises z_mean error when a z_mean is not
@@ -545,6 +848,16 @@ class Test_Coulomb_logarithm:
                 self.temperature2, self.density2, self.particles, method="GMS-2"
             )
 
+    def test_hls_max_interp_zmean_error(self):
+        """
+        Tests whether hls_max_interp raises z_mean error when a z_mean is not
+        provided.
+        """
+        with pytest.raises(ValueError):
+            methodVal = Coulomb_logarithm(
+                self.temperature2, self.density2, self.particles, method="hls_max_interp"
+            )
+
     def test_GMS5_zmean_error(self):
         """
         Tests whether GMS-5 raises z_mean error when a z_mean is not
@@ -553,6 +866,16 @@ class Test_Coulomb_logarithm:
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
                 self.temperature2, self.density2, self.particles, method="GMS-5"
+            )
+
+    def test_hls_full_interp_zmean_error(self):
+        """
+        Tests whether hls_full_interp raises z_mean error when a z_mean is not
+        provided.
+        """
+        with pytest.raises(ValueError):
+            methodVal = Coulomb_logarithm(
+                self.temperature2, self.density2, self.particles, method="hls_full_interp"
             )
 
     def test_GMS6_zmean_error(self):

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -70,7 +70,7 @@ class Test_Coulomb_logarithm:
         "kwargs",
         [
             {"method": "classical"},
-            {"method": "LS"},
+            {"method": "ls"},
             {"method": "ls_min_interp"},
             {"method": "GMS-1"},
             {"method": "ls_full_interp", "z_mean": 1.0},

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -59,7 +59,7 @@ class Test_Coulomb_logarithm:
         self.gms5 = 3.7196690506837693
         self.hls_max_interp_negative = 0.03126832674323108
         self.gms5_negative = 0.03126832674323108
-        self.hls_full_interp = 3.635342040477818 
+        self.hls_full_interp = 3.635342040477818
         self.gms6 = 3.635342040477818
         self.hls_full_interp_negative = 0.030720859361047514
         self.gms6_negative = 0.030720859361047514
@@ -488,7 +488,9 @@ class Test_Coulomb_logarithm:
                 V=np.nan * u.m / u.s,
                 method="ls_clamp_mininterp",
             )
-        testTrue = np.isclose(methodVal, self.ls_clamp_mininterp_negative, rtol=1e-6, atol=0.0)
+        testTrue = np.isclose(
+            methodVal, self.ls_clamp_mininterp_negative, rtol=1e-6, atol=0.0
+        )
         errStr = (
             f"Coulomb logarithm for GMS-3 should be "
             f"{self.ls_clamp_mininterp_negative} and not {methodVal}."
@@ -534,7 +536,9 @@ class Test_Coulomb_logarithm:
                 V=np.nan * u.m / u.s,
                 method="ls_clamp_mininterp",
             )
-        testTrue = np.isclose(methodVal, self.ls_clamp_mininterp_non_scalar, rtol=1e-6, atol=0.0)
+        testTrue = np.isclose(
+            methodVal, self.ls_clamp_mininterp_non_scalar, rtol=1e-6, atol=0.0
+        )
         errStr = (
             f"Coulomb logarithm for GMS-3 should be "
             f"{self.ls_clamp_mininterp_non_scalar} and not {methodVal}."
@@ -622,7 +626,9 @@ class Test_Coulomb_logarithm:
                 V=np.nan * u.m / u.s,
                 method="hls_min_interp",
             )
-        testTrue = np.isclose(methodVal, self.hls_min_interp_negative, rtol=1e-6, atol=0.0)
+        testTrue = np.isclose(
+            methodVal, self.hls_min_interp_negative, rtol=1e-6, atol=0.0
+        )
         errStr = (
             f"Coulomb logarithm for GMS-4 should be "
             f"{self.hls_min_interp_negative} and not {methodVal}."
@@ -710,7 +716,9 @@ class Test_Coulomb_logarithm:
                 V=np.nan * u.m / u.s,
                 method="hls_max_interp",
             )
-        testTrue = np.isclose(methodVal, self.hls_max_interp_negative, rtol=1e-6, atol=0.0)
+        testTrue = np.isclose(
+            methodVal, self.hls_max_interp_negative, rtol=1e-6, atol=0.0
+        )
         errStr = (
             f"Coulomb logarithm for GMS-5 should be "
             f"{self.hls_max_interp_negative} and not {methodVal}."
@@ -798,7 +806,9 @@ class Test_Coulomb_logarithm:
                 V=np.nan * u.m / u.s,
                 method="hls_full_interp",
             )
-        testTrue = np.isclose(methodVal, self.hls_full_interp_negative, rtol=1e-6, atol=0.0)
+        testTrue = np.isclose(
+            methodVal, self.hls_full_interp_negative, rtol=1e-6, atol=0.0
+        )
         errStr = (
             f"Coulomb logarithm for GMS-6 should be "
             f"{self.hls_full_interp_negative} and not {methodVal}."
@@ -835,7 +845,10 @@ class Test_Coulomb_logarithm:
         """
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
-                self.temperature2, self.density2, self.particles, method="ls_full_interp"
+                self.temperature2,
+                self.density2,
+                self.particles,
+                method="ls_full_interp",
             )
 
     def test_GMS2_zmean_error(self):
@@ -855,7 +868,10 @@ class Test_Coulomb_logarithm:
         """
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
-                self.temperature2, self.density2, self.particles, method="hls_max_interp"
+                self.temperature2,
+                self.density2,
+                self.particles,
+                method="hls_max_interp",
             )
 
     def test_GMS5_zmean_error(self):
@@ -875,7 +891,10 @@ class Test_Coulomb_logarithm:
         """
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
-                self.temperature2, self.density2, self.particles, method="hls_full_interp"
+                self.temperature2,
+                self.density2,
+                self.particles,
+                method="hls_full_interp",
             )
 
     def test_GMS6_zmean_error(self):


### PR DESCRIPTION
- [x] I have added a changelog entry for this pull request.
- [x] If adding new functionality, I have added tests and
      docstrings.
- [ ] I have fixed any newly failing tests.

-| Part of Issue #931.
-| Renames the methods for Coulomb logarithms to "LS", "LS_min_I", "LS_full_I", "LS_clamp", "hyp_LS", "hyp_LS_max_I", and "hyp_LS_full_I". Underscores could be removed, "hyp" could be shortened to "H", and "I" could be changed to "i", "interp", or something similar.
-| Other minor updates.