### PR TITLE
Add security analysis linter

### DIFF
--- a/changelog/1280.trivial.1.rst
+++ b/changelog/1280.trivial.1.rst
@@ -1,0 +1,3 @@
+Added using [dlint](https://github.com/dlint-py/dlint)
+to the ``linters`` testing environment in :file:`tox.ini`
+as a static analysis tool to search for security issues.

--- a/changelog/1280.trivial.2.rst
+++ b/changelog/1280.trivial.2.rst
@@ -1,0 +1,1 @@
+Replaced usage of `eval` inside |IonizationStateCollection| with `getattr`.

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -359,8 +359,8 @@ class IonizationStateCollection:
         # that np.nan == np.nan is False.
 
         for attribute in ["T_e", "n_e", "kappa"]:
-            this = eval(f"self.{attribute}")
-            that = eval(f"other.{attribute}")
+            this = getattr(self, attribute)
+            that = getattr(other, attribute)
 
             # TODO: Maybe create a function in utils called same_enough
             # TODO: that would take care of all of these disparate
@@ -381,8 +381,8 @@ class IonizationStateCollection:
 
         for attribute in ["ionic_fractions", "number_densities"]:
 
-            this_dict = eval(f"self.{attribute}")
-            that_dict = eval(f"other.{attribute}")
+            this_dict = getattr(self, attribute)
+            that_dict = getattr(other, attribute)
 
             for particle in self.base_particles:
 

--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,7 @@ deps =
     pydocstyle
     flake8-rst-docstrings
     pygments
+    dlint
 commands =
     flake8 --bug-report
     flake8 {toxinidir}{/}plasmapy --count --show-source --statistics


### PR DESCRIPTION
This PR adds [dlint](https://github.com/dlint-py/dlint) as one of our static analysis tools run in the linters environment for tox.  

It came up with one "stop using `eval`" error when running locally, so we should get that here too if the tests are running.

An alternative would be to use [bandit](https://bandit.readthedocs.io/en/latest/), but for the time being either one would be helpful.  