### PR TITLE
Minor changes to `plasmapy.online_help`

### DIFF
--- a/changelog/1213.doc.rst
+++ b/changelog/1213.doc.rst
@@ -1,0 +1,1 @@
+Improve the docstring for `plasmapy.online_help`.

--- a/changelog/1213.trivial.rst
+++ b/changelog/1213.trivial.rst
@@ -1,0 +1,2 @@
+Make queries to `plasmapy.online_help` for "quantity" or "quantities" redirect to the
+help page for `astropy.units` (which was already the case for "unit" and "units").

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -81,12 +81,13 @@ __citation__ = (
 )
 
 
-def online_help(query):
+def online_help(query: str):
     """
-    Search the online PlasmaPy documentation for the given query from plasmapy.org
-    Opens the results in the default web browser.
-    Requires an active Internet connection.
-    Redirects to Astropy.units in case of query 'unit' or 'units'
+    Open a webpage containing a search page in `PlasmaPy's online
+    documentation`_, or another page that contains relevant online help.
+
+    This function requires an active internet connection, and will open
+    the page in the default web browser.
 
     Parameters
     ----------
@@ -102,7 +103,7 @@ def online_help(query):
         "{0}&check_keywords=yes&area=default"
     ).format(urlencode({"q": query}))
 
-    if query.lower() in ("unit", "units"):
+    if query.lower() in ("unit", "units", "quantity"):
         url = "http://docs.astropy.org/en/stable/units/"
 
     webbrowser.open(url)

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -103,7 +103,7 @@ def online_help(query: str):
         "{0}&check_keywords=yes&area=default"
     ).format(urlencode({"q": query}))
 
-    if query.lower() in ("unit", "units", "quantity"):
+    if query.lower() in ("unit", "units", "quantity", "quantities"):
         url = "http://docs.astropy.org/en/stable/units/"
 
     webbrowser.open(url)

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -83,8 +83,8 @@ __citation__ = (
 
 def online_help(query: str):
     """
-    Open a webpage containing a search page in `PlasmaPy's online
-    documentation`_, or another page that contains relevant online help.
+    Open a webpage containing a search page in `PlasmaPy's documentation`_,
+    or another page that contains relevant online help.
 
     This function requires an active internet connection, and will open
     the page in the default web browser.


### PR DESCRIPTION
This PR makes two changes:
 - Improvements to the docstring for `plasmapy.online_help`
 - Have searches for `"quantity"` or `"quantities"` also be redirected to the help for `astropy.units`.  (This was already the case for `"unit"` and `"units"`.)

If this looks good, feel free to merge.