### PR TITLE
Patch to address the "Documention" check failure

### DIFF
--- a/changelog/1199.doc.rst
+++ b/changelog/1199.doc.rst
@@ -1,0 +1,3 @@
+Make `plasmapy.analysis.fit_functions.AbstractFitFunction.FitParamTuple` a
+property to fix the documentation build warning caused by the release
+of `sphinx` `v4.1.0`.

--- a/changelog/1199.doc.rst
+++ b/changelog/1199.doc.rst
@@ -1,3 +1,3 @@
 Make `plasmapy.analysis.fit_functions.AbstractFitFunction.FitParamTuple` a
 property to fix the documentation build warning caused by the release
-of `sphinx` `v4.1.0`.
+of `sphinx` ``v4.1.0``.

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -51,12 +51,7 @@ class AbstractFitFunction(ABC):
 
         """
 
-        self.FitParamTuple = namedtuple("FitParamTuple", self._param_names)
-        """
-        A `~collections.namedtuple` used for attributes :attr:`params` and
-        :attr:`param_errors`.  The attribute :attr:`parameter_names` defines
-        the tuple field names.
-        """
+        self._FitParamTuple = namedtuple("FitParamTuple", self._param_names)
 
         if params is None:
             self._params = None
@@ -220,6 +215,15 @@ class AbstractFitFunction(ABC):
         `scipy.optimize.curve_fit`.
         """
         return self._curve_fit_results
+
+    @property
+    def FitParamTuple(self):
+        """
+        A `~collections.namedtuple` used for attributes :attr:`params` and
+        :attr:`param_errors`.  The attribute :attr:`parameter_names` defines
+        the tuple field names.
+        """
+        return self._FitParamTuple
 
     @property
     def params(self) -> Union[None, tuple]:


### PR DESCRIPTION
As mentioned in issue #1197, the resent release of `sphinx>=4.1.0` has caused the "Documentation" check to start failing.  I currently don't know what was changed in the `sphinx.ext.autodoc` functionality that created this issue, but I'm side stepping it by making `AbstractFitFunction.FitParamTuple` a property instead of a document attribute in the `__init__` method.

----

Closes #1197 