### PR TITLE
[PROTO] Framework for lite "fast" formulary functionality

### DIFF
--- a/docs/api_static/plasmapy.formulary.rst
+++ b/docs/api_static/plasmapy.formulary.rst
@@ -28,4 +28,3 @@ Sub-Packages & Modules
 .. automodapi:: plasmapy.formulary
    :no-main-docstr:
    :no-heading:
-   :include-all-objects:

--- a/docs/formulary/parameters.rst
+++ b/docs/formulary/parameters.rst
@@ -1,11 +1,12 @@
 .. _parameters:
 
-***********************************************************
+***************************************************
 Plasma parameters (`plasmapy.formulary.parameters`)
-***********************************************************
+***************************************************
 
 .. automodapi:: plasmapy.formulary.parameters
    :no-heading:
+   :include-all-objects:
 
 .. nbgallery::
     :caption: Examples

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -537,11 +537,17 @@ cs_ = ion_sound_speed
 # This dictionary defines coefficients for thermal speeds
 # calculated for different methods and values of ndim.
 # Created here to avoid re-instantiating on each call
-_coefficients = {
+#
+thermal_speed_coefficients = {
     1: {"most_probable": 0, "rms": 1, "mean_magnitude": 2 / np.pi},
     2: {"most_probable": 1, "rms": 2, "mean_magnitude": np.pi / 2},
     3: {"most_probable": 2, "rms": 3, "mean_magnitude": 8 / np.pi},
 }
+"""
+Dictionary of various coefficients used in calculating the
+`~plasmapy.formulary.parameters.thermal_speed`.
+"""
+
 
 
 @check_relativistic

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -535,6 +535,7 @@ def ion_sound_speed(
 cs_ = ion_sound_speed
 """ Alias to :func:`ion_sound_speed`. """
 
+# -----                                                             thermal_speed  -----
 
 # This dictionary defines coefficients for thermal speeds
 # calculated for different methods and values of ndim.
@@ -560,6 +561,12 @@ def thermal_speed_lite(T, mass, coeff):
     """
     return np.sqrt(coeff * k_B_si_unitless * T / mass)
 
+
+@add_lite(
+    thermal_speed_lite,
+    attrs=[("coefficients", "thermal_speed_coefficients")],
+    scope=globals(),
+)
 @check_relativistic
 @validate_quantities(
     T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
@@ -577,7 +584,9 @@ def thermal_speed(
     Return the most probable speed for a particle within a Maxwellian
     distribution.
 
-    **Aliases:** `vth_`
+    **Aliases:** `~plasmapy.formulary.parameters.vth_`
+
+    **Lightwieght Version:** `~plasmapy.formulary.parameters.thermal_speed_lite`
 
     Parameters
     ----------
@@ -703,7 +712,9 @@ def thermal_speed(
 
 
 vth_ = thermal_speed
-""" Alias to :func:`thermal_speed`. """
+""" Alias to :func:`~plasmapy.formulary.parameters.thermal_speed`. """
+
+# -----                                                          thermal_pressure  -----
 
 
 @validate_quantities(

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -549,6 +549,14 @@ Dictionary of various coefficients used in calculating the
 """
 
 
+@preserve_signature
+@njit
+def thermal_speed_lite(T, mass, coeff):
+    """
+    A lite weight version of `thermal_speed` intended for computational used
+    and, thus, does not do any argument validation/conditioning.
+    """
+    return np.sqrt(coeff * k_B_si_unitless * T / mass)
 
 @check_relativistic
 @validate_quantities(

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -686,12 +686,12 @@ class _ThermalSpeed:
         2: {"most_probable": 1, "rms": 2, "mean_magnitude": np.pi / 2},
         3: {"most_probable": 2, "rms": 3, "mean_magnitude": 8 / np.pi},
     }
+    """A docstring for coefficients."""
 
-    def __init__(self):
-        ...
 
     @staticmethod
     def unitless(T, mass, coef):
+        """A docstring for unitless."""
         return np.sqrt(coef * k_B_si_unitless * T / mass)
 
     @check_relativistic
@@ -708,6 +708,7 @@ class _ThermalSpeed:
         mass: u.kg = None,
         ndim=3,
     ) -> u.m / u.s:
+        """A docstring for the __call__"""
         if mass is None:
             mass = particles.particle_mass(particle)
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -689,7 +689,6 @@ class _ThermalSpeed:
     }
     """A docstring for coefficients."""
 
-
     @staticmethod
     @njit
     def unitless(T, mass, coef):
@@ -714,16 +713,16 @@ class _ThermalSpeed:
         if mass is None:
             mass = particles.particle_mass(particle)
 
-            # different methods, as per https://en.wikipedia.org/wiki/Thermal_velocity
-            try:
-                coef = self.coefficients[ndim]
-            except KeyError:
-                raise ValueError(
-                    "{ndim} is not a supported value for ndim in thermal_speed")
-            try:
-                coef = coef[method]
-            except KeyError:
-                raise ValueError("Method {method} not supported in thermal_speed")
+        # different methods, as per https://en.wikipedia.org/wiki/Thermal_velocity
+        try:
+            coef = self.coefficients[ndim]
+        except KeyError:
+            raise ValueError(
+                "{ndim} is not a supported value for ndim in thermal_speed")
+        try:
+            coef = coef[method]
+        except KeyError:
+            raise ValueError("Method {method} not supported in thermal_speed")
 
         speed = self.unitless(T=T.value, mass=mass.value, coef=coef)
         return speed * u.m / u.s

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -684,12 +684,16 @@ def _thermal_speed(
 
 
 class _ThermalSpeed:
-    coefficients = {
+    _coefficients = {
         1: {"most_probable": 0, "rms": 1, "mean_magnitude": 2 / np.pi},
         2: {"most_probable": 1, "rms": 2, "mean_magnitude": np.pi / 2},
         3: {"most_probable": 2, "rms": 3, "mean_magnitude": 8 / np.pi},
     }
-    """A docstring for coefficients."""
+
+    @property
+    def coefficients(self):
+        """A docstring for coefficients."""
+        return self._coefficients
 
     @staticmethod
     @njit

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -696,8 +696,9 @@ class _ThermalSpeed:
         return self._coefficients
 
     @staticmethod
+    @preserve_signature
     @njit
-    def unitless(T, mass, coef):
+    def lite(T, mass, coef):
         """A docstring for unitless."""
         return np.sqrt(coef * k_B_si_unitless * T / mass)
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -47,6 +47,7 @@ import numpy as np
 import warnings
 
 from astropy.constants.si import c, e, eps0, k_B, mu0
+from numba import njit
 from typing import Optional, Union
 
 from plasmapy import particles
@@ -690,6 +691,7 @@ class _ThermalSpeed:
 
 
     @staticmethod
+    @njit
     def unitless(T, mass, coef):
         """A docstring for unitless."""
         return np.sqrt(coef * k_B_si_unitless * T / mass)

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -716,7 +716,17 @@ class _ThermalSpeed:
         mass: u.kg = None,
         ndim=3,
     ) -> u.m / u.s:
-        """A docstring for the __call__"""
+        """
+        This is the docstring defined in `_ThermalSpeed.__call__`.  It is inherited
+        by the function `thermal_speed` and thus would be written as if it's
+        the docstring for `thermal_speed` while in the `_ThermalSpeed` class.
+
+        Examples
+        --------
+
+        >>> thermal_speed(...)
+        >>> thermal_speed.lite(...)
+        """
         if mass is None:
             mass = particles.particle_mass(particle)
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -30,6 +30,8 @@ __all__ = [
     "rhoc_",
     "thermal_pressure",
     "thermal_speed",
+    "thermal_speed_coefficients",
+    "thermal_speed_lite",
     "ub_",
     "upper_hybrid_frequency",
     "va_",

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -741,7 +741,7 @@ class _ThermalSpeed:
         except KeyError:
             raise ValueError("Method {method} not supported in thermal_speed")
 
-        speed = self.unitless(T=T.value, mass=mass.value, coef=coef)
+        speed = self.lite(T=T.value, mass=mass.value, coef=coef)
         return speed * u.m / u.s
 
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -58,6 +58,8 @@ from plasmapy.utils.decorators import (
     angular_freq_to_hz,
     check_relativistic,
     validate_quantities,
+    preserve_signature,
+    modify_docstring,
 )
 from plasmapy.utils.exceptions import PhysicsWarning
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -55,11 +55,11 @@ from plasmapy.particles import Particle
 from plasmapy.particles.exceptions import ChargeError
 from plasmapy.utils import PhysicsError
 from plasmapy.utils.decorators import (
+    add_lite,
     angular_freq_to_hz,
     check_relativistic,
     validate_quantities,
     preserve_signature,
-    modify_docstring,
 )
 from plasmapy.utils.exceptions import PhysicsWarning
 

--- a/plasmapy/utils/decorators/__init__.py
+++ b/plasmapy/utils/decorators/__init__.py
@@ -2,6 +2,7 @@
 A module to contain various decorators used to build readable and useful code.
 """
 __all__ = [
+    "add_lite",
     "angular_freq_to_hz",
     "check_relativistic",
     "check_values",
@@ -24,5 +25,7 @@ from plasmapy.utils.decorators.checks import (
     CheckValues,
 )
 from plasmapy.utils.decorators.converter import angular_freq_to_hz
-from plasmapy.utils.decorators.helpers import modify_docstring, preserve_signature
+from plasmapy.utils.decorators.helpers import (
+    add_lite, modify_docstring, preserve_signature,
+)
 from plasmapy.utils.decorators.validators import validate_quantities, ValidateQuantities

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -142,3 +142,49 @@ def preserve_signature(f):
         wrapper.__signature__ = inspect.signature(f)
 
     return wrapper
+
+
+def add_lite(flite, attrs=None, scope=None):
+    """
+    Decorator to bind lightweight "lite" versions of formulary functions to the full
+    formulary function.
+    """
+    if attrs is None:
+        attrs = []
+    elif scope is None:
+        raise ValueError(
+            f"If 'attrs' are being bound to the decorate function, then 'scope'"
+            f" needs to be defined and contain the objects to be bound.  "
+            f"Setting 'scope=globals()' will typically suffice.")
+
+    def decorator(f):
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+
+        wrapper_doc = inspect.cleandoc(getattr(wrapper, "__doc__", """"""))
+
+        setattr(wrapper, "lite", flite)
+
+        wrapper_doc += "\n\n" + inspect.cleandoc(f"""
+        .. note:: To increase usability of `{f.__name__}` several attributes/functions
+           are manually bound to this function.
+
+           - `{f.__name__}.lite` <--> `~{flite.__module__}.{flite.__name__}`
+        """)
+
+        for bound_name, attr_name in attrs:
+            attr = scope[attr_name]
+
+            setattr(wrapper, bound_name, attr)
+
+            wrapper_doc += (
+                f"\n   - `{f.__name__}.{bound_name}` <--> `~{f.__module__}.{attr_name}`"
+            )
+
+        wrapper.__doc__ = wrapper_doc
+
+        return wrapper
+
+    return decorator

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -1,7 +1,7 @@
 """
 Miscellaneous decorators for various package uses.
 """
-__all__ = ["modify_docstring", "preserve_signature"]
+__all__ = ["add_lite", "modify_docstring", "preserve_signature"]
 
 import functools
 import inspect


### PR DESCRIPTION
This is a prototype for developing a framework to implement lite ("lightweight") formulary functionality whose design intent is for computation.  The current formulary functionality is constructed around Astropy's units for user convenience and to reduce calculation errors from improper unit use.  This is great, but yields very slow executing code.  The goal here is to develop a framework that still has our traditional formulary functionality but also an intuitive lite version for computation.

This prototype is developed for the `thermal_speed` function.  The approach this prototype takes is...

1. A lightweight thermal speed function is developed as `thermal_speed_lite`.   The formula this function has is based on SI units, but there is no argument validations (values or units).  The assumption here is the user knows what is going and can insure proper values are passed to the function.  The function is also decorated with `numba.njit`.
2. The previous `thermal_speed` function exists as it always has, but now utilizes `thermal_speed_lite` within the code for calculation.
3. A decorator `add_lite` is developed to bind `thermal_speed_lite` to `thermal_speed` as `thermal_speed.lite`, as well as update `thermal_speed`'s docstrings to indicate the addition of `lite`.

This all works something like...

```python
@preserve_signature  # this is needed since njit destroys the signature
@numba.njit
def thermal_speed_lite(...):
    ...

@add_lite(thermal_speed_lite)
@validate_quantities(...)
@particle_inpute
def thermal_speed(...):
    ...
```

The use now looks like...

```python
>>> T = 5 * u.K
>>> par = Particle("He+)
>>> thermal_speed(T, par)
<Quantity 144.13705752 m / s>

>>> %timeit thermal_speed(T, par)
717 µs ± 34.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

>>> # now using lite
>>> coef = thermal_speed.coefficients[3]["most_probable"]  # coefficients is also bound using add_lite
>>> thermal_speed.lite(T.value, par.mass.value, coef)
144.13705751725402

>>> %timeit thermal_speed.lite(T.value, par.mass.value, coef)
71.7 µs ± 3.16 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

>>> # better performance can be achieved if units don't have to be used at all
>>> T_unitless, mass_unitless = T.value, par.mass.value
>>> %timeit thermal_speed.lite(T_unitless, mass_unitless, coef)
397 ns ± 5.09 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```


---
See further discussions in #1090 