### PR TITLE
Change code & docs to reflect a default branch named main

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -211,7 +211,7 @@ Backwards Incompatible Changes
 ------------------------------
 
 - Created `plasmapy.dispersion` in accordance with PlasmaPy Enhancement Proposal 7
-  (`PLEP 7 <https://github.com/PlasmaPy/PlasmaPy-PLEPs/blob/master/PLEP-0007.rst>`_)
+  (`PLEP 7 <https://github.com/PlasmaPy/PlasmaPy-PLEPs/blob/main/PLEP-0007.rst>`_)
   and migrated the dispersion functionality (`dispersionfunction.py`) from
   `plasmapy.formulary` to `plasmapy.dispersion`. (`#910 <https://github.com/plasmapy/plasmapy/pull/910>`__)
 - Removed default values for the `ion` and `particle` arguments of functions contained in `plasmapy.formulary.parameters`, in accordance with issue [#453](https://github.com/PlasmaPy/PlasmaPy/issues/453), and updated all relevant calls to modified functionality. (`#911 <https://github.com/plasmapy/plasmapy/pull/911>`__)
@@ -228,7 +228,7 @@ Features
 - Added support for multiple electron components to diagnostics.thomson.spectral_density. Also fixed a bug for multiple ion populations. (`#893 <https://github.com/plasmapy/plasmapy/pull/893>`__)
 - Add dependency `pygments >= 2.4.1`. (`#898 <https://github.com/plasmapy/plasmapy/pull/898>`__)
 - Create the `plasmapy.analysis` package as per
-  `PLEP-7 <https://github.com/PlasmaPy/PlasmaPy-PLEPs/blob/master/PLEP-0007.rst>`_ and
+  `PLEP-7 <https://github.com/PlasmaPy/PlasmaPy-PLEPs/blob/main/PLEP-0007.rst>`_ and
   initialize the package with the `~plasmapy.analysis.fit_functions` module.  Fit
   functions are designed to wrap together an analytical function, a curve fitter,
   uncertainty propagation, and a root solver to make curve fitting a little less

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="https://raw.githubusercontent.com/PlasmaPy/PlasmaPy-logo/master/exports/with-text-dark.png" width="600"/></div>
+<div align="center"><img src="https://raw.githubusercontent.com/PlasmaPy/PlasmaPy-logo/main/exports/with-text-dark.png" width="600"/></div>
 
 # PlasmaPy
 
@@ -11,12 +11,12 @@
 [![YouTube](https://img.shields.io/badge/Twitter%20-follow-red?style=flat&logo=twitter)](https://www.youtube.com/channel/UCSH6qzslhqIZKTAJmHPxIxw)
 [![YouTube](https://img.shields.io/badge/YouTube%20-subscribe-red?style=flat&logo=youtube)](https://www.youtube.com/channel/UCSH6qzslhqIZKTAJmHPxIxw)
 
-[![GitHub Actions — CI](https://github.com/PlasmaPy/PlasmaPy/workflows/CI/badge.svg)](https://github.com/PlasmaPy/PlasmaPy/actions?query=workflow%3ACI+branch%3Amaster)
-[![GitHub Actions — Style linters](https://github.com/PlasmaPy/PlasmaPy/workflows/Style%20linters/badge.svg)](https://github.com/PlasmaPy/PlasmaPy/actions?query=workflow%3AStyle-linters+branch%3Amaster)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/PlasmaPy/PlasmaPy/master.svg)](https://results.pre-commit.ci/latest/github/PlasmaPy/PlasmaPy/master)
-[![codecov](https://codecov.io/gh/PlasmaPy/PlasmaPy/branch/master/graph/badge.svg)](https://codecov.io/gh/PlasmaPy/PlasmaPy)
+[![GitHub Actions — CI](https://github.com/PlasmaPy/PlasmaPy/workflows/CI/badge.svg)](https://github.com/PlasmaPy/PlasmaPy/actions?query=workflow%3ACI+branch%3Amain)
+[![GitHub Actions — Style linters](https://github.com/PlasmaPy/PlasmaPy/workflows/Style%20linters/badge.svg)](https://github.com/PlasmaPy/PlasmaPy/actions?query=workflow%3AStyle-linters+branch%3Amain)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/PlasmaPy/PlasmaPy/main.svg)](https://results.pre-commit.ci/latest/github/PlasmaPy/PlasmaPy/main)
+[![codecov](https://codecov.io/gh/PlasmaPy/PlasmaPy/branch/main/graph/badge.svg)](https://codecov.io/gh/PlasmaPy/PlasmaPy)
 [![Read the Docs Status](https://readthedocs.org/projects/plasmapy/badge/?version=latest&logo=twitter)](http://plasmapy.readthedocs.io/en/latest/?badge=latest)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PlasmaPy/PlasmaPy/master?filepath=docs/notebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PlasmaPy/PlasmaPy/main?filepath=docs/notebooks)
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1436011.svg)](https://doi.org/10.5281/zenodo.1436011)
 [![astropy](http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat&logo=astropy)](http://www.astropy.org/)

--- a/changelog/1150.doc.rst
+++ b/changelog/1150.doc.rst
@@ -1,0 +1,4 @@
+Changed the default branch name to ``main``.  Locations in the code
+and documentation that referred to the default branch of PlasmaPy (and
+certain other packages) were changed to reflect the new name (including,
+for example, in the development guide in the documentation).

--- a/docs/about/vision_statement.rst
+++ b/docs/about/vision_statement.rst
@@ -130,7 +130,7 @@ code <https://www.python.org/dev/peps/pep-0008/>`_ and the established
 coding style within PlasmaPy. New code should be submitted with
 documentation and tests. Documentation should be written primarily in
 docstrings and follow the `numpydoc documentation style
-guide <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_.
+guide <https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt>`_.
 Every new module, class and function should have an appropriate
 docstring. The documentation should describe the interface and the
 purpose for the method, but generally not the implementation. The code

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -268,7 +268,7 @@ nbsphinx_thumbnails = {
 nbsphinx_prolog = r"""
 {% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
 {% set nb_base = 'tree' if env.config.revision else 'blob' %}
-{% set nb_where = env.config.revision if env.config.revision else 'master' %}
+{% set nb_where = env.config.revision if env.config.revision else 'main' %}
 
 .. raw:: html
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,8 +94,8 @@ templates_path = ["_templates"]
 # source_suffix = ['.rst', '.md']
 source_suffix = ".rst"
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # General information about the project.
 project = "PlasmaPy"
@@ -209,7 +209,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (
-        master_doc,
+        root_doc,
         "PlasmaPy.tex",
         "PlasmaPy Documentation",
         "PlasmaPy Community",
@@ -222,7 +222,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "plasmapy", "PlasmaPy Documentation", [author], 1)]
+man_pages = [(root_doc, "plasmapy", "PlasmaPy Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -232,7 +232,7 @@ man_pages = [(master_doc, "plasmapy", "PlasmaPy Documentation", [author], 1)]
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "PlasmaPy",
         "PlasmaPy Documentation",
         author,

--- a/docs/development/code_guide.rst
+++ b/docs/development/code_guide.rst
@@ -34,7 +34,7 @@ with version, so, rather than apply `black` and `isort` manually, let
 pre-commit do the version management for you instead!
 
 Our pre-commit suite can be found in `.pre-commit-config.yaml
-<https://github.com/PlasmaPy/PlasmaPy/blob/master/.pre-commit-config.yaml>`_.
+<https://github.com/PlasmaPy/PlasmaPy/blob/main/.pre-commit-config.yaml>`_.
 It includes
 
 * `black <https://black.readthedocs.io/en/stable/>`_ to automatically
@@ -103,7 +103,7 @@ repository:
   git fetch upstream
 
 Changes to PlasmaPy should be made using branches.  It is usually best
-to avoid making changes on your master branch so that it can be kept
+to avoid making changes on your main branch so that it can be kept
 consistent with the upstream repository.  Instead we can create a new
 branch for the specific feature that you would like to work on:
 
@@ -141,7 +141,7 @@ recommend reading about `best practices for scientific computing
 `PEP 8 style guide for Python code
 <https://www.python.org/dev/peps/pep-0008/>`_ and the `numpydoc format
 for docstrings
-<https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_
+<https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt>`_
 to maintain consistency and readability.  New contributors should not
 worry too much about precisely matching these styles when first
 submitting a pull request, as the `PEP8 Speaks
@@ -335,7 +335,7 @@ by an angular frequency to get a length scale:
 Examples
 ========
 
-.. _docs/notebooks: https://github.com/PlasmaPy/PlasmaPy/tree/master/docs/notebooks
+.. _docs/notebooks: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/notebooks
 .. _nbsphinx: https://nbsphinx.readthedocs.io/en/latest/
 
 Examples in PlasmaPy are written as Jupyter notebooks, taking advantage

--- a/docs/development/doc_guide.rst
+++ b/docs/development/doc_guide.rst
@@ -8,7 +8,7 @@ packages.
 
 Building documentation
 ======================
-Documentation is built from the master branch on every commit pushed
+Documentation is built from the main branch on every commit pushed
 to it.
 
 Sphinx, the documentation generator of PlasmaPy, uses reStructuredText (reST) as its markup language. A primer on reST is available at this `webpage

--- a/docs/development/release_guide.rst
+++ b/docs/development/release_guide.rst
@@ -41,13 +41,13 @@ Release
   consistent with the Zenodo record.  Update any other tags if necessary. Check
   ``.mailmap``, ``codemeta.json``, and ``docs/about/credits.rst``.
 
-* ``hub ci-status master -v`` — Check that the Continuous Integration is passing
-  for the correct version `(see the latest commit on master)
-  <https://github.com/PlasmaPy/PlasmaPy/commits/master>`_. You can use the handy
+* ``hub ci-status main -v`` — Check that the Continuous Integration is passing
+  for the correct version `(see the latest commit on main)
+  <https://github.com/PlasmaPy/PlasmaPy/commits/main>`_. You can use the handy
   `hub <https://github.com/github/hub>`_ command line interface (CLI) tool.
 
 * ``git checkout -b v0.6.x`` — create a new branch for the release that is
-  separate from the master branch, with the bugfix version replaced by ``x``, for
+  separate from the main branch, with the bugfix version replaced by ``x``, for
   example, ``v0.6.x``. This is the branch for the entire series of releases — if
   you're releasing, say, ``0.6.1``, the main repository should already have a
   branch for that.
@@ -83,7 +83,7 @@ Release
 
 * Commit and push your changes up until now.
 
-* Open them up as a Pull Request from the ``0.6.x`` branch to the master branch.
+* Open them up as a Pull Request from the ``0.6.x`` branch to the main branch.
 
 * Make sure that tests pass and that documentation builds without issue.
 
@@ -111,7 +111,7 @@ for the new version!
 Post-release
 ------------
 
-* Merge the pull request from the version branch to master.
+* Merge the pull request from the version branch to main.
 
 * If necessary (for MINOR+ and not for BUGFIX versions) activate the new
   branch's version `on Read the Docs

--- a/docs/notebooks/langmuir_samples/_generate_noisy.ipynb
+++ b/docs/notebooks/langmuir_samples/_generate_noisy.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "# read in example data\n",
     "# this can be found at\n",
-    "#   https://github.com/PlasmaPy/PlasmaPy/blob/master/docs/notebooks/langmuir_samples/Beckers2017.npy\n",
+    "#   https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/notebooks/langmuir_samples/Beckers2017.npy\n",
     "#\n",
     "filename = \"Beckers2017\"\n",
     "voltage, current = np.load(filename + \".npy\")\n",

--- a/docs/whatsnew/0.1.0.rst
+++ b/docs/whatsnew/0.1.0.rst
@@ -18,7 +18,7 @@ New Features
 * Created a guide on :ref:`contributing-to-plasmapy`.
 
 * Adopted a permissive BSD 3-clause `license
-  <https://github.com/PlasmaPy/PlasmaPy/blob/master/LICENSE.md>`_ with
+  <https://github.com/PlasmaPy/PlasmaPy/blob/main/LICENSE.md>`_ with
   protections against software patents.
 
 * Set up continuous integration testing with `Travis CI

--- a/docs/whatsnew/0.5.0.rst
+++ b/docs/whatsnew/0.5.0.rst
@@ -20,7 +20,7 @@ Backwards Incompatible Changes
 ------------------------------
 
 - Created `plasmapy.dispersion` in accordance with PlasmaPy Enhancement Proposal 7
-  (`PLEP 7 <https://github.com/PlasmaPy/PlasmaPy-PLEPs/blob/master/PLEP-0007.rst>`_)
+  (`PLEP 7 <https://github.com/PlasmaPy/PlasmaPy-PLEPs/blob/main/PLEP-0007.rst>`_)
   and migrated the dispersion functionality (`dispersionfunction.py`) from
   `plasmapy.formulary` to `plasmapy.dispersion`. (`#910 <https://github.com/plasmapy/plasmapy/pull/910>`__)
 - Removed default values for the `ion` and `particle` arguments of functions contained in `plasmapy.formulary.parameters`, in accordance with issue [#453](https://github.com/PlasmaPy/PlasmaPy/issues/453), and updated all relevant calls to modified functionality. (`#911 <https://github.com/plasmapy/plasmapy/pull/911>`__)
@@ -37,7 +37,7 @@ Features
 - Added support for multiple electron components to diagnostics.thomson.spectral_density. Also fixed a bug for multiple ion populations. (`#893 <https://github.com/plasmapy/plasmapy/pull/893>`__)
 - Add dependency `pygments >= 2.4.1`. (`#898 <https://github.com/plasmapy/plasmapy/pull/898>`__)
 - Create the `plasmapy.analysis` package as per
-  `PLEP-7 <https://github.com/PlasmaPy/PlasmaPy-PLEPs/blob/master/PLEP-0007.rst>`_ and
+  `PLEP-7 <https://github.com/PlasmaPy/PlasmaPy-PLEPs/blob/main/PLEP-0007.rst>`_ and
   initialize the package with the `~plasmapy.analysis.fit_functions` module.  Fit
   functions are designed to wrap together an analytical function, a curve fitter,
   uncertainty propagation, and a root solver to make curve fitting a little less

--- a/licenses/PlasmaPy_LICENSE_preOct2017.md
+++ b/licenses/PlasmaPy_LICENSE_preOct2017.md
@@ -32,7 +32,7 @@ of this software, even if advised of the possibility of such damage.
 # Notice
 
 [PlasmaPy's
-license](https://github.com/PlasmaPy/PlasmaPy/blob/master/LICENSE.md)
+license](https://github.com/PlasmaPy/PlasmaPy/blob/main/LICENSE.md)
 was [updated on 2017 October
 19](https://github.com/PlasmaPy/PlasmaPy/pull/114) to include
 protections against software patents from the [BSD+Patent
@@ -42,7 +42,7 @@ license](plasmapy-license-prior-to-2017-october-19).  Most
 contributors to PlasmaPy [have
 agreed](https://github.com/PlasmaPy/PlasmaPy/pull/114) to have
 their contributions covered by the [new
-license](https://github.com/PlasmaPy/PlasmaPy/blob/master/LICENSE.md).
+license](https://github.com/PlasmaPy/PlasmaPy/blob/main/LICENSE.md).
 Pull requests
 [#63](https://github.com/PlasmaPy/PlasmaPy/pull/63),
 [#77](https://github.com/PlasmaPy/PlasmaPy/pull/77),

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -32,7 +32,7 @@ class BasePlasma(ABC):
     # abstract methods.
 
     # For reference, see
-    # https://github.com/sunpy/ndcube/blob/master/ndcube/ndcube.py#L26
+    # https://github.com/sunpy/ndcube/blob/main/ndcube/ndcube.py#L26
 
     @property
     @abstractmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,9 @@ build-backend = "setuptools.build_meta"
   [ tool.gilesbot.towncrier_changelog ]
       enabled = true
       changelog_skip_label = "No changelog entry needed"
-      help_url = "https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst"
+      help_url = "https://github.com/PlasmaPy/PlasmaPy/blob/main/changelog/README.rst"
       changelog_missing = "Missing changelog entry"
-      changelog_missing_long = "This pull request needs a changelog entry file in `changelog/NUMBER.TYPE.rst`. For more information, consult https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst "
+      changelog_missing_long = "This pull request needs a changelog entry file in `changelog/NUMBER.TYPE.rst`. For more information, consult https://github.com/PlasmaPy/PlasmaPy/blob/main/changelog/README.rst "
       number_incorrect = "Incorrect changelog entry number (match PR!)"
       number_incorrect_long = "The changelog entry's number does not match this pull request's number."
       type_incorrect = "Incorrect changelog entry type (see list in changelog README)"

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ commands =
 
 description =
     run tests
-    numpydev: with the git master version of numpy
-    astropydev: with the git master version of astropy
+    numpydev: with the git main version of numpy
+    astropydev: with the git main version of astropy
     xarraydev: with the git master version of xarray
     minimal: with minimal versions of dependencies
     cov: with code coverage


### PR DESCRIPTION
This PR makes the changes in the code associated with default branch name change from `master` to `main` in our repositories.  GitHub has made it [easier to change the name of the default branch](https://github.com/github/renaming), which will make this change significantly smoother.  For example, pull requests to `master` will be automagically shifted to `main`.  One-time instructions will pop up for people coming to the repository in order to update clones on their local computers.

A few other packages have changed `master` → `main`, including Astropy and NumPy, so some of the changes are associated with that.  Two packages that have not yet done so are Sphinx and xarray, so I've left those links alone.  The change in `conf.py` from `master_doc` → `root_doc` comes from a [name change in Sphinx](https://www.sphinx-doc.org/en/master/usage/configuration.html?highlight=master_doc#confval-root_doc).

Tasks yet to do include:

 - [ ] Change PlasmaPy default branch to `main`
 - [ ] Update branch name on read the docs
 - [ ] Change PlasmaPy-logo default branch to `main`
 - [ ] Change PlasmaPy-PLEPs default branch to `main`
 - [ ] Change `master` to `main` as needed within code in plasmapy.github.io
 - [ ] Change branch name in plasmapy.github.io

Closes #1087.