### PR TITLE
Add some unicode particle aliases

### DIFF
--- a/changelog/1036.trivial.rst
+++ b/changelog/1036.trivial.rst
@@ -1,0 +1,5 @@
+Add unicode particle aliases for electrons (``"β-"``, ``"β⁻"``), muons
+(``"μ-"``, ``"μ⁻"``), anti-muons (``"μ+"``, ``"μ⁺"``), tau particles
+(``"τ"``, ``"τ-"``, ``"τ⁻"``), anti-tau particles (``"τ+"``, ``"τ⁺"``)
+electron neutrinos (``"ν_e"``), muon neutrinos (``"ν_μ"``), tau neutrinos
+(``"ν_τ"``), and alpha particles (``"α"``).

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -47,13 +47,21 @@ def _create_alias_dicts(Particles: dict) -> (Dict[str, str], Dict[str, str]):
         case_insensitive_aliases[name.lower()] = symbol
 
     case_sensitive_aliases_for_a_symbol = [
-        (["beta-", "e"], "e-"),
-        (["beta+"], "e+"),
-        (["p", "H-1+", "H-1 1+", "H-1 +1", "H-1 II"], "p+"),
-        (["n-1"], "n"),
+        (["beta-", "β-", "β⁻", "e", "e⁻"], "e-"),
+        (["beta+", "β+", "β⁺", "e⁺"], "e+"),
+        (["p", "p⁺", "H-1+", "H-1 1+", "H-1 +1", "H-1 II"], "p+"),
+        (["n-1", "n⁰"], "n"),
         (["H-2"], "D"),
         (["H-2+", "H-2 1+", "H-2 +1", "D+", "D II"], "D 1+"),
         (["H-3+", "H-3 1+", "H-3 +1", "T+", "T II"], "T 1+"),
+        (["α"], "He-4 2+"),
+        (["τ", "τ-", "τ⁻"], "tau-"),
+        (["τ+", "τ⁺"], "tau+"),
+        (["μ-", "μ⁻"], "mu-"),
+        (["μ+", "μ⁺"], "mu+"),
+        (["ν_e"], "nu_e"),
+        (["ν_μ"], "nu_mu"),
+        (["ν_τ"], "nu_tau"),
     ]
 
     case_insensitive_aliases_for_a_symbol = [
@@ -78,6 +86,8 @@ def _create_alias_dicts(Particles: dict) -> (Dict[str, str], Dict[str, str]):
         (["deuteron", "deuterium+", "deuterium 1+", "deuterium +1"], "D 1+"),
         (["tritium", "hydrogen-3"], "T"),
         (["triton", "tritium+", "tritium 1+", "tritium +1"], "T 1+"),
+        (["diproton"], "He-2 2+"),
+        (["helion"], "He-3 2+"),
         (["alpha"], "He-4 2+"),
     ]
 

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -1,12 +1,11 @@
 import pytest
 
-from plasmapy.particles import Particle
 from plasmapy.particles.exceptions import (
     InvalidElementError,
     InvalidParticleError,
     ParticleWarning,
 )
-from plasmapy.particles.parsing import (  # duplicate with utils.pytest_helpers.error_messages.call_string?
+from plasmapy.particles.parsing import (
     _case_insensitive_aliases,
     _case_sensitive_aliases,
     _dealias_particle_aliases,
@@ -14,18 +13,6 @@ from plasmapy.particles.parsing import (  # duplicate with utils.pytest_helpers.
 )
 from plasmapy.particles.special_particles import ParticleZoo
 from plasmapy.utils.code_repr import call_string
-
-
-def _particle_call_string(arg, kwargs=None) -> str:
-    """
-    Return a `str` that recreates the call to create a particular
-    `~plasmapy.particles.Particle` instance from the input.
-    """
-    if kwargs is None:
-        kwargs = {}
-
-    return call_string(Particle, arg, kwargs)
-
 
 aliases_and_symbols = [
     ("electron", "e-"),
@@ -52,6 +39,12 @@ aliases_and_symbols = [
     ("H-1+", "p+"),
     ("H-1 +1", "p+"),
     ("hydrogen-1+", "p+"),
+    ("α", "He-4 2+"),
+    ("β-", "e-"),
+    ("β⁻", "e-"),
+    ("β+", "e+"),
+    ("τ", "tau-"),
+    ("τ+", "tau+"),
 ]
 
 
@@ -332,7 +325,8 @@ def test_parse_InvalidParticleErrors(arg, kwargs):
         _parse_and_check_atomic_input(arg, **kwargs)
         pytest.fail(
             "An InvalidParticleError was expected to be raised by "
-            f"{_particle_call_string(arg, kwargs)}, but no exception was raised."
+            f"{call_string(_parse_and_check_atomic_input, arg, kwargs)}, "
+            f"but no exception was raised."
         )
 
 
@@ -345,7 +339,8 @@ def test_parse_InvalidElementErrors(arg):
         _parse_and_check_atomic_input(arg)
         pytest.fail(
             "An InvalidElementError was expected to be raised by "
-            f"{_particle_call_string(arg)}, but no exception was raised."
+            f"{call_string(_parse_and_check_atomic_input, arg)}, "
+            f"but no exception was raised."
         )
 
 
@@ -369,12 +364,13 @@ def test_parse_AtomicWarnings(arg, kwargs, num_warnings):
         if not record:
             pytest.fail(
                 f"No AtomicWarning was issued by "
-                f"{_particle_call_string(arg, kwargs)} but the expected number "
+                f"{call_string(_parse_and_check_atomic_input, arg, kwargs)} but the expected number "
                 f"of warnings was {num_warnings}"
             )
 
     assert len(record) == num_warnings, (
-        f"The number of AtomicWarnings issued by {_particle_call_string(arg, kwargs)} "
+        f"The number of AtomicWarnings issued by "
+        f"{call_string(_parse_and_check_atomic_input, arg, kwargs)} "
         f"was {len(record)}, which differs from the expected number "
         f"of {num_warnings} warnings."
     )


### PR DESCRIPTION
Because I'd apparently rather play with unicode than make the increasingly wise life decision of going to bed, this pull request adds a few additional unicode particle aliases (e.g., we would be able to do `Particle("α")` for an alpha particle).  This could be useful for code and examples that will be read much more frequently than they are written.

At present a lot of the aliases are not documented.  I wonder if it would be helpful to have an ``aliases`` attribute to `Particle` that could list all of the valid aliases for the different particles.  I've also been thinking about ``unicode_symbol``, ``mathml``, and ``latex_str`` attributes too for different representations, but that's not for this PR.