### PR TITLE
Update communication page in docs

### DIFF
--- a/changelog/1272.doc.rst
+++ b/changelog/1272.doc.rst
@@ -1,0 +1,1 @@
+Updated the feedback and communication page.

--- a/docs/COMMUNICATION.rst
+++ b/docs/COMMUNICATION.rst
@@ -3,47 +3,38 @@
 Feedback and Communication
 ==========================
 
-Matrix chat <https://app.element.io/#/room/#plasmapy:openastronomy.org>`__
---------------------------------------------------------------------------
+Matrix chat room
+----------------
 
-The primary communication channel for PlasmaPy, and the quickest way to ask
-a question and get a response, is our `Matrix room
-<https://app.element.io/#/room/#plasmapy:openastronomy.org>`__, which is also
-bridged (mirrored) to `Gitter <https://gitter.im/PlasmaPy/Lobby>`__.
+The primary communication channel for PlasmaPy is our `Matrix chat
+room`_. There is also a `Gitter bridge`_ to this chat room.
 
-`GitHub Discussions <https://github.com/PlasmaPy/PlasmaPy/discussions>`__
--------------------------------------------------------------------------
+GitHub Discussions page
+-----------------------
 
-PlasmaPy's `GitHub Discussions page
-<https://github.com/PlasmaPy/PlasmaPy/discussions>`__ is a great place to
-suggest ideas, bring up discussion topics, and ask questions in threaded public
+PlasmaPy's `GitHub Discussions page`_ is a great place to suggest ideas,
+bring up discussion topics, and ask questions in threaded public
 discussions.
 
-`Mailing list <https://groups.google.com/forum/#!forum/plasmapy>`__
--------------------------------------------------------------------
+Mailing list
+------------
 
-We also have a `mailing
-list <https://groups.google.com/forum/#!forum/plasmapy>`__ that serves
-as a less volatile discussion forum.
+We also have a low traffic `mailing list`_ for occasional announcements
+and infrequent discussions.
 
-`Suggestion box <https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform?usp=sf_link>`__
-------------------------------------------------------------------------------------------------------------------------------------
+Suggestion box
+--------------
 
-We have `a suggestion
-box <https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform?usp=sf_link>`__
-if you would like to (optionally anonymously) suggest a feature/topic
-for consideration. These will be reposted on the mailing list or
-directly in GitHub issues, as appropriate, for further discussion.
+We have a `suggestion box`_ if you would like to (optionally
+anonymously) suggest a feature/topic for consideration. These will be
+reposted as GitHub issues, as appropriate, for further discussion.
 
-`Weekly <https://calendar.google.com/calendar?cid=bzVsb3ZkcW0zaWxsam00ZTlrMDd2cmw5bWdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ>`__ `community meetings <https://meet.jit.si/plasmapy>`__
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-We have approximately weekly community meetings in the
-`PlasmaPy room on Jitsi <https://meet.jit.si/plasmapy>`__.
-The schedule of our community meetings is on our `calendar
-<https://calendar.google.com/calendar?cid=bzVsb3ZkcW0zaWxsam00ZTlrMDd2cmw5bWdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ>`__,
-and you may access the `minutes and agendas
-<https://drive.google.com/drive/folders/0ByPG8nie6fTPV1FQUEkzMTgtRTg?usp=sharing>`__.
-Any last minute changes will be discussed on `Matrix
-<https://app.element.io/#/room/#plasmapy:openastronomy.org>`__.
-As of November 2020, our meetings are on Tuesdays at
-`19:00 UTC <http://time.unitarium.com/utc/6pm>`__.
+Meetings and events
+-------------------
+
+Please check `PlasmaPy meetings`_ for regularly scheduled meetings
+and special events. The regularly scheduled meetings include a
+community meeting to discuss code development, a project meeting to
+discuss broader aspects of the PlasmaPy project like education and
+outreach to the broader plasma community, and meetings of PlasmaPy
+working groups. The special events include `Plasma Hack Week`_.

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -53,17 +53,23 @@
 .. _git: https://git-scm.com/
 .. _GitHub: https://github.com/
 .. _`GitHub Actions`: https://docs.github.com/en/actions
+.. _`GitHub Discussions page`: https://github.com/PlasmaPy/PlasmaPy/discussions
+.. _`Gitter bridge`: https://gitter.im/PlasmaPy/Lobby
 .. _intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 .. _isort: https://pycqa.github.io/isort/
 .. _Jupyter: https://jupyter.org/
+.. _`mailing list`: https://groups.google.com/forum/#!forum/plasmapy
 .. _Markdown: https://www.markdownguide.org/
 .. _matplotlib: https://matplotlib.org/
+.. _`Matrix chat room`: https://app.element.io/#/room/#plasmapy:openastronomy.org
 .. _NumPy: https://numpy.org/
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
 .. _pip: https://pip.pypa.io
 .. _PlasmaPy: https://www.plasmapy.org
 .. _`PlasmaPy's GitHub repository`: https://github.com/PlasmaPy/plasmapy
 .. _`PlasmaPy's documentation`: https://docs.plasmapy.org/en/stable/
+.. _`Plasma Hack Week`: https://hack.plasmapy.org
+.. _`PlasmaPy meetings`: https://www.plasmapy.com/meetings
 .. _PyPI: https://pypi.org/
 .. _Python: https://www.python.org/
 .. _`Python's documentation`: https://docs.python.org/3/
@@ -71,7 +77,9 @@
 .. _reST: https://docutils.sourceforge.io/rst.html
 .. _SciPy: https://www.scipy.org/
 .. _Sphinx: https://www.sphinx-doc.org/
+.. _`suggestion box`: https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform?usp=sf_link
 .. _towncrier: https://towncrier.readthedocs.io/en/actual-freaking-docs/
 .. _tox: https://tox.readthedocs.io/
 .. _virtualenv: https://pypi.org/project/virtualenv
 .. _Zenodo: https://zenodo.org/
+7

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -46,40 +46,39 @@
 .. --------
 
 .. _Astropy: https://www.astropy.org/
-.. _`Astropy docs`: https://docs.astropy.org/
+.. _Astropy docs: https://docs.astropy.org/
 .. _black: https://black.readthedocs.io
-.. _`docs/common_links.rst`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/common_links.rst
+.. _docs/common_links.rst: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/common_links.rst
 .. _Conda: https://conda.io/en/latest/
 .. _git: https://git-scm.com/
 .. _GitHub: https://github.com/
-.. _`GitHub Actions`: https://docs.github.com/en/actions
-.. _`GitHub Discussions page`: https://github.com/PlasmaPy/PlasmaPy/discussions
-.. _`Gitter bridge`: https://gitter.im/PlasmaPy/Lobby
+.. _GitHub Actions: https://docs.github.com/en/actions
+.. _GitHub Discussions page: https://github.com/PlasmaPy/PlasmaPy/discussions
+.. _Gitter bridge: https://gitter.im/PlasmaPy/Lobby
 .. _intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 .. _isort: https://pycqa.github.io/isort/
 .. _Jupyter: https://jupyter.org/
-.. _`mailing list`: https://groups.google.com/forum/#!forum/plasmapy
+.. _mailing list: https://groups.google.com/forum/#!forum/plasmapy
 .. _Markdown: https://www.markdownguide.org/
 .. _matplotlib: https://matplotlib.org/
-.. _`Matrix chat room`: https://app.element.io/#/room/#plasmapy:openastronomy.org
+.. _Matrix chat room: https://app.element.io/#/room/#plasmapy:openastronomy.org
 .. _NumPy: https://numpy.org/
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
 .. _pip: https://pip.pypa.io
 .. _PlasmaPy: https://www.plasmapy.org
-.. _`PlasmaPy's GitHub repository`: https://github.com/PlasmaPy/plasmapy
-.. _`PlasmaPy's documentation`: https://docs.plasmapy.org/en/stable/
-.. _`Plasma Hack Week`: https://hack.plasmapy.org
-.. _`PlasmaPy meetings`: https://www.plasmapy.com/meetings
+.. _PlasmaPy's GitHub repository: https://github.com/PlasmaPy/plasmapy
+.. _PlasmaPy's documentation: https://docs.plasmapy.org/en/stable/
+.. _Plasma Hack Week: https://hack.plasmapy.org
+.. _PlasmaPy meetings: https://www.plasmapy.com/meetings
 .. _PyPI: https://pypi.org/
 .. _Python: https://www.python.org/
-.. _`Python's documentation`: https://docs.python.org/3/
-.. _`Read the Docs`: https://readthedocs.org/
+.. _Python's documentation: https://docs.python.org/3/
+.. _Read the Docs: https://readthedocs.org/
 .. _reST: https://docutils.sourceforge.io/rst.html
 .. _SciPy: https://www.scipy.org/
 .. _Sphinx: https://www.sphinx-doc.org/
-.. _`suggestion box`: https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform?usp=sf_link
+.. _suggestion box: https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform?usp=sf_link
 .. _towncrier: https://towncrier.readthedocs.io/en/actual-freaking-docs/
 .. _tox: https://tox.readthedocs.io/
 .. _virtualenv: https://pypi.org/project/virtualenv
 .. _Zenodo: https://zenodo.org/
-7

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -45,40 +45,40 @@
 .. Websites
 .. --------
 
-.. _Astropy: https://www.astropy.org/
 .. _Astropy docs: https://docs.astropy.org/
-.. _black: https://black.readthedocs.io
-.. _docs/common_links.rst: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/common_links.rst
+.. _Astropy: https://www.astropy.org/
 .. _Conda: https://conda.io/en/latest/
-.. _git: https://git-scm.com/
-.. _GitHub: https://github.com/
 .. _GitHub Actions: https://docs.github.com/en/actions
 .. _GitHub Discussions page: https://github.com/PlasmaPy/PlasmaPy/discussions
+.. _GitHub: https://github.com/
 .. _Gitter bridge: https://gitter.im/PlasmaPy/Lobby
-.. _intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
-.. _isort: https://pycqa.github.io/isort/
 .. _Jupyter: https://jupyter.org/
-.. _mailing list: https://groups.google.com/forum/#!forum/plasmapy
 .. _Markdown: https://www.markdownguide.org/
-.. _matplotlib: https://matplotlib.org/
 .. _Matrix chat room: https://app.element.io/#/room/#plasmapy:openastronomy.org
 .. _NumPy: https://numpy.org/
-.. _numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
-.. _pip: https://pip.pypa.io
-.. _PlasmaPy: https://www.plasmapy.org
-.. _PlasmaPy's GitHub repository: https://github.com/PlasmaPy/plasmapy
-.. _PlasmaPy's documentation: https://docs.plasmapy.org/en/stable/
 .. _Plasma Hack Week: https://hack.plasmapy.org
 .. _PlasmaPy meetings: https://www.plasmapy.com/meetings
+.. _PlasmaPy's GitHub repository: https://github.com/PlasmaPy/plasmapy
+.. _PlasmaPy's documentation: https://docs.plasmapy.org/en/stable/
+.. _PlasmaPy: https://www.plasmapy.org
 .. _PyPI: https://pypi.org/
-.. _Python: https://www.python.org/
 .. _Python's documentation: https://docs.python.org/3/
+.. _Python: https://www.python.org/
 .. _Read the Docs: https://readthedocs.org/
-.. _reST: https://docutils.sourceforge.io/rst.html
 .. _SciPy: https://www.scipy.org/
 .. _Sphinx: https://www.sphinx-doc.org/
+.. _Zenodo: https://zenodo.org/
+.. _black: https://black.readthedocs.io
+.. _docs/common_links.rst: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/common_links.rst
+.. _git: https://git-scm.com/
+.. _intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+.. _isort: https://pycqa.github.io/isort/
+.. _mailing list: https://groups.google.com/forum/#!forum/plasmapy
+.. _matplotlib: https://matplotlib.org/
+.. _numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
+.. _pip: https://pip.pypa.io
+.. _reST: https://docutils.sourceforge.io/rst.html
 .. _suggestion box: https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform?usp=sf_link
 .. _towncrier: https://towncrier.readthedocs.io/en/actual-freaking-docs/
 .. _tox: https://tox.readthedocs.io/
 .. _virtualenv: https://pypi.org/project/virtualenv
-.. _Zenodo: https://zenodo.org/


### PR DESCRIPTION
This is an update to our [communication page](https://docs.plasmapy.org/en/stable/COMMUNICATION.html), which has gotten a little out-of-date.  I'm attempting to future-proof it by referring readers to the corresponding page on PlasmaPy's website, which would also be worth updating.  Closes #1265.