### PR TITLE
Disallow v0.17 of docutils

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # these are dependencies required to build package documentation
 # ought to mirror 'docs' under options.extras_require in setup.cfg
 -r extras.txt
-docutils < 0.18
+docutils != 0.17
 ipykernel
 ipywidgets
 nbsphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ tests =
 docs =
   # ought to mirror requirements/docs.txt
   %(extras)s
-  docutils < 0.18
+  docutils != 0.17
   ipykernel
   ipywidgets
   nbsphinx


### PR DESCRIPTION
This is a follow up to PR #1203 that bumped `docutils < 0.18` without properly considering PR #1107.  The current documentation has been built using `v0.17.1` and does not show the same issue reported in #1107 that was seen with `v0.17`.  Thus, I'm removing the upper bound for `docutils` and just excluding `v0.17` instead.