### PR TITLE
Add an attribute for `mean_particle` to ionization state classes

### DIFF
--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -8,6 +8,7 @@ __all__ = ["IonizationState", "IonicFraction"]
 import numpy as np
 import warnings
 
+from astropy import constants as const
 from astropy import units as u
 from numbers import Integral, Real
 from typing import List, Optional, Union
@@ -18,7 +19,7 @@ from plasmapy.particles.exceptions import (
     InvalidParticleError,
     ParticleError,
 )
-from plasmapy.particles.particle_class import Particle
+from plasmapy.particles.particle_class import CustomParticle, Particle
 from plasmapy.utils.decorators import validate_quantities
 
 _number_density_errmsg = (
@@ -731,6 +732,20 @@ class IonizationState:
                 states_info.append(state_info)
 
         return states_info
+
+    def mean_particle(self, include_neutrals: bool = True) -> CustomParticle:
+        """
+        Return a `~plasmapy.particles.particle_class.CustomParticle`
+        instance representing the mean particle in this ionization state.
+
+        Parameters
+        ----------
+        include_neutrals : `bool`, optional
+            If `True`, include neutrals when calculating the mean values
+            of the different particles.  If `False`, include only ions.
+            Defaults to `True`.
+        """
+        pass
 
     def summarize(self, minimum_ionic_fraction: Real = 0.01) -> None:
         """

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -5,7 +5,6 @@ isotopes.
 __all__ = ["IonizationStateCollection"]
 
 import astropy.units as u
-import collections
 import numpy as np
 
 from numbers import Integral, Real
@@ -18,7 +17,7 @@ from plasmapy.particles.exceptions import (
     ParticleError,
 )
 from plasmapy.particles.ionization_state import IonicFraction, IonizationState
-from plasmapy.particles.particle_class import Particle, ParticleLike
+from plasmapy.particles.particle_class import CustomParticle, Particle, ParticleLike
 from plasmapy.particles.symbols import particle_symbol
 from plasmapy.utils.decorators import validate_quantities
 
@@ -858,6 +857,23 @@ class IonizationStateCollection:
             self._tol = np.real(atol)
         else:
             raise ValueError("Need 0 <= tol <= 1.")
+
+    def mean_particle(self, include_neutrals: bool = True) -> CustomParticle:
+        """
+        Return a `~plasmapy.particles.particle_class.CustomParticle`
+        instance representing the mean particle included across all
+        ionization states.
+
+        Parameters
+        ----------
+        include_neutrals : `bool`, optional
+            If `True`, include neutrals when calculating the mean values
+            of the different particles.  If `False`, include only ions.
+            Defaults to `True`.
+        """
+        # If the relative abundances are NaN, then this should return a
+        # `CustomParticle` with NaNs for the charge and mass.
+        pass
 
     def summarize(self, minimum_ionic_fraction: Real = 0.01) -> None:
         """


### PR DESCRIPTION
If we want to make `IonizationState` instances compatible with `plasmapy.formulary`, it would be helpful to have a way to convert `IonizationState` and `IonizationStateCollection` instances to `CustomParticle` instances.  I started this and then realized that it'll be a bit easier with `ParticleList` from #1017, so I'm going to wait until #1017 is done before finishing this.

If the ionization fraction is 1 for a particular ionic level in an `IonizationState` instance, then it should return the corresponding `Particle` rather than the `CustomParticle`.  For example, if 100% of the `He-4` is doubly ionized, then it should return `Particle("alpha")`.  

I'm including a keyword for `include_neutrals` because there may be some instances where only charged particles matter.  

There will probably be applications where users want, e.g., the gyroradius of all of the ions.  Converting all of this into a `CustomParticle` instance will not take care of this use case.  

It'll also be worth thinking about how this might interplay with `@particle_input` and if we could eventually consider `IonizationState` and `IonizationStateCollection` to be `ParticleLike`.