### PR TITLE
Add linter to enforce usage of f-strings 

### DIFF
--- a/changelog/1281.trivial.1.rst
+++ b/changelog/1281.trivial.1.rst
@@ -1,3 +1,3 @@
-Enabled using [flake8-use-fstring](https://github.com/MichaelKim0407/flake8-use-fstring)
+Enabled using `flake8-use-fstring <https://github.com/MichaelKim0407/flake8-use-fstring>`__
 to the ``linters`` testing environment in :file:`tox.ini` to enforce
 usage of formatted string literals (f-strings).

--- a/changelog/1281.trivial.1.rst
+++ b/changelog/1281.trivial.1.rst
@@ -1,2 +1,3 @@
-Enabled using [flake8-use-fstring]()
-in
+Enabled using [flake8-use-fstring](https://github.com/MichaelKim0407/flake8-use-fstring)
+to the ``linters`` testing environment in :file:`tox.ini` to enforce
+usage of formatted string literals (f-strings).

--- a/changelog/1281.trivial.1.rst
+++ b/changelog/1281.trivial.1.rst
@@ -1,0 +1,2 @@
+Enabled using [flake8-use-fstring]()
+in

--- a/changelog/1281.trivial.2.rst
+++ b/changelog/1281.trivial.2.rst
@@ -1,0 +1,2 @@
+Switched usage of `str.format` to formatted string literals (f-strings)
+in several files.

--- a/plasmapy/formulary/magnetostatics.py
+++ b/plasmapy/formulary/magnetostatics.py
@@ -40,7 +40,6 @@ class MagnetoStatics(abc.ABC):
         -------
         B : `~astropy.units.Quantity`
             Magnetic field at the specified position.
-
         """
 
 
@@ -55,7 +54,6 @@ class MagneticDipole(MagnetoStatics):
 
     p0: `~astropy.units.Quantity`
         Position of the dipole.
-
     """
 
     @validate_quantities
@@ -66,13 +64,12 @@ class MagneticDipole(MagnetoStatics):
         self._p0_u = p0.unit
 
     def __repr__(self):
-        return "{name}(moment={moment}{moment_u}, p0={p0}{p0_u})".format(
-            name=self.__class__.__name__,
-            moment=self.moment,
-            p0=self.p0,
-            moment_u=self._moment_u,
-            p0_u=self._p0_u,
-        )
+        name = self.__class__.__name__
+        moment = self.moment
+        p0 = self.p0
+        moment_u = self._moment_u
+        p0_u = self._p0_u
+        return f"{name}(moment={moment}{moment_u}, p0={p0}{p0_u})"
 
     def magnetic_field(self, p: u.m) -> u.T:
         r"""
@@ -87,7 +84,6 @@ class MagneticDipole(MagnetoStatics):
         -------
         B : `~astropy.units.Quantity`
             Magnetic field at the specified position.
-
         """
         r = p - self.p0
         m = self.moment
@@ -125,7 +121,6 @@ class GeneralWire(Wire):
 
     current: `~astropy.units.Quantity`
         Electric current.
-
     """
 
     @validate_quantities
@@ -143,16 +138,15 @@ class GeneralWire(Wire):
         self._current_u = current.unit
 
     def __repr__(self):
+        name = self.__class__.__name__
+        parametric_eq = self.parametric_eq.__name__
+        t1 = self.t1
+        t2 = self.t2
+        current = self.current
+        current_u = self._current_u
         return (
-            "{name}(parametric_eq={parametric_eq}, t1={t1}, t2={t2}, "
-            "current={current}{current_u})".format(
-                name=self.__class__.__name__,
-                parametric_eq=self.parametric_eq.__name__,
-                t1=self.t1,
-                t2=self.t2,
-                current=self.current,
-                current_u=self._current_u,
-            )
+            f"{name}(parametric_eq={parametric_eq}, t1={t1}, t2={t2}, "
+            f"current={current}{current_u})"
         )
 
     def magnetic_field(self, p: u.m, n: numbers.Integral = 1000) -> u.T:
@@ -185,7 +179,6 @@ class GeneralWire(Wire):
             \left[\vec p - \frac{\vec l(t_{i}) + \vec l(t_{i-1})}{2}\right]}
             {\left|\vec p - \frac{\vec l(t_{i}) + \vec l(t_{i-1})}{2}\right|^3},
             \quad \text{where}\, t_i = t_{\min}+i/n*(t_{\max}-t_{\min})
-
         """
 
         p1 = self.parametric_eq(self.t1)
@@ -219,7 +212,6 @@ class FiniteStraightWire(Wire):
 
     current : `astropy.units.Quantity`
         Electric current.
-
     """
 
     @validate_quantities
@@ -267,7 +259,6 @@ class FiniteStraightWire(Wire):
             \vec B = \frac{(\overrightarrow{P_2P_1}\times\overrightarrow{PP_f})^0}
                      {|\overrightarrow{PP_f}|}
                      \frac{μ_0 I}{4π} (\cos θ_1 - \cos θ_2)
-
         """
         # foot of perpendicular
         p1, p2 = self.p1, self.p2
@@ -319,7 +310,6 @@ class InfiniteStraightWire(Wire):
 
     current : `~astropy.units.Quantity`
         Electric current.
-
     """
 
     @validate_quantities
@@ -331,13 +321,15 @@ class InfiniteStraightWire(Wire):
         self._current_u = current.unit
 
     def __repr__(self):
-        return "{name}(direction={direction}, p0={p0}{p0_u}, current={current}{current_u})".format(
-            name=self.__class__.__name__,
-            direction=self.direction,
-            p0=self.p0,
-            current=self.current,
-            p0_u=self._p0_u,
-            current_u=self._current_u,
+        name = self.__class__.__name__
+        direction = self.direction
+        p0 = self.p0
+        current = self.current
+        p0_u = self._p0_u
+        current_u = self._current_u
+        return (
+            f"{name}(direction={direction}, p0={p0}{p0_u}, "
+            f"current={current}{current_u})"
         )
 
     def magnetic_field(self, p) -> u.T:
@@ -360,7 +352,6 @@ class InfiniteStraightWire(Wire):
             \vec B = \frac{μ_0 I}{2π r}*(\vec l^0\times \vec{PP_0})^0,
             \text{where}\, \vec l^0\, \text{is the unit vector of current direction},
             r\, \text{is the perpendicular distance between} P_0 \text{and the infinite wire}
-
         """
         r = np.cross(self.direction, p - self.p0)
         B_unit = r / np.linalg.norm(r)
@@ -386,22 +377,20 @@ class CircularWire(Wire):
 
     current: `~astropy.units.Quantity`
         Electric current.
-
     """
 
     def __repr__(self):
+        name = (self.__class__.__name__,)
+        normal = (self.normal,)
+        center = (self.center,)
+        radius = (self.radius,)
+        current = (self.current,)
+        center_u = (self._center_u,)
+        radius_u = (self._radius_u,)
+        current_u = (self._current_u,)
         return (
-            "{name}(normal={normal}, center={center}{center_u}, "
-            "radius={radius}{radius_u}, current={current}{current_u})".format(
-                name=self.__class__.__name__,
-                normal=self.normal,
-                center=self.center,
-                radius=self.radius,
-                current=self.current,
-                center_u=self._center_u,
-                radius_u=self._radius_u,
-                current_u=self._current_u,
-            )
+            f"{name}(normal={normal}, center={center}{center_u}, "
+            f"radius={radius}{radius_u}, current={current}{current_u})"
         )
 
     @validate_quantities
@@ -477,9 +466,7 @@ class CircularWire(Wire):
 
         We use ``n`` points using Gauss-Legendre quadrature to compute
         the integral. The default ``n`` is 300.
-
         """
-
         x, w = self.roots_legendre
         t = x * np.pi
         pt = self.curve(t)

--- a/plasmapy/formulary/magnetostatics.py
+++ b/plasmapy/formulary/magnetostatics.py
@@ -380,14 +380,14 @@ class CircularWire(Wire):
     """
 
     def __repr__(self):
-        name = (self.__class__.__name__,)
-        normal = (self.normal,)
-        center = (self.center,)
-        radius = (self.radius,)
-        current = (self.current,)
-        center_u = (self._center_u,)
-        radius_u = (self._radius_u,)
-        current_u = (self._current_u,)
+        name = self.__class__.__name__
+        normal = self.normal
+        center = self.center
+        radius = self.radius
+        current = self.current
+        center_u = self._center_u
+        radius_u = self._radius_u
+        current_u = self._current_u
         return (
             f"{name}(normal={normal}, center={center}{center_u}, "
             f"radius={radius}{radius_u}, current={current}{current_u})"

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -673,11 +673,11 @@ def thermal_speed(
     try:
         coef = _coefficients[ndim]
     except KeyError:
-        raise ValueError("{ndim} is not a supported value for ndim in thermal_speed")
+        raise ValueError(f"{ndim} is not a supported value for ndim in thermal_speed")
     try:
         coef = coef[method]
     except KeyError:
-        raise ValueError("Method {method} not supported in thermal_speed")
+        raise ValueError(f"Method {method} not supported in thermal_speed")
 
     return np.sqrt(coef * k_B * T / m)
 

--- a/plasmapy/formulary/radiation.py
+++ b/plasmapy/formulary/radiation.py
@@ -127,7 +127,7 @@ def thermal_bremsstrahlung(
 
         raise PhysicsError(
             "Rayleigh-Jeans limit not satisfied: "
-            "hbar*ω/kT_e = {rj_const.value:.2e} > 0.1. "
+            f"ℏω/kT_e = {rj_const.value:.2e} > 0.1. "
             "Try lower ω or higher T_e."
         )
 

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -664,7 +664,7 @@ class IonizationState:
             )
 
             if value.size == 5 and self._number_of_particles != 5:
-                error_str += " For {self.base_particle}, five is right out."
+                error_str += f" For {self.base_particle}, five is right out."
             raise ParticleError(error_str)
 
     @property
@@ -883,17 +883,8 @@ class IonizationState:
         """
         separator_line = [64 * "-"]
 
-        scientific = "{:.2e}"
-        floaty = "{:.2f}"
-
-        n_elem = scientific.format(self.n_elem.value)
-        n_e = scientific.format(self.n_e.value)
-        T_e = scientific.format(self.T_e.value)
-        kappa = floaty.format(self.kappa)
-        Z_mean = floaty.format(self.Z_mean)
-
         output = [
-            f"IonizationState instance for {self.base_particle} with Z_mean = {Z_mean}"
+            f"IonizationState instance for {self.base_particle} with Z_mean = {self.Z_mean:.2f}"
         ]
         attributes = []
 
@@ -904,12 +895,12 @@ class IonizationState:
             # TODO add T_i somewhere around here, probably
 
         if not np.isnan(self.n_elem):
-            attributes.append(f"n_elem = {n_elem} m**-3")
-            attributes.append(f"n_e = {n_e} m**-3")
+            attributes.append(f"n_elem = {self.n_elem.value:.2e} m**-3")
+            attributes.append(f"n_e = {self.n_e.value:.2e} m**-3")
         if not np.isnan(self.T_e):
-            attributes.append(f"T_e = {T_e} K")
+            attributes.append(f"T_e = {self.T_e.value:.2f} K")
         if np.isfinite(self.kappa):
-            attributes.append(f"kappa = {kappa}")
+            attributes.append(f"kappa = {self.kappa:.2f}")
 
         if attributes:
             attributes += separator_line

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -908,11 +908,11 @@ class IonizationStateCollection:
 
         attributes = []
         if np.isfinite(self.n_e):
-            attributes.append("n_e = " + "{:.2e}".format(self.n_e.value) + " m**-3")
+            attributes.append(f"n_e = {self.n_e.value:.2e} m**-3")
         if np.isfinite(self.T_e):
-            attributes.append("T_e = " + "{:.2e}".format(self.T_e.value) + " K")
+            attributes.append(f"T_e = {self.T_e.value:.2e} K")
         if np.isfinite(self.kappa):
-            attributes.append("kappa = " + "{:.2f}".format(self.kappa))
+            attributes.append(f"kappa = {self.kappa:.2f}")
 
         if attributes:
             attributes.append(separator_line)

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -131,9 +131,9 @@ class BasicRegistrationFactory:
         elif n_matches > 1:
             print(candidate_widget_types)
             raise MultipleMatchError(
-                "Too many candidate types identified ({0})."
+                f"Too many candidate types identified ({n_matches}). "
                 "Specify enough keywords to guarantee unique type "
-                "identification.".format(n_matches)
+                "identification."
             )
 
         # Only one is found
@@ -189,15 +189,13 @@ class BasicRegistrationFactory:
                         break
                     else:
                         raise ValidationFunctionError(
-                            "{0}.{1} must be a classmethod.".format(
-                                WidgetType.__name__, vfunc_str
-                            )
+                            f"{WidgetType.__name__}.{vfunc_str} must be a classmethod."
                         )
 
             if not found:
                 raise ValidationFunctionError(
-                    "No proper validation function for class {0} "
-                    "found.".format(WidgetType.__name__)
+                    "No proper validation function for class "
+                    f"{WidgetType.__name__} found."
                 )
 
     def unregister(self, WidgetType):

--- a/plasmapy/utils/roman.py
+++ b/plasmapy/utils/roman.py
@@ -144,7 +144,7 @@ def from_roman(s: str) -> Integral:
     if not isinstance(s, str):
         raise TypeError("The argument to from_roman must be a string.")
     if not _romanNumeralPattern.search(s):
-        raise InvalidRomanNumeralError("Invalid Roman numeral: %s" % s)
+        raise InvalidRomanNumeralError(f"Invalid Roman numeral: {s}")
 
     result = 0
     index = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -195,8 +195,15 @@ rst-directives =
     nbgallery
     rst:directive
     todo
+enable-extensions =
+    # Look for strings that have {} in them but aren't f-strings.
+    # If there is a false positive from this in a file, put that in
+    # per-file-ignores.
+    FS003
 per-file-ignores =
     plasmapy/formulary/__init__.py:F403
+    plasmapy/__init__.py:FS003
+    plasmapy/diagnostics/proton_radiography.py:FS003
 
 [coverage:run]
 omit =

--- a/tox.ini
+++ b/tox.ini
@@ -107,6 +107,7 @@ deps =
     flake8
     pydocstyle
     flake8-rst-docstrings
+    flake8-use-fstring
     pygments
 commands =
     flake8 --bug-report


### PR DESCRIPTION
This PR:
 - Adds the [flake8-use-fstring](https://github.com/MichaelKim0407/flake8-use-fstring) linter to `tox.ini`
 - Removes the last of our `.format` and `% s` usage with f-strings.
