### PR TITLE
Bump required tqdm down to 4.41.0

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -23,7 +23,7 @@ PlasmaPy requires the following packages for installation:
 - `Astropy`_ — 4.0 or newer
 - `pandas <https://pandas.pydata.org/>`_ — 1.0 or newer
 - `xarray <http://xarray.pydata.org>`_ — above 0.14
-- `tqdm <https://tqdm.github.io/>`_ — 4.56 or newer
+- `tqdm <https://tqdm.github.io/>`_ — 4.41 or newer
 - `cached_property <https://pypi.org/project/cached-property/>`_ — 1.5.2 or newer
 
 PlasmaPy also depends on the following packages for optional features:

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -7,5 +7,5 @@ numpy >= 1.18.1
 pandas >= 1.0.0
 scipy >= 1.2
 setuptools >= 41.2
-tqdm >= 4.56.0
+tqdm >= 4.41.0
 xarray >= 0.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
   pandas >= 1.0.0
   scipy >= 1.2
   setuptools >= 41.2
-  tqdm >= 4.56.0
+  tqdm >= 4.41.0
   xarray >= 0.14.0
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ deps =
   matplotlib==2.0
   pytest==5.1
   mpmath==1.0
+  tqdm==4.41.0
   pillow
   hypothesis
   pytest-regressions


### PR DESCRIPTION
as per report by @qudsiramiz 
at https://matrix.to/#/!hkWCiyhQyxiYJlUtKF:matrix.org/$162274090999775hfdGF:matrix.org?via=matrix.org

this is to accomodate the version available at google colab