### PR TITLE
Have Giles verify PR number of changelog entries

### DIFF
--- a/changelog/999999.trivial.rst
+++ b/changelog/999999.trivial.rst
@@ -1,0 +1,1 @@
+Changelog entry with the wrong pull request number.

--- a/changelog/999999.trivial.rst
+++ b/changelog/999999.trivial.rst
@@ -1,1 +1,0 @@
-Changelog entry with the wrong pull request number.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ build-backend = "setuptools.build_meta"
       help_url = "https://github.com/PlasmaPy/PlasmaPy/blob/main/changelog/README.rst"
       changelog_missing = "Missing changelog entry"
       changelog_missing_long = "This pull request needs a changelog entry file in `changelog/NUMBER.TYPE.rst`. For more information, consult https://github.com/PlasmaPy/PlasmaPy/blob/main/changelog/README.rst "
+      verify_pr_number = true
       number_incorrect = "Incorrect changelog entry number (match PR!)"
       number_incorrect_long = "The changelog entry's number does not match this pull request's number."
       type_incorrect = "Incorrect changelog entry type (see list in changelog README)"


### PR DESCRIPTION
On #1223 I accidentally had the wrong pull request number for the changelog files, and noticed that the Giles towncrier check for the changelog entry still passed.  I looked up the documentation for [baldrick](https://baldrick.readthedocs.io/en/latest/plugins.html#towncrier-changelog-checker) and noticed that we were missing `verify_pr_number = true`, which I just added.  