### PR TITLE
First draft of CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,16 @@
+# in decreasing order of priority
+
+# any file, anywhere
+*                                                        @PlasmaPy/plasmapy-reviewers
+
+plasmapy/particles/                                      @namurphy
+
+plasmapy/analysis/                                       @rocco8773
+plasmapy/diagnostics/                                    @rocco8773
+
+plasmapy/simulation/                                     @StanczakDominik
+
+# any conftest.py, anywhere
+conftest.py                                              @StanczakDominik
+
+plasmapy/diagnostics/proton_radiography.py               @pheuer


### PR DESCRIPTION
Following #1080 and as discussed at [yesterday's telecon](https://hackmd.io/y3davOJCR36wJMaQx2uiBg), here's the next automationy/refactory/etc change from #1059.

The [CODEOWNERS file](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) automatically asks the people mentioned  (@PlasmaPy/plasmapy-reviewers in general, @namurphy for Particles, @rocco8773 for Analysis/Diagnostics, @pheuer for proton radiography and myself for simulation in this first draft) for review on any newly opened, non-draft PR that modifies the files relevant files.

If you don't feel up to a review, you can just un-request yourself from the PR and someone else will always take over asap.

If any of you want to adjust the scope or opt out, I can of course do that for you, or you can modify the file yourself; [the syntax is pretty simple.](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax)

I think if you turn a draft PR into a "full" PR, it still triggers in the same way.