### PR TITLE
Add github action to automatically label PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+Diagnostics: plasmapy/diagnostics/**/*
+
+Formulary: plasmapy/formulary/**/*
+
+Mathematics: plasmapy/formulary/mathematics.py
+
+parameters.quantum: plasmapy/formulary/quantum.py
+
+Particles: plasmapy/particles/**/*
+
+Documentation: docs/**/*
+
+Plasma class: plasmapy/plasma/**/*
+
+simulations: plasmapy/simulations/**/*
+
+Utilities: plasmapy/utils/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        synt-labels: true
+        sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        synt-labels: true


### PR DESCRIPTION
This adds https://github.com/actions/labeler. PRs that modify, say, plasmapy.particles should now automatically get the Particles label. I mirrored the existing labels; we can add more if needed.

I'm not 100% sure I've got the YAML set up properly, but I don't want to duplicate our labels on my own fork, so I'll have to adjust things here afterwards, anyway.

This PR is more of a "do we want this cool new thing that astropy's already trying out?". It's also a prelude to [finally adding the new contributor greeter bot, which can be done here in a basic form](https://github.com/PlasmaPy/PlasmaPy/new/master?filename=.github%2Fworkflows%2Fgreetings.yml&workflow_template=greetings) but I need to write some concise greetings first.