### PR TITLE
Remove deprecated Particle.particle

### DIFF
--- a/changelog/1146.removal.rst
+++ b/changelog/1146.removal.rst
@@ -1,0 +1,2 @@
+The ``particle`` attribute of `~plasmapy.particles.particle_class.Particle`
+has been removed after having been deprecated in 0.6.0.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -741,23 +741,6 @@ class Particle(AbstractPhysicalParticle):
         return particle_dictionary
 
     @property
-    def particle(self) -> str:
-        """
-        The symbol of the particle, atom, isotope, or ion.
-
-        .. deprecated:: 0.6.0
-            `Particle.particle` has been deprecated and will be removed in
-            a subsequent release of PlasmaPy.  Use `Particle.symbol`
-            instead.
-        """
-        warnings.warn(
-            "Particle.particle has been deprecated and will be removed in "
-            "a subsequent release. Use Particle.symbol instead.",
-            FutureWarning,
-        )
-        return self.symbol
-
-    @property
     def symbol(self) -> str:
         """
         The symbol of the particle, atom, isotope, or ion.


### PR DESCRIPTION
This PR removes `Particle.particle`, which had previously been deprecated in favor of `Particle.symbol` in #984.  This wasn't a widely used feature so it should be fine to have it emit a `FutureWarning` in 0.6.0, and then to remove it in the next release (0.7.0).