### PR TITLE
Normalize wavevector in thomson.spectral_density()

### DIFF
--- a/changelog/1190.bugfix.rst
+++ b/changelog/1190.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed normalization of wavevector in thomson spectral density function.

--- a/changelog/1190.bugfix.rst
+++ b/changelog/1190.bugfix.rst
@@ -1,1 +1,2 @@
-Fixed normalization of wavevector in thomson spectral density function.
+Fixed normalization of wavevector in thomson spectral density function,
+:func:`~plasmapy.diagnostics.thomson.spectral_density`.

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -40,6 +40,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Thomas Fan <https://github.com/thomasjpfan>`__
 * `Samaiyah I. Farid <https://github.com/samaiyahfarid>`__
 * `Michael Fischer <https://github.com/mj-fischer>`__
+* `Bryan Foo <https://github.com/bryancfoo>`__
 * `Brian Goodall <https://github.com/goodab>`__
 * `Graham Goudeau <https://github.com/GrahamGoudeau>`__
 * `Silvina Guidoni <https://www.american.edu/cas/faculty/guidoni.cfm>`__

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -257,9 +257,9 @@ def test_multiple_ion_species_spectrum():
     max_wavelength = wavelength.value[np.argmax(Skw.value)]
 
     # Check width
-    assert np.isclose(width, 0.049999, 1e-2), (
+    assert np.isclose(width, 0.14, 1e-2), (
         f"Multiple ion species case spectrum width is {width} instead of "
-        "expected 0.04999"
+        "expected 0.14"
     )
 
     # Check max value

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -261,6 +261,7 @@ def spectral_density(
     # Normal vector along k
     k_vec = (scatter_vec - probe_vec) * u.dimensionless_unscaled
     k_vec = k_vec / np.linalg.norm(k_vec)  # normalization
+    print(k_vec)
 
     # Compute Doppler-shifted frequencies for both the ions and electrons
     # Matmul is simultaneously conducting dot product over all wavelengths

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -260,6 +260,7 @@ def spectral_density(
     k = np.sqrt(ks ** 2 + kl ** 2 - 2 * ks * kl * np.cos(scattering_angle))
     # Normal vector along k
     k_vec = (scatter_vec - probe_vec) * u.dimensionless_unscaled
+    k_vec = k_vec / np.linalg.norm(k_vec)  # normalization
 
     # Compute Doppler-shifted frequencies for both the ions and electrons
     # Matmul is simultaneously conducting dot product over all wavelengths

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -258,10 +258,9 @@ def spectral_density(
     scattering_angle = np.arccos(np.dot(probe_vec, scatter_vec))
     # Eq. 1.7.10 in Sheffield
     k = np.sqrt(ks ** 2 + kl ** 2 - 2 * ks * kl * np.cos(scattering_angle))
-    # Normal vector along k
+    # Normalized vector along k
     k_vec = (scatter_vec - probe_vec) * u.dimensionless_unscaled
-    k_vec = k_vec / np.linalg.norm(k_vec)  # normalization
-    print(k_vec)
+    k_vec = k_vec / np.linalg.norm(k_vec)
 
     # Compute Doppler-shifted frequencies for both the ions and electrons
     # Matmul is simultaneously conducting dot product over all wavelengths


### PR DESCRIPTION
In calculation of the spectral density, wavevector k_vec was not unit normalized. Proper normalization noticeably changes the resultant spectra.