### PR TITLE
Pickleable particles

### DIFF
--- a/changelog/1122.bugfix.rst
+++ b/changelog/1122.bugfix.rst
@@ -1,0 +1,1 @@
+Made `~plasmapy.particles.Particle` instances pickleable.

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -14,9 +14,15 @@ import collections
 import json
 import pkgutil
 
-_PeriodicTable = collections.namedtuple(
-    "periodic_table", ["group", "category", "block", "period"]
-)
+from dataclasses import dataclass
+
+
+@dataclass
+class _PeriodicTable:
+    group: int
+    period: int
+    block: str
+    category: str
 
 
 def _element_obj_hook(obj):

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -19,17 +19,15 @@ class TestPickling:
     Test that different objects in `plasmapy.particles` can be pickled.
     """
 
-    xfail = pytest.mark.xfail(reason="see issue #1011")
-
     @pytest.mark.parametrize(
         "instance",
         [
             CustomParticle(mass=1 * u.kg, charge=1 * u.C),
             DimensionlessParticle(mass=5, charge=5),
-            pytest.param(Particle("p+"), marks=xfail),
-            pytest.param(IonicLevel("p+", 0.1, 1e9 * u.m ** -3), marks=xfail),
-            pytest.param(IonizationState("H", [0.5, 0.5]), marks=xfail),
-            pytest.param(IonizationStateCollection({"H": [0.5, 0.5]}), marks=xfail),
+            pytest.param(Particle("p+")),
+            pytest.param(IonicLevel("p+", 0.1, 1e9 * u.m ** -3)),
+            pytest.param(IonizationState("H", [0.5, 0.5])),
+            pytest.param(IonizationStateCollection({"H": [0.5, 0.5]})),
         ],
     )
     def test_pickling(self, instance, tmp_path):

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -24,10 +24,10 @@ class TestPickling:
         [
             CustomParticle(mass=1 * u.kg, charge=1 * u.C),
             DimensionlessParticle(mass=5, charge=5),
-            pytest.param(Particle("p+")),
-            pytest.param(IonicLevel("p+", 0.1, 1e9 * u.m ** -3)),
-            pytest.param(IonizationState("H", [0.5, 0.5])),
-            pytest.param(IonizationStateCollection({"H": [0.5, 0.5]})),
+            Particle("p+"),
+            IonicLevel("p+", 0.1, 1e9 * u.m ** -3),
+            IonizationState("H", [0.5, 0.5]),
+            IonizationStateCollection({"H": [0.5, 0.5]}),
         ],
     )
     def test_pickling(self, instance, tmp_path):


### PR DESCRIPTION
Closes #1011!

I do not fully understand why this works. But it seems that it does.

I was tinkering with slicing of IonizationState as part of #1059 (@namurphy I have actual arguments for that, and it's just the first of many travesties I want to do to IonizationState). I then somehow stumbled upon [this](https://docs.python.org/3/library/pickle.html#pickle-picklable:~:text=instances%20of%20such%20classes%20whose%20__dict__,section%20Pickling%20Class%20Instances%20for%20details), that got me thinking, I started looking at `Particle.__dict__`, noticed that `json.dumps(particle)` complains about `_PeriodicTable` contained within that `__dict__`, realized that's a namedtuple, thought hey, if namedtuples have trouble pickling (I don't understand why they would, that's my whole problem with this solutin!), maybe dataclasses wouldn't. And guess what, they don't. And the xfailing tests started passing.

@pheuer could you look at that issue you had previously with scipy.optimize, maybe even add a smaller test case of that somewhere as a failing (`pytest.mark.xfail`)? I'd like to check again. Maybe this got fixed.