### PR TITLE
Added relativistic boris push

### DIFF
--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -60,7 +60,10 @@ class ParticleTracker:
     .. _`Particle Stepper Notebook`: ../notebooks/particle_stepper.ipynb
     """
 
-    integrators = {"explicit_boris": particle_integrators.boris_push}
+    integrators = {
+        "explicit_boris": particle_integrators.boris_push,
+        "explicit_boris_relativistic": particle_integrators.boris_push_relativistic,
+    }
 
     _wip_integrators = {}
 


### PR DESCRIPTION
Added relativistic Boris push to `simulation.particle_integrators`. This is necessary for the synthetic proton radiography module (protons are typically > 1% c). 

I think I wrote it correctly (based on Birdsall), but it would be great if someone could check my work. 

Also, currently there are no tests. Ideally this should be tested as part of the particletracker tests (maybe showing that it produces the same result in the non-relativistic limit as the regular Boris push) but those tests are currently in flux.