### PR TITLE
Specify docutils < 0.17

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # these are dependencies required to build package documentation
 # ought to mirror 'docs' under options.extras_require in setup.cfg
 -r extras.txt
-docutils != 0.17
+docutils < 0.17
 ipykernel
 ipywidgets
 nbsphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ tests =
 docs =
   # ought to mirror requirements/docs.txt
   %(extras)s
-  docutils != 0.17
+  docutils < 0.17
   ipykernel
   ipywidgets
   nbsphinx


### PR DESCRIPTION
Closes #1230.  I hope.  

This is an attempt to fix problems with unordered bullet point lists, following discussion on.  I think doing docutils != 0.17 may have allowed docutils == 0.17.1 since 0.17 is a specific version which they did instead of 0.17.0.

See also https://github.com/readthedocs/sphinx_rtd_theme/issues/1115 and https://github.com/readthedocs/sphinx_rtd_theme/pull/1185.