### PR TITLE
Move pre-commit to pre-commit.ci, but disable autofix

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,13 +6,6 @@ on:
     branches: [master]
 
 jobs:
-  pre-commit:
-    name: pre-commit
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
   gitHubActionForFlake8:
     name: flake8
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+  autofix_prs: false
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0

--- a/changelog/1106.trivial.rst
+++ b/changelog/1106.trivial.rst
@@ -1,0 +1,4 @@
+Move our custom pre-commit style testing suite to pre-commit.ci,
+taking advantage of the new `pre-commit.ci autofix` command that
+allows manually calling for pre-commit to be run. Simply type
+that as a comment to a PR.


### PR DESCRIPTION
I got the following email this morning:

> pre-commit.ci has just passed 45,000 total runs!
>
> A few new features to announce today:
>
> - pre-commit.ci runs on a pull requests can be retriggered by commenting "pre-commit.ci run" instead of needing to open / close the PR
>
> - pre-commit.ci pull request autofix can now be disabled using `autofix_prs: false` -- a manual trigger of autofixing can be done by commenting "pre-commit.ci autofix".  for more information see: https://pre-commit.ci/#configuration-autofix_prs
>
> Anthony

I believe that solves the issues raised by @rocco8773, so let's get this in!
:)

- [ ] I will still have to enable the service at pre-commit.ci after this is merged.