### PR TITLE
Adopt a code highlighting style with higher contrast

### DIFF
--- a/changelog/1268.doc.rst
+++ b/changelog/1268.doc.rst
@@ -1,2 +1,3 @@
-Adopted the ``"xcode"`` code highlighting style for `pygments `__ to
+Adopted the ``"xcode"`` code highlighting style for
+`pygments <https://pygments.org/>`__ to
 increase color contrast and improve web accessibility.

--- a/changelog/1268.doc.rst
+++ b/changelog/1268.doc.rst
@@ -1,0 +1,2 @@
+Adopted the ``"xcode"`` code highlighting style for `pygments `__ to
+increase color contrast and improve web accessibility.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,26 +160,6 @@ todo_include_todos = False
 
 default_role = "obj"
 
-from pygments.style import Style
-from pygments.token import (
-    Comment,
-    Error,
-    Escape,
-    Generic,
-    Keyword,
-    Literal,
-    Name,
-    Number,
-    Operator,
-    Other,
-    Punctuation,
-    STANDARD_TYPES,
-    String,
-    Text,
-    Token,
-    Whitespace,
-)
-
 # Use a code highlighting style that meets the WCAG AA contrast standard
 pygments_style = "xcode"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,8 +160,28 @@ todo_include_todos = False
 
 default_role = "obj"
 
-# Use a high contrast code highlighting style for web accessibility
-pygments_style = "borland"
+from pygments.style import Style
+from pygments.token import (
+    Comment,
+    Error,
+    Escape,
+    Generic,
+    Keyword,
+    Literal,
+    Name,
+    Number,
+    Operator,
+    Other,
+    Punctuation,
+    STANDARD_TYPES,
+    String,
+    Text,
+    Token,
+    Whitespace,
+)
+
+# Use a code highlighting style that meets the WCAG AA contrast standard
+pygments_style = "xcode"
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,6 +160,9 @@ todo_include_todos = False
 
 default_role = "obj"
 
+# Use a high contrast code highlighting style for web accessibility
+pygments_style = "borland"
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -197,7 +200,6 @@ modindex_common_prefix = ["plasmapy."]
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "PlasmaPydoc"
-
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
According to the results posted in https://github.com/pygments/pygments/issues/1718, `"xcode"` is the only [pygments](https://pygments.org/) style that meets the [WCAG AA contrast standard](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) for web accessibility, apart from `"bw"` for black & white.  This PR changes our code formatting style to meet this accessibility standard.  

This should fix a bunch of the contrast errors that we get when [checking our docs against the WAVE accessibility tool](https://wave.webaim.org/report#/https://docs.plasmapy.org/en/latest/), though there are other style elements that are giving contrast errors too.