### PR TITLE
Temporary workarounds to pip install -e, packaging, xarray 0.17 issues

### DIFF
--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pandas
   - pillow
   - pip
-  - xarray
+  - xarray < 0.17
   - pip:
     - numpydoc
     - pytest

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,4 +11,4 @@ pandas >= 1.0.0
 scipy >= 1.2
 setuptools >= 41.2
 tqdm >= 4.56.0
-xarray  >= 0.14.0
+xarray  >= 0.14.0,<0.17.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,10 @@ doctest_optionflags =
     ELLIPSIS
     NUMBER
 addopts = --doctest-modules --doctest-continue-on-failure --ignore=docs/conf.py
+filterwarnings =
+    ignore:.*Creating a LegacyVersion.*:DeprecationWarning
+
+
 
 [pycodestyle]
 # E101 - mix of tabs and spaces

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
   scipy >= 1.2
   setuptools >= 41.2
   tqdm >= 4.56.0
-  xarray >= 0.14.0
+  xarray >= 0.14.0, <0.17.0
 
 [options.extras_require]
 classes =

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
+# https://github.com/pypa/pip/issues/7953#issuecomment-645133255
+import site
+import sys
+
 from itertools import chain
 from setuptools import setup
 from setuptools.config import read_configuration
+
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
 ################################################################################
 # Programmatically generate some extras combos.


### PR DESCRIPTION
This does two things:

1. temporarily applies a fix from https://github.com/pypa/pip/issues/7953#issuecomment-645133255 that allows `pip install --user --editable .` to work despite our pyproject.toml
2. Temporarily filters out warnings I've been getting related to https://github.com/pypa/packaging/issues/368.

I will keep an eye out and remove those as they stop being useful.

---

This also temporarily limits xarray to <0.17, which got a few hours ago and broke some of our new grids functionality. I ran https://github.com/PlasmaPy/PlasmaPy/actions/runs/598915034, for which CI passed yesterday, to verify that.

- [ ] make issue on grids vs xarray 0.17 (cc @pheuer just to say that this - and probably an xarray-dev test - is something we'll need to put on our radar!)