### PR TITLE
Make sure units are not in math mode in formulary docstrings (#1228)

### DIFF
--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -253,7 +253,7 @@ def Alfven_speed(
     Returns
     -------
     V_A : `~astropy.units.Quantity`
-        The Alfvén speed in units :math:`m/s`.
+        The Alfvén speed in units m s\ :sup:`-1`.
 
     Raises
     ------


### PR DESCRIPTION
Closes issue #1228

I searched for ":math:" in all files recursively in the "formulary" folder and went through all the results (100+), changing those referring to units.

I only found one change to make!

I checked by building the documentation again locally and saw the changes had the desired effect.
