### PR TITLE
Separate tox env for slow tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,6 +38,11 @@ jobs:
             python: 3.8
             toxenv: py38-cov
 
+          - name: Python 3.8, slow tests with code coverage
+            os: ubuntu-latest
+            python: 3.8
+            toxenv: py38-slow-cov
+
           - name: Python 3.8 with Numpy dev
             os: ubuntu-latest
             python: 3.8

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,9 @@ deps =
     !minimal: pytest-xdist
     pytest-github-actions-annotate-failures
 commands =
-    !cov: {env:PYTEST_COMMAND} {posargs}
-    cov: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}/setup.cfg --cov-append --cov-report xml:coverage.xml
+    !cov: {env:PYTEST_COMMAND} {posargs} -m 'not slow'
+    cov: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}/setup.cfg --cov-append --cov-report xml:coverage.xml -m 'not slow'
+    cov-slow: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}/setup.cfg --cov-append --cov-report xml:coverage.xml -m 'slow'
 
 description =
     run tests


### PR DESCRIPTION
~~Okay, admittedly I'm doing a little bit of a trick here: I'm limiting our existing envs to tests NOT marked as slow, and having the slow tests env run either slow or not slow tests. This is because~~

1. ~~the not-slow tests aren't going to impact the runtime of the slow tests that much;~~
2. ~~I don't know how to merge coverage reports from different action runs.~~

cc @pheuer 

Turns out codecov is smarter than that, and doing it the simplest way does work!

I ended up running "not slow" tests in most envs and only the "slow" tests in a single env. This limits the variance in runtimes a little.