### PR TITLE
Fix some broken and redirected links

### DIFF
--- a/changelog/1257.doc.rst
+++ b/changelog/1257.doc.rst
@@ -1,0 +1,1 @@
+Fixed multiple broken and redirected links.

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -122,6 +122,6 @@ Parts of these guidelines have been adapted from the `Contributor
 Covenant (version 1.4)
 <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>`_,
 the `Astropy Community Code of Conduct
-<http://www.astropy.org/code_of_conduct.html>`_, and the
+<https://www.astropy.org/code_of_conduct.html>`_, and the
 `Python Software Foundation code of conduct
 <https://www.python.org/psf/codeofconduct/>`_.

--- a/docs/COMMUNICATION.rst
+++ b/docs/COMMUNICATION.rst
@@ -3,8 +3,8 @@
 Feedback and Communication
 ==========================
 
-`Matrix chat <https://app.element.io/#/room/#plasmapy:openastronomy.org>`__
---------------------------------------------------------------------
+Matrix chat <https://app.element.io/#/room/#plasmapy:openastronomy.org>`__
+--------------------------------------------------------------------------
 
 The primary communication channel for PlasmaPy, and the quickest way to ask
 a question and get a response, is our `Matrix room

--- a/docs/COMMUNICATION.rst
+++ b/docs/COMMUNICATION.rst
@@ -3,7 +3,7 @@
 Feedback and Communication
 ==========================
 
-`Matrix chat <https://app.element.io/#/room/#plasmapy:matrix.org>`__
+`Matrix chat <https://app.element.io/#/room/#plasmapy:openastronomy.org>`__
 --------------------------------------------------------------------
 
 The primary communication channel for PlasmaPy, and the quickest way to ask

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -12,7 +12,7 @@ and highlights the importance of software as a vital research product.
 Version 0.6.0 of PlasmaPy may be cited with the following reference:
 
    PlasmaPy Community et al. (2021). *PlasmaPy*, version 0.6.0, Zenodo,
-   http://doi.org/10.5281/zenodo.4602818
+   https://doi.org/10.5281/zenodo.4602818
 
 This reference may be made, for example, by adding the following line
 to the methods or acknowledgements section of a paper.

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -38,7 +38,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Erik Everson <https://github.com/rocco8773>`__
 * `Thomas Fan <https://github.com/thomasjpfan>`__
 * `Samaiyah I. Farid <https://github.com/samaiyahfarid>`__
-* `Michael Fischer <https://github.com/mj-fischer>`__
+* Michael Fischer
 * `Bryan Foo <https://github.com/bryancfoo>`__
 * `Brian Goodall <https://github.com/goodab>`__
 * `Graham Goudeau <https://github.com/GrahamGoudeau>`__
@@ -67,9 +67,9 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `nrb1324 <https://github.com/nrb1324>`__
 * `Tulasi Parashar <https://github.com/tulasinandan>`__ (`0000-0003-0602-8381 <https://orcid.org/0000-0003-0602-8381>`__)
 * `Neil Patel <https://github.com/ministrike3>`__
-* `Francisco Silva Pavon <https://github.com/fsilvapavon>`__
-* `Roberto Díaz Pérez <https://github.com/RobertTnf>`__
-* `Jakub Polak <https://github.com/Ishinomori>`__
+* Francisco Silva Pavon
+* `Roberto Díaz Pérez <https://github.com/RoberTnf>`__
+* Jakub Polak
 * `Raajit Raj <https://github.com/raajitr>`__
 * `Vishwas Rajashekar <https://github.com/DarkAEther>`__ (`0000-0002-4914-6612 <https://orcid.org/0000-0002-4914-6612>`__)
 * `Antonia Savcheva <https://github.com/savcheva>`__ (`0000-0002-5598-046X <https://orcid.org/0000-0002-5598-046X>`__)
@@ -77,17 +77,17 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Dawa Nurbu Sherpa <https://github.com/nurbu5>`__
 * `Angad Singh <https://github.com/singha95>`__
 * `Ankit Singh <https://github.com/Griffintaur>`__
-* `Brigitta Sipőcz <http://github.com/bsipocz>`__
+* `Brigitta Sipőcz <https://github.com/bsipocz>`__
 * `David Stansby <https://github.com/dstansby>`__ (`0000-0002-1365-1908 <https://orcid.org/0000-0002-1365-1908>`__)
 * `Dominik Stańczak <https://github.com/StanczakDominik>`__ (`0000-0001-6291-8843 <https://orcid.org/0000-0001-6291-8843>`__)
-* `Antoine Tavant <https://github.com/antoinelpp>`__
+* `Antoine Tavant <https://github.com/antoinetavant>`__
 * `Thomas Ulrich <https://github.com/Elfhelm>`__
 * `Thomas Varnish <https://github.com/tvarnish>`__
 * `Anthony Vo <https://github.com/anthony-vo>`__
 * `Sixue Xu <https://github.com/hzxusx>`__
 * `Carol Zhang <https://github.com/carolyz>`__
-* `Cody Skinner <https://github.com/wskinner74>`__
-* `Ramiz Qudsi <https://github.com/ahmadryan>`__ (`0000-0001-8358-0482 <https://orcid.org/0000-0001-8358-0482>`__)
+* `Cody Skinner <https://github.com/cskinner74>`__
+* `Ramiz Qudsi <https://github.com/qudsiramiz>`__ (`0000-0001-8358-0482 <https://orcid.org/0000-0001-8358-0482>`__)
 * `Steve Richardson <https://github.com/arichar6>`__ (`0000-0002-3056-6334 <https://orcid.org/0000-0002-3056-6334>`__)
 * `Tiger Du <https://github.com/Tiger-Du>`__ (`0000-0002-8676-1710 <https://orcid.org/0000-0002-8676-1710>`__)
 * `Kevin Montes <https://github.com/kjmontes>`__ (`0000-0002-0762-3708 <https://orcid.org/0000-0002-0762-3708>`__)
@@ -127,7 +127,7 @@ Environment Enhancements (HDEE) grant 80NSSC20K0174.  PlasmaPy is
 being developed with support from the U.S. National Science Foundation
 through grants 1931388, 1931393, 1931429, and 1931435 that were awarded
 through `a collaborative proposal
-<http://doi.org/10.5281/zenodo.3406803>`__ submitted to the
+<https://doi.org/10.5281/zenodo.3406803>`__ submitted to the
 Cyberinfrastructure for Sustained Scientific Innovation (CSSI) program.
 
 All opinions, findings, conclusions, and recommendations expressed

--- a/docs/about/vision_statement.rst
+++ b/docs/about/vision_statement.rst
@@ -25,7 +25,7 @@ software package for plasma physics.
 
 There is considerable need in plasma physics for open, general purpose
 software framework using modern `best practices for scientific
-computing <http://dx.doi.org/10.1371/journal.pbio.1001745>`_. As most
+computing <https://dx.doi.org/10.1371/journal.pbio.1001745>`_. As most
 scientific programmers are largely self-taught, software often does not
 take advantage of these practices and is instead written in a rush to
 produce results for the next research paper. The resulting code is often
@@ -98,7 +98,7 @@ committee. Major decisions should ideally be made by general consensus
 among the PlasmaPy community, but when consensus is not possible then
 the committees may decide via majority vote. Much of this section is
 following the `organizational structure of
-Astropy <http://www.astropy.org/team.html>`_.
+Astropy <https://www.astropy.org/team.html>`_.
 
 Development Procedure
 ---------------------
@@ -182,7 +182,7 @@ maintaining the significant advantages of using a high level language.
 Versioning
 ~~~~~~~~~~
 
-PlasmaPy will use `Semantic Versioning <http://semver.org/>`_. Releases
+PlasmaPy will use `Semantic Versioning <https://semver.org/>`_. Releases
 will be given version numbers of the form *MAJOR*.\ *MINOR*.\ *PATCH*,
 where *MAJOR*, *MINOR*, and *PATCH* are nonnegative integers. Starting
 with version 1.0, *MAJOR* will be incremented when backwards

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -48,7 +48,7 @@
 .. _Astropy: https://www.astropy.org/
 .. _`Astropy docs`: https://docs.astropy.org/
 .. _`docs/common_links.rst`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/common_links.rst
-.. _Conda: https://conda.io/docs/
+.. _Conda: https://conda.io/en/latest/
 .. _git: https://git-scm.com/
 .. _intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 .. _Jupyter: https://jupyter.org/
@@ -61,7 +61,7 @@
 .. _`PlasmaPy's documentation`: https://docs.plasmapy.org/en/stable/
 .. _PyPI: https://pypi.org/
 .. _Python: https://www.python.org/
-.. _`Python's documentation`: https://docs.python.org/
+.. _`Python's documentation`: https://docs.python.org/3/
 .. _`Read the Docs`: https://readthedocs.org/
 .. _reST: https://docutils.sourceforge.io/rst.html
 .. _SciPy: https://www.scipy.org/

--- a/docs/development/code_guide.rst
+++ b/docs/development/code_guide.rst
@@ -50,7 +50,7 @@ PlasmaPy Code Style Guide, codified
 -----------------------------------
 
 * PlasmaPy follows the `PEP8 Style Guide for Python Code
-  <http://www.python.org/dev/peps/pep-0008/>`_.  This style choice
+  <https://www.python.org/dev/peps/pep-0008/>`_.  This style choice
   helps ensure that the code will be consistent and readable.
 
   * Line lengths should be chosen to maximize the readability and

--- a/docs/development/install_dev.rst
+++ b/docs/development/install_dev.rst
@@ -75,9 +75,8 @@ activate via
 where ``/home/user/anaconda3/`` can be swapped to wherever your anaconda
 installation resides.
 
-On `newer versions of Anaconda <https://conda.io/docs/release-notes
-.html#recommended-change-to-enable-conda-in-your-shell>`_ the
-recommended activation process has changed to:
+On newer versions of Anaconda the recommended activation process has
+changed to:
 
 .. code-block:: bash
 

--- a/docs/development/release_guide.rst
+++ b/docs/development/release_guide.rst
@@ -8,7 +8,7 @@ The following is a partial list of tasks to be performed for each
 release.  This list is currently under development.  Developers should
 revise and expand the instructions while performing each release,
 and may refer to `Astropy's release procedures
-<http://docs.astropy.org/en/stable/development/releasing.html>`_ for
+<https://docs.astropy.org/en/stable/development/releasing.html>`_ for
 guidance.
 
 Throughout this guide, ``0.6.0`` denotes the version you're releasing,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,9 +2,21 @@
 
 .. _plasmapy-documentation:
 
+.. image:: _static/graphic-circular.png
+   :alt: PlasmaPy logo
+   :align: right
+   :scale: 40%
+
 ######################
 PlasmaPy Documentation
 ######################
+
+`PlasmaPy <http://www.plasmapy.org/>`_ is an open source
+community-developed core `Python <https://www.python.org/>`_ 3.7+
+package for plasma physics currently under development.
+
+Example highlights
+------------------
 
 .. nbgallery::
    :hidden:
@@ -12,16 +24,9 @@ PlasmaPy Documentation
    notebooks/diagnostics/proton_radiography_particle_tracing
    notebooks/dispersion/two_fluid_dispersion
    notebooks/diagnostics/thomson
-
-.. image:: _static/graphic-circular.png
-   :alt: PlasmaPy logo
-   :align: right
-   :scale: 80%
-
-
-`PlasmaPy <http://www.plasmapy.org/>`_ is an open source
-community-developed core `Python <https://www.python.org/>`_ 3.7+
-package for plasma physics currently under development.
+   notebooks/analysis/swept_langmuir/find_floating_potential
+   notebooks/formulary/thermal_bremsstrahlung
+   notebooks/plasma/grids_nonuniform
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@
 PlasmaPy Documentation
 ######################
 
-`PlasmaPy <http://www.plasmapy.org/>`_ is an open source
+`PlasmaPy <https://www.plasmapy.org/>`_ is an open source
 community-developed core `Python <https://www.python.org/>`_ 3.7+
 package for plasma physics currently under development.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,7 +22,7 @@ PlasmaPy requires the following packages for installation:
 - `SciPy`_ — 1.2 or newer
 - `Astropy`_ — 4.0 or newer
 - `pandas <https://pandas.pydata.org/>`_ — 1.0 or newer
-- `xarray <http://xarray.pydata.org>`_ — above 0.14
+- `xarray <https://xarray.pydata.org/en/stable/>`_ — above 0.14
 - `tqdm <https://tqdm.github.io/>`_ — 4.41 or newer
 - `cached_property <https://pypi.org/project/cached-property/>`_ — 1.5.2 or newer
 
@@ -30,8 +30,8 @@ PlasmaPy also depends on the following packages for optional features:
 
 - `h5py <https://www.h5py.org/>`_ — 2.8 or newer
 - `lmfit <https://lmfit.github.io/lmfit-py/>`_ — 1.0.1 or newer
-- `matplotlib`_ — 2.0 or newer
-- `mpmath <https:htt//mpmath.org/>`_ — 1.0 or newer
+- matplotlib_ — 2.0 or newer
+- `mpmath <https://mpmath.org/>`_ — 1.0 or newer
 
 .. _install-process:
 
@@ -69,12 +69,12 @@ Installation with conda
 -----------------------
 
 We recommend installing PlasmaPy from a Python environment
-created using `Conda`_.  Conda allows us to
+created using Conda_.  Conda_ allows us to
 create and switch between Python environments that are isolated from
 each other and the system installation (in contrast to `this xkcd
 <https://xkcd.com/1987/>`_).
 
-After `installing conda <https://conda.io/docs/user-guide/install/>`_,
+After `installing conda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_,
 create a PlasmaPy environment with all required and optional dependencies
 by running:
 

--- a/docs/whatsnew/0.1.0.rst
+++ b/docs/whatsnew/0.1.0.rst
@@ -31,7 +31,7 @@ New Features
   <https://pep8speaks.com/>`_.
 
 * Developed `online documentation for PlasmaPy
-  <http://docs.plasmapy.org>`_ that is hosted by `Read the Docs
+  <https://docs.plasmapy.org>`_ that is hosted by `Read the Docs
   <https://readthedocs.org/>`_.
 
   - Automated documentation builds with Sphinx_.
@@ -84,7 +84,7 @@ New Features
 * Began using `type hint annotations
   <https://docs.python.org/3/library/typing.html>`_.
 
-* Set up architecture to incorporate `Cython <http://cython.org/>`_ into
+* Set up architecture to incorporate `Cython <https://cython.org/>`_ into
   performance-critical sections of code.
 
 * Incorporated import and setup tools from the ``astropy_helpers``

--- a/docs/whatsnew/0.2.0.rst
+++ b/docs/whatsnew/0.2.0.rst
@@ -11,7 +11,7 @@ New Features
 ------------
 
 - Implement machinery for a ``Plasma`` class factory based on
-  `PLEP 6 <http://doi.org/10.5281/zenodo.1460977>`__
+  `PLEP 6 <https://doi.org/10.5281/zenodo.1460977>`__
 - Create an openPMD ``Plasma`` subclass
 - Create classes to represent ionization state distributions for one
   or more elements or isotopes.

--- a/docs/whatsnew/0.3.0.rst
+++ b/docs/whatsnew/0.3.0.rst
@@ -35,8 +35,8 @@ Bug Fixes
 Improved Documentation
 ----------------------
 
-- Added real-world examples to examples/plot_physics.py and adjusted the plots to be more human-friendly. (`#448 <https://github.com/plasmapy/plasmapy/pull/448>`__)
-- Add examples images to the top of the main doc page in ``docs\index.rst`` (`#655 <https://github.com/plasmapy/plasmapy/pull/655>`__)
+- Added real-world examples to examples/plot_physics.py and adjusted the plots to be more human-friendly. (`#721 <https://github.com/plasmapy/plasmapy/pull/721>`__)
+- Add examples images to the top of the main doc page in :file:`docs\index.rst` (`#655 <https://github.com/plasmapy/plasmapy/pull/655>`__)
 - Added examples to the documentation to ``mass_density``
    and ``Hall_parameter`` functions (`#709 <https://github.com/plasmapy/plasmapy/pull/709>`__)
 - Add docstrings to decorator :func:`plasmapy.utils.decorators.converter.angular_freq_to_hz`. (`#729 <https://github.com/plasmapy/plasmapy/pull/729>`__)
@@ -59,7 +59,7 @@ Trivial/Internal Changes
 - Patch ``sphinx_gallery.binder`` to output custom links to Binder instance (`#658 <https://github.com/plasmapy/plasmapy/pull/658>`__)
 - Remove the now unnecessary ``astropy_helpers`` submodule (`#663 <https://github.com/plasmapy/plasmapy/pull/663>`__)
 - Followup PR to CI overhaul (`#664 <https://github.com/plasmapy/plasmapy/pull/664>`__)
-- Add a Codemeta file (``codemeta.json``) (`#676 <https://github.com/plasmapy/plasmapy/pull/676>`__)
+- Add a Codemeta file (:file:`codemeta.json`) (`#676 <https://github.com/plasmapy/plasmapy/pull/676>`__)
 - Overhaul and simplify CI, add Python 3.8 to tests, bump minimal required package versions, fix docs. (`#712 <https://github.com/plasmapy/plasmapy/pull/712>`__)
 - Update communication channels in docs (`#715 <https://github.com/plasmapy/plasmapy/pull/715>`__)
 - Code style fixes to the ``atomic`` subpackage (`#716 <https://github.com/plasmapy/plasmapy/pull/716>`__)
@@ -76,5 +76,5 @@ Trivial/Internal Changes
   :class:`~plasmapy.utils.decorators.checks.CheckUnits`, and
   :class:`~plasmapy.utils.decorators.validators.ValidateQuantities`. (`#648 <https://github.com/plasmapy/plasmapy/pull/648>`__)
 - Create a decorator to change output of physics functions from "radians/s" to "hz" (`#667 <https://github.com/plasmapy/plasmapy/pull/667>`__)
-- Added pytest.mark.slow to pytest markers.
+- Added ``pytest.mark.slow`` to pytest markers.
   Updated documentation to notify developers of functionality. (`#677 <https://github.com/plasmapy/plasmapy/pull/677>`__)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -1020,7 +1020,6 @@ def Coulomb_cross_section(impact_param: u.m) -> u.m ** 2:
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Cross_section_(physics)#Collision_among_gas_particles
-
     """
     sigma = np.pi * (2 * impact_param) ** 2
     return sigma

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -390,7 +390,6 @@ def Coulomb_logarithm(
     .. [3] Comparison of Coulomb Collision Rates in the Plasma Physics
        and Magnetically Confined Fusion Literature, W. Fundamenski and
        O.E. Garcia, EFDA–JET–R(07)01
-       (http://www.euro-fusionscipub.org/wp-content/uploads/2014/11/EFDR07001.pdf)
 
     .. [4] Dense plasma temperature equilibration in the binary collision
        approximation. D. O. Gericke et. al. PRE,  65, 036418 (2002).
@@ -931,7 +930,10 @@ def collision_frequency(
     ----------
     .. [1] Francis, F. Chen. Introduction to plasma physics and controlled
        fusion 3rd edition. Ch 5 (Springer 2015).
-    .. [2] http://homepages.cae.wisc.edu/~callen/chap2.pdf
+    .. [2] `Draft Material for "Fundamentals of Plasma Physics" Book
+       <https://docs.google.com/document/d/e/2PACX-1vQmvQ_b8p0P2cYsWGMQYVd92OBLX9Sm6XGiCMRBidoVSoJffj2MBvWiwpix46mqlq_HQvHD5ofpfrNF/pub>`__,
+       by James D. Callen
+
     """
     # boiler plate checks
     T, masses, charges, reduced_mass, V_r = _boilerPlate(T=T, species=species, V=V)
@@ -1018,6 +1020,7 @@ def Coulomb_cross_section(impact_param: u.m) -> u.m ** 2:
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Cross_section_(physics)#Collision_among_gas_particles
+
     """
     sigma = np.pi * (2 * impact_param) ** 2
     return sigma

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -1019,7 +1019,8 @@ def Coulomb_cross_section(impact_param: u.m) -> u.m ** 2:
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Cross_section_(physics)#Collision_among_gas_particles
+    .. [1] `Cross Section: Collision among gas particles
+       <https://en.wikipedia.org/wiki/Cross_section_(physics)#Collision_among_gas_particles>`__
     """
     sigma = np.pi * (2 * impact_param) ** 2
     return sigma
@@ -1106,8 +1107,9 @@ def fundamental_electron_collision_freq(
        revised." Naval Research Lab. Report NRL/PU/6790-16-614 (2016).
        https://www.nrl.navy.mil/ppd/content/nrl-plasma-formulary
 
-    .. [3] J.D. Callen, Fundamentals of Plasma Physics draft material,
-       Chapter 2, http://homepages.cae.wisc.edu/~callen/chap2.pdf
+    .. [3] `Draft Material for "Fundamentals of Plasma Physics" Book
+       <https://docs.google.com/document/d/e/2PACX-1vQmvQ_b8p0P2cYsWGMQYVd92OBLX9Sm6XGiCMRBidoVSoJffj2MBvWiwpix46mqlq_HQvHD5ofpfrNF/pub>`__,
+       by James D. Callen
 
     Examples
     --------
@@ -1243,8 +1245,9 @@ def fundamental_ion_collision_freq(
        revised." Naval Research Lab. Report NRL/PU/6790-16-614 (2016).
        https://www.nrl.navy.mil/ppd/content/nrl-plasma-formulary
 
-    .. [3] J.D. Callen, Fundamentals of Plasma Physics draft material,
-       Chapter 2, http://homepages.cae.wisc.edu/~callen/chap2.pdf
+    .. [3] `Draft Material for "Fundamentals of Plasma Physics" Book
+       <https://docs.google.com/document/d/e/2PACX-1vQmvQ_b8p0P2cYsWGMQYVd92OBLX9Sm6XGiCMRBidoVSoJffj2MBvWiwpix46mqlq_HQvHD5ofpfrNF/pub>`__,
+       by James D. Callen
 
     Examples
     --------

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -253,7 +253,7 @@ def Alfven_speed(
     Returns
     -------
     V_A : `~astropy.units.Quantity`
-        The Alfvén speed in units :math:`m/s`.
+        The Alfvén speed in units m s\ :sup:`-1`.
 
     Raises
     ------

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -2,7 +2,7 @@
 Module for loading atomic data for elements from
 :file:`plasmapy/particles/data/elements.json`.
 
-The periodic tabla data is from: http://periodic.lanl.gov/index.shtml
+The periodic tabla data is from: https://periodic.lanl.gov/index.shtml
 
 .. attention::
     This module is not part of PlasmaPy's public API.

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -38,7 +38,7 @@ def _valid_version(openPMD_version, outdated=_OUTDATED_VERSION, newer=_NEWER_VER
 
 class HDF5Reader(GenericPlasma):
     """
-    .. _OpenPMD: http://openpmd.org/
+    .. _OpenPMD: https://www.openpmd.org/
 
     Core class for accessing various attributes on HDF5 files that
     are based on OpenPMD_ standards.


### PR DESCRIPTION
This PR makes a few quick corrections to web links that were either broken or were redirects.  One of the changes is for an old changelog entry that had linked to the issue it closed rather than the pull request number.  I found these out doing `make linkcheck` in `docs/` which was pretty handy.  (I made a reST update here and there while I was the area too.)