### PR TITLE
Optimizing formulary functions

### DIFF
--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -529,6 +529,8 @@ cs_ = ion_sound_speed
 """ Alias to :func:`ion_sound_speed`. """
 
 
+_k_B = k_B.si.value
+
 # This dictionary defines coefficients for thermal speeds
 # calculated for different methods and values of ndim.
 # Created here to avoid re-instantiating on each call
@@ -559,7 +561,7 @@ def _thermal_speed(T, m, coef):
         Thermal speed in m/s
 
     """
-    return np.sqrt(coef * 1.38e-23 * T / m)
+    return np.sqrt(coef * _k_B * T / m)
 
 
 @check_relativistic

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -539,6 +539,29 @@ _coefficients = {
 }
 
 
+def _thermal_speed(T, m, coef):
+    r"""
+    Optimized sub-function for `thermal_speed`
+
+    Parameters
+    ----------
+    T : np.ndarray
+        Temperature in K
+    m : np.ndarray
+        Mass in kg
+    coef : float
+        Coefficient for the thermal speed calculation: depends on ndim and
+        method. See documentation for `thermal_speed`.
+
+    Returns
+    -------
+    vth
+        Thermal speed in m/s
+
+    """
+    return np.sqrt(coef * 1.38e-23 * T / m)
+
+
 @check_relativistic
 @validate_quantities(
     T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
@@ -675,7 +698,7 @@ def thermal_speed(
     except KeyError:
         raise ValueError("Method {method} not supported in thermal_speed")
 
-    return np.sqrt(coef * k_B * T / m)
+    return _thermal_speed(T.to(u.K).value, m.to(u.kg).value, coef) * u.m / u.s
 
 
 vth_ = thermal_speed
@@ -1349,7 +1372,7 @@ def plasma_frequency(n: u.m ** -3, particle: Particle, z_mean=None) -> u.rad / u
 
     omega_p = u.rad * Z * e * np.sqrt(n / (eps0 * m))
 
-    return omega_p.to(u.rad/u.s)
+    return omega_p.to(u.rad / u.s)
 
 
 wp_ = plasma_frequency

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1349,7 +1349,7 @@ def plasma_frequency(n: u.m ** -3, particle: Particle, z_mean=None) -> u.rad / u
 
     omega_p = u.rad * Z * e * np.sqrt(n / (eps0 * m))
 
-    return omega_p.si
+    return omega_p.to(u.rad/u.s)
 
 
 wp_ = plasma_frequency


### PR DESCRIPTION
This PR would optimize some formulary functions for use in numerical work. 

We can also use this branch to try out bigger changes such as a specialized decorator that converts units and then strips them only if units are provided?

This PR continues discussion on #974 . A quick summary of the conclusions from that thread:

1. Replacing `.si` with `.to(unit)` is substantially faster. Doing this in the return line of `plasma_frequency` resulted in a 75% performance increase! 
2. The `plasma_dispersion_func` and `plasma_dispersion_func_deriv` are pretty well optimized already, taking ~ 30 and 50 us respectively. 
3. `@particle_input` seems to consume  ~ 100 us. Maybe worth improving, but certainly not the biggest cost.



I'll include @StanczakDominik 's line_profiler result for `thomson.spectral_density` here:

<details>
<summary>line_profiler results for spectral_density</summary>

```
Timer unit: 1e-06 s

Total time: 0.115834 s
File: /mnt/hdd/Code/github/PlasmaPy/PlasmaPy/plasmapy/diagnostics/thomson.py
Function: spectral_density at line 48

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    48                                           def spectral_density(
    49                                               wavelengths: u.nm,
    50                                               probe_wavelength: u.nm,
    51                                               n: u.m ** -3,
    52                                               Te: u.K,
    53                                               Ti: u.K,
    54                                               efract: np.ndarray = None,
    55                                               ifract: np.ndarray = None,
    56                                               ion_species: Union[str, List[str], Particle, List[Particle]] = "H+",
    57                                               electron_vel: u.m / u.s = None,
    58                                               electron_vdir: np.ndarray = None,
    59                                               electron_speed: u.m / u.s = None,
    60                                               ion_vel: u.m / u.s = None,
    61                                               ion_vdir: np.ndarray = None,
    62                                               ion_speed: np.ndarray = None,
    63                                               probe_vec=np.array([1, 0, 0]),
    64                                               scatter_vec=np.array([0, 1, 0]),
    65                                               inst_fcn=None,
    66                                           ) -> Tuple[Union[np.floating, np.ndarray], np.ndarray]:
    67                                               r"""
    68                                               Calculate the spectral density function for Thomson scattering of a
    69                                               probe laser beam by a multi-species Maxwellian plasma.
    70                                           
    71                                               This function calculates the spectral density function for Thomson
    72                                               scattering of a probe laser beam by a plasma consisting of one or more ion
    73                                               species and a one or more thermal electron populations (the entire plasma
    74                                               is assumed to be quasi-neutral)
    75                                           
    76                                               .. math::
    77                                                   S(k,\omega) = \sum_e \frac{2\pi}{k}
    78                                                   \bigg |1 - \frac{\chi_e}{\epsilon} \bigg |^2
    79                                                   f_{e0,e} \bigg (\frac{\omega}{k} \bigg ) +
    80                                                   \sum_i \frac{2\pi Z_i}{k}
    81                                                   \bigg |\frac{\chi_e}{\epsilon} \bigg |^2 f_{i0,i}
    82                                                   \bigg ( \frac{\omega}{k} \bigg )
    83                                           
    84                                               where :math:`\chi_e` is the electron component susceptibility of the
    85                                               plasma and :math:`\epsilon = 1 + \sum_e \chi_e + \sum_i \chi_i` is the total
    86                                               plasma dielectric  function (with :math:`\chi_i` being the ion component
    87                                               of the susceptibility), :math:`Z_i` is the charge of each ion, :math:`k`
    88                                               is the scattering wavenumber, :math:`\omega` is the scattering frequency,
    89                                               and :math:`f_{e0,e}` and :math:`f_{i0,i}` are the electron and ion velocity
    90                                               distribution functions respectively. In this function the electron and ion
    91                                               velocity distribution functions are assumed to be Maxwellian, making this
    92                                               function equivalent to Eq. 3.4.6 in `Sheffield`_.
    93                                           
    94                                               Parameters
    95                                               ----------
    96                                           
    97                                               wavelengths : `~astropy.units.Quantity`
    98                                                   Array of wavelengths over which the spectral density function
    99                                                   will be calculated. (convertible to nm)
   100                                           
   101                                               probe_wavelength : `~astropy.units.Quantity`
   102                                                   Wavelength of the probe laser. (convertible to nm)
   103                                           
   104                                               n : `~astropy.units.Quantity`
   105                                                   Mean (0th order) density of all plasma components combined.
   106                                                   (convertible to cm^-3.)
   107                                           
   108                                               Te : `~astropy.units.Quantity`, shape (Ne, )
   109                                                   Temperature of each electron component. Shape (Ne, ) must be equal to the
   110                                                   number of electron components Ne. (in K or convertible to eV)
   111                                           
   112                                               Ti : `~astropy.units.Quantity`, shape (Ni, )
   113                                                   Temperature of each ion component. Shape (Ni, ) must be equal to the
   114                                                   number of ion components Ni. (in K or convertible to eV)
   115                                           
   116                                               efract : array_like, shape (Ne, ), optional
   117                                                   An array-like object where each element represents the fraction (or ratio)
   118                                                   of the electron component number density to the total electron number density.
   119                                                   Must sum to 1.0. Default is a single electron component.
   120                                           
   121                                               ifract : array_like, shape (Ni, ), optional
   122                                                   An array-like object where each element represents the fraction (or ratio)
   123                                                   of the ion component number density to the total ion number density.
   124                                                   Must sum to 1.0. Default is a single ion species.
   125                                           
   126                                               ion_species : str or `~plasmapy.particles.Particle`, shape (Ni, ), optional
   127                                                   A list or single instance of `~plasmapy.particles.Particle`, or strings
   128                                                   convertible to `~plasmapy.particles.Particle`. Default is `'H+'`
   129                                                   corresponding to a single species of hydrogen ions.
   130                                           
   131                                               electron_vel : `~astropy.units.Quantity`, shape (Ne, 3), optional
   132                                                   Velocity of each electron component in the rest frame. (convertible to m/s)
   133                                                   If set, overrides electron_vdir and electron_speed.
   134                                                   Defaults to a stationary plasma [0, 0, 0] m/s.
   135                                           
   136                                               electron_vdir : np.ndarray, shape (Ne,3), optional
   137                                                   Unit vectors describing the velocity of each electron population.
   138                                                   Setting electron_vel overrides this keyword.
   139                                           
   140                                               electron_speed : `~astropy.units.Quantity`, shape (Ne), optional
   141                                                   A scalar speed for each electron population. Must be used along with
   142                                                   electron_vdir. Setting electron_vel overrides this keyword.
   143                                           
   144                                               ion_vel : `~astropy.units.Quantity`, shape (Ni, 3), optional
   145                                                   Velocity vectors for each electron population in the rest frame
   146                                                   (convertible to m/s). If set, overrides ion_vdir and ion_speed.
   147                                                   Defaults zero drift for all specified ion species.
   148                                           
   149                                               ion_vdir : np.ndarray, shape (Ne,3), optional
   150                                                   Unit vectors describing the velocity of each ion population.
   151                                                   Setting ion_vel overrides this keyword.
   152                                           
   153                                               ion_speed : `~astropy.units.Quantity`, shape (Ne), optional
   154                                                   A scalar speed for each ion population. Must be used along with
   155                                                   ion_vdir. Setting ion_vel overrides this keyword.
   156                                           
   157                                               probe_vec : float `~numpy.ndarray`, shape (3, )
   158                                                   Unit vector in the direction of the probe laser. Defaults to
   159                                                   [1, 0, 0].
   160                                           
   161                                               scatter_vec : float `~numpy.ndarray`, shape (3, )
   162                                                   Unit vector pointing from the scattering volume to the detector.
   163                                                   Defaults to [0, 1, 0] which, along with the default `probe_vec`,
   164                                                   corresponds to a 90 degree scattering angle geometry.
   165                                           
   166                                               inst_fcn : function
   167                                                   A function representing the instrument function that takes an `~astropy.units.Quantity`
   168                                                   of wavelengths (centered on zero) and returns the instrument point
   169                                                   spread function. The resulting array will be convolved with the
   170                                                   spectral density function before it is returned.
   171                                           
   172                                               Returns
   173                                               -------
   174                                               alpha : float
   175                                                   Mean scattering parameter, where `alpha` > 1 corresponds to collective
   176                                                   scattering and `alpha` < 1 indicates non-collective scattering. The
   177                                                   scattering parameter is calculated based on the total plasma density n.
   178                                           
   179                                               Skw : `~astropy.units.Quantity`
   180                                                   Computed spectral density function over the input `wavelengths` array
   181                                                   with units of s/rad.
   182                                           
   183                                               Notes
   184                                               -----
   185                                           
   186                                               For details, see "Plasma Scattering of Electromagnetic Radiation" by
   187                                               Sheffield et al. `ISBN 978\\-0123748775`_. This code is a modified version
   188                                               of the program described therein.
   189                                           
   190                                               For a concise summary of the relevant physics, see Chapter 5 of Derek
   191                                               Schaeffer's thesis, DOI: `10.5281/zenodo.3766933`_.
   192                                           
   193                                               .. _`ISBN 978\\-0123748775`: https://www.sciencedirect.com/book/9780123748775/plasma-scattering-of-electromagnetic-radiation
   194                                               .. _`10.5281/zenodo.3766933`: https://doi.org/10.5281/zenodo.3766933
   195                                               .. _`Sheffield`: https://doi.org/10.1016/B978-0-12-374877-5.00003-8
   196                                               """
   197                                           
   198                                               # Validate efract
   199         1          3.0      3.0      0.0      if efract is None:
   200         1         31.0     31.0      0.0          efract = np.ones(1)
   201                                               else:
   202                                                   efract = np.asarray(efract, dtype=np.float64)
   203                                           
   204                                               # Validate ifract
   205         1          2.0      2.0      0.0      if ifract is None:
   206                                                   ifract = np.ones(1)
   207                                               else:
   208         1         13.0     13.0      0.0          ifract = np.asarray(ifract, dtype=np.float64)
   209                                           
   210                                               # TODO: Write tests and update docstring for these different ways
   211                                               # of specifying velocities
   212                                           
   213                                               # Condition the electron velocity keywords
   214         1          2.0      2.0      0.0      if electron_vel is not None:
   215         1          1.0      1.0      0.0          pass
   216                                               elif (electron_speed is not None) and (electron_vdir is not None):
   217                                                   norm = np.linalg.norm(electron_vdir, axis=1, keepdims=True)
   218                                                   if all(norm == 0):
   219                                                       electron_vel = np.zeros(3) * u.m / u.s
   220                                                   else:
   221                                                       electron_vel = electron_speed[:, np.newaxis] * electron_vdir
   222                                               else:
   223                                                   electron_vel = np.zeros([efract.size, 3]) * u.m / u.s
   224                                           
   225                                               # Condition the electron velocity keywords
   226         1          2.0      2.0      0.0      if ion_vel is not None:
   227         1          2.0      2.0      0.0          pass
   228                                               elif (ion_speed is not None) and (ion_vdir is not None):
   229                                                   norm = np.linalg.norm(ion_vdir, axis=1, keepdims=True)
   230                                                   if all(norm == 0):
   231                                                       ion_vel = np.zeros(3) * u.m / u.s
   232                                                   else:
   233                                                       ion_vel = ion_speed[:, np.newaxis] * ion_vdir
   234                                               else:
   235                                                   ion_vel = np.zeros([ifract.size, 3]) * u.m / u.s
   236                                           
   237                                               # Condition ion_species
   238         1          7.0      7.0      0.0      if isinstance(ion_species, (str, Particle)):
   239                                                   ion_species = [ion_species]
   240         1          2.0      2.0      0.0      if len(ion_species) == 0:
   241                                                   raise ValueError("At least one ion species needs to be defined.")
   242         3          8.0      2.7      0.0      for ii, ion in enumerate(ion_species):
   243         2          5.0      2.5      0.0          if isinstance(ion, Particle):
   244                                                       continue
   245         2        645.0    322.5      0.6          ion_species[ii] = Particle(ion)
   246                                           
   247                                               # Condition Ti
   248         1          2.0      2.0      0.0      if Ti.size == 1:
   249                                                   # If a single quantity is given, put it in an array so it's iterable
   250                                                   # If Ti.size != len(ion_species), assume same temp. for all species
   251                                                   Ti = [Ti.value] * len(ion_species) * Ti.unit
   252         1          2.0      2.0      0.0      elif Ti.size != len(ion_species):
   253                                                   raise ValueError(
   254                                                       f"Got {Ti.size} ion temperatures and expected {len(ion_species)}."
   255                                                   )
   256                                           
   257                                               # Make sure the sizes of ion_species, ifract, ion_vel, and Ti all match
   258         3          4.0      1.3      0.0      if (
   259         1          3.0      3.0      0.0          (len(ion_species) != ifract.size)
   260         1          2.0      2.0      0.0          or (ion_vel.shape[0] != ifract.size)
   261         1          1.0      1.0      0.0          or (Ti.size != ifract.size)
   262                                               ):
   263                                                   raise ValueError(
   264                                                       f"Inconsistent number of species in ifract ({ifract}), "
   265                                                       f"ion_species ({len(ion_species)}), Ti ({Ti.size}), "
   266                                                       f"and/or ion_vel ({ion_vel.shape[0]})."
   267                                                   )
   268                                           
   269                                               # Condition Te
   270         1          2.0      2.0      0.0      if Te.size == 1:
   271                                                   # If a single quantity is given, put it in an array so it's iterable
   272                                                   # If Te.size != len(efract), assume same temp. for all species
   273         1         46.0     46.0      0.0          Te = [Te.value] * len(efract) * Te.unit
   274                                               elif Te.size != len(efract):
   275                                                   raise ValueError(
   276                                                       f"Got {Te.size} electron temperatures and expected {len(efract)}."
   277                                                   )
   278                                           
   279                                               # Make sure the sizes of efract, electron_vel, and Te all match
   280         1          3.0      3.0      0.0      if (electron_vel.shape[0] != efract.size) or (Te.size != efract.size):
   281                                                   raise ValueError(
   282                                                       f"Inconsistent number of electron populations in efract ({efract.size}), "
   283                                                       f"Te ({Te.size}), or electron velocity ({electron_vel.shape[0]})."
   284                                                   )
   285                                           
   286         1        386.0    386.0      0.3      probe_vec = probe_vec / np.linalg.norm(probe_vec)
   287         1         30.0     30.0      0.0      scatter_vec = scatter_vec / np.linalg.norm(scatter_vec)
   288         1          9.0      9.0      0.0      scattering_angle = np.arccos(np.dot(probe_vec, scatter_vec))
   289                                           
   290                                               # Calculate plasma parameters
   291         1       4440.0   4440.0      3.8      vTe = thermal_speed(Te, particle="e-")
   292         1          3.0      3.0      0.0      vTi, ion_z = [], []
   293         3         51.0     17.0      0.0      for T, ion in zip(Ti, ion_species):
   294         2       7147.0   3573.5      6.2          vTi.append(thermal_speed(T, particle=ion).value)
   295         2        115.0     57.5      0.1          ion_z.append(ion.integer_charge * u.dimensionless_unscaled)
   296         1         39.0     39.0      0.0      vTi = vTi * vTe.unit
   297         1         38.0     38.0      0.0      zbar = np.sum(ifract * ion_z)
   298                                           
   299                                               # Compute electron and ion densities
   300                                               # np.nan_to_num and warning filter catch nan's generated when
   301                                               # efract or ifract == 0 (when calculating EPW or IAW spectra separately)
   302         1         16.0     16.0      0.0      with warnings.catch_warnings():
   303         1         13.0     13.0      0.0          warnings.simplefilter("ignore", RuntimeWarning)
   304         1        494.0    494.0      0.4          ne = np.nan_to_num(efract * n, nan=0)
   305         1        436.0    436.0      0.4          ni = np.nan_to_num(ifract * n / zbar, nan=0)  # ne/zbar = sum(ni)
   306                                           
   307                                               # wpe is calculated for the entire plasma (all electron populations combined)
   308         1      19304.0  19304.0     16.7      wpe = plasma_frequency(n=n, particle="e-")
   309                                           
   310                                               # Convert wavelengths to angular frequencies (electromagnetic waves, so
   311                                               # phase speed is c)
   312         1        470.0    470.0      0.4      ws = (2 * np.pi * u.rad * C / wavelengths).to(u.rad / u.s)
   313         1        415.0    415.0      0.4      wl = (2 * np.pi * u.rad * C / probe_wavelength).to(u.rad / u.s)
   314                                           
   315                                               # Compute the frequency shift (required by energy conservation)
   316         1         57.0     57.0      0.0      w = ws - wl
   317                                           
   318                                               # Compute the wavenumbers in the plasma
   319                                               # See Sheffield Sec. 1.8.1 and Eqs. 5.4.1 and 5.4.2
   320         1        396.0    396.0      0.3      ks = np.sqrt(ws ** 2 - wpe ** 2) / C
   321         1        374.0    374.0      0.3      kl = np.sqrt(wl ** 2 - wpe ** 2) / C
   322                                           
   323                                               # Compute the wavenumber shift (required by momentum conservation)\
   324                                               # Eq. 1.7.10 in Sheffield
   325         1        519.0    519.0      0.4      k = np.sqrt(ks ** 2 + kl ** 2 - 2 * ks * kl * np.cos(scattering_angle))
   326                                               # Normal vector along k
   327         1         39.0     39.0      0.0      k_vec = (scatter_vec - probe_vec) * u.dimensionless_unscaled
   328                                           
   329                                               # Compute Doppler-shifted frequencies for both the ions and electrons
   330                                               # Matmul is simultaneously conducting dot product over all wavelengths
   331                                               # and ion components
   332         1        446.0    446.0      0.4      w_e = w - np.matmul(electron_vel, np.outer(k, k_vec).T)
   333         1        429.0    429.0      0.4      w_i = w - np.matmul(ion_vel, np.outer(k, k_vec).T)
   334                                           
   335                                               # Compute the scattering parameter alpha
   336                                               # expressed here using the fact that v_th/w_p = root(2) * Debye length
   337         1        316.0    316.0      0.3      alpha = np.sqrt(2) * wpe / np.outer(k, vTe)
   338                                           
   339                                               # Calculate the normalized phase velocities (Sec. 3.4.2 in Sheffield)
   340         1        464.0    464.0      0.4      xe = (np.outer(1 / vTe, 1 / k) * w_e).to(u.dimensionless_unscaled)
   341         1        473.0    473.0      0.4      xi = (np.outer(1 / vTi, 1 / k) * w_i).to(u.dimensionless_unscaled)
   342                                           
   343                                               # Calculate the susceptibilities
   344         1          8.0      8.0      0.0      chiE = np.zeros([efract.size, w.size], dtype=np.complex128)
   345         2         11.0      5.5      0.0      for i, fract in enumerate(efract):
   346         1      25299.0  25299.0     21.8          chiE[i, :] = permittivity_1D_Maxwellian(w_e[i, :], k, Te[i], ne[i], "e-")
   347                                           
   348                                               # Treatment of multiple species is an extension of the discussion in
   349                                               # Sheffield Sec. 5.1
   350         1          8.0      8.0      0.0      chiI = np.zeros([ifract.size, w.size], dtype=np.complex128)
   351         3         10.0      3.3      0.0      for i, ion in enumerate(ion_species):
   352         4      49836.0  12459.0     43.0          chiI[i, :] = permittivity_1D_Maxwellian(
   353         2         66.0     33.0      0.1              w_i[i, :], k, Ti[i], ni[i], ion, z_mean=ion_z[i]
   354                                                   )
   355                                           
   356                                               # Calculate the longitudinal dielectric function
   357         1         53.0     53.0      0.0      epsilon = 1 + np.sum(chiE, axis=0) + np.sum(chiI, axis=0)
   358                                           
   359         1        124.0    124.0      0.1      econtr = np.zeros([efract.size, w.size], dtype=np.complex128) * u.s / u.rad
   360         2          6.0      3.0      0.0      for m in range(efract.size):
   361         2        105.0     52.5      0.1          econtr[m, :] = efract[m] * (
   362         6        370.0     61.7      0.3              2
   363         1          5.0      5.0      0.0              * np.sqrt(np.pi)
   364         1          2.0      2.0      0.0              / k
   365         1         17.0     17.0      0.0              / vTe[m]
   366         1         56.0     56.0      0.0              * np.power(np.abs(1 - np.sum(chiE, axis=0) / epsilon), 2)
   367         1        173.0    173.0      0.1              * np.exp(-xe[m, :] ** 2)
   368                                                   )
   369                                           
   370         1        117.0    117.0      0.1      icontr = np.zeros([ifract.size, w.size], dtype=np.complex128) * u.s / u.rad
   371         3          9.0      3.0      0.0      for m in range(ifract.size):
   372         4        197.0     49.2      0.2          icontr[m, :] = ifract[m] * (
   373        14        836.0     59.7      0.7              2
   374         2         10.0      5.0      0.0              * np.sqrt(np.pi)
   375         2          4.0      2.0      0.0              * ion_z[m]
   376         2          4.0      2.0      0.0              / k
   377         2         31.0     15.5      0.0              / vTi[m]
   378         2        101.0     50.5      0.1              * np.power(np.abs(np.sum(chiE, axis=0) / epsilon), 2)
   379         2        342.0    171.0      0.3              * np.exp(-xi[m, :] ** 2)
   380                                                   )
   381                                           
   382                                               # Recast as real: imaginary part is already zero
   383         1        231.0    231.0      0.2      Skw = np.real(np.sum(econtr, axis=0) + np.sum(icontr, axis=0))
   384                                           
   385                                               # Apply an insturment function if one is provided
   386         1          2.0      2.0      0.0      if inst_fcn is not None and callable(inst_fcn):
   387                                                   # Create an array of wavelengths of the same size as wavelengths
   388                                                   # but centered on zero
   389                                                   wspan = (np.max(wavelengths) - np.min(wavelengths)) / 2
   390                                                   eval_w = np.linspace(-wspan, wspan, num=wavelengths.size)
   391                                                   # Evaluate the insturment function
   392                                                   inst_fcn_arr = inst_fcn(eval_w)
   393                                                   # Ensure inst_fcn is normalized
   394                                                   inst_fcn_arr *= 1 / np.sum(inst_fcn_arr)
   395                                                   # Convolve the insturment function with the spectral density
   396                                                   # linear rather than circular convolution is important here!
   397                                           
   398                                                   # TODO: Is numpy, scipy.signal, or astropy the best convolution
   399                                                   # function here??
   400                                                   Skw = np.convolve(Skw.value, inst_fcn_arr.value, mode="same") * Skw.unit
   401                                           
   402         1         94.0     94.0      0.1      return np.mean(alpha), Skw
```

</details>