### PR TITLE
Use full namespaces in docstrings for formulary aliases

### DIFF
--- a/changelog/1238.doc.rst
+++ b/changelog/1238.doc.rst
@@ -1,1 +1,1 @@
-Fixed broken reST links in docstrings for aliases in `plasmapy.formulary`.
+Fixed broken reST_ links in docstrings for aliases in `plasmapy.formulary`.

--- a/changelog/1238.doc.rst
+++ b/changelog/1238.doc.rst
@@ -1,0 +1,1 @@
+Fixed broken reST links in docstrings for aliases in `plasmapy.formulary`.

--- a/plasmapy/formulary/dimensionless.py
+++ b/plasmapy/formulary/dimensionless.py
@@ -215,7 +215,7 @@ def Reynolds_number(
 
 
 Re_ = Reynolds_number
-""" Alias to :func:`Reynolds_number`. """
+"""Alias to `~plasmapy.formulary.dimensionless.Reynolds_number`."""
 
 
 @validate_quantities(U={"can_be_negative": True})
@@ -289,4 +289,4 @@ def Mag_Reynolds(U: u.m / u.s, L: u.m, sigma: u.S / u.m) -> u.dimensionless_unsc
 
 
 Rm_ = Mag_Reynolds
-""" Alias to :func:`Mag_Reynolds`. """
+"""Alias to `~plasmapy.formulary.dimensionless.Mag_Reynolds`."""

--- a/plasmapy/formulary/drifts.py
+++ b/plasmapy/formulary/drifts.py
@@ -72,7 +72,7 @@ def diamagnetic_drift(dp: u.Pa / u.m, B: u.T, n: u.m ** (-3), q: u.C) -> u.m / u
 
 
 vd_ = diamagnetic_drift
-""" Alias to :func:`diamagnetic_drift`. """
+"""Alias to `~plasmapy.formulary.drifts.diamagnetic_drift`."""
 
 
 @validate_quantities
@@ -129,7 +129,7 @@ def ExB_drift(E: u.V / u.m, B: u.T) -> u.m / u.s:
 
 
 veb_ = ExB_drift
-""" Alias to :func:`ExB_drift`. """
+"""Alias to `~plasmapy.formulary.drifts.ExB_drift`."""
 
 
 @validate_quantities
@@ -187,4 +187,4 @@ def force_drift(F: u.N, B: u.T, q: u.C) -> u.m / u.s:
 
 
 vfd_ = force_drift
-""" Alias to :func:`force_drift`. """
+"""Alias to `~plasmapy.formulary.drifts.force_drift`."""

--- a/plasmapy/formulary/ionization.py
+++ b/plasmapy/formulary/ionization.py
@@ -91,7 +91,7 @@ def ionization_balance(n: u.m ** -3, T_e: u.K) -> u.dimensionless_unscaled:
 
 
 Z_bal_ = ionization_balance
-"""Alias for :func:`ionization_balance`."""
+"""Alias for `~plasmapy.formulary.ionization.ionization_balance`."""
 
 
 @validate_quantities(

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1977,7 +1977,7 @@ def Bohm_diffusion(T_e: u.K, B: u.T) -> u.m ** 2 / u.s:
     Returns
     -------
     D_B : `~astropy.units.Quantity`
-    The Bohm diffusion coefficient in meters squared per second.
+        The Bohm diffusion coefficient in meters squared per second.
 
     """
     D_B = k_B * T_e / (16 * e * B)

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -198,7 +198,7 @@ def mass_density(
 
 
 rho_ = mass_density
-""" Alias to :func:`mass_density`. """
+"""Alias to `~plasmapy.formulary.parameters.mass_density`."""
 
 
 @check_relativistic
@@ -342,7 +342,7 @@ def Alfven_speed(
 
 
 va_ = Alfven_speed
-""" Alias to :func:`Alfven_speed`. """
+"""Alias to `~plasmapy.formulary.parameters.Alfven_speed`."""
 
 
 @check_relativistic
@@ -530,7 +530,7 @@ def ion_sound_speed(
 
 
 cs_ = ion_sound_speed
-""" Alias to :func:`ion_sound_speed`. """
+"""Alias to `~plasmapy.formulary.parameters.ion_sound_speed`."""
 
 
 # This dictionary defines coefficients for thermal speeds
@@ -683,7 +683,7 @@ def thermal_speed(
 
 
 vth_ = thermal_speed
-""" Alias to :func:`thermal_speed`. """
+"""Alias to `~plasmapy.formulary.parameters.thermal_speed`."""
 
 
 @validate_quantities(
@@ -737,7 +737,7 @@ def thermal_pressure(T: u.K, n: u.m ** -3) -> u.Pa:
 
 
 pth_ = thermal_pressure
-""" Alias to :func:`thermal_pressure`. """
+"""Alias to `~plasmapy.formulary.parameters.thermal_pressure`."""
 
 
 @check_relativistic
@@ -851,7 +851,7 @@ def kappa_thermal_speed(
 
 
 vth_kappa_ = kappa_thermal_speed
-""" Alias to :func:`kappa_thermal_speed`. """
+"""Alias to `~plasmapy.formulary.parameters.kappa_thermal_speed`."""
 
 
 @validate_quantities(
@@ -970,7 +970,7 @@ def Hall_parameter(
 
 
 betaH_ = Hall_parameter
-""" Alias to :func:`Hall_parameter`. """
+"""Alias to `~plasmapy.formulary.parameters.Hall_parameter`."""
 
 
 @validate_quantities(
@@ -1085,10 +1085,10 @@ def gyrofrequency(B: u.T, particle: Particle, signed=False, Z=None) -> u.rad / u
 
 
 oc_ = gyrofrequency
-""" Alias to :func:`gyrofrequency`. """
+"""Alias to `~plasmapy.formulary.parameters.gyrofrequency`."""
 
 wc_ = gyrofrequency
-""" Alias to :func:`gyrofrequency`. """
+"""Alias to `~plasmapy.formulary.parameters.gyrofrequency`."""
 
 
 @validate_quantities(
@@ -1260,10 +1260,10 @@ def gyroradius(
 
 
 rc_ = gyroradius
-""" Alias to :func:`gyroradius`. """
+"""Alias to `~plasmapy.formulary.parameters.gyroradius`."""
 
 rhoc_ = gyroradius
-""" Alias to :func:`gyroradius`. """
+"""Alias to `~plasmapy.formulary.parameters.gyroradius`."""
 
 
 @validate_quantities(
@@ -1372,7 +1372,7 @@ def plasma_frequency(n: u.m ** -3, particle: Particle, z_mean=None) -> u.rad / u
 
 
 wp_ = plasma_frequency
-""" Alias to :func:`plasma_frequency`. """
+"""Alias to `~plasmapy.formulary.parameters.plasma_frequency`."""
 
 
 @validate_quantities(
@@ -1446,7 +1446,7 @@ def Debye_length(T_e: u.K, n_e: u.m ** -3) -> u.m:
 
 
 lambdaD_ = Debye_length
-""" Alias to :func:`Debye_length`. """
+"""Alias to `~plasmapy.formulary.parameters.Debye_length`."""
 
 
 @validate_quantities(
@@ -1520,7 +1520,7 @@ def Debye_number(T_e: u.K, n_e: u.m ** -3) -> u.dimensionless_unscaled:
 
 
 nD_ = Debye_number
-""" Alias to :func:`Debye_number`. """
+"""Alias to `~plasmapy.formulary.parameters.Debye_number`."""
 
 
 @validate_quantities(
@@ -1594,9 +1594,9 @@ def inertial_length(n: u.m ** -3, particle: Particle) -> u.m:
 
 cwp_ = inertial_length
 """
-Alias to :func:`inertial_length`.
+Alias to `~plasmapy.formulary.parameters.inertial_length`.
 
-* Name is shorthand for :math:`c / \\omega_p`.
+* Name is shorthand for :math:`c / ω_p`.
 """
 
 
@@ -1662,7 +1662,7 @@ def magnetic_pressure(B: u.T) -> u.Pa:
 
 
 pmag_ = magnetic_pressure
-""" Alias to :func:`magnetic_pressure`. """
+"""Alias to `~plasmapy.formulary.parameters.magnetic_pressure`."""
 
 
 @validate_quantities
@@ -1727,7 +1727,7 @@ def magnetic_energy_density(B: u.T) -> u.J / u.m ** 3:
 
 
 ub_ = magnetic_energy_density
-""" Alias to :func:`magnetic_energy_density`. """
+"""Alias to `~plasmapy.formulary.parameters.magnetic_energy_density`."""
 
 
 @validate_quantities(
@@ -1811,7 +1811,7 @@ def upper_hybrid_frequency(B: u.T, n_e: u.m ** -3) -> u.rad / u.s:
 
 
 wuh_ = upper_hybrid_frequency
-""" Alias to :func:`upper_hybrid_frequency`. """
+"""Alias to `~plasmapy.formulary.parameters.upper_hybrid_frequency`."""
 
 
 @validate_quantities(
@@ -1914,7 +1914,7 @@ def lower_hybrid_frequency(B: u.T, n_i: u.m ** -3, ion: Particle) -> u.rad / u.s
 
 
 wlh_ = lower_hybrid_frequency
-""" Alias to :func:`lower_hybrid_frequency`. """
+"""Alias to `~plasmapy.formulary.parameters.lower_hybrid_frequency`."""
 
 
 @validate_quantities(
@@ -1985,4 +1985,4 @@ def Bohm_diffusion(T_e: u.K, B: u.T) -> u.m ** 2 / u.s:
 
 
 DB_ = Bohm_diffusion
-""" Alias to :func:`Bohm_diffusion`. """
+"""Alias to `~plasmapy.formulary.parameters.Bohm_diffusion`."""

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -135,7 +135,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
 
 
 lambdaDB_ = deBroglie_wavelength
-""" Alias to :func:`deBroglie_wavelength`. """
+"""Alias to `~plasmapy.formulary.quantum.deBroglie_wavelength`."""
 
 
 @validate_quantities(
@@ -194,7 +194,7 @@ def thermal_deBroglie_wavelength(T_e: u.K) -> u.m:
 
 
 lambdaDB_th_ = thermal_deBroglie_wavelength
-""" Alias to :func:`thermal_deBroglie_wavelength`. """
+"""Alias to `~plasmapy.formulary.quantum.thermal_deBroglie_wavelength`."""
 
 
 @validate_quantities(
@@ -261,7 +261,7 @@ def Fermi_energy(n_e: u.m ** -3) -> u.J:
 
 
 Ef_ = Fermi_energy
-""" Alias to :func:`Fermi_energy`. """
+"""Alias to `~plasmapy.formulary.quantum.Fermi_energy`."""
 
 
 @validate_quantities(


### PR DESCRIPTION
Some quick changes to make sure that the reST links show up correctly in the docs for aliases.