### PR TITLE
change behaviour of gyroradius when arguments are nan

### DIFF
--- a/changelog/1187.feature.rst
+++ b/changelog/1187.feature.rst
@@ -1,0 +1,3 @@
+The behaviour of the function `~plasmapy.formulary.parameters.gyroradius` has
+been changed: if NaN-values are provided for T_i or Vperp, no longer is a 
+slightly misleading error raised, but simply NaN is returned.

--- a/changelog/1187.feature.rst
+++ b/changelog/1187.feature.rst
@@ -1,3 +1,3 @@
 The behaviour of the function `~plasmapy.formulary.parameters.gyroradius` has
-been changed: if NaN-values are provided for T_i or Vperp, no longer is a 
+been changed: if NaN-values are provided for T_i or Vperp, no longer is a
 slightly misleading error raised, but simply NaN is returned.

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1198,7 +1198,7 @@ def gyroradius(
 
     # check 1: ensure either Vperp or T_i invalid, keeping in mind that
     # the underlying values of the astropy quantity may be numpy arrays
-    if np.any(np.logical_not(np.logical_xor(isfinite_Vperp, isfinite_Ti))):
+    if np.any(np.logical_and(isfinite_Vperp, isfinite_Ti)):
         raise ValueError(
             "Must give Vperp or T_i, but not both, as arguments to gyroradius"
         )

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -802,6 +802,11 @@ def test_gyroradius():
 
     assert gyroradius(B, "e-", Vperp=25 * u.m / u.s).unit.is_equivalent(u.m)
 
+    # test for possiblity to allow nan for input values
+    assert np.isnan(gyroradius(np.nan*u.T, particle="e-", T_i=T_i))
+    assert np.isnan(gyroradius(1*u.T, particle="e-", T_i=np.nan*u.K))
+    assert np.isnan(gyroradius(1*u.T, particle="e-", Vperp=np.nan*u.m/u.s))
+
     Vperp = 1e6 * u.m / u.s
     Bmag = 1 * u.T
     omega_ce = gyrofrequency(Bmag, "e-")

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -803,9 +803,9 @@ def test_gyroradius():
     assert gyroradius(B, "e-", Vperp=25 * u.m / u.s).unit.is_equivalent(u.m)
 
     # test for possiblity to allow nan for input values
-    assert np.isnan(gyroradius(np.nan*u.T, particle="e-", T_i=1*u.K))
-    assert np.isnan(gyroradius(1*u.T, particle="e-", T_i=np.nan*u.K))
-    assert np.isnan(gyroradius(1*u.T, particle="e-", Vperp=np.nan*u.m/u.s))
+    assert np.isnan(gyroradius(np.nan * u.T, particle="e-", T_i=1 * u.K))
+    assert np.isnan(gyroradius(1 * u.T, particle="e-", T_i=np.nan * u.K))
+    assert np.isnan(gyroradius(1 * u.T, particle="e-", Vperp=np.nan * u.m / u.s))
 
     Vperp = 1e6 * u.m / u.s
     Bmag = 1 * u.T

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -803,7 +803,7 @@ def test_gyroradius():
     assert gyroradius(B, "e-", Vperp=25 * u.m / u.s).unit.is_equivalent(u.m)
 
     # test for possiblity to allow nan for input values
-    assert np.isnan(gyroradius(np.nan*u.T, particle="e-", T_i=T_i))
+    assert np.isnan(gyroradius(np.nan*u.T, particle="e-", T_i=1*u.K))
     assert np.isnan(gyroradius(1*u.T, particle="e-", T_i=np.nan*u.K))
     assert np.isnan(gyroradius(1*u.T, particle="e-", Vperp=np.nan*u.m/u.s))
 


### PR DESCRIPTION
This PR closes #1022 . The general behaviour of `gyroradius` is changed such that if one of the arguments (`T_i`, `Vperp`) is nan, and the other is not supplied, no error is raised, but nan is returned.

<!--
Thank you for contributing to PlasmaPy! Here's a bunch of pointers to
make things easier for all of us:

* If this PR will solve an issue tracked by GitHub, then please add
  "Closes #42" so the issue automatically closes once this pull request
  is merged.  In this example, issue #42 would have been closed.
  If your PR will not completely solve the issue, then please still reference
  still reference the issue like "issue #42".  (For more info see [GitHub's primer
  on linking issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)

* Remember to add some description of your changes in this text box.

* If your pull request is not yet ready for review - either because
  you're just looking for feedback on a change or because you're not
  perfectly satisfied with your change - submit it as a draft pull request.
  Remember to change its' status once it's ready.

* If this is your first contribution, please add your name to the author
  list in `docs/about/credits.rst`.

* Feel free to chat with other developers on our Matrix channel at:
   https://app.element.io/#/room/#plasmapy:openastronomy.org

* We have a developer's guide to help answer some of your questions.
  http://docs.plasmapy.org/en/latest/development/index.html

Many thanks in advance for following these pointers and for being willing to contribute!

When submitting a pull request, please ensure that you can (eventually,
sometime before it is merged) check the following basic requirements:

-->

- [x] I have added a changelog entry for this pull request.

<!--

In short: A changelog entry is a short description of your PR's changes.
Each entry is written in a `<PULL REQUEST>.<TYPE>.rst` file and stored in
the `changelog` directory,  where `<PULL REQUEST>` is a pull request
number and `<TYPE>` is one of:

* `breaking`: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
* `feature`: New user facing features and any new behavior.
* `bugfix`: Fixes a reported bug.
* `doc`: Documentation addition or improvement, like rewording an entire session or adding missing docs.
* `removal`: Feature deprecation and/or feature removal.
* `trivial`: A change which has no user facing effect or is tiny change.

A PR number is generated after you successfully submit a new PR, so the changelog
file can only be added after you open the PR.```

For more information, see:
https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst

--->

- [x] If adding new functionality, I have added tests and
      docstrings.

<!--
(Tests pop up at the bottom, in the checks box.)
-->

- [ ] I have fixed any newly failing tests.

<!--
(If you're unsure why they're failing, ask!)
-->
