### PR TITLE
`hypothesis` tests; numba-based fixes for `Chandrasekhar_G`

### DIFF
--- a/changelog/1125.bugfix.rst
+++ b/changelog/1125.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the behavior of `~plasmapy.formulary.mathematics.Chandrasekhar_G` at very small and very large argument values.

--- a/changelog/1125.trivial.rst
+++ b/changelog/1125.trivial.rst
@@ -1,0 +1,1 @@
+Added tests using ```hypothesis`` <https://hypothesis.readthedocs.io/>`__.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+from hypothesis import settings, Verbosity
+
+settings.register_profile("ci", max_examples=1000)
+settings.register_profile("dev", max_examples=10)
+settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
+settings.load_profile(os.getenv(u"HYPOTHESIS_PROFILE", "default"))

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -2,14 +2,14 @@
 
 __all__ = ["Fermi_integral", "Chandrasekhar_G", "rot_a_to_b"]
 
+import numba
+import numba_scipy
 import numbers
 import numpy as np
 
+from numba import float64, vectorize
 from scipy import special
 from typing import Union
-import numba
-import numba_scipy
-from numba import vectorize, float64
 
 
 def Fermi_integral(
@@ -94,9 +94,11 @@ def Fermi_integral(
         raise TypeError(f"Improper type {type(x)} given for argument x.")
 
 
-@vectorize([
-    float64(float64),
-])
+@vectorize(
+    [
+        float64(float64),
+    ]
+)
 def Chandrasekhar_G(x: float):
     r"""
     Calculate the Chandrasekhar G function used in transport theory.

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -7,6 +7,9 @@ import numpy as np
 
 from scipy import special
 from typing import Union
+import numba
+import numba_scipy
+from numba import vectorize, float64
 
 
 def Fermi_integral(
@@ -91,6 +94,9 @@ def Fermi_integral(
         raise TypeError(f"Improper type {type(x)} given for argument x.")
 
 
+@vectorize([
+    float64(float64),
+])
 def Chandrasekhar_G(x: float):
     r"""
     Calculate the Chandrasekhar G function used in transport theory.
@@ -144,6 +150,8 @@ def Chandrasekhar_G(x: float):
 
     """
 
+    if abs(x) < np.finfo(np.float64).eps:
+        return 2 * x / 3 / np.sqrt(np.pi)
     erf = special.erf(x)
     erf_derivative = 2 * np.exp(-(x ** 2)) / np.sqrt(np.pi)
     return 0.5 * (erf / x ** 2 - erf_derivative / x)

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -152,10 +152,10 @@ def Chandrasekhar_G(x: float):
 
     """
 
-    if abs(x) < np.finfo(np.float64).eps:
+    if 100 * abs(x) < np.finfo(np.float64).eps:
         return 2 * x / 3 / np.sqrt(np.pi)
     elif abs(x) > np.finfo(np.float64).max:
-        return 1 / (2 * x ** 2) 
+        return 1 / (2 * x ** 2)
     erf = special.erf(x)
     erf_derivative = 2 * np.exp(-(x ** 2)) / np.sqrt(np.pi)
     return 0.5 * (erf / x ** 2 - erf_derivative / x)

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -152,6 +152,8 @@ def Chandrasekhar_G(x: float):
 
     if abs(x) < np.finfo(np.float64).eps:
         return 2 * x / 3 / np.sqrt(np.pi)
+    elif abs(x) > np.finfo(np.float64).max:
+        return 1 / (2 * x ** 2) 
     erf = special.erf(x)
     erf_derivative = 2 * np.exp(-(x ** 2)) / np.sqrt(np.pi)
     return 0.5 * (erf / x ** 2 - erf_derivative / x)

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -131,7 +131,7 @@ def Chandrasekhar_G(x: float):
     >>> Chandrasekhar_G(1)
     0.21379664776456
     >>> Chandrasekhar_G(1e-6)
-    3.7608262858090935e-07
+    3.7602148950099945e-07
     >>> Chandrasekhar_G(1e6)
     5e-13
     >>> Chandrasekhar_G(-1)
@@ -146,7 +146,7 @@ def Chandrasekhar_G(x: float):
 
     erf = special.erf(x)
     erf_derivative = 2 * np.exp(-(x ** 2)) / np.sqrt(np.pi)
-    return (erf - x * erf_derivative) / (2 * x ** 2)
+    return 0.5 * (erf / x ** 2 - erf_derivative / x)
 
 
 def rot_a_to_b(a: np.ndarray, b: np.ndarray) -> np.ndarray:

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -23,7 +23,7 @@ def test_Chandrasekhar_with_hypothesis(x):
     assert abs(result) < 0.21399915915288345  # maximum bound found via scipy optimize
     assert np.isfinite(result)
     
-    symmetric_result = Chandrasekhar_g(-x)   # antisymmetric function
+    symmetric_result = Chandrasekhar_G(-x)   # antisymmetric function
     assert result == -symmetric_result
 
 

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -22,8 +22,8 @@ def test_Chandrasekhar_with_hypothesis(x):
     result = Chandrasekhar_G(x)
     assert abs(result) <= 0.21399915915288345  # maximum bound found via scipy optimize
     assert np.isfinite(result)
-    
-    symmetric_result = Chandrasekhar_G(-x)   # antisymmetric function
+
+    symmetric_result = Chandrasekhar_G(-x)  # antisymmetric function
     assert result == -symmetric_result
 
 

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -1,6 +1,26 @@
+import hypothesis
 import numpy as np
 
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
 from plasmapy.formulary.mathematics import Chandrasekhar_G
+
+
+@given(
+    x=st.floats(
+        min_value=6e-150,
+        max_value=1e90,
+        exclude_min=True,
+        allow_nan=False,
+        allow_infinity=False,
+    )
+)
+@settings(max_examples=500)
+def test_Chandrasekhar_with_hypothesis(x):
+    result = Chandrasekhar_G(x)
+    assert x > 0
+    assert np.isfinite(x)
 
 
 def test_Chandrasekhar_regression(num_regression):

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -1,7 +1,7 @@
 import hypothesis
 import numpy as np
 
-from hypothesis import given
+from hypothesis import example, given
 from hypothesis import strategies as st
 
 from plasmapy.formulary.mathematics import Chandrasekhar_G
@@ -13,6 +13,11 @@ from plasmapy.formulary.mathematics import Chandrasekhar_G
         allow_infinity=False,
     )
 )
+@example(x=np.finfo(np.float64).eps)
+@example(x=np.finfo(np.float64).max)
+@example(x=np.finfo(np.float64).min)
+@example(x=0)
+@example(x=3.761264e-20)
 def test_Chandrasekhar_with_hypothesis(x):
     result = Chandrasekhar_G(x)
     assert abs(result) < 0.21399915915288345  # maximum bound found via scipy optimize
@@ -37,7 +42,7 @@ def test_limiting_behavior_small_x():
 
 
 def test_limiting_behavior_high_x():
-    x = np.logspace(6, 9, 100)
+    x = np.logspace(6, 90, 100)
     y = Chandrasekhar_G(x)
     limiting_behavior = x ** -2 / 2
     np.testing.assert_allclose(y, limiting_behavior)

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -9,7 +9,6 @@ from plasmapy.formulary.mathematics import Chandrasekhar_G
 
 @given(
     x=st.floats(
-        max_value=1e90,
         allow_nan=False,
         allow_infinity=False,
     )

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -20,7 +20,7 @@ from plasmapy.formulary.mathematics import Chandrasekhar_G
 @example(x=3.761264e-20)
 def test_Chandrasekhar_with_hypothesis(x):
     result = Chandrasekhar_G(x)
-    assert abs(result) < 0.21399915915288345  # maximum bound found via scipy optimize
+    assert abs(result) <= 0.21399915915288345  # maximum bound found via scipy optimize
     assert np.isfinite(result)
     
     symmetric_result = Chandrasekhar_G(-x)   # antisymmetric function

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -9,9 +9,7 @@ from plasmapy.formulary.mathematics import Chandrasekhar_G
 
 @given(
     x=st.floats(
-        min_value=6e-150,
         max_value=1e90,
-        exclude_min=True,
         allow_nan=False,
         allow_infinity=False,
     )

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -17,8 +17,8 @@ from plasmapy.formulary.mathematics import Chandrasekhar_G
 @settings(max_examples=500)
 def test_Chandrasekhar_with_hypothesis(x):
     result = Chandrasekhar_G(x)
-    assert x > 0
-    assert np.isfinite(x)
+    assert abs(result) < 0.21399915915288345  # maximum bound found via scipy optimize
+    assert np.isfinite(result)
 
 
 def test_Chandrasekhar_regression(num_regression):

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -1,7 +1,7 @@
 import hypothesis
 import numpy as np
 
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from plasmapy.formulary.mathematics import Chandrasekhar_G
@@ -13,7 +13,6 @@ from plasmapy.formulary.mathematics import Chandrasekhar_G
         allow_infinity=False,
     )
 )
-@settings(max_examples=500)
 def test_Chandrasekhar_with_hypothesis(x):
     result = Chandrasekhar_G(x)
     assert abs(result) < 0.21399915915288345  # maximum bound found via scipy optimize

--- a/plasmapy/formulary/tests/test_Chandrasekhar_G.py
+++ b/plasmapy/formulary/tests/test_Chandrasekhar_G.py
@@ -22,6 +22,9 @@ def test_Chandrasekhar_with_hypothesis(x):
     result = Chandrasekhar_G(x)
     assert abs(result) < 0.21399915915288345  # maximum bound found via scipy optimize
     assert np.isfinite(result)
+    
+    symmetric_result = Chandrasekhar_g(-x)   # antisymmetric function
+    assert result == -symmetric_result
 
 
 def test_Chandrasekhar_regression(num_regression):

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -16,7 +16,10 @@ dependencies:
   - pillow
   - pip
   - xarray
+  - numba
   - pip:
+    - numba-scipy
+    - hypothesis
     - docutils < 0.17
     - numpydoc
     - pytest

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -3,5 +3,7 @@
 h5py
 lmfit
 mpmath
+numba
+numba-scipy
 pytest >= 5.1
 setuptools_scm

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,6 @@
 # these are dependencies required to run package tests
 # ought to mirror 'tests' under options.extras_require in setup.cfg
 -r extras.txt
+hypothesis
 pytest >= 5.1
 pytest-regressions

--- a/setup.cfg
+++ b/setup.cfg
@@ -221,3 +221,5 @@ exclude_lines =
     coverage: ignore
     ImportError
     ModuleNotFoundError
+    @vectorize
+    @numba.vectorize

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,10 +57,13 @@ extras =
   # for plasmapy.formulary
   mpmath
   lmfit
+  numba
+  numba-scipy
 tests =
   # ought to mirror requirements/tests.txt
   %(extras)s
   pytest >= 5.1
+  hypothesis
   pytest-regressions
 docs =
   # ought to mirror requirements/docs.txt

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,10 @@ conda_deps =
   pillow
   sphinx
   sphinx_rtd_theme
+  pytest-regressions
+  numba-scipy
+  numba
+  hypothesis
 
 # This env tests minimal versions of each dependency.
 [testenv:py37-minimal]
@@ -86,7 +90,11 @@ deps =
   pytest==5.1
   mpmath==1.0
   pillow
+  hypothesis
   pytest-regressions
+  numba-scipy
+  numba
+  hypothesis
 
 setenv =
     PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 {toxinidir}/docs --ignore={toxinidir}/docs/conf.py


### PR DESCRIPTION
From #1059. This PR:

* adds tests for `Chandrasekhar_G` using [`hypothesis`](https://hypothesis.readthedocs.io/); **I would like to use this as an example for the tutorial I was supposed to give yesterday and will give at the telecon sometime soon.** So I suspect it will become clearer what it does then. I suspect we'll record that, too. Thus, this is reviewable, but with that caveat.
* turns `Chandrasekhar_G` into a numpy `ufunc` using `numba.vectorize`. This lets me handle the cases of very small and very large arguments cleanly, while allowing application to numpy arrays, without the annoyances of floating point numerical errors.
* uses https://github.com/numba/numba-scipy 's implementation of `erf`. It does so implicitly through numba's clever overload mechanisms. I just import the package and it registers its overload for `scipy.special.erf`