### PR TITLE
Set docutils < 0.17 requirement

### DIFF
--- a/requirements/automated-documentation-tests.txt
+++ b/requirements/automated-documentation-tests.txt
@@ -4,7 +4,7 @@
 ipykernel
 ipywidgets
 nbsphinx
-
+docutils < 0.17
 numpydoc
 pillow
 pygments >= 2.4.1

--- a/requirements/automated-documentation-tests.txt
+++ b/requirements/automated-documentation-tests.txt
@@ -1,10 +1,9 @@
+# requirments for documentation
 -r requirements.txt
-
-# doc pkgs
+docutils < 0.17
 ipykernel
 ipywidgets
 nbsphinx
-docutils < 0.17
 numpydoc
 pillow
 pygments >= 2.4.1

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - pip
   - xarray
   - pip:
+    - docutils < 0.17
     - numpydoc
     - pytest
     - lmfit

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ theory =
   mpmath
   lmfit
 docs =
+  docutils < 0.17
   numpydoc
   pillow
   pygments >= 2.4.1


### PR DESCRIPTION
The recent release (2021-04-03) of `docutils` `v0.17.0` is causing issues with rendering on RTD, https://github.com/readthedocs/sphinx_rtd_theme/issues/1115.  We are specifically suffering from improper rendering of the sidebar, like https://github.com/rdswift/picard-docs/issues/96.  This PR sets the requirement `docutils < 0.17`.