### PR TITLE
Made `is_uniform` a documented public attribute of AbstractGrid (closes #1071)

### DIFF
--- a/changelog/1072.feature.rst
+++ b/changelog/1072.feature.rst
@@ -1,0 +1,1 @@
+Made `is_uniform` a properly-documented public attribute of `~plasmapy.plasma.grids.AbstractGrid`

--- a/changelog/1072.feature.rst
+++ b/changelog/1072.feature.rst
@@ -1,1 +1,2 @@
-Made `is_uniform` a properly-documented public attribute of `~plasmapy.plasma.grids.AbstractGrid`
+Made `~plasmapy.plasma.grids.AbstractGrid.is_uniform` a properly-documented
+public attribute of `~plasmapy.plasma.grids.AbstractGrid`.

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -243,7 +243,7 @@ class AbstractGrid(ABC):
         return u.Quantity(self.ds[key].data, self.ds[key].attrs["unit"], copy=False)
 
     @property
-    def is_uniform(self):
+    def is_uniform(self) -> bool:
         """
         A boolean value reflecting whether or not the grid points are
         uniformly spaced.

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -248,13 +248,6 @@ class AbstractGrid(ABC):
         A boolean value reflecting whether or not the grid points are
         uniformly spaced.
         """
-
-        if self._is_uniform is None:
-            raise ValueError(
-                "The `is_uniform` attribute is not accessible "
-                "before a grid has been loaded."
-            )
-
         return self._is_uniform
 
     @property

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -248,6 +248,13 @@ class AbstractGrid(ABC):
         A boolean value reflecting whether or not the grid points are
         uniformly spaced.
         """
+
+        if self._is_uniform is None:  # coverage: ignore
+            raise ValueError(
+                "The `is_uniform` attribute is not accessible "
+                "before a grid has been loaded."
+            )
+
         return self._is_uniform
 
     @property

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -49,6 +49,7 @@ class AbstractGrid(ABC):
 
         # Initialize some variables
         self._interpolator = None
+        self._is_uniform = None
 
         # If three inputs are given, assume it's a user-provided grid
         if len(seeds) == 3:
@@ -240,6 +241,21 @@ class AbstractGrid(ABC):
         in the underlying DataArray.
         """
         return u.Quantity(self.ds[key].data, self.ds[key].attrs["unit"], copy=False)
+
+    @property
+    def is_uniform(self):
+        """
+        A boolean value reflecting whether or not the grid points are
+        uniformly spaced.
+        """
+
+        if self._is_uniform is None:
+            raise ValueError(
+                "The `is_uniform` attribute is not accessible "
+                "before a grid has been loaded."
+            )
+
+        return self._is_uniform
 
     @property
     def shape(self):
@@ -502,7 +518,7 @@ class AbstractGrid(ABC):
                 f"pts2 = {pts2.shape}."
             )
 
-        self.is_uniform = _detect_is_uniform_grid(pts0, pts1, pts2)
+        self._is_uniform = _detect_is_uniform_grid(pts0, pts1, pts2)
 
         # Create dataset
         self.ds = xr.Dataset()

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -86,13 +86,17 @@ def test_AbstractGrid():
     with pytest.raises(KeyError):
         grid.require_quantities(req_q, replace_with_zeros=False)
     # Do replace
-    grid.require_quantities(req_q, replace_with_zeros=True)
+    with pytest.warns(RuntimeWarning, match="This quantity will be assumed to be zero"):
+        grid.require_quantities(req_q, replace_with_zeros=True)
     req_q = ["B_x", "B_y"]
     # Test with a key that is not there, but cannot be replaced because
     # it's not a recognized key
     req_q = ["B_x", "not_a_recognized_key"]
     with pytest.raises(KeyError):
-        grid.require_quantities(req_q, replace_with_zeros=True)
+        with pytest.warns(
+            RuntimeWarning, match="This quantity will be assumed to be zero"
+        ):
+            grid.require_quantities(req_q, replace_with_zeros=True)
 
     # Test adding a quantity with wrong units
     q = np.random.randn(10, 10, 10) * u.kg


### PR DESCRIPTION
Properly documented this property