### PR TITLE
Describe conventions for putting formulae in docstrings

### DIFF
--- a/docs/development/doc_guide.rst
+++ b/docs/development/doc_guide.rst
@@ -750,6 +750,9 @@ Docstring guidelines
   be ≲ 4 sentences long. Any additional information should included in
   the "Notes" section.
 
+* Put any necessary highly technical information in the "Notes" section
+  of a docstring.
+
 * The short summary should start on the line immediately following the
   triple quotes. There should not be any blank lines immediately before
   the closing triple quotes.
@@ -792,8 +795,11 @@ Docstring guidelines
          Plasma beta is the ratio of thermal pressure to magnetic pressure.
          """
 
-* Put any necessary highly technical information in the "Notes" section
-  of a docstring.
+* When a function calculates a formula, put the formula in the extended
+  summary section when it can be done so concisely. When the formula is
+  particularly complicated, put it in the "Notes" section. Put
+  derivations and extensive discussions of mathematics in the "Notes"
+  section.
 
 * Private code objects (e.g., code objects that begin with a single
   underscore, like ``_private_object``) should have docstrings. A


### PR DESCRIPTION
Following up on #935 and #1156, this PR adds a description of where formulae and extended mathematical stuff should be put in docstrings.  I'll likely make a few other small changes here too.