### PR TITLE
Add symbol attribute to CustomParticle and DimensionlessParticle

### DIFF
--- a/changelog/1015.feature.rst
+++ b/changelog/1015.feature.rst
@@ -1,0 +1,3 @@
+Both `plasmapy.particles.CustomParticle` and `plasmapy.particles.DimensionlessParticle`
+now allow users to define a custom symbol via the ``symbol`` keyword argument, which
+can then be accessed by the ``symbol`` attribute in each of these classes.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -163,23 +163,6 @@ class AbstractParticle(ABC):
         }
         return json_dictionary
 
-    @property
-    def symbol(self) -> str:
-        """
-        Return the symbol assigned to the particle.  If no symbol was
-        defined, then return the value given by `repr`.
-        """
-        return self._symbol
-
-    @symbol.setter
-    def symbol(self, new_symbol: str):
-        if new_symbol is None:
-            self._symbol = repr(self)
-        elif isinstance(new_symbol, str):
-            self._symbol = new_symbol
-        else:
-            raise TypeError("symbol needs to be a string.")
-
     def __bool__(self):
         """
         Raise an `~plasmapy.particles.exceptions.ParticleError` because particles
@@ -265,6 +248,11 @@ class Particle(AbstractParticle):
     `~plasmapy.particles.exceptions.ParticleError`
         Raised for attempts at converting a
         `~plasmapy.particles.Particle` object to a `bool`.
+
+    See Also
+    --------
+    ~plasmapy.particles.CustomParticle
+    ~plasmapy.particles.DimensionlessParticle
 
     Examples
     --------
@@ -1724,10 +1712,16 @@ class DimensionlessParticle(AbstractParticle):
         The mass of the dimensionless particle.  Defaults to `numpy.nan`.
 
     charge : real number, keyword-only, optional
-        The electric charge of the dimensionless particle.
+        The electric charge of the dimensionless particle.  Defaults to
+        `numpy.nan`.
 
     symbol : str, optional
         The symbol to be assigned to the dimensionless particle.
+
+    See Also
+    --------
+    ~plasmapy.particles.Particle
+    ~plasmapy.particles.CustomParticle
 
     Notes
     -----
@@ -1868,6 +1862,23 @@ class DimensionlessParticle(AbstractParticle):
                 "DimensionlessParticle charge set to NaN", MissingParticleDataWarning
             )
 
+    @property
+    def symbol(self) -> str:
+        """
+        Return the symbol assigned to the dimensionless particle.  If no
+        symbol was defined, then return the value given by `repr`.
+        """
+        return self._symbol
+
+    @symbol.setter
+    def symbol(self, new_symbol: str):
+        if new_symbol is None:
+            self._symbol = repr(self)
+        elif isinstance(new_symbol, str):
+            self._symbol = new_symbol
+        else:
+            raise TypeError("symbol needs to be a string.")
+
 
 class CustomParticle(AbstractParticle):
     """
@@ -1910,11 +1921,13 @@ class CustomParticle(AbstractParticle):
     --------
     >>> from astropy import units as u
     >>> from plasmapy.particles import CustomParticle
-    >>> custom_particle = CustomParticle(mass=1.5e-26 * u.kg, charge=-1)
+    >>> custom_particle = CustomParticle(mass=1.5e-26 * u.kg, charge=-1, symbol="Ξ")
     >>> custom_particle.mass
     <Quantity 1.5e-26 kg>
     >>> custom_particle.charge
     <Quantity -1.60217...e-19 C>
+    >>> custom_particle.symbol
+    'Ξ'
     """
 
     def __init__(self, mass: u.kg = None, charge: (u.C, Real) = None, symbol=None):
@@ -2050,6 +2063,37 @@ class CustomParticle(AbstractParticle):
                 raise u.UnitsError(
                     "The mass of a custom particle must have units of mass."
                 ) from exc
+
+    @property
+    def mass_energy(self) -> u.J:
+        """
+        Return the mass energy of the custom particle.
+
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> custom_particle = CustomParticle(mass = 2e-25 * u.kg, charge = 0 * u.C)
+        >>> custom_particle.mass_energy.to('GeV')
+        <Quantity 112.19177208 GeV>
+        """
+        return (self.mass * const.c ** 2).to(u.J)
+
+    @property
+    def symbol(self) -> str:
+        """
+        Return the symbol assigned to the custom particle.  If no symbol
+        was defined, then return the value given by `repr`.
+        """
+        return self._symbol
+
+    @symbol.setter
+    def symbol(self, new_symbol: str):
+        if new_symbol is None:
+            self._symbol = repr(self)
+        elif isinstance(new_symbol, str):
+            self._symbol = new_symbol
+        else:
+            raise TypeError("symbol needs to be a string.")
 
 
 # TODO: Describe valid particle representations in docstring of particle_like

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -164,9 +164,21 @@ class AbstractParticle(ABC):
         return json_dictionary
 
     @property
-    def symbol(self):
-        """Return a string representation of the particle."""
-        return self.__repr__()
+    def symbol(self) -> str:
+        """
+        Return the symbol assigned to the particle.  If no symbol was
+        defined, then return the value given by `repr`.
+        """
+        return self._symbol
+
+    @symbol.setter
+    def symbol(self, new_symbol: str):
+        if new_symbol is None:
+            self._symbol = repr(self)
+        elif isinstance(new_symbol, str):
+            self._symbol = new_symbol
+        else:
+            raise TypeError("symbol needs to be a string.")
 
     def __bool__(self):
         """
@@ -1787,23 +1799,6 @@ class DimensionlessParticle(AbstractParticle):
         return new_obj
 
     @property
-    def symbol(self) -> str:
-        """
-        Return the symbol assigned to the dimensionless particle.  If no
-        symbol was defined, then return the value given by `repr`
-        """
-        return self._symbol
-
-    @symbol.setter
-    def symbol(self, new_symbol: str):
-        if new_symbol is None:
-            self._symbol = repr(self)
-        elif isinstance(new_symbol, str):
-            self._symbol = new_symbol
-        else:
-            raise TypeError("symbol needs to be a string.")
-
-    @property
     def json_dict(self) -> dict:
         """
         A `json` friendly dictionary representation of the particle. (see
@@ -2055,23 +2050,6 @@ class CustomParticle(AbstractParticle):
                 raise u.UnitsError(
                     "The mass of a custom particle must have units of mass."
                 ) from exc
-
-    @property
-    def symbol(self) -> str:
-        """
-        Return the symbol assigned to the custom. particle.  If no symbol
-        was defined, then return the value given by `repr`.
-        """
-        return self._symbol
-
-    @symbol.setter
-    def symbol(self, new_symbol: str):
-        if new_symbol is None:
-            self._symbol = repr(self)
-        elif isinstance(new_symbol, str):
-            self._symbol = new_symbol
-        else:
-            raise TypeError("symbol needs to be a string.")
 
 
 # TODO: Describe valid particle representations in docstring of particle_like

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -977,6 +977,8 @@ customized_particle_errors = [
     (CustomParticle, {"mass": np.complex128(5 + 2j) * u.kg}, InvalidParticleError),
     (CustomParticle, {"charge": "not a charge"}, InvalidParticleError),
     (CustomParticle, {"charge": "5.0 km"}, InvalidParticleError),
+    (CustomParticle, {"symbol": 1}, TypeError),
+    (DimensionlessParticle, {"symbol": 2}, TypeError),
 ]
 
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -977,8 +977,6 @@ customized_particle_errors = [
     (CustomParticle, {"mass": np.complex128(5 + 2j) * u.kg}, InvalidParticleError),
     (CustomParticle, {"charge": "not a charge"}, InvalidParticleError),
     (CustomParticle, {"charge": "5.0 km"}, InvalidParticleError),
-    (CustomParticle, {"symbol": 1}, TypeError),
-    (DimensionlessParticle, {"symbol": 2}, TypeError),
 ]
 
 
@@ -1021,6 +1019,15 @@ def test_customized_particle_repr(cls, kwargs, expected_repr):
             f"from_str: {from_str}"
             f"from_repr: {from_repr}"
         )
+
+
+@pytest.mark.parametrize("cls", [CustomParticle, DimensionlessParticle])
+@pytest.mark.parametrize("not_a_str", [1, u.kg])
+def test_typeerror_redefining_symbol(cls, not_a_str):
+    """Test that the symbol attribute cannot be set to something besides a string"""
+    instance = cls()
+    with pytest.raises(TypeError):
+        instance.symbol = not_a_str
 
 
 custom_particles_from_json_tests = [

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -928,6 +928,20 @@ def test_customized_particles(cls, kwargs, attr, expected):
         )
 
 
+@pytest.mark.parametrize(
+    "cls, symbol, expected",
+    [
+        (CustomParticle, None, "CustomParticle(mass=nan kg, charge=nan C)"),
+        (CustomParticle, "η", "η"),
+        (DimensionlessParticle, None, "DimensionlessParticle(mass=nan, charge=nan)"),
+        (DimensionlessParticle, "η", "η"),
+    ],
+)
+def test_custom_particle_symbol(cls, symbol, expected):
+    instance = cls(symbol=symbol)
+    assert instance.symbol == expected
+
+
 customized_particle_errors = [
     (DimensionlessParticle, {"mass": -1e-36}, InvalidParticleError),
     (DimensionlessParticle, {"mass": [1, 1]}, InvalidParticleError),
@@ -1010,32 +1024,33 @@ def test_customized_particle_repr(cls, kwargs, expected_repr):
 custom_particles_from_json_tests = [
     (
         DimensionlessParticle,
-        {"mass": 5.2, "charge": 6.3},
+        {"mass": 5.2, "charge": 6.3, "symbol": "ξ"},
         '{"plasmapy_particle": {"type": "DimensionlessParticle", \
         "module": "plasmapy.particles.particle_class", \
         "date_created": "...", "__init__": { \
             "args": [], \
-            "kwargs": {"mass": 5.2, "charge": 6.3}}}}',
+            "kwargs": {"mass": 5.2, "charge": 6.3, "symbol": "ξ"}}}}',
         None,
     ),
     (
         DimensionlessParticle,
-        {"mass": 5.2},
+        {"mass": 5.2, "symbol": "ξ"},
         '{"plasmapy_particle": {"type": "DimensionlessParticle", \
         "module": "plasmapy.particles.particle_class", \
         "date_created": "...", "__init__": { \
             "args": [], \
-            "kwargs": {"mass": 5.2, "charge": NaN}}}}',
+            "kwargs": {"mass": 5.2, "charge": NaN, "symbol": "ξ"}}}}',
         None,
     ),
     (
         CustomParticle,
-        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C},
+        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C, "symbol": "ξ"},
         '{"plasmapy_particle": {"type": "CustomParticle", \
         "module": "plasmapy.particles.particle_class", \
         "date_created": "...", "__init__": { \
             "args": [], \
-            "kwargs": {"mass": "5.12 kg", "charge": "6.2 C"}}}}',
+            "kwargs": {"mass": "5.12 kg", "charge": "6.2 C", '
+        '"symbol": "ξ"}}}}',
         None,
     ),
     (
@@ -1256,21 +1271,21 @@ particle_json_repr_table = [
     ),
     (
         CustomParticle,
-        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C},
+        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C, "symbol": "ξ"},
         '{"plasmapy_particle": {"type": "CustomParticle", \
         "module": "plasmapy.particles.particle_class", \
         "date_created": "...", "__init__": {\
             "args": [], \
-            "kwargs": {"mass": "5.12 kg", "charge": "6.2 C"}}}}',
+            "kwargs": {"mass": "5.12 kg", "charge": "6.2 C", "symbol": "ξ"}}}}',
     ),
     (
         DimensionlessParticle,
-        {"mass": 5.2, "charge": 6.3},
+        {"mass": 5.2, "charge": 6.3, "symbol": "ξ"},
         '{"plasmapy_particle": {"type": "DimensionlessParticle",\
         "module": "plasmapy.particles.particle_class",\
         "date_created": "...", "__init__": {\
             "args": [], \
-            "kwargs": {"mass": 5.2, "charge": 6.3}}}}',
+            "kwargs": {"mass": 5.2, "charge": 6.3, "symbol": "ξ"}}}}',
     ),
 ]
 


### PR DESCRIPTION
To help `CustomParticle` and `DimensionlessParticle` behave a little bit more like `Particle`, I've added a `symbol` attribute to both of these.  This will give users the opportunity to define a symbol for particles that can be used in, say, plotting.
