### PR TITLE
Remove lambda functions

### DIFF
--- a/changelog/1013.trivial.rst
+++ b/changelog/1013.trivial.rst
@@ -1,0 +1,1 @@
+Remove `lambda` expressions from `plasmapy.particles` and `plasmapy.utils`.

--- a/docs/development/code_guide.rst
+++ b/docs/development/code_guide.rst
@@ -49,9 +49,8 @@ Coding Style
 * Use ``Optional[type]`` for type hinted keyword arguments with a
   default value of ``None``.
 
-* Avoid using `lambda`.  Anonymous functions created with `lambda`
-  cannot be pickled, and `lambda` notation may be unfamiliar to
-  newcomers to Python.
+* Avoid using `lambda` to define functions, as this notation may be
+  unfamiliar to newcomers to Python.
 
 * There should be at most one pun per 1284 lines of code.
 

--- a/docs/development/code_guide.rst
+++ b/docs/development/code_guide.rst
@@ -49,6 +49,10 @@ Coding Style
 * Use ``Optional[type]`` for type hinted keyword arguments with a
   default value of ``None``.
 
+* Avoid using `lambda`.  Anonymous functions created with `lambda`
+  cannot be pickled, and `lambda` notation may be unfamiliar to
+  newcomers to Python.
+
 * There should be at most one pun per 1284 lines of code.
 
 pre-commit hooks

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -23,7 +23,7 @@ from plasmapy.particles.symbols import particle_symbol
 from plasmapy.utils.decorators import validate_quantities
 
 
-def atomic_number_and_mass_number(p: Particle):
+def _atomic_number_and_mass_number(p: Particle):
     return (p.atomic_number, p.mass_number if p.isotope else 0)
 
 
@@ -637,7 +637,7 @@ class IonizationStateCollection:
                     "Invalid inputs to IonizationStateCollection."
                 ) from exc
 
-            _particle_instances.sort(key=atomic_number_and_mass_number)
+            _particle_instances.sort(key=_atomic_number_and_mass_number)
 
             _elements_and_isotopes = [
                 particle.symbol for particle in _particle_instances

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -166,11 +166,8 @@ class IonizationStateCollection:
                     )
                 set_abundances = False
 
-        def return_none():
-            return None
-
         try:
-            self._pars = collections.defaultdict(return_none)
+            self._pars = dict()
             self.T_e = T_e
             self.n0 = n0
             self.tol = tol

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -23,6 +23,10 @@ from plasmapy.particles.symbols import particle_symbol
 from plasmapy.utils.decorators import validate_quantities
 
 
+def atomic_number_and_mass_number(p: Particle):
+    return (p.atomic_number, p.mass_number if p.isotope else 0)
+
+
 class IonizationStateCollection:
     """
     Describe the ionization state distributions of multiple elements
@@ -162,8 +166,11 @@ class IonizationStateCollection:
                     )
                 set_abundances = False
 
+        def return_none():
+            return None
+
         try:
-            self._pars = collections.defaultdict(lambda: None)
+            self._pars = collections.defaultdict(return_none)
             self.T_e = T_e
             self.n0 = n0
             self.tol = tol
@@ -526,12 +533,14 @@ class IonizationStateCollection:
             # mass number since we will often want to plot and analyze
             # things and this is the most sensible order.
 
-            sorted_keys = sorted(
-                original_keys,
-                key=lambda k: (
+            def _sort_entries_by_atomic_and_mass_numbers(k):
+                return (
                     particles[k].atomic_number,
                     particles[k].mass_number if particles[k].isotope else 0,
-                ),
+                )
+
+            sorted_keys = sorted(
+                original_keys, key=_sort_entries_by_atomic_and_mass_numbers
             )
 
             _elements_and_isotopes = []
@@ -628,9 +637,8 @@ class IonizationStateCollection:
                     "Invalid inputs to IonizationStateCollection."
                 ) from exc
 
-            _particle_instances.sort(
-                key=lambda p: (p.atomic_number, p.mass_number if p.isotope else 0)
-            )
+            _particle_instances.sort(key=atomic_number_and_mass_number)
+
             _elements_and_isotopes = [
                 particle.symbol for particle in _particle_instances
             ]

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -405,7 +405,8 @@ class Particle(AbstractParticle):
         if Z is not None and not isinstance(Z, Integral):
             raise TypeError("Z is not an integer.")
 
-        self._attributes = defaultdict(lambda: None)
+        # For Python 3.10, change `type(None)` to `types.NoneType`
+        self._attributes = defaultdict(type(None))
         attributes = self._attributes
 
         # Use this set to keep track of particle categories such as

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -217,13 +217,10 @@ class TestIonizationStateCollection:
         if isinstance(inputs, dict):
             input_keys = list(tests[test_name]["inputs"].keys())
 
-            input_keys = sorted(
-                input_keys,
-                key=lambda k: (
-                    atomic_number(k),
-                    mass_number(k) if Particle(k).isotope else 0,
-                ),
-            )
+            def sort_key(k):
+                return atomic_number(k), mass_number(k) if Particle(k).isotope else 0
+
+            input_keys = sorted(input_keys, key=sort_key)
 
             for element, input_key in zip(elements_actual, input_keys):
                 expected = tests[test_name]["inputs"][input_key]

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -992,13 +992,13 @@ class CheckUnits(CheckBase):
 
         normalized = []
 
-        def return_arg(x):
+        def return_argument(x):
             return x
 
         for i, equiv in enumerate(equivalencies):
             if len(equiv) == 2:
                 from_unit, to_unit = equiv
-                a = b = return_arg
+                a = b = return_argument
             elif len(equiv) == 3:
                 from_unit, to_unit, a = equiv
                 b = a

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -19,6 +19,7 @@ import warnings
 from astropy import units as u
 from astropy.constants import c
 from functools import reduce
+from operator import add
 from typing import Any, Dict, List, Tuple, Union
 
 from plasmapy.utils.decorators.helpers import preserve_signature
@@ -724,7 +725,7 @@ class CheckUnits(CheckBase):
                 #     (from_unit, to_unit, forward_func, backward_func)
                 #
                 if all(isinstance(el, Equivalency) for el in _equivs):
-                    _equivs = reduce(lambda x, y: x + y, _equivs)
+                    _equivs = reduce(add, _equivs)
                 else:
                     _equivs = self._normalize_equivalencies(_equivs)
 
@@ -991,10 +992,13 @@ class CheckUnits(CheckBase):
 
         normalized = []
 
+        def return_arg(x):
+            return x
+
         for i, equiv in enumerate(equivalencies):
             if len(equiv) == 2:
                 from_unit, to_unit = equiv
-                a = b = lambda x: x
+                a = b = return_arg
             elif len(equiv) == 3:
                 from_unit, to_unit, a = equiv
                 b = a


### PR DESCRIPTION
This pull request removes some `lambda` expressions from `plasmapy.particles` and `plasmapy.utils` because `lambda` expressions cannot be pickled. This partially address #1011.  However, more would need to be done in order to pickle `Particle` instances.  I left the `lambda` expressions in Langmuir stuff to avoid conflicts with #889.  

I propose a new tongue twister:
> I pickled a Particle of pickled PEP8ers.

