### PR TITLE
Changed behavour of Particle.__eq__ to return false when used with other types

### DIFF
--- a/changelog/1225.breaking.rst
+++ b/changelog/1225.breaking.rst
@@ -1,1 +1,1 @@
-Changed behaviour of `~plasmapy.particles.Particle.__eq__` to return False instead of an error when used to compare with an other type or a string that doesn't represents a particle.
+Changed behaviour of `~plasmapy.particles.particle_class.Particle.__eq__` to return `False` instead of an error when used to compare with another type or a string that does not represent a particle.

--- a/changelog/1225.breaking.rst
+++ b/changelog/1225.breaking.rst
@@ -1,0 +1,1 @@
+Changed behaviour of `~plasmapy.particles.Particle.__eq__` to return False instead of an error when used to compare with an other type or a string that doesn't represents a particle.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -605,7 +605,7 @@ class Particle(AbstractPhysicalParticle):
         This method will return `True` if ``other`` is an identical
         |Particle| instance or a `str` representing the same particle,
         and return `False` if ``other`` is a different |Particle|, a
-        `str` representing a different particle or an other type.
+        `str` representing a different particle or another type.
 
         Examples
         --------

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -620,7 +620,7 @@ class Particle(AbstractPhysicalParticle):
             try:
                 other_particle = Particle(other)
                 return self.symbol == other_particle.symbol
-            except InvalidParticleError as exc:
+            except InvalidParticleError:
                 return False
 
         if not isinstance(other, self.__class__):

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -604,13 +604,8 @@ class Particle(AbstractPhysicalParticle):
 
         This method will return `True` if ``other`` is an identical
         |Particle| instance or a `str` representing the same particle,
-        and return `False` if ``other`` is a different |Particle| or a
-        `str` representing a different particle.
-
-        If ``other`` is not a `str` or |Particle| instance, then this
-        method will raise a `TypeError`.  If ``other.symbol`` equals
-        ``self.symbol`` but the attributes differ, then this method
-        will raise a `~plasmapy.particles.exceptions.ParticleError`.
+        and return `False` if ``other`` is a different |Particle|, a
+        `str` representing a different particle or an other type.
 
         Examples
         --------
@@ -626,14 +621,10 @@ class Particle(AbstractPhysicalParticle):
                 other_particle = Particle(other)
                 return self.symbol == other_particle.symbol
             except InvalidParticleError as exc:
-                raise InvalidParticleError(
-                    f"{other} is not a particle and cannot be compared to {self}."
-                ) from exc
+                return False
 
         if not isinstance(other, self.__class__):
-            raise TypeError(
-                f"The equality of a Particle object with a {type(other)} is undefined."
-            )
+            return False
 
         no_symbol_attr = "symbol" not in dir(self) or "symbol" not in dir(other)
         no_attributes_attr = "_attributes" not in dir(self) or "_attributes" not in dir(
@@ -641,7 +632,7 @@ class Particle(AbstractPhysicalParticle):
         )
 
         if no_symbol_attr or no_attributes_attr:  # coverage: ignore
-            raise TypeError(f"The equality of {self} with {other} is undefined.")
+            return False
 
         same_particle = self.symbol == other.symbol
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -634,11 +634,9 @@ def test_Particle_cmp():
     assert proton1 == proton2, "Particle('p+') == Particle('proton') is False."
     assert proton1 != electron, "Particle('p+') == Particle('e-') is True."
 
-    with pytest.raises(TypeError):
-        electron == 1
+    assert electron != 1
 
-    with pytest.raises(ParticleError):
-        electron == "dfasdf"
+    assert electron != "dfasdf"
 
 
 nuclide_mass_and_mass_equiv_table = [


### PR DESCRIPTION
This PR changes the behavior oh the `__eq__` method of |Particle| in instances where an error would be raised if the compared object isn't a |Particle| or a valid str. This make the use of both |Particle| and |CustomParticle| more convenient when mixed in a list or as dict keys.
The only case where an error is raised is when the comparison is maid with an other |Particle| with se same symbol but different attributes.

<!--
Thank you for contributing to PlasmaPy! Here's a bunch of pointers to
make things easier for all of us:

* If this PR will solve an issue tracked by GitHub, then please add
  "Closes #42" so the issue automatically closes once this pull request
  is merged.  In this example, issue #42 would have been closed.
  If your PR will not completely solve the issue, then please still reference
  still reference the issue like "issue #42".  (For more info see [GitHub's primer
  on linking issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)

* Remember to add some description of your changes in this text box.

* If your pull request is not yet ready for review - either because
  you're just looking for feedback on a change or because you're not
  perfectly satisfied with your change - submit it as a draft pull request.
  Remember to change its' status once it's ready.

* If this is your first contribution, please add your name to the author
  list in `docs/about/credits.rst`.

* Feel free to chat with other developers on our Matrix channel at:
   https://app.element.io/#/room/#plasmapy:openastronomy.org

* We have a developer's guide to help answer some of your questions.
  http://docs.plasmapy.org/en/latest/development/index.html

Many thanks in advance for following these pointers and for being willing to contribute!

When submitting a pull request, please ensure that you can (eventually,
sometime before it is merged) check the following basic requirements:

-->

- [x] I have added a changelog entry for this pull request.

<!--

In short: A changelog entry is a short description of your PR's changes.
Each entry is written in a `<PULL REQUEST>.<TYPE>.rst` file and stored in
the `changelog` directory,  where `<PULL REQUEST>` is a pull request
number and `<TYPE>` is one of:

* `breaking`: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
* `feature`: New user facing features and any new behavior.
* `bugfix`: Fixes a reported bug.
* `doc`: Documentation addition or improvement, like rewording an entire session or adding missing docs.
* `removal`: Feature deprecation and/or feature removal.
* `trivial`: A change which has no user facing effect or is tiny change.

A PR number is generated after you successfully submit a new PR, so the changelog
file can only be added after you open the PR.```

For more information, see:
https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst

--->

- [x] If adding new functionality, I have added tests and
      docstrings.

<!--
(Tests pop up at the bottom, in the checks box.)
-->

- [x] I have fixed any newly failing tests.

<!--
(If you're unsure why they're failing, ask!)
-->
