### PR TITLE
Use yield in __iter__ for IonizationState and IonizationStateCollection

### DIFF
--- a/changelog/1025.bugfix.rst
+++ b/changelog/1025.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug that prevented nested iterations of a single
+`~plasmapy.particles.IonizationState` or
+`~plasmapy.particles.IonizationStateCollection` instance.

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -342,26 +342,7 @@ class IonizationState:
         )
 
     def __iter__(self):
-        """Initialize an instance prior to iteration."""
-        self._charge_index = 0
-        return self
-
-    def __next__(self):
-        """
-        Return a `~plasmapy.particles.IonicFraction` instance that contains
-        information about a particular ionization level.
-        """
-        if self._charge_index <= self.atomic_number:
-            result = IonicFraction(
-                ion=Particle(self.base_particle, Z=self._charge_index),
-                ionic_fraction=self.ionic_fractions[self._charge_index],
-                number_density=self.number_densities[self._charge_index],
-            )
-            self._charge_index += 1
-            return result
-        else:
-            del self._charge_index
-            raise StopIteration
+        yield from [self[i] for i in range(self.atomic_number + 1)]
 
     def __eq__(self, other):
         """

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -335,28 +335,7 @@ class IonizationStateCollection:
         self._ionic_fractions[particle][:] = new_fractions[:]
 
     def __iter__(self):
-        """
-        Prepare an `~plasmapy.particles.IonizationStateCollection` instance for
-        iteration.
-        """
-        self._element_index = 0
-        return self
-
-    def __next__(self):
-        if self._element_index < len(self.base_particles):
-            particle = self.base_particles[self._element_index]
-            result = IonizationState(
-                particle,
-                self.ionic_fractions[particle],
-                T_e=self.T_e,
-                n_elem=np.sum(self.number_densities[particle]),
-                tol=self.tol,
-            )
-            self._element_index += 1
-            return result
-        else:
-            del self._element_index
-            raise StopIteration
+        yield from [self[key] for key in self.ionic_fractions.keys()]
 
     def __eq__(self, other):
 

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -902,3 +902,15 @@ def test_number_density_assignment():
     instance = IonizationStateCollection(["H", "He"])
     number_densities = [2, 3, 5] * u.m ** -3
     instance["He"] = number_densities
+
+
+def test_iteration_with_nested_iterator():
+    ionization_states = IonizationStateCollection(["H", "He"])
+
+    i = 0
+    for ionization_state1 in ionization_states:
+        assert isinstance(ionization_state1, IonizationState)
+        for ionization_state2 in ionization_states:
+            assert isinstance(ionization_state2, IonizationState)
+            i += 1
+    assert i == 4

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -709,7 +709,6 @@ class Test_IonizationStateNumberDensitiesSetter:
         assert np.isinf(self.instance.kappa)
 
 
-@pytest.mark.xfail
 def test_iteration_with_nested_iterator():
     hydrogen = IonizationState("p+", n_elem=1e20 * u.m ** -3, T_e=10 * u.eV)
 
@@ -717,6 +716,4 @@ def test_iteration_with_nested_iterator():
     for fraction in hydrogen:
         for fraction2 in hydrogen:
             i += 1
-            print(i, fraction, fraction2)
-            # should output 4 pairs...
     assert i == 4


### PR DESCRIPTION
Fixes the failing test contributed by @StanczakDominik in #1021.  This makes `IonizationState` and `IonizationStateCollection` multiply iterable by using `yield`.