### PR TITLE
Enable type aliases in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,6 +154,14 @@ exclude_patterns = [
     "common_links.rst",
 ]
 
+napoleon_google_docstring = False
+napoleon_use_param = True
+napoleon_use_keyword = True
+napoleon_type_aliases = {
+    "keyword-only": ":term:`keyword-only`",
+    "particle-like": ":term:`particle-like`",
+}
+napoleon_preprocess_types = True
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ extensions = [
     "sphinx_gallery.load_style",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinx_changelog",
-    "plasmapy_sphinx",
+    # "plasmapy_sphinx",  ← temporary
 ]
 
 # Intersphinx generates automatic links to the documentation of objects

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -240,7 +240,7 @@ class Particle(AbstractPhysicalParticle):
 
     Parameters
     ----------
-    argument : `ParticleLike`, excluding `CustomParticle` instances
+    argument : particle-like, excluding `CustomParticle` instances
         A string representing a particle, element, isotope, or ion; an
         integer representing the atomic number of an element; or a
         |Particle| instance.


### PR DESCRIPTION
This is an attempt following #1270 to get type aliases to work in our documentation. At the very least, this PR is intended to set up the infrastructure for the type aliases, even if they don't get displayed yet.

To check if it's working, there should be a link for [particle-like](https://docs.plasmapy.org/en/latest/glossary.html#term-particle-like) in the docstring for `Particle`.