### PR TITLE
Add tox and remove pytest from extra requirements

### DIFF
--- a/changelog/1195.doc.rst
+++ b/changelog/1195.doc.rst
@@ -1,1 +1,0 @@
-Removed pytest from the extra requirements.

--- a/changelog/1195.doc.rst
+++ b/changelog/1195.doc.rst
@@ -1,0 +1,1 @@
+Added `tox` to intersphinx.

--- a/changelog/1195.doc.rst
+++ b/changelog/1195.doc.rst
@@ -1,0 +1,1 @@
+Removed pytest from the extra requirements.

--- a/changelog/1195.doc.rst
+++ b/changelog/1195.doc.rst
@@ -1,1 +1,0 @@
-Added `tox` to intersphinx.

--- a/changelog/1195.trivial.rst
+++ b/changelog/1195.trivial.rst
@@ -1,1 +1,1 @@
-Added tox as an extra requirement.
+Added tox and removed pytest as extra requirement.

--- a/changelog/1195.trivial.rst
+++ b/changelog/1195.trivial.rst
@@ -1,1 +1,1 @@
-Added tox and removed pytest as extra requirement.
+Added `tox` and removed pytest as extra requirement.

--- a/changelog/1195.trivial.rst
+++ b/changelog/1195.trivial.rst
@@ -1,1 +1,2 @@
-Added `tox <https://tox.readthedocs.io/en/latest/>`_ and removed `pytest <https://docs.pytest.org/>`_ as extra requirement.
+Added `tox <https://tox.readthedocs.io/en/latest/>`_ and removed
+`pytest <https://docs.pytest.org/>`_ as extra requirements.

--- a/changelog/1195.trivial.rst
+++ b/changelog/1195.trivial.rst
@@ -1,0 +1,1 @@
+Added tox as an extra requirement.

--- a/changelog/1195.trivial.rst
+++ b/changelog/1195.trivial.rst
@@ -1,1 +1,1 @@
-Added `tox` and removed pytest as extra requirement.
+Added `tox <https://tox.readthedocs.io/en/latest/>`_ and removed `pytest <https://docs.pytest.org/>`_ as extra requirement.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,6 @@ intersphinx_mapping = {
         None,
     ),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-    "tox": ("https://tox.readthedocs.io/en/latest/", None),
 }
 
 autoclass_content = "both"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ intersphinx_mapping = {
         None,
     ),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-    "tox": ("https://tox.readthedocs.io/en/stable/", None),
+    "tox": ("https://tox.readthedocs.io/en/latest/", None),
 }
 
 autoclass_content = "both"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ intersphinx_mapping = {
         "https://sphinx-automodapi.readthedocs.io/en/latest/",
         None,
     ),
-    "spihnx": ("https://www.sphinx-doc.org/en/master/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
     "tox": ("https://tox.readthedocs.io/en/stable/", None),
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ intersphinx_mapping = {
         None,
     ),
     "spihnx": ("https://www.sphinx-doc.org/en/master/", None),
+    "tox": ("https://tox.readthedocs.io/en/stable/", None),
 }
 
 autoclass_content = "both"

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -5,6 +5,5 @@ lmfit
 mpmath
 numba
 numba-scipy
-pytest >= 5.1
 setuptools_scm
 tox

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -7,3 +7,4 @@ numba
 numba-scipy
 pytest >= 5.1
 setuptools_scm
+tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ extras =
   # ought to mirror requirements/extras.txt
   # for developers
   setuptools_scm
+  tox
   # for plasmapy.plasma
   h5py
   # for plasmapy.formulary


### PR DESCRIPTION
Following [this discussion](https://github.com/PlasmaPy/PlasmaPy/pull/1156#discussion_r653073272) in #1156, this PR adds tox to `requirements/extras.txt` since it's used a lot in tests and such.