### PR TITLE
Minor docstring fixes in particles

### DIFF
--- a/changelog/1064.doc.rst
+++ b/changelog/1064.doc.rst
@@ -1,0 +1,1 @@
+Make minor fixes in `plasmapy.particles` docstrings.

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -34,7 +34,7 @@ from plasmapy.particles.exceptions import (
     InvalidParticleError,
     MissingParticleDataError,
 )
-from plasmapy.particles.isotopes import _Isotopes
+from plasmapy.particles.isotopes import _isotopes
 from plasmapy.particles.particle_class import Particle
 from plasmapy.particles.symbols import atomic_symbol
 
@@ -573,7 +573,7 @@ def known_isotopes(argument: Union[str, Integral] = None) -> List[str]:
     def known_isotopes_for_element(argument):
         element = atomic_symbol(argument)
         isotopes = []
-        for isotope in _Isotopes.keys():
+        for isotope in _isotopes.keys():
             if element + "-" in isotope and isotope[0 : len(element)] == element:
                 isotopes.append(isotope)
         if element == "H":
@@ -683,11 +683,11 @@ def common_isotopes(
         isotopes = known_isotopes(argument)
 
         CommonIsotopes = [
-            isotope for isotope in isotopes if "abundance" in _Isotopes[isotope].keys()
+            isotope for isotope in isotopes if "abundance" in _isotopes[isotope].keys()
         ]
 
         isotopic_abundances = [
-            _Isotopes[isotope]["abundance"] for isotope in CommonIsotopes
+            _isotopes[isotope]["abundance"] for isotope in CommonIsotopes
         ]
 
         sorted_isotopes = [
@@ -801,7 +801,7 @@ def stable_isotopes(
         StableIsotopes = [
             isotope
             for isotope in KnownIsotopes
-            if _Isotopes[isotope]["stable"] == stable_only
+            if _isotopes[isotope]["stable"] == stable_only
         ]
         return StableIsotopes
 

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -27,7 +27,7 @@ from numbers import Integral, Real
 from typing import Any, List, Optional, Union
 
 from plasmapy.particles.decorators import particle_input
-from plasmapy.particles.elements import _Elements
+from plasmapy.particles.elements import _elements
 from plasmapy.particles.exceptions import (
     InvalidElementError,
     InvalidIsotopeError,
@@ -599,7 +599,7 @@ def known_isotopes(argument: Union[str, Integral] = None) -> List[str]:
             raise InvalidParticleError("Invalid particle in known_isotopes.")
     elif argument is None:
         isotopes_list = []
-        for atomic_numb in range(1, len(_Elements.keys()) + 1):
+        for atomic_numb in range(1, len(_elements.keys()) + 1):
             isotopes_list += known_isotopes_for_element(atomic_numb)
 
     return isotopes_list
@@ -945,7 +945,7 @@ def periodic_table_period(argument: Union[str, Integral]) -> Integral:
             "integer representing its atomic number."
         )
     symbol = atomic_symbol(argument)
-    period = _Elements[symbol]["period"]
+    period = _elements[symbol]["period"]
     return period
 
 
@@ -999,7 +999,7 @@ def periodic_table_group(argument: Union[str, Integral]) -> Integral:
             "symbol, or an integer representing its atomic number."
         )
     symbol = atomic_symbol(argument)
-    group = _Elements[symbol]["group"]
+    group = _elements[symbol]["group"]
     return group
 
 
@@ -1053,7 +1053,7 @@ def periodic_table_block(argument: Union[str, Integral]) -> str:
             "symbol, or an integer representing its atomic number."
         )
     symbol = atomic_symbol(argument)
-    block = _Elements[symbol]["block"]
+    block = _elements[symbol]["block"]
     return block
 
 
@@ -1105,7 +1105,7 @@ def periodic_table_category(argument: Union[str, Integral]) -> str:
             "symbol, or an integer representing its atomic number."
         )
     symbol = atomic_symbol(argument)
-    category = _Elements[symbol]["category"]
+    category = _elements[symbol]["category"]
     return category
 
 

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -5,8 +5,7 @@ Module for loading atomic data for elements from
 The periodic tabla data is from: http://periodic.lanl.gov/index.shtml
 
 .. attention::
-    This module only contains non-public functionality.  To learn more about the
-    package functionality, examine the code itself.
+    This module is not part of PlasmaPy's public API.
 """
 __all__ = []
 

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -40,16 +40,16 @@ def _element_obj_hook(obj):
 #    json.dump(_Elements, f, default=plasma_default, indent=2)
 
 
-_Elements = json.loads(
+_elements = json.loads(
     pkgutil.get_data("plasmapy", "particles/data/elements.json"),
     object_hook=_element_obj_hook,
 )
 
 
 _atomic_numbers_to_symbols = {
-    elemdict["atomic number"]: symb for (symb, elemdict) in _Elements.items()
+    elemdict["atomic number"]: symb for (symb, elemdict) in _elements.items()
 }
 
 _element_names_to_symbols = {
-    elemdict["element name"]: symb for (symb, elemdict) in _Elements.items()
+    elemdict["element name"]: symb for (symb, elemdict) in _elements.items()
 }

--- a/plasmapy/particles/exceptions.py
+++ b/plasmapy/particles/exceptions.py
@@ -1,6 +1,5 @@
-"""
-Collection of exceptions and warnings for `plasmapy.particles`.
-"""
+"""Collection of exceptions and warnings for `plasmapy.particles`."""
+
 __all__ = [
     "ParticleError",
     "ParticleWarning",

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -100,18 +100,18 @@ class IonicFraction:
 
     @property
     def ionic_symbol(self) -> str:
-        """The symbol of the ion."""
+        """Return the symbol of the ion."""
         return self._particle.ionic_symbol
 
     @property
     def integer_charge(self) -> Integral:
-        """The integer charge of the ion."""
+        """Return the integer charge of the ion."""
         return self._particle.integer_charge
 
     @property
     def ionic_fraction(self) -> Real:
         r"""
-        The fraction of particles of an element that are at this
+        Return the fraction of particles of an element that are at this
         ionization level.
 
         Notes
@@ -140,7 +140,7 @@ class IonicFraction:
 
     @property
     def number_density(self) -> u.m ** -3:
-        """The number density of the ion."""
+        """Return the number density of the ion."""
         return self._number_density.to(u.m ** -3)
 
     @number_density.setter

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -100,18 +100,18 @@ class IonicFraction:
 
     @property
     def ionic_symbol(self) -> str:
-        """Return the symbol of the ion."""
+        """The symbol of the ion."""
         return self._particle.ionic_symbol
 
     @property
     def integer_charge(self) -> Integral:
-        """Return the integer charge of the ion."""
+        """The integer charge of the ion."""
         return self._particle.integer_charge
 
     @property
     def ionic_fraction(self) -> Real:
         r"""
-        Return the fraction of particles of an element that are at this
+        The fraction of particles of an element that are at this
         ionization level.
 
         Notes
@@ -140,7 +140,7 @@ class IonicFraction:
 
     @property
     def number_density(self) -> u.m ** -3:
-        """Return the number density of the ion."""
+        """The number density of the ion."""
         return self._number_density.to(u.m ** -3)
 
     @number_density.setter

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -410,7 +410,6 @@ class IonizationStateCollection:
         isotope.  The values will be `~numpy.ndarray` objects containing
         the ionic fractions for each ionization level corresponding to
         each element or isotope.
-
         """
         return self._ionic_fractions
 
@@ -773,9 +772,7 @@ class IonizationStateCollection:
 
     @log_abundances.setter
     def log_abundances(self, value: Optional[Dict[str, Real]]):
-        """
-        Set the base 10 logarithm of the relative abundances.
-        """
+        """Set the base 10 logarithm of the relative abundances."""
         if value is not None:
             try:
                 new_abundances_input = {}
@@ -849,9 +846,7 @@ class IonizationStateCollection:
 
     @tol.setter
     def tol(self, atol: Real):
-        """
-        Set the absolute tolerance for comparisons.
-        """
+        """Set the absolute tolerance for comparisons."""
         if not isinstance(atol, Real):
             raise TypeError("The attribute tol must be a real number.")
         if 0 <= atol <= 1.0:

--- a/plasmapy/particles/isotopes.py
+++ b/plasmapy/particles/isotopes.py
@@ -2,8 +2,7 @@
 Module for loading isotope data from :file:`plasmapy/particles/data/isotopes.json`.
 
 .. attention::
-    This module only contains non-public functionality.  To learn more about the
-    package functionality, then examine the code itself.
+    This module is not part of PlasmaPy's public API.
 """
 __all__ = []
 
@@ -26,14 +25,14 @@ import pkgutil
 
 
 def _isotope_obj_hook(obj):
-    """An `object_hook` designed for `json.load` and `json.loads`."""
+    """Provide an `object_hook` designed for `json.load` and `json.loads`."""
     if "unit" in obj:
         return obj["value"] * u.Unit(obj["unit"])
     return obj
 
 
 #: Dictionary of isotope data.
-_Isotopes = json.loads(
+_isotopes = json.loads(
     pkgutil.get_data("plasmapy", "particles/data/isotopes.json"),
     object_hook=_isotope_obj_hook,
 )

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -91,7 +91,8 @@ def mass_energy(particle: Particle, mass_numb: Optional[int] = None) -> u.Quanti
     Returns
     -------
     mass_energy: `~astropy.units.Quantity`
-        The mass energy of the particle (or in the case of ) in units of joules.
+        The mass energy of the particle (or, in the case of an isotope,
+        its nuclide) in units of joules.
 
     Raises
     ------
@@ -106,7 +107,6 @@ def mass_energy(particle: Particle, mass_numb: Optional[int] = None) -> u.Quanti
 
     Examples
     --------
-
     >>> mass_energy('He-4')
     <Quantity 5.9719e-10 J>
     """

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -17,7 +17,7 @@ from typing import Dict, Union
 from plasmapy.particles.elements import (
     _atomic_numbers_to_symbols,
     _element_names_to_symbols,
-    _Elements,
+    _elements,
 )
 from plasmapy.particles.exceptions import (
     InvalidElementError,
@@ -439,10 +439,10 @@ def _parse_and_check_atomic_input(
         Z = Z_from_arg
 
     if isinstance(Z, Integral):
-        if Z > _Elements[element]["atomic number"]:
+        if Z > _elements[element]["atomic number"]:
             raise InvalidParticleError(
                 f"The integer charge Z = {Z} cannot exceed the atomic number "
-                f"of {element}, which is {_Elements[element]['atomic number']}."
+                f"of {element}, which is {_elements[element]['atomic number']}."
             )
         elif Z <= -3:
             warnings.warn(

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -2,8 +2,8 @@
 Functionality to parse representations of particles into standard form.
 
 .. attention::
-    This module only contains non-public functionality.  To learn more about the
-    package functionality, examine the code itself.
+    This module is not part of PlasmaPy's public API.
+
 """
 __all__ = []
 
@@ -24,7 +24,7 @@ from plasmapy.particles.exceptions import (
     InvalidParticleError,
     ParticleWarning,
 )
-from plasmapy.particles.isotopes import _Isotopes
+from plasmapy.particles.isotopes import _isotopes
 from plasmapy.particles.special_particles import _Particles, ParticleZoo
 from plasmapy.utils import roman
 
@@ -338,7 +338,7 @@ def _parse_and_check_atomic_input(
             elif isotope == "H-3":
                 isotope = "T"
 
-            if isotope not in _Isotopes.keys():
+            if isotope not in _isotopes.keys():
                 raise InvalidParticleError(
                     f"The string '{isotope}' does not correspond to "
                     f"a valid isotope."

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -35,7 +35,7 @@ from plasmapy.particles.exceptions import (
     ParticleError,
     ParticleWarning,
 )
-from plasmapy.particles.isotopes import _Isotopes
+from plasmapy.particles.isotopes import _isotopes
 from plasmapy.particles.parsing import (
     _dealias_particle_aliases,
     _invalid_particle_errmsg,
@@ -108,29 +108,29 @@ def _category_errmsg(particle, category: str) -> str:
 
 
 class AbstractParticle(ABC):
-    """
-    An abstract base class that defines the interface for particles.
-    """
+    """An abstract base class that defines the interface for particles."""
 
     @property
     @abstractmethod
     def mass(self) -> Union[u.Quantity, Real]:
+        """Provide the particle's mass."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def charge(self) -> Union[u.Quantity, Real]:
+        """Provide the particle's electric charge."""
         raise NotImplementedError
 
     @property
     def json_dict(self) -> dict:
         """
-        A dictionary representation of the particle object that is JSON friendly
-        (i.e. convertible to a JSON object).
+        Provide a dictionary representation of the particle object that
+        is JSON friendly (i.e. convertible to a JSON object).
 
         The dictionary should maintain the following format so
-        `~plasmapy.particles.ParticleJSONDecoder` knows how to decoded the resulting
-        JSON object.
+        `~plasmapy.particles.ParticleJSONDecoder` knows how to decoded
+        the resulting JSON object.
 
         .. code-block:: python
 
@@ -154,7 +154,7 @@ class AbstractParticle(ABC):
                 },
             }}
 
-        Only the `"__init__"` entry should be modified by the subclass.
+        Only the ``"__init__"`` entry should be modified by the subclass.
         """
         json_dictionary = {
             "plasmapy_particle": {
@@ -168,14 +168,15 @@ class AbstractParticle(ABC):
 
     def __bool__(self):
         """
-        Raise an `~plasmapy.particles.exceptions.ParticleError` because particles
-        do not have a truth value.
+        Raise an `~plasmapy.particles.exceptions.ParticleError` because
+        particles do not have a truth value.
         """
         raise ParticleError("The truth value of a particle is not defined.")
 
     def json_dump(self, fp, **kwargs):
         """
-        Writes the particle's `json_dict` to the `fp` file object using `json.dump`.
+        Write the particle's `json_dict` to the ``fp`` file object using
+        `json.dump`.
 
         Parameters
         ----------
@@ -189,8 +190,8 @@ class AbstractParticle(ABC):
 
     def json_dumps(self, **kwargs) -> str:
         """
-        Serialize the particle's `json_dict` into a JSON formatted `str` using
-        `json.dumps`.
+        Serialize the particle's `json_dict` into a JSON formatted `str`
+        using `json.dumps`.
 
         Parameters
         ----------
@@ -530,7 +531,7 @@ class Particle(AbstractPhysicalParticle):
 
             if isotope:
 
-                Isotope = _Isotopes[isotope]
+                Isotope = _isotopes[isotope]
 
                 attributes["baryon number"] = Isotope["mass number"]
                 attributes["isotope mass"] = Isotope.get("mass", None)
@@ -703,8 +704,9 @@ class Particle(AbstractPhysicalParticle):
     @property
     def json_dict(self) -> dict:
         """
-        A `json` friendly dictionary representation of the particle. (see
-        `AbstractParticle.json_dict` for more details)
+        Provide `json` friendly dictionary representation of the particle.
+
+        See `AbstractParticle.json_dict` for more details.
 
         Examples
         --------
@@ -1488,7 +1490,7 @@ class Particle(AbstractPhysicalParticle):
         ``valid_categories`` attribute of `~Particle.is_category`.
 
         Examples
-        -----
+        --------
         Required categories may be entered as positional arguments,
         including as a `list`, `set`, or `tuple` of required categories.
 
@@ -1879,8 +1881,9 @@ class DimensionlessParticle(AbstractParticle):
     @property
     def json_dict(self) -> dict:
         """
-        A `json` friendly dictionary representation of the particle. (see
-        `AbstractParticle.json_dict` for more details)
+        Provide a `json` friendly dictionary representation of the particle.
+
+        See `AbstractParticle.json_dict` for more details.
 
         Examples
         --------
@@ -2040,8 +2043,9 @@ class CustomParticle(AbstractPhysicalParticle):
     @property
     def json_dict(self) -> dict:
         """
-        A `json` friendly dictionary representation of the particle. (see
-        `AbstractParticle.json_dict` for more details)
+        Provide a `json` friendly dictionary representation of the particle.
+
+        See `AbstractParticle.json_dict` for more details.
 
         Examples
         --------

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -125,8 +125,8 @@ class AbstractParticle(ABC):
     @property
     def json_dict(self) -> dict:
         """
-        Provide a dictionary representation of the particle object that
-        is JSON friendly (i.e. convertible to a JSON object).
+        A dictionary representation of the particle object that is JSON
+        friendly (i.e. convertible to a JSON object).
 
         The dictionary should maintain the following format so
         `~plasmapy.particles.ParticleJSONDecoder` knows how to decoded
@@ -693,7 +693,7 @@ class Particle(AbstractPhysicalParticle):
         """
         return hash(self.__repr__())
 
-    def __invert__(self):
+    def __invert__(self) -> Particle:
         """
         Return the corresponding antiparticle, or raise an
         `~plasmapy.particles.exceptions.ParticleError` if the particle is not an
@@ -704,7 +704,7 @@ class Particle(AbstractPhysicalParticle):
     @property
     def json_dict(self) -> dict:
         """
-        Provide `json` friendly dictionary representation of the particle.
+        A JSON friendly dictionary representation of the particle.
 
         See `AbstractParticle.json_dict` for more details.
 
@@ -730,7 +730,7 @@ class Particle(AbstractPhysicalParticle):
     @property
     def particle(self) -> str:
         """
-        Return the symbol of the particle, atom, isotope, or ion.
+        The symbol of the particle, atom, isotope, or ion.
 
         .. deprecated:: 0.6.0
             `Particle.particle` has been deprecated and will be removed in
@@ -747,7 +747,7 @@ class Particle(AbstractPhysicalParticle):
     @property
     def symbol(self) -> str:
         """
-        Return the symbol of the particle, atom, isotope, or ion.
+        The symbol of the particle, atom, isotope, or ion.
 
         This attribute will return the canonical symbol for special
         particles (e.g., ``"p+"``, ``"e-"``, or ``"n"``), the atomic
@@ -767,14 +767,18 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["symbol"]
 
     @property
-    def antiparticle(self):
+    def antiparticle(self) -> Particle:
         """
-        Return the corresponding antiparticle, or raise an
-        `~plasmapy.particles.exceptions.ParticleError` if the particle is not an
-        elementary particle.
+        The antiparticle corresponding to the particle.
 
         This attribute may be accessed by using the unary operator ``~``
-        acting on a `~plasmapy.particles.Particle` instance.
+        on a `~plasmapy.particles.Particle` instance.
+
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.ParticleError`
+            If the particle is not an elementary particle and does not
+            have a defined antiparticle.
 
         Examples
         --------
@@ -797,8 +801,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def element(self) -> Optional[str]:
         """
-        Return the atomic symbol if the particle corresponds to an
-        element, and `None` otherwise.
+        The atomic symbol if the particle corresponds to an element, and
+        `None` otherwise.
 
         Examples
         --------
@@ -811,8 +815,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def isotope(self) -> Optional[str]:
         """
-        Return the isotope symbol if the particle corresponds to an
-        isotope, and `None` otherwise.
+        The isotope symbol if the particle corresponds to an isotope,
+        and `None` otherwise.
 
         Examples
         --------
@@ -825,7 +829,7 @@ class Particle(AbstractPhysicalParticle):
     @property
     def ionic_symbol(self) -> Optional[str]:
         """
-        Return the ionic symbol if the particle corresponds to an ion or
+        The ionic symbol if the particle corresponds to an ion or
         neutral atom, and `None` otherwise.
 
         Examples
@@ -842,12 +846,14 @@ class Particle(AbstractPhysicalParticle):
     @property
     def roman_symbol(self) -> Optional[str]:
         """
-        Return the spectral name of the particle (i.e. the ionic symbol
-        in Roman numeral notation).  If the particle is not an ion or
-        neutral atom, return `None`. The roman numeral represents one
-        plus the integer charge. Raise `ChargeError` if no charge has
-        been specified and `~plasmapy.utils.roman.roman.OutOfRangeError`
-        if the charge is negative.
+        The spectral name of the particle (i.e. the ionic symbol in
+        Roman numeral notation).
+
+        If the particle is not an ion or neutral atom, return `None`.
+        The roman numeral represents one plus the integer charge. Raise
+        `ChargeError` if no charge has been specified and
+        `~plasmapy.utils.roman.roman.OutOfRangeError` if the charge is
+        negative.
 
         Examples
         --------
@@ -873,9 +879,12 @@ class Particle(AbstractPhysicalParticle):
     @property
     def element_name(self) -> str:
         """
-        Return the name of the element corresponding to this
-        particle, or raise an `~plasmapy.particles.exceptions.InvalidElementError` if
-        the particle does not correspond to an element.
+        The name of the element corresponding to this particle.
+
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidElementError`
+            If the particle does not correspond to an element.
 
         Examples
         --------
@@ -888,16 +897,18 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["element name"]
 
     @property
-    def isotope_name(self) -> str:
+    def isotope_name(self) -> Optional[str]:
         """
-        Return the name of the element along with the isotope
-        symbol if the particle corresponds to an isotope, and
-        `None` otherwise.
+        The name of the element along with the isotope symbol if the
+        particle corresponds to an isotope, or `None` if it does not.
 
-        If the particle is not a valid element, then this
-        attribute will raise an `~plasmapy.particles.exceptions.InvalidElementError`.
-        If it is not an isotope, then this attribute will raise an
-        `~plasmapy.particles.exceptions.InvalidIsotopeError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidElementError`
+            If the particle is not a valid element.
+
+        `~plasmapy.particles.exceptions.InvalidIsotopeError`
+            If the particle is not a valid isotope.
 
         Examples
         --------
@@ -925,10 +936,12 @@ class Particle(AbstractPhysicalParticle):
     @property
     def integer_charge(self) -> Integral:
         """
-        Return the particle's integer charge.
+        The particle's electrical charge in units of the elementary charge.
 
-        This attribute will raise a `~plasmapy.particles.exceptions.ChargeError` if the
-        charge has not been specified.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.ChargeError`
+            If the charge has not been specified.
 
         Examples
         --------
@@ -941,12 +954,14 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["integer charge"]
 
     @property
-    def charge(self) -> u.Quantity:
+    def charge(self) -> u.C:
         """
-        Return the particle's electron charge in coulombs.
+        The particle's electrical charge in coulombs.
 
-        This attribute will raise a `~plasmapy.particles.exceptions.ChargeError` if the
-        charge has not been specified.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.ChargeError`
+            If the charge has not been specified.
 
         Examples
         --------
@@ -962,16 +977,19 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["charge"]
 
     @property
-    def standard_atomic_weight(self) -> u.Quantity:
+    def standard_atomic_weight(self) -> u.kg:
         """
-        Return an element's standard atomic weight in kg.
+        The element's standard atomic weight in kg.
 
-        If the particle is isotope or ion or not an element, this
-        attribute will raise an `~plasmapy.particles.exceptions.InvalidElementError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidElementError`
+            If the particle is not an element or corresponds to an
+            isotope or ion.
 
-        If the element does not have a defined standard atomic weight,
-        this attribute will raise a
-        `~plasmapy.particles.exceptions.MissingParticleDataError`.
+        `~plasmapy.particles.exceptions.MissingParticleDataError`
+            If the element does not have a defined standard atomic
+            weight.
 
         Examples
         --------
@@ -988,9 +1006,9 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["standard atomic weight"].to(u.kg)
 
     @property
-    def mass(self) -> u.Quantity:
+    def mass(self) -> u.kg:
         """
-        Return the mass of the particle in kilograms.
+        The mass of the particle in kilograms.
 
         If the particle is an element and not an isotope or ion, then
         this attribute will return the standard atomic weight, if
@@ -1007,9 +1025,11 @@ class Particle(AbstractPhysicalParticle):
         For special particles, this attribute will return the standard
         value for the particle's mass.
 
-        If the mass is unavailable (e.g., for neutrinos or elements with
-        no standard atomic weight), then this attribute will raise a
+        Raises
+        ------
         `~plasmapy.particles.exceptions.MissingParticleDataError`.
+            If the mass is unavailable (e.g., for neutrinos or elements
+            with no standard atomic weight.
 
         Examples
         --------
@@ -1055,15 +1075,17 @@ class Particle(AbstractPhysicalParticle):
         raise MissingParticleDataError(f"The mass of {self} is not available.")
 
     @property
-    def nuclide_mass(self) -> u.Quantity:
+    def nuclide_mass(self) -> u.kg:
         """
-        Return the mass of the bare nucleus of an isotope or a neutron.
+        The mass of the bare nucleus of an isotope or a neutron.
 
-        This attribute will raise a
-        `~plasmapy.particles.exceptions.InvalidIsotopeError` if the particle is not an
-        isotope or neutron, or a
-        `~plasmapy.particles.exceptions.MissingParticleDataError` if the isotope mass is
-        not available.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidIsotopeError`
+            If the particle is not an isotope or neutron.
+
+        `~plasmapy.particles.exceptions.MissingParticleDataError`
+            If the isotope mass is not available.
 
         Examples
         --------
@@ -1098,9 +1120,9 @@ class Particle(AbstractPhysicalParticle):
         return _nuclide_mass.to(u.kg)
 
     @property
-    def mass_energy(self) -> u.Quantity:
+    def mass_energy(self) -> u.J:
         """
-        Return the mass energy of the particle in joules.
+        The mass energy of the particle in joules.
 
         If the particle is an isotope or nuclide, return the mass energy
         of the nucleus only.
@@ -1133,13 +1155,14 @@ class Particle(AbstractPhysicalParticle):
             ) from None
 
     @property
-    def binding_energy(self) -> u.Quantity:
+    def binding_energy(self) -> u.J:
         """
-        Return the nuclear binding energy in joules.
+        The particle's nuclear binding energy.
 
-        This attribute will raise an
-        `~plasmapy.particles.exceptions.InvalidIsotopeError` if the particle is not a
-        nucleon or isotope.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidIsotopeError`
+            If the particle is not a nucleon or isotope.
 
         Examples
         --------
@@ -1185,8 +1208,10 @@ class Particle(AbstractPhysicalParticle):
         """
         Return the number of protons in an element, isotope, or ion.
 
-        If the particle is not an element, then this attribute will
-        raise an `~plasmapy.particles.exceptions.InvalidElementError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidElementError`.
+            If the particle does not correspond to an element.
 
         Examples
         --------
@@ -1204,13 +1229,12 @@ class Particle(AbstractPhysicalParticle):
     @property
     def mass_number(self) -> Integral:
         """
-        Return the number of nucleons in an isotope.
+        The total number of protons and neutrons in an isotope or nuclide.
 
-        This attribute will return the number of protons plus the number
-        of neutrons in an isotope or nuclide.
-
-        If the particle is not an isotope, then this attribute will
-        raise an `~plasmapy.particles.exceptions.InvalidIsotopeError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidIsotopeError`.
+            If the particle does not correspond to an isotope.
 
         Examples
         --------
@@ -1251,13 +1275,15 @@ class Particle(AbstractPhysicalParticle):
     @property
     def electron_number(self) -> Integral:
         """
-        Return the number of electrons in an ion.
+        The number of electrons in an ion.
 
         This attribute will return the number of bound electrons in an
         ion, or ``1`` for an electron.
 
-        If this particle is not an ion or electron, then this attribute
-        will raise an `~plasmapy.particles.exceptions.InvalidIonError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidIonError`
+            If this particle is not an ion or electron.
 
         Examples
         --------
@@ -1276,12 +1302,15 @@ class Particle(AbstractPhysicalParticle):
     @property
     def isotopic_abundance(self) -> u.Quantity:
         """
-        Return the isotopic abundance of an isotope.
+        The isotopic abundance of an isotope.
 
-        If the isotopic abundance is not available, this attribute will
-        raise a `~plasmapy.particles.exceptions.MissingParticleDataError`.  If the
-        particle is not an isotope or is an ion of an isotope, then this
-        attribute will raise an `~plasmapy.particles.exceptions.InvalidIsotopeError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidIsotopeError`
+            If the particle does not correspond to an isotope.
+
+        `~plasmapy.particles.exceptions.MissingParticleDataError`
+            If the isotopic abundance is not available.
 
         Examples
         --------
@@ -1308,14 +1337,16 @@ class Particle(AbstractPhysicalParticle):
     @property
     def baryon_number(self) -> Integral:
         """
-        Return the number of baryons in a particle.
+        The number of baryons in a particle.
 
         This attribute will return the number of protons and neutrons
         minus the number of antiprotons and antineutrons. The baryon
         number is equivalent to the mass number for isotopes.
 
-        If the baryon number is unavailable, then this attribute will
-        raise a `~plasmapy.particles.exceptions.MissingParticleDataError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.MissingParticleDataError`
+            If the baryon number is unavailable.
 
         Examples
         --------
@@ -1338,8 +1369,10 @@ class Particle(AbstractPhysicalParticle):
         This attribute returns the number of leptons minus the number of
         antileptons, excluding bound electrons in an atom or ion.
 
-        If the lepton number is unavailable, then this attribute will
-        raise a `~plasmapy.particles.exceptions.MissingParticleDataError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.MissingParticleDataError`
+            If the lepton number is unavailable.
 
         Examples
         --------
@@ -1359,8 +1392,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def half_life(self) -> Union[u.Quantity, str]:
         """
-        Return the particle's half-life in seconds, or a `str`
-        with half-life information.
+        The particle's half-life in seconds, or a `str` with half-life
+        information.
 
         Particles that do not have sufficiently well-constrained
         half-lives will return a `str` containing the information
@@ -1413,11 +1446,13 @@ class Particle(AbstractPhysicalParticle):
     @property
     def periodic_table(self) -> namedtuple:
         """
-        Return a `~collections.namedtuple` to access category, period,
-        group, and block information about an element.
+        A `~collections.namedtuple` that provides access to category,
+        period, group, and block information about an element.
 
-        If the particle is not an element, isotope, or ion, then this
-        attribute will raise an `~plasmapy.particles.exceptions.InvalidElementError`.
+        Raises
+        ------
+        `~plasmapy.particles.exceptions.InvalidElementError`
+            If the particle is not an element, isotope, or ion.
 
         Examples
         --------
@@ -1881,7 +1916,7 @@ class DimensionlessParticle(AbstractParticle):
     @property
     def json_dict(self) -> dict:
         """
-        Provide a `json` friendly dictionary representation of the particle.
+        A `json` friendly dictionary representation of the particle.
 
         See `AbstractParticle.json_dict` for more details.
 
@@ -1913,12 +1948,12 @@ class DimensionlessParticle(AbstractParticle):
 
     @property
     def mass(self) -> np.float64:
-        """Return the dimensionless mass of the particle."""
+        """The dimensionless mass of the particle."""
         return self._mass
 
     @property
     def charge(self) -> np.float64:
-        """Return the dimensionless charge of the particle."""
+        """The dimensionless charge of the particle."""
         return self._charge
 
     @mass.setter
@@ -1952,8 +1987,9 @@ class DimensionlessParticle(AbstractParticle):
     @property
     def symbol(self) -> str:
         """
-        Return the symbol assigned to the dimensionless particle.  If no
-        symbol was defined, then return the value given by `repr`.
+        The symbol assigned to the dimensionless particle.
+
+        If no symbol was defined, then return the value given by `repr`.
         """
         return self._symbol
 
@@ -2043,7 +2079,7 @@ class CustomParticle(AbstractPhysicalParticle):
     @property
     def json_dict(self) -> dict:
         """
-        Provide a `json` friendly dictionary representation of the particle.
+        A `json` friendly dictionary representation of the particle.
 
         See `AbstractParticle.json_dict` for more details.
 
@@ -2155,7 +2191,7 @@ class CustomParticle(AbstractPhysicalParticle):
     @property
     def mass_energy(self) -> u.J:
         """
-        Return the mass energy of the custom particle.
+        The mass energy of the custom particle.
 
         Examples
         --------
@@ -2169,8 +2205,9 @@ class CustomParticle(AbstractPhysicalParticle):
     @property
     def symbol(self) -> str:
         """
-        Return the symbol assigned to the custom particle.  If no symbol
-        was defined, then return the value given by `repr`.
+        The symbol assigned to the custom particle.
+
+        If no symbol was defined, then return the value given by `repr`.
         """
         return self._symbol
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from numbers import Integral, Real
 from typing import Iterable, List, Optional, Set, Tuple, Union
 
-from plasmapy.particles.elements import _Elements, _PeriodicTable
+from plasmapy.particles.elements import _elements, _PeriodicTable
 from plasmapy.particles.exceptions import (
     ChargeError,
     InvalidElementError,
@@ -518,7 +518,7 @@ class Particle(AbstractPhysicalParticle):
 
             # Element properties
 
-            Element = _Elements[element]
+            Element = _elements[element]
 
             attributes["atomic number"] = Element["atomic number"]
             attributes["element name"] = Element["element name"]

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -188,7 +188,7 @@ class ParticleList(collections.UserList):
     @property
     def charge(self) -> u.C:
         """
-        Return a `~astropy.units.Quantity` array of the electric charges
+        A `~astropy.units.Quantity` array of the electric charges
         of the particles.
         """
         return self._get_particle_attribute("charge", unit=u.C, default=np.nan * u.C)
@@ -196,7 +196,7 @@ class ParticleList(collections.UserList):
     @property
     def data(self) -> List[Union[Particle, CustomParticle]]:
         """
-        Return a `list` containing the particles contained in the
+        A `list` containing the particles contained in the
         `ParticleList` instance.
 
         The `~plasmapy.particles.ParticleList.data` attribute should not
@@ -218,8 +218,8 @@ class ParticleList(collections.UserList):
     @property
     def half_life(self) -> u.s:
         """
-        Return a `~astropy.units.Quantity` array of the half-lives of
-        the particles.
+        A `~astropy.units.Quantity` array of the half-lives of the
+        particles.
         """
         return self._get_particle_attribute("half_life", unit=u.s, default=np.nan * u.s)
 
@@ -233,24 +233,21 @@ class ParticleList(collections.UserList):
     @property
     def integer_charge(self) -> np.array:
         """
-        Return an array of the quantized charges of the particles, as
+        An array of the quantized charges of the particles, as
         multiples of the elementary charge.
         """
         return np.array(self._get_particle_attribute("integer_charge", default=np.nan))
 
     @property
     def mass(self) -> u.kg:
-        """
-        Return a `~astropy.units.Quantity` array of the masses of the
-        particles.
-        """
+        """A `~astropy.units.Quantity` array of the masses of the particles."""
         return self._get_particle_attribute("mass", unit=u.kg, default=np.nan * u.J)
 
     @property
     def mass_energy(self) -> u.J:
         """
-        Return a `~astropy.units.Quantity` array of the mass energies of
-        the particles.
+        A `~astropy.units.Quantity` array of the mass energies of the
+        particles.
 
         If the particle is an isotope or nuclide, return the mass energy
         of the nucleus only.
@@ -272,7 +269,7 @@ class ParticleList(collections.UserList):
 
     @property
     def symbols(self) -> List[str]:
-        """Return a `list` of the symbols of the particles."""
+        """A `list` of the symbols of the particles."""
         return self._get_particle_attribute("symbol")
 
 

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -188,16 +188,16 @@ class ParticleList(collections.UserList):
     @property
     def charge(self) -> u.C:
         """
-        A `~astropy.units.Quantity` array of the electric charges of the
-        particles.
+        Return a `~astropy.units.Quantity` array of the electric charges
+        of the particles.
         """
         return self._get_particle_attribute("charge", unit=u.C, default=np.nan * u.C)
 
     @property
     def data(self) -> List[Union[Particle, CustomParticle]]:
         """
-        A `list` containing the particles contained in the `ParticleList`
-        instance.
+        Return a `list` containing the particles contained in the
+        `ParticleList` instance.
 
         The `~plasmapy.particles.ParticleList.data` attribute should not
         be modified directly.
@@ -217,7 +217,10 @@ class ParticleList(collections.UserList):
 
     @property
     def half_life(self) -> u.s:
-        """A `~astropy.units.Quantity` array of the half-lives of the particles."""
+        """
+        Return a `~astropy.units.Quantity` array of the half-lives of
+        the particles.
+        """
         return self._get_particle_attribute("half_life", unit=u.s, default=np.nan * u.s)
 
     def insert(self, index, particle: ParticleLike):
@@ -230,21 +233,24 @@ class ParticleList(collections.UserList):
     @property
     def integer_charge(self) -> np.array:
         """
-        An array of the quantized charges of the particles, as multiples
-        of the elementary charge.
+        Return an array of the quantized charges of the particles, as
+        multiples of the elementary charge.
         """
         return np.array(self._get_particle_attribute("integer_charge", default=np.nan))
 
     @property
     def mass(self) -> u.kg:
-        """A `~astropy.units.Quantity` array of the masses of the particles."""
+        """
+        Return a `~astropy.units.Quantity` array of the masses of the
+        particles.
+        """
         return self._get_particle_attribute("mass", unit=u.kg, default=np.nan * u.J)
 
     @property
     def mass_energy(self) -> u.J:
         """
-        A `~astropy.units.Quantity` array of the mass energies of the
-        particles.
+        Return a `~astropy.units.Quantity` array of the mass energies of
+        the particles.
 
         If the particle is an isotope or nuclide, return the mass energy
         of the nucleus only.
@@ -255,8 +261,9 @@ class ParticleList(collections.UserList):
 
     def sort(self, key: Callable = None, reverse: bool = False):
         """
-        Sort the `ParticleList` in-place.  For more information, refer
-        to the documentation for `list.sort`.
+        Sort the `ParticleList` in-place.
+
+        For more information, refer to the documentation for `list.sort`.
         """
         if key is None:
             raise TypeError("Unable to sort a ParticleList without a key.")
@@ -265,7 +272,7 @@ class ParticleList(collections.UserList):
 
     @property
     def symbols(self) -> List[str]:
-        """A list of the symbols of the particles."""
+        """Return a `list` of the symbols of the particles."""
         return self._get_particle_attribute("symbol")
 
 

--- a/plasmapy/particles/serialization.py
+++ b/plasmapy/particles/serialization.py
@@ -1,6 +1,4 @@
-"""
-Functionality for JSON deserialization of PlasmaPy particles.
-"""
+"""Functionality for JSON deserialization of particle objects."""
 __all__ = [
     "json_load_particle",
     "json_loads_particle",
@@ -21,7 +19,7 @@ from plasmapy.particles.particle_class import (
 class ParticleJSONDecoder(json.JSONDecoder):
     """
     A custom `~json.JSONDecoder` class to deserialize JSON objects into
-    PlasmaPy particle objects.
+    the appropriate particle objects.
 
     Parameters
     ----------
@@ -29,8 +27,9 @@ class ParticleJSONDecoder(json.JSONDecoder):
         If specified, will be called with the result of every JSON object
         decoded and its return value will be used in place of the given `dict`.
         This can be used to provide custom deserializations (e.g. to support
-        JSON-RPC class hinting)
-        (If not specified, then defaults to `particle_hook`.).
+        JSON-RPC class hinting).  If not specified, then defaults to
+        `particle_hook`.).
+
     **kwargs :
         Any keyword accepted by `~json.JSONDecoder`.
     """
@@ -43,9 +42,12 @@ class ParticleJSONDecoder(json.JSONDecoder):
     @staticmethod
     def particle_hook(json_dict):
         """
-        An `object_hook` utilized by the `json` deserialization processes to decode
-        json strings into a `plasmapy` particle class (`AbstractParticle`,
-        `CustomParticle`, `DimensionlessParticle`, `Particle`).
+        Decode JSON strings into the appropriate particle class.
+
+        This method is an `object_hook` utilized by the `json`
+        deserialization processes to decode json strings into a particle
+        class (`AbstractParticle`, `CustomParticle`,
+        `DimensionlessParticle`, `Particle`).
         """
         particle_types = {
             "AbstractParticle": AbstractParticle,
@@ -71,16 +73,20 @@ class ParticleJSONDecoder(json.JSONDecoder):
 
 def json_load_particle(fp, *, cls=ParticleJSONDecoder, **kwargs):
     """
-    A convenient form of `json.load` to deserialize a JSON document into a
-    PlasmaPy particle object. (Mirrors `json.load` with `cls` defaulting to
-    `ParticleJSONDecoder`.).
+    Deserialize a JSON document into the appropriate particle object.
+
+    This function is a convenient form of `json.load` to deserialize a
+    JSON document into a particle object. (Mirrors `json.load` with
+    `cls` defaulting to `ParticleJSONDecoder`.).
 
     Parameters
     ----------
     fp : `file object <https://docs.python.org/3/glossary.html#term-file-object>`_
         A file object containing a JSON document.
+
     cls : `json.JSONDecoder` class
         A `~json.JSONDecoder` class. (Default `ParticleJSONDecoder`).
+
     **kwargs :
         Any keyword accepted by `json.load`.
     """
@@ -89,16 +95,20 @@ def json_load_particle(fp, *, cls=ParticleJSONDecoder, **kwargs):
 
 def json_loads_particle(s, *, cls=ParticleJSONDecoder, **kwargs):
     """
-    A convenient form of `json.loads` to deserialize a JSON string into a
-    PlasmaPy particle object. (Mirrors `json.loads` with `cls` defaulting to
-    `ParticleJSONDecoder`.).
+    Deserialize a JSON string into the appropriate particle object.
+
+    This function is convenient form of `json.loads` to deserialize a
+    JSON string into a particle object. (Mirrors `json.loads` with `cls`
+    defaulting to `ParticleJSONDecoder`.).
 
     Parameters
     ----------
     s : str
         A JSON string.
+
     cls : `json.JSONDecoder` class
         A `~json.JSONDecoder` class. (Default `ParticleJSONDecoder`).
+
     **kwargs :
         Any keyword accepted by `json.loads`.
     """

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -35,7 +35,7 @@ from ..atomic import (
     stable_isotopes,
     standard_atomic_weight,
 )
-from ..isotopes import _Isotopes
+from ..isotopes import _isotopes
 from ..nuclear import nuclear_binding_energy, nuclear_reaction_energy
 from ..symbols import atomic_symbol, element_name, isotope_symbol
 
@@ -623,10 +623,10 @@ def test_half_life():
 def test_half_life_unstable_isotopes():
     """Test that `half_life` returns `None` and raises an exception for
     all isotopes that do not yet have half-life data."""
-    for isotope in _Isotopes.keys():
+    for isotope in _isotopes.keys():
         if (
-            "half_life" not in _Isotopes[isotope].keys()
-            and not _Isotopes[isotope].keys()
+            "half_life" not in _isotopes[isotope].keys()
+            and not _isotopes[isotope].keys()
         ):
             with pytest.raises(MissingParticleDataError):
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -24,7 +24,7 @@ from plasmapy.particles.exceptions import (
     ParticleError,
     ParticleWarning,
 )
-from plasmapy.particles.isotopes import _Isotopes
+from plasmapy.particles.isotopes import _isotopes
 from plasmapy.particles.particle_class import (
     CustomParticle,
     DimensionlessParticle,
@@ -712,7 +712,7 @@ def test_particle_half_life_string():
     """
 
     for isotope in known_isotopes():
-        half_life = _Isotopes[isotope].get("half-life", None)
+        half_life = _isotopes[isotope].get("half-life", None)
         if isinstance(half_life, str):
             break
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,7 @@ max-line-length = 88
 # line, which is sometimes necessary for even concise descriptions of plasma
 # physics functions and classes.
 convention = numpy
-add-select = D402,D413
+add-select = D402
 add-ignore = D202,D205,D302,D400,D105
 
 [flake8]


### PR DESCRIPTION
Here are a bunch of more docstring fixes using my new favorite programming paradigm of PDD.¹  This time these are for `plasmapy.particles`, and were primarily inspired by running `pydocstyle`.  If this looks good, I'm okay with it being merged.

I also renamed two private dictionaries to be more PEP8ish: `_Elements` to `_elements` and `_Isotopes` to `_isotopes` (since these aren't classes).  

¹Procrastination-driven development.