### PR TITLE
Put back import of __version__ from plasmapy in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ from sphinx.application import Sphinx
 
 sys.path.insert(0, os.path.abspath(".."))
 
-from plasmpy import __version__ as release
+from plasmapy import __version__ as release
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,9 +27,7 @@ from sphinx.application import Sphinx
 
 sys.path.insert(0, os.path.abspath(".."))
 
-from pkg_resources import get_distribution
-
-release = get_distribution("plasmapy").version
+from plasmpy import __version__ as release
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
Using `pkg_resources.get_distribution("plasmapy")` severely limits the use of `make html` to build documentation.  This forces `plasmapy` to be installed when building docs versus just being in the python path.  The later is my preferred workflow since editable installs don't properly reflect version increments unless you reinstall (version is frozen in the EGG info).  I don't want to reinstall `plasmapy` for each documentation build.

https://github.com/PlasmaPy/PlasmaPy/blob/d9f3b197fbaca9e875ce5ea34e79ef7aeb020159/plasmapy/__init__.py#L37-L42