### PR TITLE
Test development version of Astropy with Python 3.8

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,10 +28,10 @@ jobs:
             python: 3.7
             toxenv: py37
 
-          - name: Python 3.7 with Astropy dev
+          - name: Python 3.8 with Astropy dev
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-astropydev
+            python: 3.8
+            toxenv: py38-astropydev
 
           - name: Python 3.8 with code coverage
             os: ubuntu-latest


### PR DESCRIPTION
We started getting a test failure with Python 3.7 for astropy-dev because they bumped their minimum version of Python to 3.8.  This PR updates our CI tests for astropy-dev to be consistent with the requirements that Astropy will have for their next release.  

If we keep the test at Python 3.8 rather than Python 3.9, we'll get a helpful test failure when Astropy bumps their minimum version again.