### PR TITLE
Use flake8 checker for absolute imports and remove unused imports

### DIFF
--- a/changelog/1283.trivial.1.rst
+++ b/changelog/1283.trivial.1.rst
@@ -1,0 +1,2 @@
+Added `flake8-absolute-import <https://github.com/bskinn/flake8-absolute-import>`_ to the
+``linters`` tox_ environment.

--- a/changelog/1283.trivial.2.rst
+++ b/changelog/1283.trivial.2.rst
@@ -1,0 +1,1 @@
+Removed unused imports, and changed several imports from relative to absolute.

--- a/plasmapy/analysis/swept_langmuir/__init__.py
+++ b/plasmapy/analysis/swept_langmuir/__init__.py
@@ -4,5 +4,8 @@ Subpackage containing routines for analyzing swept Langmuir probe traces.
 __all__ = ["check_sweep", "find_floating_potential", "find_vf_"]
 __aliases__ = ["find_vf_"]
 
-from .floating_potential import find_floating_potential, find_vf_
-from .helpers import check_sweep
+from plasmapy.analysis.swept_langmuir.floating_potential import (
+    find_floating_potential,
+    find_vf_,
+)
+from plasmapy.analysis.swept_langmuir.helpers import check_sweep

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -6,18 +6,18 @@ from plasma science.
 __all__ = []
 __aliases__ = []
 
-from .braginskii import *
-from .collisions import *
-from .dielectric import *
-from .dimensionless import *
-from .distribution import *
-from .drifts import *
-from .ionization import *
-from .magnetostatics import *
-from .mathematics import *
-from .parameters import *
-from .quantum import *
-from .relativity import *
+from plasmapy.formulary.braginskii import *
+from plasmapy.formulary.collisions import *
+from plasmapy.formulary.dielectric import *
+from plasmapy.formulary.dimensionless import *
+from plasmapy.formulary.distribution import *
+from plasmapy.formulary.drifts import *
+from plasmapy.formulary.ionization import *
+from plasmapy.formulary.magnetostatics import *
+from plasmapy.formulary.mathematics import *
+from plasmapy.formulary.parameters import *
+from plasmapy.formulary.quantum import *
+from plasmapy.formulary.relativity import *
 
 # auto populate __all__
 for obj_name in list(globals()):

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -58,7 +58,7 @@ import numpy as np
 import warnings
 
 from astropy import units as u
-from astropy.constants.si import c, e, eps0, hbar, k_B, m_e
+from astropy.constants.si import e, eps0, hbar, k_B, m_e
 from numpy import pi
 
 from plasmapy import particles, utils

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -54,10 +54,10 @@ __all__ = [
     "coupling_parameter",
 ]
 
+import astropy.units as u
 import numpy as np
 import warnings
 
-from astropy import units as u
 from astropy.constants.si import e, eps0, hbar, k_B, m_e
 from numpy import pi
 
@@ -372,7 +372,7 @@ def Coulomb_logarithm(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> n = 1e19 * u.m**-3
     >>> T = 1e6 * u.K
     >>> Coulomb_logarithm(T, n, ('e-', 'p+'))
@@ -574,7 +574,7 @@ def impact_parameter_perp(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> T = 1e6*u.K
     >>> species = ('e', 'p')
     >>> impact_parameter_perp(T, species)
@@ -701,7 +701,7 @@ def impact_parameter(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> n = 1e19*u.m**-3
     >>> T = 1e6*u.K
     >>> species = ('e', 'p')
@@ -919,7 +919,7 @@ def collision_frequency(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> n = 1e19*u.m**-3
     >>> T = 1e6*u.K
     >>> species = ('e', 'p')
@@ -1113,7 +1113,8 @@ def fundamental_electron_collision_freq(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
+    >>> from astropy.constants import c
     >>> fundamental_electron_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p')
     <Quantity 0.001801... 1 / s>
     >>> fundamental_electron_collision_freq(1e6 * u.K, 1e6 / u.m ** 3, 'p')
@@ -1251,7 +1252,8 @@ def fundamental_ion_collision_freq(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
+    >>> from astropy.constants import c
     >>> fundamental_ion_collision_freq(0.1 * u.eV, 1e6 / u.m ** 3, 'p')
     <Quantity 2.868...e-05 1 / s>
     >>> fundamental_ion_collision_freq(1e6 * u.K, 1e6 / u.m ** 3, 'p')
@@ -1394,7 +1396,7 @@ def mean_free_path(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> n = 1e19 * u.m ** -3
     >>> T = 1e6 * u.K
     >>> mean_free_path(T, n, ('e-', 'p+'))
@@ -1524,7 +1526,7 @@ def Spitzer_resistivity(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> n = 1e19*u.m**-3
     >>> T = 1e6*u.K
     >>> species = ('e', 'p')
@@ -1656,7 +1658,7 @@ def mobility(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> n = 1e19*u.m**-3
     >>> T = 1e6*u.K
     >>> species = ('e', 'p')
@@ -1788,7 +1790,7 @@ def Knudsen_number(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> L = 1e-3 * u.m
     >>> n = 1e19*u.m**-3
     >>> T = 1e6*u.K
@@ -1943,7 +1945,7 @@ def coupling_parameter(
 
     Examples
     --------
-    >>> from astropy import units as u
+    >>> import astropy.units as u
     >>> n = 1e19*u.m**-3
     >>> T = 1e6*u.K
     >>> species = ('e', 'p')

--- a/plasmapy/formulary/dimensionless.py
+++ b/plasmapy/formulary/dimensionless.py
@@ -20,10 +20,9 @@ __aliases__ = ["Re_", "Rm_"]
 
 from astropy import constants
 from astropy import units as u
-from astropy.constants import c
 from astropy.constants.codata2010 import mu0
 
-from plasmapy.formulary import electron_viscosity, parameters, quantum
+from plasmapy.formulary import parameters, quantum
 from plasmapy.utils.decorators import validate_quantities
 
 

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -5,7 +5,6 @@ __all__ = ["Fermi_integral", "rot_a_to_b"]
 import numbers
 import numpy as np
 
-from scipy import special
 from typing import Union
 
 

--- a/plasmapy/formulary/tests/test_dimensionless.py
+++ b/plasmapy/formulary/tests/test_dimensionless.py
@@ -2,8 +2,6 @@ import astropy.units as u
 import numpy as np
 import pytest
 
-from astropy.constants import c
-
 from plasmapy.formulary.dimensionless import (
     beta,
     Mag_Reynolds,
@@ -12,7 +10,6 @@ from plasmapy.formulary.dimensionless import (
     Reynolds_number,
     Rm_,
 )
-from plasmapy.utils import RelativityError
 
 B = 1.0 * u.T
 n = 5e19 * u.m ** -3

--- a/plasmapy/formulary/tests/test_distribution.py
+++ b/plasmapy/formulary/tests/test_distribution.py
@@ -5,7 +5,7 @@ import pytest
 import scipy.integrate as spint
 
 from astropy import units as u
-from astropy.constants import c, e, eps0, k_B, m_e, m_p, mu0
+from astropy.constants import k_B, m_e
 
 from ..distribution import (
     kappa_velocity_1D,

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from astropy import units as u
-from astropy.constants import m_e, m_p, mu0
+from astropy.constants import m_e, m_p
 from astropy.tests.helper import assert_quantity_allclose
 
 from plasmapy.formulary.parameters import (

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -2,7 +2,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 
-from astropy.constants import c, h
+from astropy.constants import c
 
 from plasmapy.utils.exceptions import RelativityError
 

--- a/plasmapy/particles/elements.py
+++ b/plasmapy/particles/elements.py
@@ -10,7 +10,6 @@ The periodic tabla data is from: https://periodic.lanl.gov/index.shtml
 __all__ = []
 
 import astropy.units as u
-import collections
 import json
 import pkgutil
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1311,7 +1311,7 @@ class Particle(AbstractPhysicalParticle):
         >>> D.isotopic_abundance
         0.000115
         """
-        from .atomic import common_isotopes
+        from plasmapy.particles.atomic import common_isotopes
 
         if not self.isotope or self.is_ion:  # coverage: ignore
             raise InvalidIsotopeError(_category_errmsg(self.symbol, "isotope"))

--- a/plasmapy/particles/symbols.py
+++ b/plasmapy/particles/symbols.py
@@ -13,8 +13,8 @@ __all__ = [
 from numbers import Integral
 from typing import Optional
 
-from .decorators import particle_input
-from .particle_class import Particle
+from plasmapy.particles.decorators import particle_input
+from plasmapy.particles.particle_class import Particle
 
 # The @particle_input decorator takes the inputs for a function or
 # method and passes through the corresponding instance of the Particle

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -1,8 +1,6 @@
 import astropy.units as u
 import collections
 import numpy as np
-import os
-import pickle
 import pytest
 
 from astropy.tests.helper import assert_quantity_allclose

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -3,8 +3,6 @@ import inspect
 import io
 import json
 import numpy as np
-import os
-import pickle
 import pytest
 
 from astropy import constants as const

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -1,7 +1,6 @@
 """Test that objects in `plasmapy.particles` can be pickled."""
 
 import astropy.units as u
-import os
 import pickle
 import pytest
 

--- a/plasmapy/plasma/__init__.py
+++ b/plasmapy/plasma/__init__.py
@@ -1,4 +1,3 @@
 from plasmapy.plasma import exceptions, grids, sources
-
-from .plasma_base import BasePlasma, GenericPlasma
-from .plasma_factory import Plasma
+from plasmapy.plasma.plasma_base import BasePlasma, GenericPlasma
+from plasmapy.plasma.plasma_factory import Plasma

--- a/plasmapy/plasma/sources/__init__.py
+++ b/plasmapy/plasma/sources/__init__.py
@@ -1,3 +1,3 @@
-from .openpmd_hdf5 import HDF5Reader
-from .plasma3d import Plasma3D
-from .plasmablob import PlasmaBlob
+from plasmapy.plasma.sources.openpmd_hdf5 import HDF5Reader
+from plasmapy.plasma.sources.plasma3d import Plasma3D
+from plasmapy.plasma.sources.plasmablob import PlasmaBlob

--- a/plasmapy/plasma/sources/tests/test_plasma3d.py
+++ b/plasmapy/plasma/sources/tests/test_plasma3d.py
@@ -2,7 +2,6 @@ import astropy.units as u
 import numpy as np
 import pytest
 
-from plasmapy.particles.exceptions import InvalidParticleError
 from plasmapy.plasma.sources import plasma3d
 
 

--- a/plasmapy/simulation/particle_integrators.py
+++ b/plasmapy/simulation/particle_integrators.py
@@ -6,10 +6,7 @@ limit overhead and increase performance.
 They act in-place on position and velocity arrays to reduce
 memory allocation.
 """
-import math
 import numpy as np
-
-from astropy import constants
 
 
 def boris_push(x, v, B, E, q, m, dt):

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -10,9 +10,8 @@ import scipy.interpolate as interp
 from astropy import constants
 
 from plasmapy.particles import atomic
+from plasmapy.simulation import particle_integrators
 from plasmapy.utils.decorators import validate_quantities
-
-from . import particle_integrators
 
 
 class ParticleTracker:

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -241,7 +241,6 @@ class ParticleTracker:
         import matplotlib.pyplot as plt
 
         from astropy.visualization import quantity_support
-        from mpl_toolkits.mplot3d import Axes3D
 
         quantity_support()
         fig = plt.figure()
@@ -269,7 +268,6 @@ class ParticleTracker:
         import matplotlib.pyplot as plt
 
         from astropy.visualization import quantity_support
-        from mpl_toolkits.mplot3d import Axes3D
 
         quantity_support()
         fig, ax = plt.subplots()

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -4,13 +4,11 @@ when possible).
 """
 import inspect
 import pytest
-import warnings
 
 from astropy import units as u
 from typing import Any, Dict, List
 from unittest import mock
 
-from plasmapy.formulary.parameters import Debye_number
 from plasmapy.utils.decorators.checks import CheckUnits, CheckValues
 from plasmapy.utils.decorators.validators import validate_quantities, ValidateQuantities
 

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,7 @@ setenv =
 [testenv:linters]
 deps =
     flake8
+    flake8-absolute-import
     pydocstyle
     flake8-rst-docstrings
     pygments


### PR DESCRIPTION
 - Used [`unimport`](https://unimport.hakancelik.dev/) to remove unused import statements.  
   - Modified a docstring example
 - Added [flake8-absolute-import](https://github.com/bskinn/flake8-absolute-import) to the tox environment for linters
 - Changed imports from relative to absolute

Something I don't understand yet is if these are compatible with pre-commit because they're done through flake8, or if we need to do something else to make it work with pre-commit.