### PR TITLE
Add mostly failing tests for pickling various objects in plasmapy.particles

### DIFF
--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -1,6 +1,8 @@
 import astropy.units as u
 import collections
 import numpy as np
+import os
+import pickle
 import pytest
 
 from plasmapy.particles import (
@@ -705,3 +707,27 @@ class Test_IonizationStateNumberDensitiesSetter:
 
     def test_kappa_isinf_when_not_set(self):
         assert np.isinf(self.instance.kappa)
+
+
+class TestPickling:
+    """
+    Test that `IonicFraction` and `IonizationState` can be pickled.
+    """
+
+    filename = "pickled_ionstates.p"
+    ionfrac = IonicFraction("p+", 0.1, 1e9 * u.m ** -3)
+    ionstate = IonizationState("H", [0.5, 0.5])
+
+    @pytest.mark.parametrize(
+        "instance",
+        [
+            pytest.param(ionfrac, marks=pytest.mark.xfail(reason="issue #1011")),
+            pytest.param(ionstate, marks=pytest.mark.xfail(reason="issue #1011")),
+        ],
+    )
+    def test_pickling_particles(self, instance):
+        with open(self.filename, "wb") as pickle_file:
+            pickle.dump(instance, pickle_file)
+
+    def teardown_method(self):
+        os.remove(self.filename)

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -707,27 +707,3 @@ class Test_IonizationStateNumberDensitiesSetter:
 
     def test_kappa_isinf_when_not_set(self):
         assert np.isinf(self.instance.kappa)
-
-
-class TestPickling:
-    """
-    Test that `IonicFraction` and `IonizationState` can be pickled.
-    """
-
-    filename = "pickled_ionstates.p"
-    ionfrac = IonicFraction("p+", 0.1, 1e9 * u.m ** -3)
-    ionstate = IonizationState("H", [0.5, 0.5])
-
-    @pytest.mark.parametrize(
-        "instance",
-        [
-            pytest.param(ionfrac, marks=pytest.mark.xfail(reason="issue #1011")),
-            pytest.param(ionstate, marks=pytest.mark.xfail(reason="issue #1011")),
-        ],
-    )
-    def test_pickling_particles(self, instance):
-        with open(self.filename, "wb") as pickle_file:
-            pickle.dump(instance, pickle_file)
-
-    def teardown_method(self):
-        os.remove(self.filename)

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -3,6 +3,8 @@ import inspect
 import io
 import json
 import numpy as np
+import os
+import pickle
 import pytest
 
 from astropy import constants as const
@@ -1318,3 +1320,27 @@ def test_particle_to_json_file(cls, kwargs, expected_repr):
         f"expected_repr = {expected_repr['__init__']}.\n\n"
         f"json_repr: {test_dict['__init__']}"
     )
+
+
+class TestPickledParticles:
+    """
+    Test that `Particle`, `CustomParticle`, and `DimensionlessParticle`
+    instances can be pickled.
+    """
+
+    filename = "pickled_particle.p"
+
+    @pytest.mark.parametrize(
+        "particle",
+        [
+            pytest.param(Particle("n"), marks=pytest.mark.xfail(reason="issue #1011")),
+            CustomParticle(mass=5e-26 * u.kg),
+            DimensionlessParticle(mass=1.2),
+        ],
+    )
+    def test_pickling_particles(self, particle):
+        with open(self.filename, "wb") as pickle_file:
+            pickle.dump(particle, pickle_file)
+
+    def teardown_method(self):
+        os.remove(self.filename)

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1320,27 +1320,3 @@ def test_particle_to_json_file(cls, kwargs, expected_repr):
         f"expected_repr = {expected_repr['__init__']}.\n\n"
         f"json_repr: {test_dict['__init__']}"
     )
-
-
-class TestPickledParticles:
-    """
-    Test that `Particle`, `CustomParticle`, and `DimensionlessParticle`
-    instances can be pickled.
-    """
-
-    filename = "pickled_particle.p"
-
-    @pytest.mark.parametrize(
-        "particle",
-        [
-            pytest.param(Particle("n"), marks=pytest.mark.xfail(reason="issue #1011")),
-            CustomParticle(mass=5e-26 * u.kg),
-            DimensionlessParticle(mass=1.2),
-        ],
-    )
-    def test_pickling_particles(self, particle):
-        with open(self.filename, "wb") as pickle_file:
-            pickle.dump(particle, pickle_file)
-
-    def teardown_method(self):
-        os.remove(self.filename)

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -36,3 +36,8 @@ class TestPickling:
         filename = tmp_path / "pickled_particles.p"
         with open(filename, "wb") as pickle_file:
             pickle.dump(instance, pickle_file)
+
+        with open(filename, "r") as pickle_file:
+            loaded_particle = pickle.load(pickle_file)
+
+        assert loaded_particle == loaded_particle

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -19,8 +19,6 @@ class TestPickling:
     Test that different objects in `plasmapy.particles` can be pickled.
     """
 
-    filename = "pickled_particles.p"
-
     xfail = pytest.mark.xfail(reason="see issue #1011")
 
     @pytest.mark.parametrize(
@@ -34,9 +32,7 @@ class TestPickling:
             pytest.param(IonizationStateCollection({"H": [0.5, 0.5]}), marks=xfail),
         ],
     )
-    def test_pickling_particles(self, instance):
-        with open(self.filename, "wb") as pickle_file:
+    def test_pickling_particles(self, instance, tmp_path):
+        filename = tmp_path / "pickled_particles.p"
+        with open(filename, "wb") as pickle_file:
             pickle.dump(instance, pickle_file)
-
-    def teardown_method(self):
-        os.remove(self.filename)

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -24,7 +24,7 @@ class TestPickling:
     @pytest.mark.parametrize(
         "instance",
         [
-            CustomParticle(mass=1 * u.kg),
+            CustomParticle(mass=1 * u.kg, charge=1 * u.C),
             DimensionlessParticle(mass=5, charge=5),
             pytest.param(Particle("p+"), marks=xfail),
             pytest.param(IonicFraction("p+", 0.1, 1e9 * u.m ** -3), marks=xfail),
@@ -32,12 +32,16 @@ class TestPickling:
             pytest.param(IonizationStateCollection({"H": [0.5, 0.5]}), marks=xfail),
         ],
     )
-    def test_pickling_particles(self, instance, tmp_path):
+    def test_pickling(self, instance, tmp_path):
+        """
+        Test that different objects contained within `plasmapy.particles`
+        can be pickled and unpickled.
+        """
         filename = tmp_path / "pickled_particles.p"
         with open(filename, "wb") as pickle_file:
             pickle.dump(instance, pickle_file)
 
-        with open(filename, "r") as pickle_file:
+        with open(filename, "rb") as pickle_file:
             loaded_particle = pickle.load(pickle_file)
 
-        assert loaded_particle == loaded_particle
+        assert str(instance) == str(loaded_particle)

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -1,0 +1,42 @@
+"""Test that objects in `plasmapy.particles` can be pickled."""
+
+import astropy.units as u
+import os
+import pickle
+import pytest
+
+from plasmapy.particles.ionization_state import IonicFraction, IonizationState
+from plasmapy.particles.ionization_state_collection import IonizationStateCollection
+from plasmapy.particles.particle_class import (
+    CustomParticle,
+    DimensionlessParticle,
+    Particle,
+)
+
+
+class TestPickling:
+    """
+    Test that different objects in `plasmapy.particles` can be pickled.
+    """
+
+    filename = "pickled_particles.p"
+
+    xfail = pytest.mark.xfail(reason="see issue #1011")
+
+    @pytest.mark.parametrize(
+        "instance",
+        [
+            CustomParticle(mass=1 * u.kg),
+            DimensionlessParticle(mass=5, charge=5),
+            pytest.param(Particle("p+"), marks=xfail),
+            pytest.param(IonicFraction("p+", 0.1, 1e9 * u.m ** -3), marks=xfail),
+            pytest.param(IonizationState("H", [0.5, 0.5]), marks=xfail),
+            pytest.param(IonizationStateCollection({"H": [0.5, 0.5]}), marks=xfail),
+        ],
+    )
+    def test_pickling_particles(self, instance):
+        with open(self.filename, "wb") as pickle_file:
+            pickle.dump(instance, pickle_file)
+
+    def teardown_method(self):
+        os.remove(self.filename)


### PR DESCRIPTION
This PR adds new tests in `plasmapy.particles` regarding the pickling of particles.  Both `CustomParticle` and `DimensionlessParticle` instances can be pickled, but `Particle` instances (and objects that contain `Particle` instances) cannot.  Hence, most of these tests are marked as failing.  These tests should help later on when we address #1011 and make particles piclkealble.  (Yeah, I gave up on trying to spell that.)

