### PR TITLE
Make CustomParticle usable as keys in a dict

### DIFF
--- a/changelog/1216.feature.rst
+++ b/changelog/1216.feature.rst
@@ -1,1 +1,1 @@
-mplemented __eq__, __ne__ and __hash__ in CustomParticle for use as dict keys
+Implemented ``__eq__``, ``__ne__`` and ``__hash__`` to allow |CustomParticle| instances to be used as `dict` keys.

--- a/changelog/1216.feature.rst
+++ b/changelog/1216.feature.rst
@@ -1,0 +1,1 @@
+mplemented __eq__, __ne__ and __hash__ in CustomParticle for use as dict keys

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -94,6 +94,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `David Drozdov <https://github.com/davemus>`__
 * `Dhawal Modi <https://github.com/Dhawal-Modi>`__
 * `Armando Salcido <https://github.com/aksalcido>`__
+* `Nicolas Lequette <https://github.com/Quettle>`__
 
 
 This list contains contributors to PlasmaPy's core package and vision

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2239,8 +2239,8 @@ class CustomParticle(AbstractPhysicalParticle):
         Test whether or not two objects are different particles.
 
         This method will return `False` if ``other`` is an identical
-        |CustomParticle| instance,
-        and return `True` if ``other`` is a different |CustomParticle|.
+        |CustomParticle| instance, and return `True` if ``other`` is
+        a different |CustomParticle|.
         """
         return not self.__eq__(other)
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2047,7 +2047,7 @@ class CustomParticle(AbstractPhysicalParticle):
     'Ξ'
     """
 
-    def __init__(self, mass: u.kg = None, charge: (u.C, Real) = None, symbol=None):
+    def __init__(self, mass: u.kg = None, charge: (u.C, Real) = None, symbol = None):
         try:
             self.mass = mass
             self.charge = charge
@@ -2215,7 +2215,43 @@ class CustomParticle(AbstractPhysicalParticle):
         else:
             raise TypeError("symbol needs to be a string.")
 
+    def __eq__(self, other) -> bool:
+        """
+        Determine if two objects correspond to the same particle.
 
+        This method will return `True` if ``other`` is an identical
+        |CustomParticle| instance with the same mass charge and symbol,
+        and return `False` if ``other`` differs on any of these attributes.
+        """
+
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"The equality of a CustomParticle object with a {type(other)} is undefined."
+            )
+
+        return (self.symbol.__eq__(other.symbol) 
+                and self.mass.__eq__(other.mass) 
+                and self.charge.__eq__(other.charge))
+
+
+    def __ne__(self, other) -> bool:
+        """
+        Test whether or not two objects are different particles.
+
+        This method will return `False` if ``other`` is an identical
+        |CustomParticle| instance,
+        and return `True` if ``other`` is a different |CustomParticle|.
+        """
+        return not self.__eq__(other)
+
+    def __hash__(self) -> int:
+        """
+        Allow use of `hash` so that a |CustomParticle| instance may be used
+        as a key in a `dict`.
+        """
+        return hash((self.__repr__(), self.symbol))
+    
+    
 ParticleLike = Union[str, Integral, Particle, CustomParticle]
 
 ParticleLike.__doc__ = """

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2229,8 +2229,8 @@ class CustomParticle(AbstractPhysicalParticle):
                 f"The equality of a CustomParticle object with a {type(other)} is undefined."
             )
 
-        return (self.symbol.__eq__(other.symbol) 
-                and self.mass.__eq__(other.mass) 
+        return (self.symbol.__eq__(other.symbol)
+                and self.mass.__eq__(other.mass)
                 and self.charge.__eq__(other.charge))
 
 
@@ -2250,8 +2250,8 @@ class CustomParticle(AbstractPhysicalParticle):
         as a key in a `dict`.
         """
         return hash((self.__repr__(), self.symbol))
-    
-    
+
+
 ParticleLike = Union[str, Integral, Particle, CustomParticle]
 
 ParticleLike.__doc__ = """

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2047,7 +2047,7 @@ class CustomParticle(AbstractPhysicalParticle):
     'Ξ'
     """
 
-    def __init__(self, mass: u.kg = None, charge: (u.C, Real) = None, symbol = None):
+    def __init__(self, mass: u.kg = None, charge: (u.C, Real) = None, symbol=None):
         try:
             self.mass = mass
             self.charge = charge
@@ -2229,10 +2229,11 @@ class CustomParticle(AbstractPhysicalParticle):
                 f"The equality of a CustomParticle object with a {type(other)} is undefined."
             )
 
-        return (self.symbol.__eq__(other.symbol)
-                and self.mass.__eq__(other.mass)
-                and self.charge.__eq__(other.charge))
-
+        return (
+            self.symbol.__eq__(other.symbol)
+            and u.isclose(self.mass, other.mass, equal_nan=True, rtol=0)
+            and u.isclose(self.charge, other.charge, equal_nan=True, rtol=0)
+        )
 
     def __ne__(self, other) -> bool:
         """

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -855,7 +855,9 @@ def test_particleing_a_particle(arg):
     )
 
 
-@pytest.mark.parametrize("key", [Particle("H"), Particle("e+")])
+@pytest.mark.parametrize("key", [Particle("H"),
+                                 Particle("e+"),
+                                 CustomParticle(2*126.90447*u.u, 0*u.C, "I2")])
 def test_that_object_can_be_dict_key(key):
     """
     Test that ``key`` can be used as the key of a `dict`.
@@ -1367,3 +1369,17 @@ def test_particle_is_category_valid_categories():
 def test_deprecated_integer_charge():
     with pytest.warns(PlasmaPyFutureWarning):
         assert Particle("e-").integer_charge == -1
+        
+        
+def test_CustomParticle_cmp():
+    """Test ``__eq__`` and ``__ne__`` in the CustomParticle class."""
+    part1 = CustomParticle(2*126.90447*u.u, 0*u.C, "I2")
+    part2 = CustomParticle(2*126.90447*u.u, 0*u.C, "I2")
+    other = CustomParticle(2*126.90447*u.u, e.si, "I2 +")
+
+    assert part1 == part2, "Particle('p+') == Particle('proton') is False."
+    assert part1 != other, "Particle('p+') == Particle('e-') is True."
+
+    with pytest.raises(TypeError):
+        part1 == 1
+

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1373,13 +1373,12 @@ def test_deprecated_integer_charge():
         
 def test_CustomParticle_cmp():
     """Test ``__eq__`` and ``__ne__`` in the CustomParticle class."""
-    part1 = CustomParticle(2*126.90447*u.u, 0*u.C, "I2")
-    part2 = CustomParticle(2*126.90447*u.u, 0*u.C, "I2")
+    particle1 = CustomParticle(2*126.90447*u.u, 0*u.C, "I2")
+    particle2 = CustomParticle(2*126.90447*u.u, 0*u.C, "I2")
     other = CustomParticle(2*126.90447*u.u, e.si, "I2 +")
 
-    assert part1 == part2, "Particle('p+') == Particle('proton') is False."
-    assert part1 != other, "Particle('p+') == Particle('e-') is True."
+    assert particle1 == particle2, "CustomParticle instances that should be equal are not."
+    assert particle1 != other, "CustomParticle instances should not be equal, but are."
 
     with pytest.raises(TypeError):
-        part1 == 1
-
+        particle1 == 1

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -855,9 +855,10 @@ def test_particleing_a_particle(arg):
     )
 
 
-@pytest.mark.parametrize("key", [Particle("H"),
-                                 Particle("e+"),
-                                 CustomParticle(2*126.90447*u.u, 0*u.C, "I2")])
+@pytest.mark.parametrize(
+    "key",
+    [Particle("H"), Particle("e+"), CustomParticle(2 * 126.90447 * u.u, 0 * u.C, "I2")],
+)
 def test_that_object_can_be_dict_key(key):
     """
     Test that ``key`` can be used as the key of a `dict`.
@@ -1369,15 +1370,17 @@ def test_particle_is_category_valid_categories():
 def test_deprecated_integer_charge():
     with pytest.warns(PlasmaPyFutureWarning):
         assert Particle("e-").integer_charge == -1
-        
-        
+
+
 def test_CustomParticle_cmp():
     """Test ``__eq__`` and ``__ne__`` in the CustomParticle class."""
-    particle1 = CustomParticle(2*126.90447*u.u, 0*u.C, "I2")
-    particle2 = CustomParticle(2*126.90447*u.u, 0*u.C, "I2")
-    other = CustomParticle(2*126.90447*u.u, e.si, "I2 +")
+    particle1 = CustomParticle(2 * 126.90447 * u.u, 0 * u.C, "I2")
+    particle2 = CustomParticle(2 * 126.90447 * u.u, 0 * u.C, "I2")
+    other = CustomParticle(2 * 126.90447 * u.u, e.si, "I2 +")
 
-    assert particle1 == particle2, "CustomParticle instances that should be equal are not."
+    assert (
+        particle1 == particle2
+    ), "CustomParticle instances that should be equal are not."
     assert particle1 != other, "CustomParticle instances should not be equal, but are."
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
As mentioned in discussion #1192, this contribution implements the necessary functions in CustomParticles to be used as keys in a dict.

<!--
Thank you for contributing to PlasmaPy! Here's a bunch of pointers to
make things easier for all of us:

* If this PR will solve an issue tracked by GitHub, then please add
  "Closes #42" so the issue automatically closes once this pull request
  is merged.  In this example, issue #42 would have been closed.
  If your PR will not completely solve the issue, then please still reference
  still reference the issue like "issue #42".  (For more info see [GitHub's primer
  on linking issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)

* Remember to add some description of your changes in this text box.

* If your pull request is not yet ready for review - either because
  you're just looking for feedback on a change or because you're not
  perfectly satisfied with your change - submit it as a draft pull request.
  Remember to change its' status once it's ready.

* If this is your first contribution, please add your name to the author
  list in `docs/about/credits.rst`.

* Feel free to chat with other developers on our Matrix channel at:
   https://app.element.io/#/room/#plasmapy:openastronomy.org

* We have a developer's guide to help answer some of your questions.
  http://docs.plasmapy.org/en/latest/development/index.html

Many thanks in advance for following these pointers and for being willing to contribute!

When submitting a pull request, please ensure that you can (eventually,
sometime before it is merged) check the following basic requirements:

-->

- [x] I have added a changelog entry for this pull request.

<!--

In short: A changelog entry is a short description of your PR's changes.
Each entry is written in a `<PULL REQUEST>.<TYPE>.rst` file and stored in
the `changelog` directory,  where `<PULL REQUEST>` is a pull request
number and `<TYPE>` is one of:

* `breaking`: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
* `feature`: New user facing features and any new behavior.
* `bugfix`: Fixes a reported bug.
* `doc`: Documentation addition or improvement, like rewording an entire session or adding missing docs.
* `removal`: Feature deprecation and/or feature removal.
* `trivial`: A change which has no user facing effect or is tiny change.

A PR number is generated after you successfully submit a new PR, so the changelog
file can only be added after you open the PR.```

For more information, see:
https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst

--->

- [x] If adding new functionality, I have added tests and
      docstrings.

<!--
(Tests pop up at the bottom, in the checks box.)
-->

- [x] I have fixed any newly failing tests.

<!--
(If you're unsure why they're failing, ask!)
-->
