### PR TITLE
Add validation skipping to @validate_quantities

### DIFF
--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -669,11 +669,17 @@ def thermal_speed(
     try:
         coef = _coefficients[ndim]
     except KeyError:
-        raise ValueError("{ndim} is not a supported value for ndim in thermal_speed")
+        raise ValueError(
+            f"Got unsupported value for argument 'ndim' ({ndim}), expect one of "
+            f"{list(_coefficients.keys())}."
+        )
     try:
         coef = coef[method]
     except KeyError:
-        raise ValueError("Method {method} not supported in thermal_speed")
+        raise ValueError(
+            f"Got unsupported value for argument 'method' ({method}), expected one "
+            f"of {list(coef.keys())}."
+        )
 
     return np.sqrt(coef * k_B * T / m)
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -682,7 +682,10 @@ def thermal_speed(
             f"of {list(coef.keys())}."
         )
 
-    return np.sqrt(coef * k_B * T / m)
+    speed = (k_B * T / m).value
+    speed = np.sqrt(coef * speed) * u.m / u.s
+
+    return speed
 
 
 vth_ = thermal_speed

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -543,6 +543,7 @@ _coefficients = {
 @validate_quantities(
     T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     mass={"can_be_negative": False, "can_be_nan": True},
+    allow_skipping=True,
 )
 @particles.particle_input
 def thermal_speed(

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -7,6 +7,8 @@ import astropy.units as u
 import functools
 import inspect
 
+from collections import OrderedDict
+
 from plasmapy.utils.decorators.helpers import preserve_signature
 
 
@@ -87,26 +89,32 @@ def angular_freq_to_hz(fn):
 
     """
     # raise exception if fn uses the 'to_hz' kwarg
-    sig = inspect.signature(fn)
-    if "to_hz" in sig.parameters:
+    fsig = inspect.signature(fn)
+    if "to_hz" in fsig.parameters:
         raise ValueError(
             f"Wrapped function '{fn.__name__}' can not use keyword 'to_hz'."
             f" Keyword reserved for decorator functionality."
         )
 
     # make new signature for fn
-    new_params = sig.parameters.copy()
-    new_params["to_hz"] = inspect.Parameter(
-        "to_hz", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=False
+    new_param = inspect.Parameter(
+        "to_hz",
+        inspect.Parameter.KEYWORD_ONLY,
+        default=False,
+        annotation=bool,
     )
+    new_sig = OrderedDict(fsig.parameters)
+    new_sig.update({"to_hz": new_param})
     new_sig = inspect.Signature(
-        parameters=new_params.values(), return_annotation=sig.return_annotation
+        parameters=tuple(new_sig.values()),
+        return_annotation=fsig.return_annotation,
     )
     fn.__signature__ = new_sig
 
     @preserve_signature
     @functools.wraps(fn)
-    def wrapper(*args, to_hz=False, **kwargs):
+    def wrapper(*args, **kwargs):
+        to_hz = kwargs.pop("to_hz", False)
         _result = fn(*args, **kwargs)
         if to_hz:
             return _result.to(u.Hz, equivalencies=[(u.cy / u.s, u.Hz)])
@@ -116,7 +124,7 @@ def angular_freq_to_hz(fn):
     Other Parameters
     ----------------
     to_hz: bool
-        Set `True` to to convert function output from angular frequency to Hz
+        Set `True` to to convert function output from angular frequency to Hz.
     """
     if wrapper.__doc__ is not None:
         wrapper.__doc__ += added_doc_bit

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -91,7 +91,7 @@ def angular_freq_to_hz(fn):
     # raise exception if fn uses the 'to_hz' kwarg
     fsig = inspect.signature(fn)
     if "to_hz" in fsig.parameters:
-        raise ValueError(
+        raise TypeError(
             f"Wrapped function '{fn.__name__}' can not use keyword 'to_hz'."
             f" Keyword reserved for decorator functionality."
         )

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -8,6 +8,7 @@ import functools
 import inspect
 import warnings
 
+from collections import OrderedDict
 from typing import Any, Dict
 
 from plasmapy.utils.decorators.checks import CheckUnits, CheckValues
@@ -145,6 +146,21 @@ class ValidateQuantities(CheckUnits, CheckValues):
         https://docs.astropy.org/en/stable/units/equivalencies.html
     """
 
+    skip_docstring = """
+    Other Parameters
+    ----------------
+    skip_validations : bool
+        (Default `False`)  When setting `True` NO value or unit validations will
+        be performed on input arguments or returned objects by 
+        `~plasmapy.utils.decorators.validators.validate_quantities`.
+
+        .. warning::
+           This keyword was added to help speed up formulary calculations
+           when the calculations have to be repeatedly performed.  Use with caution
+           since objects are no longer validated and atypical behavior (with 
+           respect to ``skip_validations==True``) can occur.
+    """
+
     def __init__(
             self,
             *,
@@ -189,35 +205,65 @@ class ValidateQuantities(CheckUnits, CheckValues):
             wrapped function of `f`
         """
         self.f = f
-        wrapped_sign = inspect.signature(f)
+        fsig = inspect.signature(f)
+
+        if "skip_validations" in fsig.parameters:
+            raise TypeError(
+                f"Wrapped function '{f.__name__}' can not use keyword "
+                f"'skip_validations'.  Keyword is reserved for decorator "
+                f"functionality."
+            )
+
+        # add skip_validations to f's signature
+        if self.allow_skipping:
+            skip_param = inspect.Parameter(
+                "skip_validations",
+                inspect.Parameter.KEYWORD_ONLY,
+                default=False,
+                annotation=bool,
+            )
+            new_sig = OrderedDict(fsig.parameters)
+            new_sig.update({"skip_validations": skip_param})
+            new_sig = inspect.Signature(
+                parameters=tuple(new_sig.values()),
+                return_annotation=fsig.return_annotation,
+            )
+            f.__signature__ = new_sig
 
         @preserve_signature
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
+            skip_validations = kwargs.pop("skip_validations", False)
+
             # combine args and kwargs into dictionary
-            bound_args = wrapped_sign.bind(*args, **kwargs)
+            bound_args = fsig.bind(*args, **kwargs)
             bound_args.apply_defaults()
 
-            # get conditioned validations
-            validations = self._get_validations(bound_args)
+            if self.allow_skipping and skip_validations:
+                validations = {}
+            else:
+                # get conditioned validations
+                validations = self._get_validations(bound_args)
 
-            # validate (input) argument units and values
-            for arg_name in validations:
-                # skip check of output/return
-                if arg_name == "validations_on_return":
-                    continue
+                # validate (input) argument units and values
+                for arg_name in validations:
+                    # skip check of output/return
+                    if arg_name == "validations_on_return":
+                        continue
 
-                # validate argument & update for conversion
-                arg = self._validate_quantity(
-                    bound_args.arguments[arg_name], arg_name, validations[arg_name]
-                )
-                bound_args.arguments[arg_name] = arg
+                    # validate argument & update for conversion
+                    arg = self._validate_quantity(
+                        bound_args.arguments[arg_name], arg_name, validations[arg_name]
+                    )
+                    bound_args.arguments[arg_name] = arg
 
             # call function
-            _return = f(**bound_args.arguments)
+            _return = f(*bound_args.args, **bound_args.kwargs)
 
             # validate output
-            if "validations_on_return" in validations:
+            if self.allow_skipping and skip_validations:
+                pass
+            elif "validations_on_return" in validations:
                 _return = self._validate_quantity(
                     _return,
                     "validations_on_return",
@@ -225,6 +271,12 @@ class ValidateQuantities(CheckUnits, CheckValues):
                 )
 
             return _return
+
+        if self.allow_skipping:
+            if wrapper.__doc__ is not None:
+                wrapper.__doc__ += self.skip_docstring
+            else:
+                wrapper.__doc__ = self.skip_docstring
 
         return wrapper
 

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -145,7 +145,13 @@ class ValidateQuantities(CheckUnits, CheckValues):
         https://docs.astropy.org/en/stable/units/equivalencies.html
     """
 
-    def __init__(self, validations_on_return=None, **validations: Dict[str, Any]):
+    def __init__(
+            self,
+            *,
+            validations_on_return=None,
+            allow_skipping: bool = False,
+            **validations: Dict[str, Any],
+    ):
 
         if "checks_on_return" in validations:
             raise TypeError(
@@ -153,6 +159,13 @@ class ValidateQuantities(CheckUnits, CheckValues):
                 f"use 'validations_on_return' to set validations "
                 f"on the return variable"
             )
+
+        if not isinstance(allow_skipping, bool):
+            raise TypeError(
+                f"Got type {type(allow_skipping)} for keyword 'allow_skipping',"
+                f" expected boolean."
+            )
+        self.allow_skipping = allow_skipping
 
         self._validations = validations
 


### PR DESCRIPTION
Unit and value validations (by `@validate_quantities`) can really slow down the performance of the decorated formulary functionality.  This is not a big issue when a formulary item is being calculated once, but can be a huge detriment when the calculation needs to be made numerous times.  This PR adds the validator setting keyword `allow_skipping` to `validate_quantities` (and `ValidateQuantities`) which then injects the `skip_validations` keyword into the decorated functions argument list.   The doctorate function's docstring is appended to reflect this addition.

As test, `thermal_speed` is decorated such that skipping is allowed.  This does not change the base behavior and is implemented like...

```python
@check_relativistic
@validate_quantities(
    T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
    mass={"can_be_negative": False, "can_be_nan": True},
    allow_skipping=True,
)
@particles.particle_input
def thermal_speed(
    T: u.K,
    particle: Particle,
    method="most_probable",
    mass: u.kg = np.nan * u.kg,
    ndim=3,
) -> u.m / u.s:
    ...
```

The way `thermal_speed` is calculated is also modified such that the returned value always has units of `u.m / u.s`, regardless of if the input arguments have (correct) units or no units.  I decided to do this since: (1) when `skip_validations==False` we are guaranteed input arguments are in SI and nothing will be affected and (2) for performance inputs arguments may be unitless when `skip_validations==True` and without this modification `@check_relativistic` would be grumpy.

At least for `thermal_speed`, this appears to reduce execution time to about 40% of the original execution time.  Here is an example of how the `skip_validations` keyword works and timing comparisons.

<img width="593" alt="image" src="https://user-images.githubusercontent.com/29869348/112709727-fefac880-8e78-11eb-821e-40a42bc306a1.png">

