### PR TITLE
Add and apply pre-commit hooks for `.ini`, `.toml`, and `.yaml` files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,19 +2,19 @@
 #
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    reviewers:
-    - "StanczakDominik"
-    assignees:
-    - "StanczakDominik"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    reviewers:
-    - "StanczakDominik"
-    assignees:
-    - "StanczakDominik"
-    schedule:
-      interval: "daily"
+- package-ecosystem: pip
+  directory: /
+  reviewers:
+  - StanczakDominik
+  assignees:
+  - StanczakDominik
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: /
+  reviewers:
+  - StanczakDominik
+  assignees:
+  - StanczakDominik
+  schedule:
+    interval: daily

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,7 +12,7 @@ Particles: plasmapy/particles/**/*
 
 # Add Documentation label to any change in docs but notebooks
 Documentation:
-- any: ['docs/**/*']
+- any: [docs/**/*]
   all: ['!docs/notebooks/**/*']
 
 Notebooks: docs/notebooks/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-name: "Pull Request Labeler"
+name: Pull Request Labeler
 on:
 - pull_request_target
 
@@ -8,5 +8,5 @@ jobs:
     steps:
     - uses: actions/labeler@main
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,18 +1,18 @@
-name: 'Close stale issues and PR'
+name: Close stale issues and PR
 on:
   schedule:
-    - cron: '30 1 * * *'
+  - cron: 30 1 * * *
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-pr-message: 'This pull request will be closed in 14 days due to a year of inactivity unless the stale label or comment is removed.'
-          close-pr-message: 'This pull request was closed because it has had no activity for the past year.'
-          days-before-pr-stale: 365
-          days-before-pr-close: 15
+    - uses: actions/stale@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: This pull request will be closed in 14 days due to a year of inactivity unless the stale label or comment is removed.
+        close-pr-message: This pull request was closed because it has had no activity for the past year.
+        days-before-pr-stale: 365
+        days-before-pr-close: 15
           # never close issues
-          days-before-close: -1
+        days-before-close: -1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - main
-      - stable
-      - v0.*.x
+    - main
+    - stable
+    - v0.*.x
     tags:
-      - "v*"
+    - v*
   pull_request:
   workflow_dispatch:
 
@@ -20,52 +20,52 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.7 with minimal dependencies
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-minimal
+        - name: Python 3.7 with minimal dependencies
+          os: ubuntu-latest
+          python: 3.7
+          toxenv: py37-minimal
 
-          - name: Python 3.7
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37
+        - name: Python 3.7
+          os: ubuntu-latest
+          python: 3.7
+          toxenv: py37
 
-          - name: Python 3.8 with code coverage
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-cov
+        - name: Python 3.8 with code coverage
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-cov
 
-          - name: Python 3.8, slow tests with code coverage
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-slow-cov
+        - name: Python 3.8, slow tests with code coverage
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-slow-cov
 
-          - name: Python 3.9
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: py39
+        - name: Python 3.9
+          os: ubuntu-latest
+          python: 3.9
+          toxenv: py39
 
-          - name: Python 3.8 (Windows)
-            os: windows-latest
-            python: 3.8
-            toxenv: py38
-            toxposargs: --durations=50
+        - name: Python 3.8 (Windows)
+          os: windows-latest
+          python: 3.8
+          toxenv: py38
+          toxposargs: --durations=50
 
-          - name: Python 3.8 (MacOS X)
-            os: macos-latest
-            python: 3.8
-            toxenv: py38
+        - name: Python 3.8 (MacOS X)
+          os: macos-latest
+          python: 3.8
+          toxenv: py38
 
-          - name: Documentation
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: build_docs
-            toxposargs: -q
+        - name: Documentation
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: build_docs
+          toxposargs: -q
 
-          - name: Linters
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: linters
+        - name: Linters
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: linters
 
     steps:
     - name: Checkout code

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,7 +2,7 @@ name: weekly tests
 
 on:
   schedule:
-    - cron: "17 7 * * 1"
+  - cron: 17 7 * * 1
   workflow_dispatch:
 
 jobs:
@@ -15,45 +15,45 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.8 with Astropy dev
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-astropydev
+        - name: Python 3.8 with Astropy dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-astropydev
 
-          - name: Python 3.8 with NumPy dev
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-numpydev
+        - name: Python 3.8 with NumPy dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-numpydev
 
-          - name: Python 3.8 with xarray dev
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-xarraydev
+        - name: Python 3.8 with xarray dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-xarraydev
 
-          - name: Documentation with Sphinx dev
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: build_docs-sphinxdev
-            toxposargs: -q
+        - name: Documentation with Sphinx dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: build_docs-sphinxdev
+          toxposargs: -q
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install Python dependencies
-        run: python -m pip install --upgrade tox codecov
-      - name: Install language-pack-fr and tzdata
-        if: startsWith(matrix.name, 'Documentation')
-        run: sudo apt-get install graphviz pandoc
-      - name: Run tests
-        run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
-      - name: Upload coverage to codecov
-        if: ${{ contains(matrix.toxenv,'-cov') }}
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          file: ./coverage.xml
+    - name: Checkout code
+      uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2.2.2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade tox codecov
+    - name: Install language-pack-fr and tzdata
+      if: startsWith(matrix.name, 'Documentation')
+      run: sudo apt-get install graphviz pandoc
+    - name: Run tests
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+    - name: Upload coverage to codecov
+      if: ${{ contains(matrix.toxenv,'-cov') }}
+      uses: codecov/codecov-action@v2.1.0
+      with:
+        file: ./coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,56 @@
 ci:
   autofix_prs: false
-  autoupdate_schedule: "quarterly"
+  autoupdate_schedule: quarterly
+
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
-    hooks:
-    -   id: check-yaml
-    -   id: check-json
-    -   id: check-symlinks
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: check-ast
-    -   id: requirements-txt-fixer
--   repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
-    hooks:
-    -   id: isort
-        name: isort
-        entry: isort
-        require_serial: true
-        language: python
-        types: [python]
--   repo: https://github.com/psf/black
-    rev: 21.4b2
-    hooks:
-    -   id: black
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.4.0
+  hooks:
+  - id: check-yaml
+  - id: check-json
+  - id: check-symlinks
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: check-ast
+  - id: requirements-txt-fixer
+
+- repo: https://github.com/PyCQA/isort
+  rev: 5.8.0
+  hooks:
+  - id: isort
+    name: isort
+    entry: isort
+    require_serial: true
+    language: python
+    types:
+    - python
+
+- repo: https://github.com/psf/black
+  rev: 21.4b2
+  hooks:
+  - id: black
+
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 0.8.0
   hooks:
-    - id: nbqa-black
-      additional_dependencies: [black==19.10b0]
-      args: [--nbqa-mutate]
-    - id: nbqa-isort
-      additional_dependencies: [isort==5.7.0]
-      args: [--nbqa-mutate]
+  - id: nbqa-black
+    additional_dependencies:
+    - black==19.10b0
+    args:
+    - --nbqa-mutate
+  - id: nbqa-isort
+    additional_dependencies:
+    - isort==5.7.0
+    args:
+    - --nbqa-mutate
+
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.1.0
+  hooks:
+  - id: pretty-format-ini
+    args: [--autofix]
+  - id: pretty-format-toml
+    args: [--autofix]
+  - id: pretty-format-yaml
+    args: [--autofix, --indent, '2']

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,14 +6,14 @@
 version: 2
 
 formats:
-  - htmlzip
+- htmlzip
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
+  version: '3.8'
   install:
-    - requirements: requirements/install.txt
-    - requirements: requirements/docs.txt
-    - method: setuptools
-      path: .
+  - requirements: requirements/install.txt
+  - requirements: requirements/docs.txt
+  - method: setuptools
+    path: .
   system_packages: true

--- a/changelog/1284.trivial.rst
+++ b/changelog/1284.trivial.rst
@@ -1,2 +1,3 @@
-Added pre-commit hooks to auto-format :file:`.ini`, :file:`.toml`, and :file:`.yaml`
+Added `pre-commit <https://pre-commit.com/>`_
+hooks to auto-format :file:`.ini`, :file:`.toml`, and :file:`.yaml`
 files, and applied changes from those hooks to existing files.

--- a/changelog/1284.trivial.rst
+++ b/changelog/1284.trivial.rst
@@ -1,0 +1,2 @@
+Added pre-commit hooks to auto-format :file:`.ini`, :file:`.toml`, and :file:`.yaml`
+files, and applied changes from those hooks to existing files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,57 +4,22 @@ requires = ["setuptools >= 41.2",
             "wheel >= 0.29.0"]  # ought to mirror 'requirements/build.txt'
 build-backend = "setuptools.build_meta"
 
-[tool.towncrier]
-    package = "plasmapy"
-    filename = "CHANGELOG.rst"
-    directory = "changelog/"
-    issue_format = "`#{issue} <https://github.com/plasmapy/plasmapy/pull/{issue}>`__"
+[tool.gilesbot]
 
-    [[tool.towncrier.type]]
-        directory = "breaking"
-        name = "Backwards Incompatible Changes"
-        showcontent = true
+[tool.gilesbot.pull_requests]
+enabled = true
 
-    [[tool.towncrier.type]]
-      directory = "removal"
-      name = "Deprecations and Removals"
-      showcontent = true
-
-    [[tool.towncrier.type]]
-      directory = "feature"
-      name = "Features"
-      showcontent = true
-
-    [[tool.towncrier.type]]
-      directory = "bugfix"
-      name = "Bug Fixes"
-      showcontent = true
-
-    [[tool.towncrier.type]]
-      directory = "doc"
-      name = "Improved Documentation"
-      showcontent = true
-
-    [[tool.towncrier.type]]
-      directory = "trivial"
-      name = "Trivial/Internal Changes"
-      showcontent = true
-
-[ tool.gilesbot ]
-  [ tool.gilesbot.pull_requests ]
-    enabled = true
-
-  [ tool.gilesbot.towncrier_changelog ]
-      enabled = true
-      changelog_skip_label = "No changelog entry needed"
-      help_url = "https://github.com/PlasmaPy/PlasmaPy/blob/main/changelog/README.rst"
-      changelog_missing = "Missing changelog entry"
-      changelog_missing_long = "This pull request needs a changelog entry file in `changelog/NUMBER.TYPE.rst`. For more information, consult https://github.com/PlasmaPy/PlasmaPy/blob/main/changelog/README.rst "
-      verify_pr_number = true
-      number_incorrect = "Incorrect changelog entry number (match PR!)"
-      number_incorrect_long = "The changelog entry's number does not match this pull request's number."
-      type_incorrect = "Incorrect changelog entry type (see list in changelog README)"
-      type_incorrect_long = "The changelog entry for this PR must have one of the types (as in NUMBER.TYPE.rst) as described in the changelog README)."
+[tool.gilesbot.towncrier_changelog]
+enabled = true
+changelog_skip_label = "No changelog entry needed"
+help_url = "https://github.com/PlasmaPy/PlasmaPy/blob/main/changelog/README.rst"
+changelog_missing = "Missing changelog entry"
+changelog_missing_long = "This pull request needs a changelog entry file in `changelog/NUMBER.TYPE.rst`. For more information, consult https://github.com/PlasmaPy/PlasmaPy/blob/main/changelog/README.rst "
+verify_pr_number = true
+number_incorrect = "Incorrect changelog entry number (match PR!)"
+number_incorrect_long = "The changelog entry's number does not match this pull request's number."
+type_incorrect = "Incorrect changelog entry type (see list in changelog README)"
+type_incorrect_long = "The changelog entry for this PR must have one of the types (as in NUMBER.TYPE.rst) as described in the changelog README)."
 
 [tool.isort]
 line_length = 88
@@ -68,3 +33,39 @@ include_trailing_comma = true
 force_alphabetical_sort_within_sections = true
 honor_noqa = true
 lines_between_types = 1
+
+[tool.towncrier]
+package = "plasmapy"
+filename = "CHANGELOG.rst"
+directory = "changelog/"
+issue_format = "`#{issue} <https://github.com/plasmapy/plasmapy/pull/{issue}>`__"
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Backwards Incompatible Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removal"
+name = "Deprecations and Removals"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bug Fixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Improved Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "trivial"
+name = "Trivial/Internal Changes"
+showcontent = true

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -1,32 +1,32 @@
 name: plasmapy
 
 channels:
-  - astropy
-  - conda-forge
+- astropy
+- conda-forge
 
 dependencies:
-  - python=3.7
-  - numpy
-  - scipy
-  - astropy
-  - h5py
-  - matplotlib
-  - mpmath
-  - pandas
-  - pillow
-  - pip
-  - xarray
-  - numba
-  - pip:
-    - hypothesis
-    - docutils < 0.17
-    - numpydoc
-    - pytest
-    - lmfit
-    - pygments>=2.4.1
-    - sphinx>=3.2.0
-    - sphinx-gallery
-    - sphinx_rtd_theme
-    - towncrier >= 19.2.0
-    - pytest-regressions
-    - notebook
+- python=3.7
+- numpy
+- scipy
+- astropy
+- h5py
+- matplotlib
+- mpmath
+- pandas
+- pillow
+- pip
+- xarray
+- numba
+- pip:
+  - hypothesis
+  - docutils < 0.17
+  - numpydoc
+  - pytest
+  - lmfit
+  - pygments>=2.4.1
+  - sphinx>=3.2.0
+  - sphinx-gallery
+  - sphinx_rtd_theme
+  - towncrier >= 19.2.0
+  - pytest-regressions
+  - notebook

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ commands =
     !cov: {env:PYTEST_COMMAND} {posargs} -m 'not slow'
     cov: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml -m 'not slow'
     cov-slow: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml -m 'slow'
-
 description =
     run tests
     numpydev: with the git main version of numpy
@@ -98,22 +97,21 @@ deps =
   hypothesis
   pytest-regressions
   numba
-
 setenv =
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25
+  PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25
 
 [testenv:linters]
 deps =
-    flake8
-    flake8-absolute-import
-    pydocstyle
-    flake8-rst-docstrings
-    flake8-use-fstring
-    pygments
-    dlint
+  flake8
+  flake8-absolute-import
+  pydocstyle
+  flake8-rst-docstrings
+  flake8-use-fstring
+  pygments
+  dlint
 commands =
-    flake8 --bug-report
-    flake8 {toxinidir}{/}plasmapy --count --show-source --statistics
+  flake8 --bug-report
+  flake8 {toxinidir}{/}plasmapy --count --show-source --statistics
 
 [testenv:py37-minimal-pypi-import]
 basepython = python3.7


### PR DESCRIPTION
This PR adds some pre-commit autoformatters for `.ini`, `.toml`, and `.yaml` files, and applies changes from those autoformatters ∀ files ∈PlasmaPy.

There don't seem to be many customization options, but autoformatters for all of these file types were available together so I'm guessing that they should all produce consistent styles.