### PR TITLE
Replace last Riot chat links with Element

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -11,9 +11,9 @@ please first look through https://github.com/PlasmaPy/PlasmaPy/issues and check
 whether no other issue already describes your problem.
 
 For more general "how do I do X?" type questions, please speak to us in real
-time on https://riot.im/app/#/room/#plasmapy:openastronomy.org or ask on Github
-Discussions: https://github.com/plasmapy/plasmapy/discussions . We'll be more
-than happy to help! :)
+time on https://app.element.io/#/room/#plasmapy:openastronomy.org or ask on 
+Github Discussions: https://github.com/plasmapy/plasmapy/discussions . We'll be 
+more than happy to help! :)
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -11,8 +11,8 @@ please first look through https://github.com/PlasmaPy/PlasmaPy/issues and check
 whether no other issue already describes your problem.
 
 For more general "how do I do X?" type questions, please speak to us in real
-time on https://app.element.io/#/room/#plasmapy:openastronomy.org or ask on 
-Github Discussions: https://github.com/plasmapy/plasmapy/discussions . We'll be 
+time on https://app.element.io/#/room/#plasmapy:openastronomy.org or ask on
+Github Discussions: https://github.com/plasmapy/plasmapy/discussions . We'll be
 more than happy to help! :)
 
 -->

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -11,8 +11,8 @@ please first look through https://github.com/PlasmaPy/PlasmaPy/issues and check
 whether no other issue already describes your problem.
 
 For more general "how do I do X?" type questions, please speak to us in real
-time on https://app.element.io/#/room/#plasmapy:openastronomy.org or ask on 
-GitHub Discussions: https://github.com/plasmapy/plasmapy/discussions . We'll be 
+time on https://app.element.io/#/room/#plasmapy:openastronomy.org or ask on
+GitHub Discussions: https://github.com/plasmapy/plasmapy/discussions . We'll be
 more than happy to help! :)
 
 -->

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -11,9 +11,9 @@ please first look through https://github.com/PlasmaPy/PlasmaPy/issues and check
 whether no other issue already describes your problem.
 
 For more general "how do I do X?" type questions, please speak to us in real
-time on https://riot.im/app/#/room/#plasmapy:openastronomy.org or ask on GitHub
-Discussions: https://github.com/plasmapy/plasmapy/discussions . We'll be more
-than happy to help! :)
+time on https://app.element.io/#/room/#plasmapy:openastronomy.org or ask on 
+GitHub Discussions: https://github.com/plasmapy/plasmapy/discussions . We'll be 
+more than happy to help! :)
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ make things easier for all of us:
   list in `docs/about/credits.rst`.
 
 * Feel free to chat with other developers on our Matrix channel at:
-   https://riot.im/app/#/room/#plasmapy:openastronomy.org
+   https://app.element.io/#/room/#plasmapy:openastronomy.org
 
 * We have a developer's guide to help answer some of your questions.
   http://docs.plasmapy.org/en/latest/development/index.html


### PR DESCRIPTION
This replaces the few straggling Riot chat links with the Element chat links (Basically those in the `.github` templates).  Change Log references were not touched.

Closes #938 