### PR TITLE
Change docstring section titles to match numpydoc standard

### DIFF
--- a/plasmapy/formulary/dielectric.py
+++ b/plasmapy/formulary/dielectric.py
@@ -291,8 +291,8 @@ def permittivity_1D_Maxwellian(
        Plasma scattering of electromagnetic radiation: theory and measurement
        techniques. Chapter 5 Pg 106 (Academic Press, 2010).
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> from numpy import pi
     >>> from astropy.constants import c

--- a/plasmapy/formulary/distribution.py
+++ b/plasmapy/formulary/distribution.py
@@ -222,8 +222,8 @@ def Maxwellian_velocity_2D(
     --------
     Maxwellian_1D
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_velocity_2D(vx=v,
@@ -368,8 +368,8 @@ def Maxwellian_velocity_3D(
     --------
     Maxwellian_1D
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_velocity_3D(vx=v,
@@ -489,8 +489,8 @@ def Maxwellian_speed_1D(v, T, particle="e", v_drift=0, vTh=np.nan, units="units"
 
     where :math:`v_{Th} = \sqrt{2 k_B T / m}` is the thermal speed.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_speed_1D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
@@ -603,8 +603,8 @@ def Maxwellian_speed_2D(v, T, particle="e", v_drift=0, vTh=np.nan, units="units"
     --------
     Maxwellian_speed_1D
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_speed_2D(v=v, T=30000 * u.K, particle='e', v_drift=0 * u.m / u.s)
@@ -720,8 +720,8 @@ def Maxwellian_speed_3D(v, T, particle="e", v_drift=0, vTh=np.nan, units="units"
     --------
     Maxwellian_speed_1D
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> Maxwellian_speed_3D(v=v, T=30000*u.K, particle='e', v_drift=0 * u.m / u.s)
@@ -1007,8 +1007,8 @@ def kappa_velocity_3D(
     kappa_velocity_1D
     kappa_thermal_speed
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> v=1 * u.m / u.s
     >>> kappa_velocity_3D(vx=v,

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -472,8 +472,8 @@ def ion_sound_speed(
     :math:`\sqrt{γ_e k_B T_e / m_i}`. Ion acoustic waves can
     therefore occur even when the ion temperature is zero.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> n = 5e19*u.m**-3
     >>> k_1 = 3e1*u.m**-1
@@ -1334,8 +1334,8 @@ def plasma_frequency(n: u.m ** -3, particle: Particle, z_mean=None) -> u.rad / u
     :math:`2π`\ . The alternatives are to convert to cycle/second or to
     do the conversion manually, as shown in the examples.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> plasma_frequency(1e19*u.m**-3, particle='p')
     <Quantity 4.16329...e+09 rad / s>
@@ -1434,8 +1434,8 @@ def Debye_length(T_e: u.K, n_e: u.m ** -3) -> u.m:
     --------
     Debye_number
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> Debye_length(5e6*u.K, 5e15*u.m**-3)
     <Quantity 0.002182... m>
@@ -1505,8 +1505,8 @@ def Debye_number(T_e: u.K, n_e: u.m ** -3) -> u.dimensionless_unscaled:
     --------
     Debye_length
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> Debye_number(5e6*u.K, 5e9*u.cm**-3)
     <Quantity 2.17658...e+08>
@@ -1578,8 +1578,8 @@ def inertial_length(n: u.m ** -3, particle: Particle) -> u.m:
 
     The inertial length is also known as the skin depth.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> inertial_length(5 * u.m ** -3, 'He+')
     <Quantity 2.02985...e+08 m>
@@ -1651,8 +1651,8 @@ def magnetic_pressure(B: u.T) -> u.Pa:
     magnetic_energy_density : returns an equivalent `~astropy.units.Quantity`,
         except in units of joules per cubic meter.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> magnetic_pressure(0.1*u.T).to(u.Pa)
     <Quantity 3978.87... Pa>
@@ -1716,8 +1716,8 @@ def magnetic_energy_density(B: u.T) -> u.J / u.m ** 3:
     magnetic_pressure : Returns an equivalent `~astropy.units.Quantity`,
         except in units of pascals.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> magnetic_energy_density(0.1*u.T)
     <Quantity 3978.87... J / m3>
@@ -1794,8 +1794,8 @@ def upper_hybrid_frequency(B: u.T, n_e: u.m ** -3) -> u.rad / u.s:
     can occur at the upper hybrid resonance, coupling to the
     electrostatic electron Bernstein wave.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> upper_hybrid_frequency(0.2*u.T, n_e=5e19*u.m**-3)
     <Quantity 4.00459...e+11 rad / s>
@@ -1886,8 +1886,8 @@ def lower_hybrid_frequency(B: u.T, n_i: u.m ** -3, ion: Particle) -> u.rad / u.s
     compared to the upper hybrid frequency. It can play an important role
     for heating and current drive in fusion plasmas.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> lower_hybrid_frequency(0.2*u.T, n_i=5e19*u.m**-3, ion='D+')
     <Quantity 5.78372...e+08 rad / s>

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -183,8 +183,8 @@ def thermal_deBroglie_wavelength(T_e: u.K) -> u.m:
 
        λ_{dbTh} = \frac{h}{\sqrt{2 π m_e k_B T_e}}
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> thermal_deBroglie_wavelength(1 * u.eV)
     <Quantity 6.9193675e-10 m>
@@ -249,8 +249,8 @@ def Fermi_energy(n_e: u.m ** -3) -> u.J:
     --------
     Thomas_Fermi_length
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> Fermi_energy(1e23 * u.cm**-3)
     <Quantity 1.2586761e-18 J>
@@ -323,8 +323,8 @@ def Thomas_Fermi_length(n_e: u.m ** -3) -> u.m:
     Fermi_energy
     plasmapy.formulary.Debye_length
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> Thomas_Fermi_length(1e23 * u.cm**-3)
     <Quantity 5.37991409e-11 m>
@@ -389,8 +389,8 @@ def Wigner_Seitz_radius(n: u.m ** -3) -> u.m:
     --------
     Fermi_energy
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> Wigner_Seitz_radius(1e29 * u.m**-3)
     <Quantity 1.33650462e-10 m>
@@ -473,8 +473,8 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
     ----------
     .. [1] Bonitz, Michael. Quantum kinetic theory. Stuttgart: Teubner, 1998.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> chemical_potential(n_e=1e21*u.cm**-3,T=11000*u.K)  # doctest: +SKIP
     <Quantity 2.00039985e-12>
@@ -586,8 +586,8 @@ def _chemical_potential_interp(n_e, T):
     .. [2] Gregori, G., et al. "Theoretical model of x-ray scattering as a
        dense matter probe." Physical Review E 67.2 (2003): 026412.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> _chemical_potential_interp(n_e=1e23*u.cm**-3, T=11000*u.K)  # doctest: +SKIP
     <Quantity 8.17649>

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -877,8 +877,8 @@ def reduced_mass(test_particle, target_particle) -> u.Quantity:
         `~plasmapy.particles.particle_class.Particle`,
         `~astropy.units.Quantity`, or `~astropy.constants.Constant`.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> reduced_mass('p+', 'e-')
     <Quantity 9.104425e-31 kg>

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -859,8 +859,8 @@ class IonizationState:
             below this level, then information for it will not be
             printed.  Defaults to 0.01.
 
-        Example
-        -------
+        Examples
+        --------
         >>> He_states = IonizationState(
         ...     'He',
         ...     [0.941, 0.058, 0.001],

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -161,7 +161,7 @@ class ParticleTracker:
         Implement the Boris algorithm for moving particles and updating their
         velocities.
 
-        Arguments
+        Parameters
         ----------
         init : `bool`, optional
             If `True`, does not change the particle positions and sets ``dt``


### PR DESCRIPTION
A quick PR to get our docstrings to match the numpydoc standard with regards to section titles.  The changes were `Example` → `Examples` and `Arguments` → `Parameters`.
