### PR TITLE
Add stale bot for PR

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-pr-message: 'This PR is stale because it has been open for a year with no activity. Remove stale label or comment or this will be closed in 14 days.'
-          close-pr-message: 'This PR was closed because it has been stalled for a year with no activity.'
+          stale-pr-message: 'This pull request will be closed in 14 days due to a year of inactivity unless the stale label or comment is removed.''
+          close-pr-message: 'This pull request was closed because it has had no activity for the past year.'
           days-before-pr-stale: 365
           days-before-pr-close: 15
           # never close issues

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-pr-message: 'This pull request will be closed in 14 days due to a year of inactivity unless the stale label or comment is removed.''
+          stale-pr-message: 'This pull request will be closed in 14 days due to a year of inactivity unless the stale label or comment is removed.'
           close-pr-message: 'This pull request was closed because it has had no activity for the past year.'
           days-before-pr-stale: 365
           days-before-pr-close: 15

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: 'This PR is stale because it has been open for a year with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for a year with no activity.'
+          days-before-pr-stale: 365
+          days-before-pr-close: 15
+          # never close issues
+          days-before-close: -1


### PR DESCRIPTION
Closes #1092

Configured as per https://github.com/marketplace/actions/close-stale-issues.

I went with a yearly cutoff; after that, it'll comment that whoa, what's *not* going on here, and then it'll wait 2 more weeks and close the issue.

I do not think this locks discussion by default. If it does and it's just not documented, I'm just going to purge it.