### PR TITLE
Add a pre-commit hook to auto-format docstrings and partially apply it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,9 @@ repos:
     args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
+
+- repo: https://github.com/myint/docformatter
+  rev: v1.3.1
+  hooks:
+  - id: docformatter
+    args: [--in-place, --pre-summary-newline, --wrap-descriptions, '72', --wrap-summaries, '79']

--- a/changelog/1288.doc.rst
+++ b/changelog/1288.doc.rst
@@ -1,0 +1,4 @@
+Added a `pre-commit <https://pre-commit.com/>`__ hook for
+`docformatter <https://pypi.org/project/docformatter/>`__ to automatically
+format docstrings in pull requests, and applied some of the formatting
+changes.

--- a/changelog/1288.doc.rst
+++ b/changelog/1288.doc.rst
@@ -1,4 +1,4 @@
 Added a `pre-commit <https://pre-commit.com/>`__ hook for
 `docformatter <https://pypi.org/project/docformatter/>`__ to automatically
 format docstrings in pull requests, and applied some of the formatting
-changes.
+changes.k

--- a/changelog/1288.doc.rst
+++ b/changelog/1288.doc.rst
@@ -1,4 +1,4 @@
 Added a `pre-commit <https://pre-commit.com/>`__ hook for
 `docformatter <https://pypi.org/project/docformatter/>`__ to automatically
 format docstrings in pull requests, and applied some of the formatting
-changes.k
+changes.

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -1,6 +1,8 @@
 """
 Welcome to the `plasmapy` package, an open source community-developed Python
-package for the plasma community.  Documentation is available in the docstrings
+package for the plasma community.
+
+Documentation is available in the docstrings
 and online at https://docs.plasmapy.org (accessible also using the
 :func:`~plasmapy.online_help` function).
 """
@@ -83,8 +85,8 @@ __citation__ = (
 
 def online_help(query: str):
     """
-    Open a webpage containing a search page in `PlasmaPy's documentation`_,
-    or another page that contains relevant online help.
+    Open a webpage containing a search page in `PlasmaPy's documentation`_, or
+    another page that contains relevant online help.
 
     This function requires an active internet connection, and will open
     the page in the default web browser.

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -1,7 +1,5 @@
-"""
-`FitFunction` classes designed to assist in curve fitting of swept Langmuir
-traces.
-"""
+"""`FitFunction` classes designed to assist in curve fitting of swept Langmuir
+traces."""
 __all__ = [
     "AbstractFitFunction",
     "Exponential",
@@ -26,10 +24,8 @@ _RootResults = namedtuple("RootResults", ("root", "err"))
 
 
 class AbstractFitFunction(ABC):
-    """
-    Abstract class for defining fit functions :math:`f(x)` and the tools for
-    fitting the function to a set of data.
-    """
+    """Abstract class for defining fit functions :math:`f(x)` and the tools for
+    fitting the function to a set of data."""
 
     _param_names = NotImplemented  # type: Tuple[str, ...]
 
@@ -301,10 +297,8 @@ class AbstractFitFunction(ABC):
 
     @staticmethod
     def _check_params(*args) -> None:
-        """
-        Check fitting parameters so that they are an expected type for the
-        class functionality.
-        """
+        """Check fitting parameters so that they are an expected type for the
+        class functionality."""
         for arg in args:
             if not isinstance(arg, (int, np.integer, float, np.floating)):
                 raise TypeError(
@@ -314,10 +308,8 @@ class AbstractFitFunction(ABC):
 
     @staticmethod
     def _check_x(x):
-        """
-        Check the independent variable ``x`` so that it is an expected
-        type for the class functionality.
-        """
+        """Check the independent variable ``x`` so that it is an expected type
+        for the class functionality."""
         if isinstance(x, (int, float, np.integer, np.floating)):
             x = np.array(x)
         else:
@@ -414,7 +406,6 @@ class AbstractFitFunction(ABC):
         range between 0 and 1.  Values close to 0 indicate that the points
         are uncorrelated and have little tendency to lie close to the model,
         whereas, values close to 1 indicate a high correlation to the model.
-
         """
         return self._rsq
 
@@ -518,7 +509,6 @@ class Linear(AbstractFitFunction):
         -------
         y: array_like
             dependent variables corresponding to `:math:``x``
-
         """
         x = self._check_x(x)
         self._check_params(m, b)
@@ -534,7 +524,6 @@ class Linear(AbstractFitFunction):
         .. math::
 
             (\\delta y)^2 = (x \\, \\delta m)^2 + (m \\, \\delta x)^2 + (\\delta b)^2
-
         """
         x, x_err = self._check_func_err_params(x, x_err)
 
@@ -559,8 +548,9 @@ class Linear(AbstractFitFunction):
     @property
     def rsq(self):
         """
-        Coefficient of determination (r-squared) value of the fit.  Calculated
-        by `scipy.stats.linregress` from the fit.
+        Coefficient of determination (r-squared) value of the fit.
+
+        Calculated by `scipy.stats.linregress` from the fit.
         """
         return self._rsq
 
@@ -706,7 +696,6 @@ class Exponential(AbstractFitFunction):
         -------
         y: array_like
             dependent variables corresponding to ``x``
-
         """
         x = self._check_x(x)
         self._check_params(a, alpha)
@@ -725,7 +714,6 @@ class Exponential(AbstractFitFunction):
                 \\left( \\frac{\\delta a}{a} \\right)^2
                 + (x \\, \\delta \\alpha)^2
                 + (\\alpha \\, \\delta x)^2
-
         """
         x, x_err = self._check_func_err_params(x, x_err)
 
@@ -871,7 +859,6 @@ class ExponentialPlusLinear(AbstractFitFunction):
         -------
         y: array_like
             dependent variables corresponding to ``x``
-
         """
         exp_term = self._exponential.func(x, a, alpha)
         lin_term = self._linear.func(x, m, b)
@@ -896,7 +883,6 @@ class ExponentialPlusLinear(AbstractFitFunction):
                 & + \\left[(
                         x \\, \\delta m)^2 + (\\delta b)^2 +(m \\, \\delta x)^2
                     \\right]
-
         """
         x, x_err = self._check_func_err_params(x, x_err)
 
@@ -939,7 +925,6 @@ class ExponentialPlusOffset(AbstractFitFunction):
     :math:`\\delta \\alpha`, :math:`\\delta b`, and :math:`\\delta x` are the
     respective uncertainties for :math:`a`, :math:`\\alpha`, and :math:`b`, and
     :math:`x`.
-
     """
 
     _param_names = ("a", "alpha", "b")
@@ -1008,7 +993,6 @@ class ExponentialPlusOffset(AbstractFitFunction):
         -------
         y: array_like
             dependent variables corresponding to ``x``
-
         """
         return self._explin.func(x, a, alpha, 0.0, b)
 
@@ -1027,7 +1011,6 @@ class ExponentialPlusOffset(AbstractFitFunction):
                     + (\\alpha \\, \\delta x)^2
                 \\right]
                 + (\\delta b)^2
-
         """
         return self._explin.func_err(x, x_err=x_err, rety=rety)
 

--- a/plasmapy/analysis/swept_langmuir/__init__.py
+++ b/plasmapy/analysis/swept_langmuir/__init__.py
@@ -1,6 +1,4 @@
-"""
-Subpackage containing routines for analyzing swept Langmuir probe traces.
-"""
+"""Subpackage containing routines for analyzing swept Langmuir probe traces."""
 __all__ = ["check_sweep", "find_floating_potential", "find_vf_"]
 __aliases__ = ["find_vf_"]
 

--- a/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/plasmapy/analysis/swept_langmuir/helpers.py
@@ -65,7 +65,6 @@ def check_sweep(
     `ValueError`
         If either the ``voltage`` or ``current`` array does not have a
         `numpy.dtype` of either `numpy.integer` or `numpy.floating`.
-
     """
     # -- examine voltage array --
     # check type

--- a/plasmapy/analysis/swept_langmuir/tests/test_floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_floating_potential.py
@@ -1,7 +1,5 @@
-"""
-Tests for functionality contained in
-`plasmapy.analysis.swept_langmuir.floating_potential`.
-"""
+"""Tests for functionality contained in
+`plasmapy.analysis.swept_langmuir.floating_potential`."""
 
 import numpy as np
 import pytest
@@ -19,10 +17,8 @@ from plasmapy.utils.exceptions import PlasmaPyWarning
 
 
 def test_floating_potential_namedtuple():
-    """
-    Test structure of the namedtuple used to return computed floating potential
-    data.
-    """
+    """Test structure of the namedtuple used to return computed floating
+    potential data."""
 
     assert issubclass(FloatingPotentialResults, tuple)
     assert hasattr(FloatingPotentialResults, "_fields")
@@ -40,8 +36,9 @@ def test_floating_potential_namedtuple():
 
 class TestFindFloatingPotential:
     """
-    Tests for function
-    `~plasmapy.analysis.swept_langmuir.floating_potential.find_floating_potential`.
+    Tests for function `~plasmapy.analysis.swept_langmuir.floating_potential.
+
+    .find_floating_potential`.
     """
 
     _null_result = FloatingPotentialResults(
@@ -57,11 +54,9 @@ class TestFindFloatingPotential:
         assert find_vf_ is find_floating_potential
 
     def test_call_of_check_sweep(self):
-        """
-        Test `find_floating_potential` appropriately calls
-        `plasmapy.analysis.swept_langmuir.helpers.check_sweep` so we can relay on
-        the `check_sweep` tests.
-        """
+        """Test `find_floating_potential` appropriately calls
+        `plasmapy.analysis.swept_langmuir.helpers.check_sweep` so we can relay
+        on the `check_sweep` tests."""
         varr = np.linspace(-20.0, 20.0, 100)
         carr = np.linspace(-20.0, 20.0, 100)
 
@@ -243,10 +238,8 @@ class TestFindFloatingPotential:
         ],
     )
     def test_kwarg_min_points(self, min_points, fit_type, islands, indices):
-        """
-        Test functionality of keyword `min_points` and how it affects the
-        size of the crossing-point island.
-        """
+        """Test functionality of keyword `min_points` and how it affects the
+        size of the crossing-point island."""
         voltage = self._voltage
         current = self._linear_current if fit_type == "linear" else self._exp_current
         results = find_floating_potential(
@@ -341,9 +334,8 @@ class TestFindFloatingPotential:
         ],
     )
     def test_island_finding(self, kwargs, expected):
-        """
-        Test scenarios related to the identification of crossing-point islands.
-        """
+        """Test scenarios related to the identification of crossing-point
+        islands."""
         results = find_floating_potential(**kwargs)
         assert isinstance(results, FloatingPotentialResults)
 
@@ -388,7 +380,8 @@ class TestFindFloatingPotential:
         [(1.0, 0.2, -0.2), (2.7, 0.2, -10.0), (6.0, 0.6, -10.0)],
     )
     def test_perfect_exponential(self, a, alpha, b):
-        """Test calculated fit parameters on a few perfectly exponential cases."""
+        """Test calculated fit parameters on a few perfectly exponential
+        cases."""
         voltage = self._voltage
         current = a * np.exp(alpha * voltage) + b
 

--- a/plasmapy/analysis/swept_langmuir/tests/test_helpers.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_helpers.py
@@ -166,7 +166,8 @@ from plasmapy.analysis.swept_langmuir.helpers import check_sweep
     ],
 )
 def test_check_sweep(voltage, current, kwargs, with_context, expected):
-    """Test functionality of `plasmapy.analysis.swept_langmuir.helpers.check_sweep`."""
+    """Test functionality of
+    `plasmapy.analysis.swept_langmuir.helpers.check_sweep`."""
     with with_context:
         rtn_voltage, rtn_current = check_sweep(
             voltage=voltage,

--- a/plasmapy/analysis/tests/test_fit_functions.py
+++ b/plasmapy/analysis/tests/test_fit_functions.py
@@ -1,6 +1,5 @@
-"""
-Tests for the fitting function classes defined in `plasmapy.analysis.fit_functions`.
-"""
+"""Tests for the fitting function classes defined in
+`plasmapy.analysis.fit_functions`."""
 import numpy as np
 import pytest
 
@@ -12,7 +11,8 @@ import plasmapy.analysis.fit_functions as ffuncs
 
 class TestAbstractFitFunction:
     """
-    Tests for fit function class `plasmapy.analysis.fit_functions.AbstractFitFunction`.
+    Tests for fit function class
+    `plasmapy.analysis.fit_functions.AbstractFitFunction`.
 
     Notes
     -----
@@ -79,6 +79,7 @@ class BaseFFTests(ABC):
     def func(x, *args):
         """
         Formula/Function that the fit function class is suppose to be modeling.
+
         This is used to test the fit function `func` method.
         """
         ...
@@ -86,8 +87,10 @@ class BaseFFTests(ABC):
     @abstractmethod
     def func_err(self, x, params, param_errors, x_err=None):
         """
-        Function representing the propagation of error associated with fit function
-        model. This is used to test the fit function `func_err` method.
+        Function representing the propagation of error associated with fit
+        function model.
+
+        This is used to test the fit function `func_err` method.
         """
         ...
 
@@ -207,10 +210,8 @@ class BaseFFTests(ABC):
                 assert ff_obj.param_errors == ff_obj.FitParamTuple(*param_errors)
 
     def test_param_namedtuple(self):
-        """
-        Test that the namedtuple used for `params` and `param_errors` is
-        constructed correctly.
-        """
+        """Test that the namedtuple used for `params` and `param_errors` is
+        constructed correctly."""
         ff_obj = self.ff_class()
         assert hasattr(ff_obj, "FitParamTuple")
         assert issubclass(ff_obj.FitParamTuple, tuple)
@@ -410,9 +411,8 @@ class BaseFFTests(ABC):
 
 
 class TestFFExponential(BaseFFTests):
-    """
-    Tests for fit function class `plasmapy.analysis.fit_functions.Exponential`.
-    """
+    """Tests for fit function class
+    `plasmapy.analysis.fit_functions.Exponential`."""
 
     ff_class = ffuncs.Exponential
     _test_params = (5.0, 1.0)
@@ -451,10 +451,8 @@ class TestFFExponential(BaseFFTests):
 
 
 class TestFFExponentialPlusLinear(BaseFFTests):
-    """
-    Tests for fit function class
-    `plasmapy.analysis.fit_functions.ExponentialPlusLinear`.
-    """
+    """Tests for fit function class
+    `plasmapy.analysis.fit_functions.ExponentialPlusLinear`."""
 
     ff_class = ffuncs.ExponentialPlusLinear
     _test_params = (2.0, 1.0, 5.0, -10.0)
@@ -499,10 +497,8 @@ class TestFFExponentialPlusLinear(BaseFFTests):
 
 
 class TestFFExponentialPlusOffset(BaseFFTests):
-    """
-    Tests for fit function class
-    `plasmapy.analysis.fit_functions.ExponentialPlusOffset`.
-    """
+    """Tests for fit function class
+    `plasmapy.analysis.fit_functions.ExponentialPlusOffset`."""
 
     ff_class = ffuncs.ExponentialPlusOffset
     _test_params = (2.0, 1.0, -10.0)
@@ -548,9 +544,8 @@ class TestFFExponentialPlusOffset(BaseFFTests):
 
 
 class TestFFLinear(BaseFFTests):
-    """
-    Tests for fit function class `plasmapy.analysis.fit_functions.Linear`.
-    """
+    """Tests for fit function class
+    `plasmapy.analysis.fit_functions.Linear`."""
 
     ff_class = ffuncs.Linear
     _test_params = (5.0, 4.0)

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -1,4 +1,4 @@
-"""Adds custom functionality to pytest"""
+"""Adds custom functionality to pytest."""
 # Force MPL to use non-gui backends for testing.
 try:
     import matplotlib
@@ -12,7 +12,8 @@ else:
 
 
 def pytest_configure(config):  # coverage: ignore
-    """Adds @pytest.mark.slow annotation for marking slow tests for optional skipping."""
+    """Adds @pytest.mark.slow annotation for marking slow tests for optional
+    skipping."""
     config.addinivalue_line(
         "markers",
         (

--- a/plasmapy/diagnostics/__init__.py
+++ b/plasmapy/diagnostics/__init__.py
@@ -1,7 +1,6 @@
-"""
-The diagnostics subpackage contains functionality for defining diagnostic parameters
-and processing data collected by diagnostics, synthetic or experimental.
-"""
+"""The diagnostics subpackage contains functionality for defining diagnostic
+parameters and processing data collected by diagnostics, synthetic or
+experimental."""
 __all__ = ["langmuir", "thomson"]
 
 from plasmapy.diagnostics import langmuir, thomson

--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -316,7 +316,7 @@ def test_get_ion_density_OML_without_return_fit(characteristic):
 
 
 def test_get_EEDF():
-    """Test the obtained EEDF"""
+    """Test the obtained EEDF."""
 
     char = langmuir.Characteristic(bias_arr[:17], current_arr[:17])
     energy, probability = langmuir.get_EEDF(char, visualize=False)

--- a/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/plasmapy/dispersion/analytical/two_fluid_.py
@@ -1,7 +1,5 @@
-"""
-This module contains functionality for calculating various analytical
-solutions to the two fluid dispersion relation.
-"""
+"""This module contains functionality for calculating various analytical
+solutions to the two fluid dispersion relation."""
 __all__ = ["two_fluid"]
 
 import astropy.units as u

--- a/plasmapy/dispersion/tests/test_dispersion.py
+++ b/plasmapy/dispersion/tests/test_dispersion.py
@@ -1,4 +1,4 @@
-"""Tests for the plasma dispersion function and its derivative"""
+"""Tests for the plasma dispersion function and its derivative."""
 
 # This file contains experimental usage of unicode characters.
 
@@ -85,8 +85,8 @@ def test_plasma_dispersion_func_symmetry(w):
 
 
 def test_plasma_dispersion_func_power_series_expansion():
-    """Test plasma_dispersion_func against a power series expansion of
-    the plasma dispersion function."""
+    """Test plasma_dispersion_func against a power series expansion of the
+    plasma dispersion function."""
 
     w_array = np.array(
         [

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -1,7 +1,5 @@
-"""
-The `~plasmapy.formulary` subpackage contains commonly used formulae
-from plasma science.
-"""
+"""The `~plasmapy.formulary` subpackage contains commonly used formulae from
+plasma science."""
 # __all__ & __aliases__ will be auto populated below
 __all__ = []
 __aliases__ = []

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -1,4 +1,5 @@
-"""Functions to calculate transport coefficients.
+"""
+Functions to calculate transport coefficients.
 
 This module includes a number of functions for handling Coulomb collisions
 spanning weakly coupled (low density) to strongly coupled (high density)
@@ -37,7 +38,6 @@ These include:
 * `mobility`
 * `Knudsen_number`
 * `coupling_parameter`
-
 """
 __all__ = [
     "Coulomb_logarithm",
@@ -465,9 +465,10 @@ def Coulomb_logarithm(
 @particles.particle_input
 def _boilerPlate(T: u.K, species: (particles.Particle, particles.Particle), V):
     """
-    Check the inputs to functions in ``collisions.py``.  Also obtains
-    reduced in mass in a 2 particle collision system along with thermal
-    velocity.
+    Check the inputs to functions in ``collisions.py``.
+
+    Also obtains reduced in mass in a 2 particle collision system along
+    with thermal velocity.
     """
     masses = [p.mass for p in species]
     charges = [np.abs(p.charge) for p in species]
@@ -486,8 +487,9 @@ def _boilerPlate(T: u.K, species: (particles.Particle, particles.Particle), V):
 def _replaceNanVwithThermalV(V, T, m):
     """
     Get thermal velocity of system if no velocity is given, for a given mass.
-    Handles vector checks for ``V``, you must already know that ``T`` and ``m``
-    are okay.
+
+    Handles vector checks for ``V``, you must already know that ``T``
+    and ``m`` are okay.
     """
     if np.any(V == 0):
         raise utils.PhysicsError("You cannot have a collision for zero velocity!")

--- a/plasmapy/formulary/dielectric.py
+++ b/plasmapy/formulary/dielectric.py
@@ -1,4 +1,4 @@
-"""Functions to calculate plasma dielectric parameters"""
+"""Functions to calculate plasma dielectric parameters."""
 __all__ = [
     "cold_plasma_permittivity_SDP",
     "cold_plasma_permittivity_LRP",

--- a/plasmapy/formulary/distribution.py
+++ b/plasmapy/formulary/distribution.py
@@ -1,7 +1,9 @@
 """
-Common distribution functions for plasmas, such as the Maxwelian or
-Kappa distributions. Functionality is intended to include generation,
-fitting and calculation.
+Common distribution functions for plasmas, such as the Maxwelian or Kappa
+distributions.
+
+Functionality is intended to include generation, fitting and
+calculation.
 """
 __all__ = [
     "Maxwellian_1D",

--- a/plasmapy/formulary/magnetostatics.py
+++ b/plasmapy/formulary/magnetostatics.py
@@ -1,7 +1,5 @@
-"""
-Define MagneticStatics class to calculate common static magnetic fields
-as first raised in issue #100.
-"""
+"""Define MagneticStatics class to calculate common static magnetic fields as
+first raised in issue #100."""
 __all__ = [
     "CircularWire",
     "FiniteStraightWire",
@@ -24,7 +22,7 @@ from plasmapy.utils.decorators import validate_quantities
 
 
 class MagnetoStatics(abc.ABC):
-    """Abstract class for all kinds of magnetic static fields"""
+    """Abstract class for all kinds of magnetic static fields."""
 
     @abc.abstractmethod
     def magnetic_field(self, p: u.m) -> u.T:

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -1,8 +1,5 @@
-"""
-Functions for quantum parameters, including electron degenerate
-gases and warm dense matter.
-
-"""
+"""Functions for quantum parameters, including electron degenerate gases and
+warm dense matter."""
 __all__ = [
     "chemical_potential",
     "deBroglie_wavelength",

--- a/plasmapy/formulary/radiation.py
+++ b/plasmapy/formulary/radiation.py
@@ -1,7 +1,5 @@
-"""
-Functions for calculating quantities associated with electromagnetic
-radiation.
-"""
+"""Functions for calculating quantities associated with electromagnetic
+radiation."""
 
 __all__ = [
     "thermal_bremsstrahlung",

--- a/plasmapy/formulary/tests/test_Fermi_integral.py
+++ b/plasmapy/formulary/tests/test_Fermi_integral.py
@@ -26,19 +26,15 @@ class Test_Fermi_integral:
         )
 
     def test_known1(self):
-        """
-        Test Fermi_integral for expected value.
-        """
+        """Test Fermi_integral for expected value."""
         methodVal = Fermi_integral(self.arg1, self.order1)
         testTrue = np.isclose(methodVal, self.True1, rtol=1e-16, atol=0.0)
         errStr = f"Fermi integral value should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Test if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Test if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 + 1e-15
         methodVal = Fermi_integral(self.arg1, self.order1)
         testTrue = not np.isclose(methodVal, fail1, rtol=1e-16, atol=0.0)
@@ -56,9 +52,7 @@ class Test_Fermi_integral:
         assert testTrue, errStr
 
     def test_invalid_type(self):
-        """
-        Test whether `TypeError` is raised when an invalid argument
-        type is passed to `~plasmapy.mathematics.Fermi_integral`.
-        """
+        """Test whether `TypeError` is raised when an invalid argument type is
+        passed to `~plasmapy.mathematics.Fermi_integral`."""
         with pytest.raises(TypeError):
             Fermi_integral([1, 2, 3], self.order1)

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -28,7 +28,7 @@ from plasmapy.utils.pytest_helpers import assert_can_handle_nparray
 class Test_Coulomb_logarithm:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.temperature1 = 10 * 11604 * u.K
         self.T_arr = np.array([1, 2]) * u.eV
         self.density1 = 1e20 * u.cm ** -3
@@ -86,13 +86,13 @@ class Test_Coulomb_logarithm:
         ],
     )
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(
             Coulomb_logarithm, insert_some_nans, insert_all_nans, kwargs
         )
 
     def test_unknown_method(self):
-        """Test that function will raise ValueError on non-existent method"""
+        """Test that function will raise ValueError on non-existent method."""
         with pytest.raises(ValueError):
             Coulomb_logarithm(
                 self.T_arr[0],
@@ -128,7 +128,7 @@ class Test_Coulomb_logarithm:
         assert_quantity_allclose(methodVal_0, methodVal_2)
 
     def test_handle_zero_V(self):
-        """Test that V == 0 returns a PhysicsError"""
+        """Test that V == 0 returns a PhysicsError."""
         with pytest.raises(exceptions.PhysicsError):
             Coulomb_logarithm(
                 self.T_arr[0],
@@ -139,7 +139,8 @@ class Test_Coulomb_logarithm:
             )
 
     def test_handle_V_arraysizes(self):
-        """Test that different sized V input array gets handled by _boilerplate"""
+        """Test that different sized V input array gets handled by
+        _boilerplate."""
         with pytest.warns(CouplingWarning):
             methodVal_0 = Coulomb_logarithm(
                 self.T_arr[0],
@@ -176,11 +177,9 @@ class Test_Coulomb_logarithm:
         assert lnLambda == lnLambdaRev
 
     def test_Chen_Q_machine(self):
-        """
-        Tests whether Coulomb logarithm gives value consistent with
-        Chen's Introduction to Plasma Physics and Controlled Fusion
-        section 5.6.2 Q-machine example.
-        """
+        """Tests whether Coulomb logarithm gives value consistent with Chen's
+        Introduction to Plasma Physics and Controlled Fusion section 5.6.2
+        Q-machine example."""
         T = 0.2 * u.eV
         T = T.to(u.K, equivalencies=u.temperature_energy())
         n = 1e15 * u.m ** -3
@@ -197,11 +196,9 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_Chen_lab(self):
-        """
-        Tests whether Coulomb logarithm gives value consistent with
-        Chen's Introduction to Plasma Physics and Controlled Fusion
-        section 5.6.2 lab plasma example.
-        """
+        """Tests whether Coulomb logarithm gives value consistent with Chen's
+        Introduction to Plasma Physics and Controlled Fusion section 5.6.2 lab
+        plasma example."""
         T = 2 * u.eV
         T = T.to(u.K, equivalencies=u.temperature_energy())
         n = 1e17 * u.m ** -3
@@ -218,11 +215,9 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_Chen_torus(self):
-        """
-        Tests whether Coulomb logarithm gives value consistent with
-        Chen's Introduction to Plasma Physics and Controlled Fusion
-        section 5.6.2 torus example.
-        """
+        """Tests whether Coulomb logarithm gives value consistent with Chen's
+        Introduction to Plasma Physics and Controlled Fusion section 5.6.2
+        torus example."""
         T = 100 * u.eV
         T = T.to(u.K, equivalencies=u.temperature_energy())
         n = 1e19 * u.m ** -3
@@ -239,11 +234,9 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_Chen_fusion(self):
-        """
-        Tests whether Coulomb logarithm gives value consistent with
-        Chen's Introduction to Plasma Physics and Controlled Fusion
-        section 5.6.2 fusion reactor example.
-        """
+        """Tests whether Coulomb logarithm gives value consistent with Chen's
+        Introduction to Plasma Physics and Controlled Fusion section 5.6.2
+        fusion reactor example."""
         T = 1e4 * u.eV
         T = T.to(u.K, equivalencies=u.temperature_energy())
         n = 1e21 * u.m ** -3
@@ -261,11 +254,9 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_Chen_laser(self):
-        """
-        Tests whether Coulomb logarithm gives value consistent with
-        Chen's Introduction to Plasma Physics and Controlled Fusion
-        section 5.6.2 laser plasma example.
-        """
+        """Tests whether Coulomb logarithm gives value consistent with Chen's
+        Introduction to Plasma Physics and Controlled Fusion section 5.6.2
+        laser plasma example."""
         T = 1e3 * u.eV
         T = T.to(u.K, equivalencies=u.temperature_energy())
         n = 1e27 * u.m ** -3
@@ -283,10 +274,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_ls_min_interp(self):
-        """
-        Test for first version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for first version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -304,10 +293,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_GMS1(self):
-        """
-        Test for first version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for first version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -326,9 +313,11 @@ class Test_Coulomb_logarithm:
 
     def test_ls_min_interp_negative(self):
         """
-        Test for first version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks for when
-        a negative (invalid) Coulomb logarithm is returned.
+        Test for first version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks for when a negative (invalid) Coulomb logarithm is
+        returned.
         """
         with pytest.warns(exceptions.CouplingWarning, match="depends on weak coupling"):
             Coulomb_logarithm(
@@ -342,9 +331,11 @@ class Test_Coulomb_logarithm:
 
     def test_GMS1_negative(self):
         """
-        Test for first version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks for when
-        a negative (invalid) Coulomb logarithm is returned.
+        Test for first version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks for when a negative (invalid) Coulomb logarithm is
+        returned.
         """
         with pytest.warns(exceptions.CouplingWarning, match="depends on weak coupling"):
             Coulomb_logarithm(
@@ -357,10 +348,8 @@ class Test_Coulomb_logarithm:
             )
 
     def test_ls_full_interp(self):
-        """
-        Test for second version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for second version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -378,10 +367,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_GMS2(self):
-        """
-        Test for second version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for second version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -400,9 +387,11 @@ class Test_Coulomb_logarithm:
 
     def test_ls_full_interp_negative(self):
         """
-        Test for second version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks for when
-        a negative (invalid) Coulomb logarithm is returned.
+        Test for second version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks for when a negative (invalid) Coulomb logarithm is
+        returned.
         """
         with pytest.warns(exceptions.CouplingWarning, match="depends on weak coupling"):
             methodVal = Coulomb_logarithm(
@@ -416,9 +405,11 @@ class Test_Coulomb_logarithm:
 
     def test_GMS2_negative(self):
         """
-        Test for second version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks for when
-        a negative (invalid) Coulomb logarithm is returned.
+        Test for second version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks for when a negative (invalid) Coulomb logarithm is
+        returned.
         """
         with pytest.warns(exceptions.CouplingWarning, match="depends on weak coupling"):
             methodVal = Coulomb_logarithm(
@@ -431,10 +422,8 @@ class Test_Coulomb_logarithm:
             )
 
     def test_ls_clamp_mininterp(self):
-        """
-        Test for third version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for third version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -452,10 +441,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_GMS3(self):
-        """
-        Test for third version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for third version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -474,10 +461,11 @@ class Test_Coulomb_logarithm:
 
     def test_ls_clamp_mininterp_negative(self):
         """
-        Test for third version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        a positive value is returned whereas the classical Coulomb
-        logarithm would return a negative value.
+        Test for third version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether a positive value is returned whereas the
+        classical Coulomb logarithm would return a negative value.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -499,10 +487,11 @@ class Test_Coulomb_logarithm:
 
     def test_GMS3_negative(self):
         """
-        Test for third version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        a positive value is returned whereas the classical Coulomb
-        logarithm would return a negative value.
+        Test for third version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether a positive value is returned whereas the
+        classical Coulomb logarithm would return a negative value.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -522,10 +511,11 @@ class Test_Coulomb_logarithm:
 
     def test_ls_clamp_mininterp_non_scalar_density(self):
         """
-        Test for third version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        passing in a collection of density values returns a
-        collection of Coulomb logarithm values.
+        Test for third version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether passing in a collection of density values
+        returns a collection of Coulomb logarithm values.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -547,10 +537,11 @@ class Test_Coulomb_logarithm:
 
     def test_GMS3_non_scalar_density(self):
         """
-        Test for third version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        passing in a collection of density values returns a
-        collection of Coulomb logarithm values.
+        Test for third version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether passing in a collection of density values
+        returns a collection of Coulomb logarithm values.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -569,10 +560,8 @@ class Test_Coulomb_logarithm:
         assert testTrue.all(), errStr
 
     def test_hls_min_interp(self):
-        """
-        Test for fourth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for fourth version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -590,10 +579,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_GMS4(self):
-        """
-        Test for fourth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for fourth version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -612,10 +599,11 @@ class Test_Coulomb_logarithm:
 
     def test_hls_min_interp_negative(self):
         """
-        Test for fourth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        a positive value is returned whereas the classical Coulomb
-        logarithm would return a negative value.
+        Test for fourth version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether a positive value is returned whereas the
+        classical Coulomb logarithm would return a negative value.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -637,10 +625,11 @@ class Test_Coulomb_logarithm:
 
     def test_GMS4_negative(self):
         """
-        Test for fourth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        a positive value is returned whereas the classical Coulomb
-        logarithm would return a negative value.
+        Test for fourth version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether a positive value is returned whereas the
+        classical Coulomb logarithm would return a negative value.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -659,10 +648,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_hls_max_interp(self):
-        """
-        Test for fifth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for fifth version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -680,10 +667,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_GMS5(self):
-        """
-        Test for fifth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for fifth version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -702,10 +687,11 @@ class Test_Coulomb_logarithm:
 
     def test_hls_max_interp_negative(self):
         """
-        Test for fifth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        a positive value is returned whereas the classical Coulomb
-        logarithm would return a negative value.
+        Test for fifth version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether a positive value is returned whereas the
+        classical Coulomb logarithm would return a negative value.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -727,10 +713,11 @@ class Test_Coulomb_logarithm:
 
     def test_GMS5_negative(self):
         """
-        Test for fifth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        a positive value is returned whereas the classical Coulomb
-        logarithm would return a negative value.
+        Test for fifth version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether a positive value is returned whereas the
+        classical Coulomb logarithm would return a negative value.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -749,10 +736,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_hls_full_interp(self):
-        """
-        Test for sixth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for sixth version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -770,10 +755,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_GMS6(self):
-        """
-        Test for sixth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002).
-        """
+        """Test for sixth version of Coulomb logarithm from Gericke, Murillo,
+        and Schlanges PRE (2002)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
@@ -792,10 +775,11 @@ class Test_Coulomb_logarithm:
 
     def test_hls_full_interp_negative(self):
         """
-        Test for sixth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        a positive value is returned whereas the classical Coulomb
-        logarithm would return a negative value.
+        Test for sixth version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether a positive value is returned whereas the
+        classical Coulomb logarithm would return a negative value.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -817,10 +801,11 @@ class Test_Coulomb_logarithm:
 
     def test_GMS6_negative(self):
         """
-        Test for sixth version of Coulomb logarithm from Gericke,
-        Murillo, and Schlanges PRE (2002). This checks whether
-        a positive value is returned whereas the classical Coulomb
-        logarithm would return a negative value.
+        Test for sixth version of Coulomb logarithm from Gericke, Murillo, and
+        Schlanges PRE (2002).
+
+        This checks whether a positive value is returned whereas the
+        classical Coulomb logarithm would return a negative value.
         """
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
@@ -839,10 +824,8 @@ class Test_Coulomb_logarithm:
         assert testTrue, errStr
 
     def test_ls_full_interp_zmean_error(self):
-        """
-        Tests whether ls_full_interp raises z_mean error when a z_mean is not
-        provided.
-        """
+        """Tests whether ls_full_interp raises z_mean error when a z_mean is
+        not provided."""
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
@@ -852,20 +835,16 @@ class Test_Coulomb_logarithm:
             )
 
     def test_GMS2_zmean_error(self):
-        """
-        Tests whether GMS-2 raises z_mean error when a z_mean is not
-        provided.
-        """
+        """Tests whether GMS-2 raises z_mean error when a z_mean is not
+        provided."""
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
                 self.temperature2, self.density2, self.particles, method="GMS-2"
             )
 
     def test_hls_max_interp_zmean_error(self):
-        """
-        Tests whether hls_max_interp raises z_mean error when a z_mean is not
-        provided.
-        """
+        """Tests whether hls_max_interp raises z_mean error when a z_mean is
+        not provided."""
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
@@ -875,20 +854,16 @@ class Test_Coulomb_logarithm:
             )
 
     def test_GMS5_zmean_error(self):
-        """
-        Tests whether GMS-5 raises z_mean error when a z_mean is not
-        provided.
-        """
+        """Tests whether GMS-5 raises z_mean error when a z_mean is not
+        provided."""
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
                 self.temperature2, self.density2, self.particles, method="GMS-5"
             )
 
     def test_hls_full_interp_zmean_error(self):
-        """
-        Tests whether hls_full_interp raises z_mean error when a z_mean is not
-        provided.
-        """
+        """Tests whether hls_full_interp raises z_mean error when a z_mean is
+        not provided."""
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
@@ -898,10 +873,8 @@ class Test_Coulomb_logarithm:
             )
 
     def test_GMS6_zmean_error(self):
-        """
-        Tests whether GMS-6 raises z_mean error when a z_mean is not
-        provided.
-        """
+        """Tests whether GMS-6 raises z_mean error when a z_mean is not
+        provided."""
         with pytest.raises(ValueError):
             methodVal = Coulomb_logarithm(
                 self.temperature2, self.density2, self.particles, method="GMS-6"
@@ -918,27 +891,22 @@ class Test_Coulomb_logarithm:
             Coulomb_logarithm(1e5 * u.K, 1 * u.m ** -3, ("e", "p"), V=1.1 * c)
 
     def test_unit_conversion_error(self):
-        """
-        Tests whether unit conversion error is raised when arguments
-        are given with incorrect units.
-        """
+        """Tests whether unit conversion error is raised when arguments are
+        given with incorrect units."""
         with pytest.raises(u.UnitTypeError):
             Coulomb_logarithm(
                 1e5 * u.g, 1 * u.m ** -3, ("e", "p"), V=29979245 * u.m / u.s
             )
 
     def test_single_particle_error(self):
-        """
-        Tests whether an error is raised if only a single particle is given.
-        """
+        """Tests whether an error is raised if only a single particle is
+        given."""
         with pytest.raises(ValueError):
             Coulomb_logarithm(1 * u.K, 5 * u.m ** -3, "e")
 
     def test_invalid_particle_error(self):
-        """
-        Tests whether an error is raised when an invalid particle name
-        is given.
-        """
+        """Tests whether an error is raised when an invalid particle name is
+        given."""
         with pytest.raises(plasmapy.particles.exceptions.InvalidParticleError):
             Coulomb_logarithm(1 * u.K, 5 * u.m ** -3, ("e", "g"))
 
@@ -951,7 +919,7 @@ class Test_Coulomb_logarithm:
 class Test_impact_parameter_perp:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 11604 * u.K
         self.particles = ("e", "p")
         self.V = 1e4 * u.km / u.s
@@ -963,9 +931,7 @@ class Test_impact_parameter_perp:
         assert result == resultRev
 
     def test_known1(self):
-        """
-        Test for known value.
-        """
+        """Test for known value."""
         methodVal = impact_parameter_perp(self.T, self.particles, V=np.nan * u.m / u.s)
         testTrue = np.isclose(self.True1, methodVal.si.value, rtol=1e-1, atol=0.0)
         errStr = (
@@ -976,10 +942,8 @@ class Test_impact_parameter_perp:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 + 1e-15
         methodVal = impact_parameter_perp(self.T, self.particles, V=np.nan * u.m / u.s)
         testTrue = not np.isclose(methodVal.si.value, fail1, rtol=1e-16, atol=0.0)
@@ -992,7 +956,7 @@ class Test_impact_parameter_perp:
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(
             impact_parameter_perp, insert_some_nans, insert_all_nans, {}
         )
@@ -1006,7 +970,7 @@ class Test_impact_parameter_perp:
 class Test_impact_parameter:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 11604 * u.K
         self.T_arr = np.array([1, 2]) * u.eV
         self.n_e = 1e17 * u.cm ** -3
@@ -1022,9 +986,7 @@ class Test_impact_parameter:
         assert result == resultRev
 
     def test_known1(self):
-        """
-        Test for known value.
-        """
+        """Test for known value."""
         methodVal = impact_parameter(
             self.T,
             self.n_e,
@@ -1040,10 +1002,8 @@ class Test_impact_parameter:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 * (1 + 1e-15)
         methodVal = impact_parameter(
             self.T,
@@ -1089,16 +1049,14 @@ class Test_impact_parameter:
         ],
     )
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(
             impact_parameter, insert_some_nans, insert_all_nans, kwargs
         )
 
     def test_extend_scalar_bmin(self):
-        """
-        Test to verify that if T is scalar and n is vector, bmin will be extended
-        to the same length as bmax
-        """
+        """Test to verify that if T is scalar and n is vector, bmin will be
+        extended to the same length as bmax."""
         (bmin, bmax) = impact_parameter(1 * u.eV, self.n_e_arr, self.particles)
         assert len(bmin) == len(bmax)
 
@@ -1106,7 +1064,7 @@ class Test_impact_parameter:
 class Test_collision_frequency:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 11604 * u.K
         self.n = 1e17 * u.cm ** -3
         self.particles = ("e", "p")
@@ -1126,9 +1084,7 @@ class Test_collision_frequency:
         assert result == resultRev
 
     def test_known1(self):
-        """
-        Test for known value.
-        """
+        """Test for known value."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
@@ -1143,10 +1099,8 @@ class Test_collision_frequency:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 * (1 + 1e-15)
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
@@ -1175,15 +1129,13 @@ class Test_collision_frequency:
         ],
     )
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(
             collision_frequency, insert_some_nans, insert_all_nans, kwargs
         )
 
     def test_electrons(self):
-        """
-        Testing collision frequency between electrons.
-        """
+        """Testing collision frequency between electrons."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
@@ -1203,9 +1155,7 @@ class Test_collision_frequency:
         assert testTrue, errStr
 
     def test_protons(self):
-        """
-        Testing collision frequency between protons (ions).
-        """
+        """Testing collision frequency between protons (ions)."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
@@ -1225,9 +1175,7 @@ class Test_collision_frequency:
         assert testTrue, errStr
 
     def test_zmean(self):
-        """
-        Test collisional frequency function when given arbitrary z_mean.
-        """
+        """Test collisional frequency function when given arbitrary z_mean."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
@@ -1245,7 +1193,7 @@ class Test_collision_frequency:
 class Test_fundamental_electron_collision_freq:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T_arr = np.array([1, 2]) * u.eV
         self.n_arr = np.array([1e20, 2e20]) * u.cm ** -3
         self.ion = "p"
@@ -1255,7 +1203,7 @@ class Test_fundamental_electron_collision_freq:
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(
             fundamental_electron_collision_freq, insert_some_nans, insert_all_nans, {}
         )
@@ -1264,7 +1212,7 @@ class Test_fundamental_electron_collision_freq:
 class Test_fundamental_ion_collision_freq:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T_arr = np.array([1, 2]) * u.eV
         self.n_arr = np.array([1e20, 2e20]) * u.cm ** -3
         self.ion = "p"
@@ -1274,7 +1222,7 @@ class Test_fundamental_ion_collision_freq:
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(
             fundamental_ion_collision_freq, insert_some_nans, insert_all_nans, {}
         )
@@ -1283,7 +1231,7 @@ class Test_fundamental_ion_collision_freq:
 class Test_mean_free_path:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 11604 * u.K
         self.n_e = 1e17 * u.cm ** -3
         self.particles = ("e", "p")
@@ -1298,9 +1246,7 @@ class Test_mean_free_path:
         assert result == resultRev
 
     def test_known1(self):
-        """
-        Test for known value.
-        """
+        """Test for known value."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = mean_free_path(
                 self.T,
@@ -1315,10 +1261,8 @@ class Test_mean_free_path:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 * (1 + 1e-15)
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = mean_free_path(
@@ -1339,14 +1283,14 @@ class Test_mean_free_path:
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(mean_free_path, insert_some_nans, insert_all_nans, {})
 
 
 class Test_Spitzer_resistivity:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 11604 * u.K
         self.n = 1e12 * u.cm ** -3
         self.particles = ("e", "p")
@@ -1361,9 +1305,7 @@ class Test_Spitzer_resistivity:
         assert result == resultRev
 
     def test_known1(self):
-        """
-        Test for known value.
-        """
+        """Test for known value."""
         methodVal = Spitzer_resistivity(
             self.T,
             self.n,
@@ -1377,10 +1319,8 @@ class Test_Spitzer_resistivity:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 * (1 + 1e-15)
         methodVal = Spitzer_resistivity(
             self.T,
@@ -1415,7 +1355,7 @@ class Test_Spitzer_resistivity:
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(
             Spitzer_resistivity, insert_some_nans, insert_all_nans, {}
         )
@@ -1424,7 +1364,7 @@ class Test_Spitzer_resistivity:
 class Test_mobility:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 11604 * u.K
         self.n_e = 1e17 * u.cm ** -3
         self.particles = ("e", "p")
@@ -1440,9 +1380,7 @@ class Test_mobility:
         assert result == resultRev
 
     def test_known1(self):
-        """
-        Test for known value.
-        """
+        """Test for known value."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = mobility(
                 self.T,
@@ -1457,10 +1395,8 @@ class Test_mobility:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 * (1 + 1e-15)
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = mobility(
@@ -1497,14 +1433,14 @@ class Test_mobility:
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(mobility, insert_some_nans, insert_all_nans, {})
 
 
 class Test_Knudsen_number:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.length = 1 * u.nm
         self.T = 11604 * u.K
         self.n_e = 1e17 * u.cm ** -3
@@ -1522,9 +1458,7 @@ class Test_Knudsen_number:
         assert result == resultRev
 
     def test_known1(self):
-        """
-        Test for known value.
-        """
+        """Test for known value."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Knudsen_number(
                 self.length,
@@ -1540,10 +1474,8 @@ class Test_Knudsen_number:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 * (1 + 1e-15)
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = Knudsen_number(
@@ -1565,14 +1497,14 @@ class Test_Knudsen_number:
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(Knudsen_number, insert_some_nans, insert_all_nans, {})
 
 
 class Test_coupling_parameter:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 11604 * u.K
         self.n_e = 1e21 * u.cm ** -3
         self.particles = ("e", "p")
@@ -1588,9 +1520,7 @@ class Test_coupling_parameter:
         assert result == resultRev
 
     def test_known1(self):
-        """
-        Test for known value.
-        """
+        """Test for known value."""
         methodVal = coupling_parameter(
             self.T,
             self.n_e,
@@ -1604,10 +1534,8 @@ class Test_coupling_parameter:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 * (1 + 1e-15)
         methodVal = coupling_parameter(
             self.T,
@@ -1625,9 +1553,7 @@ class Test_coupling_parameter:
         assert testTrue, errStr
 
     def test_zmean(self):
-        """
-        Test value obtained when arbitrary z_mean is passed
-        """
+        """Test value obtained when arbitrary z_mean is passed."""
         methodVal = coupling_parameter(
             self.T,
             self.n_e,
@@ -1646,7 +1572,7 @@ class Test_coupling_parameter:
     # @pytest.mark.parametrize("kwargs", [{"method": "classical"},
     #                                     {"method": "quantum"},])   # TODO quantum issues
     def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
-        """Test for ability to handle numpy array quantities"""
+        """Test for ability to handle numpy array quantities."""
         assert_can_handle_nparray(
             coupling_parameter, insert_some_nans, insert_all_nans, {}
         )
@@ -1655,9 +1581,7 @@ class Test_coupling_parameter:
         reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
     )
     def test_quantum(self):
-        """
-        Testing quantum method for coupling parameter.
-        """
+        """Testing quantum method for coupling parameter."""
         methodVal = coupling_parameter(
             self.T, self.n_e, self.particles, method="quantum"
         )
@@ -1668,6 +1592,6 @@ class Test_coupling_parameter:
         assert testTrue, errStr
 
     def test_kwarg_method_error(self):
-        """Testing kwarg `method` fails is not 'classical' or 'quantum'"""
+        """Testing kwarg `method` fails is not 'classical' or 'quantum'."""
         with pytest.raises(ValueError):
             coupling_parameter(self.T, self.n_e, self.particles, method="not a method")

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -1,5 +1,5 @@
 """Tests for functions that calculate plasma dielectric parameters in
-dielectric.py"""
+dielectric.py."""
 
 import numpy as np
 
@@ -25,10 +25,8 @@ three_species = ["e", "D+", "H+"]
 
 class Test_ColdPlasmaPermittivity(object):
     def test_proton_electron_plasma(self):
-        """
-        Test proton-electron plasma against the (approximate)
-        analytical formulas
-        """
+        """Test proton-electron plasma against the (approximate) analytical
+        formulas."""
         B = 1 * u.T
         n = [1, 1] * 1 / u.m ** 3
         omega = 1 * u.rad / u.s
@@ -70,9 +68,8 @@ class Test_ColdPlasmaPermittivity(object):
         assert isinstance(rotating_tuple_result, RotatingTensorElements)
 
     def test_three_species(self):
-        """
-        Test with three species (2 ions): D plasma with 5%H minority fraction
-        """
+        """Test with three species (2 ions): D plasma with 5%H minority
+        fraction."""
         n_3 = np.array([1, 1, 5 / 100]) * 1e19 / u.m ** 3
         S, D, P = cold_plasma_permittivity_SDP(B, three_species, n_3, omega)
         assert np.isclose(S, -11753.3)
@@ -81,9 +78,10 @@ class Test_ColdPlasmaPermittivity(object):
 
     def test_SD_to_LR_relationships(self):
         """
-        Test the relationships between (S, D, P) notation in Stix basis and
-        (L, R, P) notation in the rotating basis, ie test:
-         S = (R+L)/2 and D = (R-L)/2
+        Test the relationships between (S, D, P) notation in Stix basis and (L,
+        R, P) notation in the rotating basis, ie test:
+
+        S = (R+L)/2 and D = (R-L)/2
         and
          R = S+D and L = S-D
         """
@@ -99,6 +97,7 @@ class Test_ColdPlasmaPermittivity(object):
     def test_numpy_array_workflow(self):
         """
         As per @jhillairet at:
+
         https://github.com/PlasmaPy/PlasmaPy/issues/539#issuecomment-425337810
         """
         ns = np.logspace(17, 19, 50) / u.m ** 3
@@ -114,7 +113,7 @@ class Test_ColdPlasmaPermittivity(object):
 class Test_permittivity_1D_Maxwellian:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 30 * 11600 * u.K
         self.n = 1e18 * u.cm ** -3
         self.particle = "Ne"
@@ -127,9 +126,7 @@ class Test_permittivity_1D_Maxwellian:
         ) * u.dimensionless_unscaled
 
     def test_known1(self):
-        """
-        Tests Fermi_integral for expected value.
-        """
+        """Tests Fermi_integral for expected value."""
         methodVal = permittivity_1D_Maxwellian(
             self.omega, self.kWave, self.T, self.n, self.particle, self.z_mean
         )
@@ -138,10 +135,8 @@ class Test_permittivity_1D_Maxwellian:
         assert testTrue, errStr
 
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 + 1e-15
         methodVal = permittivity_1D_Maxwellian(
             self.omega, self.kWave, self.T, self.n, self.particle, self.z_mean

--- a/plasmapy/formulary/tests/test_distribution.py
+++ b/plasmapy/formulary/tests/test_distribution.py
@@ -23,7 +23,7 @@ from ..parameters import kappa_thermal_speed, thermal_speed
 class Test_Maxwellian_1D(object):
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T_e = 30000 * u.K
         self.v = 1e5 * u.m / u.s
         self.v_drift = 1000000 * u.m / u.s
@@ -40,29 +40,24 @@ class Test_Maxwellian_1D(object):
         self.distFuncTrue = 5.851627151617136e-07
 
     def test_max_noDrift(self):
-        """
-        Checks maximum value of distribution function is in expected place,
-        when there is no drift applied.
-        """
+        """Checks maximum value of distribution function is in expected place,
+        when there is no drift applied."""
         max_index = Maxwellian_1D(
             self.v_vect, T=self.T_e, particle=self.particle, v_drift=0 * u.m / u.s
         ).argmax()
         assert np.isclose(self.v_vect[max_index].value, 0.0)
 
     def test_max_drift(self):
-        """
-        Checks maximum value of distribution function is in expected place,
-        when there is drift applied.
-        """
+        """Checks maximum value of distribution function is in expected place,
+        when there is drift applied."""
         max_index = Maxwellian_1D(
             self.v_vect, T=self.T_e, particle=self.particle, v_drift=self.v_drift
         ).argmax()
         assert np.isclose(self.v_vect[max_index].value, self.v_drift.value)
 
     def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
+        """Tests whether distribution function is normalized, and integrates to
+        1."""
         # converting vTh to unitless
         vTh = self.vTh.si.value
         # setting up integration from -10*vTh to 10*vTh, which is close to Inf
@@ -83,9 +78,7 @@ class Test_Maxwellian_1D(object):
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_std(self):
-        """
-        Tests standard deviation of function?
-        """
+        """Tests standard deviation of function?"""
         std = (
             Maxwellian_1D(self.v_vect, T=self.T_e, particle=self.particle)
             * self.v_vect ** 2
@@ -96,9 +89,7 @@ class Test_Maxwellian_1D(object):
         assert np.isclose(T_distri.value, self.T_e.value)
 
     def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
+        """Tests distribution function with units, but not passing vTh."""
         distFunc = Maxwellian_1D(
             v=self.v, T=self.T_e, particle=self.particle, units="units"
         )
@@ -111,9 +102,7 @@ class Test_Maxwellian_1D(object):
         ), errStr
 
     def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
+        """Tests distribution function with units and passing vTh."""
         distFunc = Maxwellian_1D(
             v=self.v, T=self.T_e, vTh=self.vTh, particle=self.particle, units="units"
         )
@@ -126,9 +115,7 @@ class Test_Maxwellian_1D(object):
         ), errStr
 
     def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
+        """Tests distribution function without units, and not passing vTh."""
         # converting T to SI then stripping units
         T_e = self.T_e.to(u.K, equivalencies=u.temperature_energy())
         T_e = T_e.si.value
@@ -142,9 +129,7 @@ class Test_Maxwellian_1D(object):
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
     def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
+        """Tests distribution function without units, and with passing vTh."""
         # converting T to SI then stripping units
         T_e = self.T_e.to(u.K, equivalencies=u.temperature_energy())
         T_e = T_e.si.value
@@ -163,8 +148,10 @@ class Test_Maxwellian_1D(object):
 
     def test_zero_drift_units(self):
         """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
+        Testing inputting drift equal to 0 with units.
+
+        These should just get passed and not have extra units applied to
+        them.
         """
         distFunc = Maxwellian_1D(
             v=self.v,
@@ -182,9 +169,7 @@ class Test_Maxwellian_1D(object):
         ), errStr
 
     def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
+        """Testing vdrifts with values."""
         testVal = ((self.vTh ** 2 * np.pi) ** (-1 / 2)).si.value
         distFunc = Maxwellian_1D(
             v=self.v,
@@ -200,7 +185,7 @@ class Test_Maxwellian_1D(object):
 class Test_Maxwellian_speed_1D(object):
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 1.0 * u.eV
         self.particle = "H+"
         # get thermal velocity and thermal velocity squared
@@ -212,9 +197,8 @@ class Test_Maxwellian_speed_1D(object):
         self.distFuncDrift = 2 * (self.vTh ** 2 * np.pi) ** (-1 / 2)
 
     def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
+        """Tests whether distribution function is normalized, and integrates to
+        1."""
         # setting up integration from 0 to 10*vTh
         xData1D = np.arange(0, 10.01, 0.01) * self.vTh
         yData1D = Maxwellian_speed_1D(v=xData1D, T=self.T, particle=self.particle)
@@ -224,9 +208,7 @@ class Test_Maxwellian_speed_1D(object):
         assert np.isclose(integ.value, 1), exceptStr
 
     def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
+        """Tests distribution function with units, but not passing vTh."""
         distFunc = Maxwellian_speed_1D(
             v=self.v, T=self.T, particle=self.particle, units="units"
         )
@@ -239,9 +221,7 @@ class Test_Maxwellian_speed_1D(object):
         ), errStr
 
     def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
+        """Tests distribution function with units and passing vTh."""
         distFunc = Maxwellian_speed_1D(
             v=self.v, T=self.T, vTh=self.vTh, particle=self.particle, units="units"
         )
@@ -254,9 +234,7 @@ class Test_Maxwellian_speed_1D(object):
         ), errStr
 
     def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
+        """Tests distribution function without units, and not passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -270,9 +248,7 @@ class Test_Maxwellian_speed_1D(object):
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
     def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
+        """Tests distribution function without units, and with passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -291,8 +267,10 @@ class Test_Maxwellian_speed_1D(object):
 
     def test_zero_drift_units(self):
         """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
+        Testing inputting drift equal to 0 with units.
+
+        These should just get passed and not have extra units applied to
+        them.
         """
         distFunc = Maxwellian_speed_1D(
             v=self.v,
@@ -310,9 +288,7 @@ class Test_Maxwellian_speed_1D(object):
         ), errStr
 
     def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
+        """Testing vdrifts with values."""
         distFunc = Maxwellian_speed_1D(
             v=self.v,
             T=self.T,
@@ -329,7 +305,7 @@ class Test_Maxwellian_speed_1D(object):
 class Test_Maxwellian_velocity_2D(object):
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 1.0 * u.eV
         self.particle = "H+"
         # get thermal velocity and thermal velocity squared
@@ -343,9 +319,8 @@ class Test_Maxwellian_velocity_2D(object):
         self.distFuncTrue = 7.477094598799251e-55
 
     def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
+        """Tests whether distribution function is normalized, and integrates to
+        1."""
         # converting vTh to unitless
         vTh = self.vTh.si.value
         # setting up integration from -10*vTh to 10*vTh, which is close to Inf
@@ -368,9 +343,7 @@ class Test_Maxwellian_velocity_2D(object):
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
+        """Tests distribution function with units, but not passing vTh."""
         distFunc = Maxwellian_velocity_2D(
             vx=self.vx, vy=self.vy, T=self.T, particle=self.particle, units="units"
         )
@@ -383,9 +356,7 @@ class Test_Maxwellian_velocity_2D(object):
         ), errStr
 
     def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
+        """Tests distribution function with units and passing vTh."""
         distFunc = Maxwellian_velocity_2D(
             vx=self.vx,
             vy=self.vy,
@@ -403,9 +374,7 @@ class Test_Maxwellian_velocity_2D(object):
         ), errStr
 
     def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
+        """Tests distribution function without units, and not passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -423,9 +392,7 @@ class Test_Maxwellian_velocity_2D(object):
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
     def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
+        """Tests distribution function without units, and with passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -445,8 +412,10 @@ class Test_Maxwellian_velocity_2D(object):
 
     def test_zero_drift_units(self):
         """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
+        Testing inputting drift equal to 0 with units.
+
+        These should just get passed and not have extra units applied to
+        them.
         """
         distFunc = Maxwellian_velocity_2D(
             vx=self.vx,
@@ -466,9 +435,7 @@ class Test_Maxwellian_velocity_2D(object):
         ), errStr
 
     def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
+        """Testing vdrifts with values."""
         testVal = ((self.vTh ** 2 * np.pi) ** (-1)).si.value
         distFunc = Maxwellian_velocity_2D(
             vx=self.vx,
@@ -487,7 +454,7 @@ class Test_Maxwellian_velocity_2D(object):
 class Test_Maxwellian_speed_2D(object):
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 1.0 * u.eV
         self.particle = "H+"
         # get thermal velocity and thermal velocity squared
@@ -498,9 +465,8 @@ class Test_Maxwellian_speed_2D(object):
         self.distFuncTrue = 2.2148166449365907e-26
 
     def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
+        """Tests whether distribution function is normalized, and integrates to
+        1."""
         # setting up integration from 0 to 10*vTh
         xData1D = np.arange(0, 10.001, 0.001) * self.vTh
         yData1D = Maxwellian_speed_2D(v=xData1D, T=self.T, particle=self.particle)
@@ -510,9 +476,7 @@ class Test_Maxwellian_speed_2D(object):
         assert np.isclose(integ.value, 1), exceptStr
 
     def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
+        """Tests distribution function with units, but not passing vTh."""
         distFunc = Maxwellian_speed_2D(
             v=self.v, T=self.T, particle=self.particle, units="units"
         )
@@ -525,9 +489,7 @@ class Test_Maxwellian_speed_2D(object):
         ), errStr
 
     def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
+        """Tests distribution function with units and passing vTh."""
         distFunc = Maxwellian_speed_2D(
             v=self.v, T=self.T, vTh=self.vTh, particle=self.particle, units="units"
         )
@@ -540,9 +502,7 @@ class Test_Maxwellian_speed_2D(object):
         ), errStr
 
     def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
+        """Tests distribution function without units, and not passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -556,9 +516,7 @@ class Test_Maxwellian_speed_2D(object):
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
     def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
+        """Tests distribution function without units, and with passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -577,8 +535,10 @@ class Test_Maxwellian_speed_2D(object):
 
     def test_zero_drift_units(self):
         """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
+        Testing inputting drift equal to 0 with units.
+
+        These should just get passed and not have extra units applied to
+        them.
         """
         distFunc = Maxwellian_speed_2D(
             v=self.v,
@@ -596,9 +556,7 @@ class Test_Maxwellian_speed_2D(object):
         ), errStr
 
     def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
+        """Testing vdrifts with values."""
         with pytest.raises(NotImplementedError):
             distFunc = Maxwellian_speed_2D(
                 v=self.v,
@@ -613,7 +571,7 @@ class Test_Maxwellian_speed_2D(object):
 class Test_Maxwellian_velocity_3D(object):
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 1.0 * u.eV
         self.particle = "H+"
         # get thermal velocity and thermal velocity squared
@@ -630,9 +588,8 @@ class Test_Maxwellian_velocity_3D(object):
         self.distFuncTrue = 6.465458269306909e-82
 
     def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
+        """Tests whether distribution function is normalized, and integrates to
+        1."""
         # converting vTh to unitless
         vTh = self.vTh.si.value
         # setting up integration from -10*vTh to 10*vTh, which is close to Inf
@@ -657,9 +614,7 @@ class Test_Maxwellian_velocity_3D(object):
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
+        """Tests distribution function with units, but not passing vTh."""
         distFunc = Maxwellian_velocity_3D(
             vx=self.vx,
             vy=self.vy,
@@ -677,9 +632,7 @@ class Test_Maxwellian_velocity_3D(object):
         ), errStr
 
     def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
+        """Tests distribution function with units and passing vTh."""
         distFunc = Maxwellian_velocity_3D(
             vx=self.vx,
             vy=self.vy,
@@ -698,9 +651,7 @@ class Test_Maxwellian_velocity_3D(object):
         ), errStr
 
     def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
+        """Tests distribution function without units, and not passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -719,9 +670,7 @@ class Test_Maxwellian_velocity_3D(object):
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
     def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
+        """Tests distribution function without units, and with passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -742,8 +691,10 @@ class Test_Maxwellian_velocity_3D(object):
 
     def test_zero_drift_units(self):
         """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
+        Testing inputting drift equal to 0 with units.
+
+        These should just get passed and not have extra units applied to
+        them.
         """
         distFunc = Maxwellian_velocity_3D(
             vx=self.vx,
@@ -765,9 +716,7 @@ class Test_Maxwellian_velocity_3D(object):
         ), errStr
 
     def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
+        """Testing vdrifts with values."""
         testVal = ((self.vTh ** 2 * np.pi) ** (-3 / 2)).si.value
         distFunc = Maxwellian_velocity_3D(
             vx=self.vx,
@@ -787,7 +736,7 @@ class Test_Maxwellian_velocity_3D(object):
 class Test_Maxwellian_speed_3D(object):
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 1.0 * u.eV
         self.particle = "H+"
         # get thermal velocity and thermal velocity squared
@@ -798,9 +747,8 @@ class Test_Maxwellian_speed_3D(object):
         self.distFuncTrue = 1.8057567503860518e-25
 
     def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
+        """Tests whether distribution function is normalized, and integrates to
+        1."""
         # setting up integration from 0 to 10*vTh
         xData1D = np.arange(0, 10.01, 0.01) * self.vTh
         yData1D = Maxwellian_speed_3D(v=xData1D, T=self.T, particle=self.particle)
@@ -810,9 +758,7 @@ class Test_Maxwellian_speed_3D(object):
         assert np.isclose(integ.value, 1), exceptStr
 
     def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
+        """Tests distribution function with units, but not passing vTh."""
         distFunc = Maxwellian_speed_3D(
             v=self.v, T=self.T, particle=self.particle, units="units"
         )
@@ -825,9 +771,7 @@ class Test_Maxwellian_speed_3D(object):
         ), errStr
 
     def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
+        """Tests distribution function with units and passing vTh."""
         distFunc = Maxwellian_speed_3D(
             v=self.v, T=self.T, vTh=self.vTh, particle=self.particle, units="units"
         )
@@ -840,9 +784,7 @@ class Test_Maxwellian_speed_3D(object):
         ), errStr
 
     def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
+        """Tests distribution function without units, and not passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -856,9 +798,7 @@ class Test_Maxwellian_speed_3D(object):
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
     def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
+        """Tests distribution function without units, and with passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -877,8 +817,10 @@ class Test_Maxwellian_speed_3D(object):
 
     def test_zero_drift_units(self):
         """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
+        Testing inputting drift equal to 0 with units.
+
+        These should just get passed and not have extra units applied to
+        them.
         """
         distFunc = Maxwellian_speed_3D(
             v=self.v,
@@ -896,9 +838,7 @@ class Test_Maxwellian_speed_3D(object):
         ), errStr
 
     def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
+        """Testing vdrifts with values."""
         with pytest.raises(NotImplementedError):
             distFunc = Maxwellian_speed_3D(
                 v=self.v,
@@ -912,7 +852,7 @@ class Test_Maxwellian_speed_3D(object):
 class Test_kappa_velocity_1D(object):
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T_e = 30000 * u.K
         self.kappa = 4
         self.kappaInvalid = 3 / 2
@@ -931,10 +871,8 @@ class Test_kappa_velocity_1D(object):
         self.distFuncTrue = 6.637935187755855e-07
 
     def test_invalid_kappa(self):
-        """
-        Checks if function raises error when kappa <= 3/2 is passed as an
-        argument.
-        """
+        """Checks if function raises error when kappa <= 3/2 is passed as an
+        argument."""
         with pytest.raises(ValueError):
             kappa_velocity_1D(
                 v=self.v,
@@ -945,10 +883,8 @@ class Test_kappa_velocity_1D(object):
             )
 
     def test_max_noDrift(self):
-        """
-        Checks maximum value of distribution function is in expected place,
-        when there is no drift applied.
-        """
+        """Checks maximum value of distribution function is in expected place,
+        when there is no drift applied."""
         max_index = kappa_velocity_1D(
             self.v_vect,
             T=self.T_e,
@@ -959,10 +895,8 @@ class Test_kappa_velocity_1D(object):
         assert np.isclose(self.v_vect[max_index].value, 0.0)
 
     def test_max_drift(self):
-        """
-        Checks maximum value of distribution function is in expected place,
-        when there is drift applied.
-        """
+        """Checks maximum value of distribution function is in expected place,
+        when there is drift applied."""
         max_index = kappa_velocity_1D(
             self.v_vect,
             T=self.T_e,
@@ -973,16 +907,13 @@ class Test_kappa_velocity_1D(object):
         assert np.isclose(self.v_vect[max_index].value, self.v_drift.value)
 
     def test_maxwellian_limit(self):
-        """
-        Tests the limit of large kappa to see if kappa distribution function
-        converges to Maxwellian.
-        """
+        """Tests the limit of large kappa to see if kappa distribution function
+        converges to Maxwellian."""
         return
 
     def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
+        """Tests whether distribution function is normalized, and integrates to
+        1."""
         # converting vTh to unitless
         vTh = self.vTh.si.value
         # setting up integration from -10*vTh to 10*vTh, which is close to Inf
@@ -1003,9 +934,7 @@ class Test_kappa_velocity_1D(object):
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_std(self):
-        """
-        Tests standard deviation of function?
-        """
+        """Tests standard deviation of function?"""
         std = (
             kappa_velocity_1D(
                 self.v_vect, T=self.T_e, kappa=self.kappa, particle=self.particle
@@ -1018,9 +947,7 @@ class Test_kappa_velocity_1D(object):
         assert np.isclose(T_distri.value, self.T_e.value)
 
     def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
+        """Tests distribution function with units, but not passing vTh."""
         distFunc = kappa_velocity_1D(
             v=self.v,
             T=self.T_e,
@@ -1037,9 +964,7 @@ class Test_kappa_velocity_1D(object):
         ), errStr
 
     def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
+        """Tests distribution function with units and passing vTh."""
         distFunc = kappa_velocity_1D(
             v=self.v,
             T=self.T_e,
@@ -1057,9 +982,7 @@ class Test_kappa_velocity_1D(object):
         ), errStr
 
     def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
+        """Tests distribution function without units, and not passing vTh."""
         # converting T to SI then stripping units
         T_e = self.T_e.to(u.K, equivalencies=u.temperature_energy())
         T_e = T_e.si.value
@@ -1077,9 +1000,7 @@ class Test_kappa_velocity_1D(object):
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
     def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
+        """Tests distribution function without units, and with passing vTh."""
         # converting T to SI then stripping units
         T_e = self.T_e.to(u.K, equivalencies=u.temperature_energy())
         T_e = T_e.si.value
@@ -1099,8 +1020,10 @@ class Test_kappa_velocity_1D(object):
 
     def test_zero_drift_units(self):
         """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
+        Testing inputting drift equal to 0 with units.
+
+        These should just get passed and not have extra units applied to
+        them.
         """
         distFunc = kappa_velocity_1D(
             v=self.v,
@@ -1119,9 +1042,7 @@ class Test_kappa_velocity_1D(object):
         ), errStr
 
     def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
+        """Testing vdrifts with values."""
         testVal = 6.755498543630533e-07
         distFunc = kappa_velocity_1D(
             v=self.v,
@@ -1139,7 +1060,7 @@ class Test_kappa_velocity_1D(object):
 class Test_kappa_velocity_3D(object):
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T = 1.0 * u.eV
         self.kappa = 4
         self.kappaInvalid = 3 / 2
@@ -1158,10 +1079,8 @@ class Test_kappa_velocity_3D(object):
         self.distFuncTrue = 1.1847914288918793e-22
 
     def test_invalid_kappa(self):
-        """
-        Checks if function raises error when kappa <= 3/2 is passed as an
-        argument.
-        """
+        """Checks if function raises error when kappa <= 3/2 is passed as an
+        argument."""
         with pytest.raises(ValueError):
             kappa_velocity_3D(
                 vx=self.vx,
@@ -1209,9 +1128,8 @@ class Test_kappa_velocity_3D(object):
     #        return
 
     def test_norm(self):
-        """
-        Tests whether distribution function is normalized, and integrates to 1.
-        """
+        """Tests whether distribution function is normalized, and integrates to
+        1."""
         # converting vTh to unitless
         vTh = self.vTh.si.value
         # setting up integration from -10*vTh to 10*vTh, which is close to Inf
@@ -1236,9 +1154,7 @@ class Test_kappa_velocity_3D(object):
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
     def test_units_no_vTh(self):
-        """
-        Tests distribution function with units, but not passing vTh.
-        """
+        """Tests distribution function with units, but not passing vTh."""
         distFunc = kappa_velocity_3D(
             vx=self.vx,
             vy=self.vy,
@@ -1257,9 +1173,7 @@ class Test_kappa_velocity_3D(object):
         ), errStr
 
     def test_units_vTh(self):
-        """
-        Tests distribution function with units and passing vTh.
-        """
+        """Tests distribution function with units and passing vTh."""
         distFunc = kappa_velocity_3D(
             vx=self.vx,
             vy=self.vy,
@@ -1279,9 +1193,7 @@ class Test_kappa_velocity_3D(object):
         ), errStr
 
     def test_unitless_no_vTh(self):
-        """
-        Tests distribution function without units, and not passing vTh.
-        """
+        """Tests distribution function without units, and not passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -1301,9 +1213,7 @@ class Test_kappa_velocity_3D(object):
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
     def test_unitless_vTh(self):
-        """
-        Tests distribution function without units, and with passing vTh.
-        """
+        """Tests distribution function without units, and with passing vTh."""
         # converting T to SI then stripping units
         T = self.T.to(u.K, equivalencies=u.temperature_energy())
         T = T.si.value
@@ -1325,8 +1235,10 @@ class Test_kappa_velocity_3D(object):
 
     def test_zero_drift_units(self):
         """
-        Testing inputting drift equal to 0 with units. These should just
-        get passed and not have extra units applied to them.
+        Testing inputting drift equal to 0 with units.
+
+        These should just get passed and not have extra units applied to
+        them.
         """
         distFunc = kappa_velocity_3D(
             vx=self.vx,
@@ -1349,9 +1261,7 @@ class Test_kappa_velocity_3D(object):
         ), errStr
 
     def test_value_drift_units(self):
-        """
-        Testing vdrifts with values
-        """
+        """Testing vdrifts with values."""
         testVal = 1.2376545373917465e-13
         distFunc = kappa_velocity_3D(
             vx=self.vx,

--- a/plasmapy/formulary/tests/test_magnetostatics.py
+++ b/plasmapy/formulary/tests/test_magnetostatics.py
@@ -21,7 +21,7 @@ class Test_MagneticDipole:
         self.p0 = np.array([0, 0, 0]) * u.m
 
     def test_value1(self):
-        "Test a known solution"
+        """Test a known solution."""
         p = np.array([1, 0, 0])
         B1 = MagneticDipole(self.moment, self.p0).magnetic_field(p)
         B1_expected = np.array([0, 0, -1]) * 1e-7 * u.T
@@ -29,7 +29,7 @@ class Test_MagneticDipole:
         assert B1.unit == u.T
 
     def test_value2(self):
-        "Test a known solution"
+        """Test a known solution."""
         p = np.array([0, 0, 1])
         B2 = MagneticDipole(self.moment, self.p0).magnetic_field(p)
         B2_expected = np.array([0, 0, 2]) * 1e-7 * u.T
@@ -37,7 +37,7 @@ class Test_MagneticDipole:
         assert B2.unit == u.T
 
     def test_repr(self):
-        "Test __repr__ function"
+        """Test __repr__ function."""
         B1 = MagneticDipole(self.moment, self.p0)
         assert repr(B1) == r"MagneticDipole(moment=[0. 0. 1.]A m2, p0=[0. 0. 0.]m)"
 
@@ -52,12 +52,14 @@ class Test_GeneralWire:
         self.fw = FiniteStraightWire(p1, p2, 1 * u.A)
 
     def test_not_callable(self):
-        "Test that `GeneralWire` raises `ValueError` if its first argument is not callale"
+        """Test that `GeneralWire` raises `ValueError` if its first argument is
+        not callale."""
         with pytest.raises(ValueError):
             GeneralWire("wire", 0, 1, 1 * u.A)
 
     def test_close_cw(self):
-        "Test if the GeneralWire is close to the CircularWire it converted from"
+        """Test if the GeneralWire is close to the CircularWire it converted
+        from."""
         gw_cw = self.cw.to_GeneralWire()
         p = np.array([0, 0, 0])
         B_cw = self.cw.magnetic_field(p)
@@ -67,7 +69,7 @@ class Test_GeneralWire:
         assert B_cw.unit == B_gw_cw.unit
 
     def test_repr(self):
-        "Test __repr__ function"
+        """Test __repr__ function."""
         gw_cw = self.cw.to_GeneralWire()
         # round numbers to avoid calculation accuracy mismatch
         gw_cw.t1 = -3.1516
@@ -78,7 +80,8 @@ class Test_GeneralWire:
         )
 
     def test_close_fw(self):
-        "Test if the GeneralWire is close to the FiniteWire it converted from"
+        """Test if the GeneralWire is close to the FiniteWire it converted
+        from."""
         gw_fw = self.fw.to_GeneralWire()
         p = np.array([1, 0, 0])
         B_fw = self.fw.magnetic_field(p)
@@ -88,7 +91,7 @@ class Test_GeneralWire:
         assert B_fw.unit == B_gw_fw.unit
 
     def test_value_error(self):
-        "Test GeneralWire raise ValueError when argument t1>t2"
+        """Test GeneralWire raise ValueError when argument t1>t2."""
         with pytest.raises(ValueError):
             gw_cw = GeneralWire(lambda t: [0, 0, t], 2, 1, 1.0 * u.A)
 
@@ -100,12 +103,12 @@ class Test_FiniteStraightWire:
         self.current = 1 * u.A
 
     def test_same_point(self):
-        "Test that `FintiteStraightWire` raises `ValueError` if p1 == p2"
+        """Test that `FintiteStraightWire` raises `ValueError` if p1 == p2."""
         with pytest.raises(ValueError):
             FiniteStraightWire(self.p1, self.p1, self.current)
 
     def test_value1(self):
-        "Test a known solution"
+        """Test a known solution."""
         fw = FiniteStraightWire(self.p1, self.p2, self.current)
         B1 = fw.magnetic_field([1, 0, 0])
         B1_expected = np.array([0, np.sqrt(2), 0]) * 1e-7 * u.T
@@ -113,7 +116,7 @@ class Test_FiniteStraightWire:
         assert B1.unit == u.T
 
     def test_repr(self):
-        "Test __repr__ function"
+        """Test __repr__ function."""
         fw = FiniteStraightWire(self.p1, self.p2, self.current)
         assert (
             repr(fw)
@@ -128,7 +131,7 @@ class Test_InfiniteStraightWire:
         self.current = 1 * u.A
 
     def test_value1(self):
-        "Test a known solution"
+        """Test a known solution."""
         iw = InfiniteStraightWire(self.direction, self.p0, self.current)
         B1 = iw.magnetic_field([1, 0, 0])
         B1_expected = np.array([0, 0, -2]) * 1e-7 * u.T
@@ -136,7 +139,7 @@ class Test_InfiniteStraightWire:
         assert B1.unit == u.T
 
     def test_repr(self):
-        "Test __repr__ function"
+        """Test __repr__ function."""
         iw = InfiniteStraightWire(self.direction, self.p0, self.current)
         assert (
             repr(iw)
@@ -153,12 +156,13 @@ class Test_CircularWire:
         self.current = 1 * u.A
 
     def test_negative_radius(self):
-        "Test that `FintiteStraightWire` raises `ValueError` if radius < 0"
+        """Test that `FintiteStraightWire` raises `ValueError` if radius <
+        0."""
         with pytest.raises(ValueError):
             CircularWire(self.normalz, self.center, -1.0 * u.m, self.current)
 
     def test_value1(self):
-        "Test a known solution"
+        """Test a known solution."""
         cw = CircularWire(self.normalz, self.center, self.radius, self.current)
         B1 = cw.magnetic_field([0, 0, 1])
         B1_expected = np.array([0, 0, 1]) * 2 * np.pi / 2 ** 1.5 * 1e-7 * u.T
@@ -166,7 +170,7 @@ class Test_CircularWire:
         assert B1.unit == u.T
 
     def test_value2(self):
-        "Test a known solution"
+        """Test a known solution."""
         cw = CircularWire(self.normalx, self.center, self.radius, self.current)
         B2 = cw.magnetic_field([1, 0, 0])
         B2_expected = np.array([1, 0, 0]) * 2 * np.pi / 2 ** 1.5 * 1e-7 * u.T
@@ -174,7 +178,7 @@ class Test_CircularWire:
         assert B2.unit == u.T
 
     def test_repr(self):
-        "Test __repr__ function"
+        """Test __repr__ function."""
         cw = CircularWire(self.normalz, self.center, self.radius, self.current)
         assert (
             repr(cw)

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -138,9 +138,7 @@ def test_Thomas_Fermi_length():
 
 
 def test_Wigner_Seitz_radius():
-    """
-    Checks Wigner-Seitz radius for a known value.
-    """
+    """Checks Wigner-Seitz radius for a known value."""
     n_e = 1e23 * u.cm ** -3
     radiusTrue = 1.3365046175719772e-10 * u.m
     radiusMeth = Wigner_Seitz_radius(n_e)
@@ -152,7 +150,7 @@ def test_Wigner_Seitz_radius():
 class Test_chemical_potential:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.n_e = 1e20 * u.cm ** -3
         self.n_e_fail = 1e23 * u.cm ** -3
         self.T = 11604 * u.K
@@ -162,9 +160,7 @@ class Test_chemical_potential:
         reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
     )
     def test_known1(self):
-        """
-        Tests Fermi_integral for expected value.
-        """
+        """Tests Fermi_integral for expected value."""
         methodVal = chemical_potential(self.n_e, self.T)
         testTrue = u.isclose(methodVal, self.True1, rtol=1e-16, atol=0.0)
         errStr = f"Chemical potential value should be {self.True1} and not {methodVal}."
@@ -174,10 +170,8 @@ class Test_chemical_potential:
         reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
     )
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 + 1e-15
         methodVal = chemical_potential(self.n_e, self.T)
         testTrue = not u.isclose(methodVal, fail1, rtol=1e-16, atol=0.0)
@@ -191,7 +185,7 @@ class Test_chemical_potential:
 class Test__chemical_potential_interp:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.n_e = 1e23 * u.cm ** -3
         self.T = 11604 * u.K
         self.True1 = 7.741256653579105
@@ -200,9 +194,7 @@ class Test__chemical_potential_interp:
         reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
     )
     def test_known1(self):
-        """
-        Tests Fermi_integral for expected value.
-        """
+        """Tests Fermi_integral for expected value."""
         methodVal = _chemical_potential_interp(self.n_e, self.T)
         testTrue = u.isclose(methodVal, self.True1, rtol=1e-16, atol=0.0)
         errStr = f"Chemical potential value should be {self.True1} and not {methodVal}."
@@ -212,10 +204,8 @@ class Test__chemical_potential_interp:
         reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
     )
     def test_fail1(self):
-        """
-        Tests if test_known1() would fail if we slightly adjusted the
-        value comparison by some quantity close to numerical error.
-        """
+        """Tests if test_known1() would fail if we slightly adjusted the value
+        comparison by some quantity close to numerical error."""
         fail1 = self.True1 + 1e-15
         methodVal = _chemical_potential_interp(self.n_e, self.T)
         testTrue = not u.isclose(methodVal, fail1, rtol=1e-16, atol=0.0)

--- a/plasmapy/optional_deps.py
+++ b/plasmapy/optional_deps.py
@@ -1,6 +1,4 @@
-"""
-Useful error messages for optional dependencies that aren't found.
-"""
+"""Useful error messages for optional dependencies that aren't found."""
 __all__ = [
     "h5py_import_error",
     "lmfit_import_error",

--- a/plasmapy/particles/__init__.py
+++ b/plasmapy/particles/__init__.py
@@ -1,7 +1,5 @@
-"""
-The `plasmapy.particles` subpackage provides access to information about
-atoms, isotopes, ions, and other particles.
-"""
+"""The `plasmapy.particles` subpackage provides access to information about
+atoms, isotopes, ions, and other particles."""
 # __all__ will be auto populated below
 __all__ = []
 

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -92,8 +92,8 @@ def atomic_number(element: Particle) -> Integral:
 
 @particle_input
 def mass_number(isotope: Particle) -> Integral:
-    """Get the mass number (the number of protons and neutrons) of an
-    isotope.
+    """
+    Get the mass number (the number of protons and neutrons) of an isotope.
 
     Parameters
     ----------
@@ -138,9 +138,9 @@ def mass_number(isotope: Particle) -> Integral:
 
 @particle_input(exclude={"isotope", "ion"})
 def standard_atomic_weight(element: Particle) -> u.Quantity:
-    """Return the standard (conventional) atomic weight of an element
-    based on the relative abundances of isotopes in terrestrial
-    environments.
+    """
+    Return the standard (conventional) atomic weight of an element based on the
+    relative abundances of isotopes in terrestrial environments.
 
     Parameters
     ----------
@@ -303,7 +303,8 @@ def isotopic_abundance(isotope: Particle, mass_numb: Optional[Integral] = None) 
 
 @particle_input(any_of={"charged", "uncharged"})
 def charge_number(particle: Particle) -> Integral:
-    """Return the charge number of a particle.
+    """
+    Return the charge number of a particle.
 
     Parameters
     ----------
@@ -426,8 +427,8 @@ def electric_charge(particle: Particle) -> u.C:
 @particle_input
 def is_stable(particle: Particle, mass_numb: Optional[Integral] = None) -> bool:
     """
-    Return `True` for stable isotopes and particles and `False` for
-    unstable isotopes.
+    Return `True` for stable isotopes and particles and `False` for unstable
+    isotopes.
 
     Parameters
     ----------
@@ -479,8 +480,8 @@ def is_stable(particle: Particle, mass_numb: Optional[Integral] = None) -> bool:
 @particle_input(any_of={"stable", "unstable", "isotope"})
 def half_life(particle: Particle, mass_numb: Optional[Integral] = None) -> u.Quantity:
     """
-    Return the half-life in seconds for unstable isotopes and particles,
-    and `~numpy.inf` in seconds for stable isotopes and particles.
+    Return the half-life in seconds for unstable isotopes and particles, and
+    `~numpy.inf` in seconds for stable isotopes and particles.
 
     Parameters
     ----------
@@ -533,8 +534,8 @@ def half_life(particle: Particle, mass_numb: Optional[Integral] = None) -> u.Qua
 
 def known_isotopes(argument: Union[str, Integral] = None) -> List[str]:
     """
-    Return a list of all known isotopes of an element, or a list of all
-    known isotopes of every element if no input is provided.
+    Return a list of all known isotopes of an element, or a list of all known
+    isotopes of every element if no input is provided.
 
     Parameters
     ----------
@@ -626,9 +627,9 @@ def common_isotopes(
     argument: Union[str, Integral] = None, most_common_only: bool = False
 ) -> List[str]:
     """
-    Return a list of isotopes of an element with an isotopic abundances
-    greater than zero, or if no input is provided, a list of all such
-    isotopes for every element.
+    Return a list of isotopes of an element with an isotopic abundances greater
+    than zero, or if no input is provided, a list of all such isotopes for
+    every element.
 
     Parameters
     ----------
@@ -890,10 +891,11 @@ def reduced_mass(test_particle, target_particle) -> u.Quantity:
     # TODO: Add equation for reduced mass to docstring
 
     def get_particle_mass(particle) -> u.Quantity:
-        """Return the mass of a particle.
+        """
+        Return the mass of a particle.
 
-        Take a representation of a particle and returns the mass in
-        kg.  If the input is a `~astropy.units.Quantity` or
+        Take a representation of a particle and returns the mass in kg.
+        If the input is a `~astropy.units.Quantity` or
         `~astropy.constants.Constant` with units of mass already, then
         this returns that mass converted to kg.
         """
@@ -1127,10 +1129,8 @@ def periodic_table_category(argument: Union[str, Integral]) -> str:
 
 
 def _is_electron(arg: Any) -> bool:
-    """
-    Return `True` if the argument corresponds to an electron, and
-    `False` otherwise.
-    """
+    """Return `True` if the argument corresponds to an electron, and `False`
+    otherwise."""
     # TODO: Remove _is_electron from all parts of code.
 
     if not isinstance(arg, str):

--- a/plasmapy/particles/data/__init__.py
+++ b/plasmapy/particles/data/__init__.py
@@ -1,5 +1,6 @@
 """
-A collection of atomic data used in constructing PlasmaPy `~plasmapy.particles`.
+A collection of atomic data used in constructing PlasmaPy
+`~plasmapy.particles`.
 
 There are currently two datasets, :file:`elements.json` and :file:`isotopes.json`.
 :file:`elements.json` contains element/atomic data that is loaded by the functionality

--- a/plasmapy/particles/data/test/__init__.py
+++ b/plasmapy/particles/data/test/__init__.py
@@ -1,7 +1,5 @@
-"""
-Test`.h5` files came from
-https://github.com/openPMD/openPMD-example-datasets/tree/b4f87b817629b99a048026a2724a5b265810d8be
-"""
+"""Test`.h5` files came from https://github.com/openPMD/openPMD-example-
+datasets/tree/b4f87b817629b99a048026a2724a5b265810d8be."""
 import glob
 import os
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -1,5 +1,6 @@
 """
 Module used to define the framework needed for the `particle_input` decorator.
+
 The decorator takes string and/or integer representations of particles
 as arguments and passes through the corresponding instance of the
 `~plasmapy.particles.particle_class.Particle` class.
@@ -30,10 +31,8 @@ def _particle_errmsg(
     mass_numb: int = None,
     funcname: str = None,
 ) -> str:
-    """
-    Return a string with an appropriate error message for an
-    `~plasmapy.particles.exceptions.InvalidParticleError`.
-    """
+    """Return a string with an appropriate error message for an
+    `~plasmapy.particles.exceptions.InvalidParticleError`."""
     errmsg = f"In {funcname}, {argname} = {repr(argval)} "
     if mass_numb is not None or Z is not None:
         errmsg += "with "
@@ -48,10 +47,8 @@ def _particle_errmsg(
 
 
 def _category_errmsg(particle, require, exclude, any_of, funcname) -> str:
-    """
-    Return an appropriate error message for when a particle does not
-    meet the required categorical specifications.
-    """
+    """Return an appropriate error message for when a particle does not meet
+    the required categorical specifications."""
     category_errmsg = (
         f"The particle {particle} does not meet the required "
         f"classification criteria to be a valid input to {funcname}. "

--- a/plasmapy/particles/exceptions.py
+++ b/plasmapy/particles/exceptions.py
@@ -23,10 +23,8 @@ class ParticleError(PlasmaPyError):
 
 
 class MissingParticleDataError(ParticleError):
-    """
-    An exception for missing atomic or particle data in the
-    `~plasmapy.particles` subpackage.
-    """
+    """An exception for missing atomic or particle data in the
+    `~plasmapy.particles` subpackage."""
 
     pass
 
@@ -44,28 +42,22 @@ class UnexpectedParticleError(ParticleError):
 
 
 class InvalidIonError(UnexpectedParticleError):
-    """
-    An exception for when an argument is a valid particle but not a
-    valid ion.
-    """
+    """An exception for when an argument is a valid particle but not a valid
+    ion."""
 
     pass
 
 
 class InvalidIsotopeError(UnexpectedParticleError):
-    """
-    An exception for when an argument is a valid particle but not a
-    valid isotope.
-    """
+    """An exception for when an argument is a valid particle but not a valid
+    isotope."""
 
     pass
 
 
 class InvalidElementError(UnexpectedParticleError):
-    """
-    An exception for when an argument is a valid particle is not a
-    valid element.
-    """
+    """An exception for when an argument is a valid particle is not a valid
+    element."""
 
     pass
 

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -1,7 +1,5 @@
-"""
-Objects for storing ionization state data for a single element or for
-a single ionization level.
-"""
+"""Objects for storing ionization state data for a single element or for a
+single ionization level."""
 
 __all__ = ["IonicLevel", "IonizationState"]
 
@@ -193,8 +191,8 @@ class IonicLevel:
 
 class IonizationState:
     """
-    Representation of the ionization state distribution of a single
-    element or isotope.
+    Representation of the ionization state distribution of a single element or
+    isotope.
 
     Parameters
     ----------
@@ -288,10 +286,8 @@ class IonizationState:
         n_elem: u.m ** -3 = np.nan * u.m ** -3,
         tol: Union[float, int] = 1e-15,
     ):
-        """
-        Initialize an `~plasmapy.particles.ionization_state.IonizationState`
-        instance.
-        """
+        """Initialize an `~plasmapy.particles.ionization_state.IonizationState`
+        instance."""
         self._number_of_particles = particle.atomic_number + 1
 
         if particle.is_ion or particle.is_category(require=("uncharged", "element")):
@@ -407,9 +403,9 @@ class IonizationState:
 
     def __eq__(self, other):
         """
-        Return `True` if the ionic fractions, number density scaling
-        factor (if set), and electron temperature (if set) are all
-        equal, and `False` otherwise.
+        Return `True` if the ionic fractions, number density scaling factor (if
+        set), and electron temperature (if set) are all equal, and `False`
+        otherwise.
 
         Raises
         ------
@@ -426,7 +422,6 @@ class IonizationState:
         True
         >>> IonizationState('H', [1, 0], tol=1e-8) == IonizationState('H', [1, 1e-6], tol=1e-5)
         False
-
         """
         if not isinstance(other, IonizationState):
             raise TypeError(
@@ -477,24 +472,20 @@ class IonizationState:
     @property
     def ionic_fractions(self) -> np.ndarray:
         """
-        The ionic fractions, where the index corresponds to the charge
-        number.
+        The ionic fractions, where the index corresponds to the charge number.
 
         Examples
         --------
         >>> hydrogen_states = IonizationState('H', [0.9, 0.1])
         >>> hydrogen_states.ionic_fractions
         array([0.9, 0.1])
-
         """
         return self._ionic_fractions
 
     @ionic_fractions.setter
     def ionic_fractions(self, fractions):
-        """
-        Set the ionic fractions, while checking that the new values are
-        valid and normalized to one.
-        """
+        """Set the ionic fractions, while checking that the new values are
+        valid and normalized to one."""
         if fractions is None or np.all(np.isnan(fractions)):
             self._ionic_fractions = np.full(
                 self.atomic_number + 1, np.nan, dtype=np.float64
@@ -535,10 +526,8 @@ class IonizationState:
             ) from exc
 
     def _is_normalized(self, tol: Optional[Real] = None) -> bool:
-        """
-        `True` if the sum of the ionization fractions is equal to
-        ``1`` within the allowed tolerance, and `False` otherwise.
-        """
+        """`True` if the sum of the ionization fractions is equal to ``1``
+        within the allowed tolerance, and `False` otherwise."""
         tol = tol if tol is not None else self.tol
         if not isinstance(tol, Real):
             raise TypeError("tol must be an int or float.")
@@ -549,8 +538,8 @@ class IonizationState:
 
     def normalize(self) -> None:
         """
-        Normalize the ionization state distribution (if set) so that the
-        sum of the ionic fractions becomes equal to one.
+        Normalize the ionization state distribution (if set) so that the sum of
+        the ionic fractions becomes equal to one.
 
         This method may be used, for example, to correct for rounding
         errors.
@@ -560,9 +549,7 @@ class IonizationState:
     @property
     @validate_quantities
     def n_e(self) -> u.m ** -3:
-        """
-        The electron number density assuming a single species plasma.
-        """
+        """The electron number density assuming a single species plasma."""
         return np.sum(self._n_elem * self.ionic_fractions * self.charge_numbers)
 
     @property
@@ -634,8 +621,10 @@ class IonizationState:
     )
     def T_i(self) -> u.K:
         """
-        The ion temperature. If the ion temperature has not been provided,
-        then this attribute will provide the electron temperature.
+        The ion temperature.
+
+        If the ion temperature has not been provided, then this
+        attribute will provide the electron temperature.
         """
         return self._T_i
 
@@ -676,7 +665,6 @@ class IonizationState:
         have a valid distribution function.  If ``kappa`` is
         `~numpy.inf`, then the distribution function reduces to a
         Maxwellian.
-
         """
         return self._kappa
 
@@ -684,7 +672,9 @@ class IonizationState:
     def kappa(self, value: Real):
         """
         Set the kappa parameter for a kappa distribution function for
-        electrons.  The value must be between ``1.5`` and `~numpy.inf`.
+        electrons.
+
+        The value must be between ``1.5`` and `~numpy.inf`.
         """
         kappa_errmsg = "kappa must be a real number greater than 1.5"
         if not isinstance(value, Real):
@@ -700,10 +690,8 @@ class IonizationState:
 
     @property
     def isotope(self) -> Optional[str]:
-        """
-        The isotope symbol for an isotope, or `None` if the particle is
-        not an isotope.
-        """
+        """The isotope symbol for an isotope, or `None` if the particle is not
+        an isotope."""
         return self._particle.isotope
 
     @property
@@ -712,10 +700,8 @@ class IonizationState:
         return self.isotope if self.isotope else self.element
 
     def to_list(self) -> ParticleList:
-        """
-        Return a `~plasmapy.particles.particle_collections.ParticleList`
-        of the ionic levels.
-        """
+        """Return a `~plasmapy.particles.particle_collections.ParticleList` of
+        the ionic levels."""
         return ionic_levels(self.base_particle)
 
     @property
@@ -796,9 +782,9 @@ class IonizationState:
         The absolute tolerance for comparisons.
 
         This attribute is used as the ``atol`` parameter in
-        `numpy.isclose`, `numpy.allclose`,
-        `astropy.units.isclose`, and `astropy.units.allclose`
-        when testing normalizations and making comparisons.
+        `numpy.isclose`, `numpy.allclose`, `astropy.units.isclose`, and
+        `astropy.units.allclose` when testing normalizations and making
+        comparisons.
         """
         return self._tol
 
@@ -814,8 +800,8 @@ class IonizationState:
 
     def _get_states_info(self, minimum_ionic_fraction=0.01) -> List[str]:
         """
-        Return a `list` containing the ion symbol, ionic fraction, and
-        (if available) the number density and temperature for that ion.
+        Return a `list` containing the ion symbol, ionic fraction, and (if
+        available) the number density and temperature for that ion.
 
         Parameters
         ----------
@@ -855,8 +841,8 @@ class IonizationState:
         use_rms_mass: bool = False,
     ) -> CustomParticle:
         """
-        Return a |CustomParticle| instance representing the average
-        particle in this ionization state.
+        Return a |CustomParticle| instance representing the average particle in
+        this ionization state.
 
         By default, the weighted mean will be used as the average, with
         the ionic fractions as the weights. If ``use_rms_charge`` or
@@ -935,7 +921,6 @@ class IonizationState:
         T_e = 5.34e+00 K
         kappa = 4.05
         ----------------------------------------------------------------
-
         """
         separator_line = [64 * "-"]
 

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -1,7 +1,5 @@
-"""
-A class for storing ionization state data for multiple elements or
-isotopes.
-"""
+"""A class for storing ionization state data for multiple elements or
+isotopes."""
 __all__ = ["IonizationStateCollection"]
 
 import astropy.units as u
@@ -29,8 +27,8 @@ def _atomic_number_and_mass_number(p: Particle):
 
 class IonizationStateCollection:
     """
-    Describe the ionization state distributions of multiple elements
-    or isotopes.
+    Describe the ionization state distributions of multiple elements or
+    isotopes.
 
     Parameters
     ----------
@@ -406,8 +404,7 @@ class IonizationStateCollection:
     @property
     def ionic_fractions(self) -> Dict[str, np.array]:
         """
-        A `dict` containing the ionic fractions for each element and
-        isotope.
+        A `dict` containing the ionic fractions for each element and isotope.
 
         The keys of this `dict` are the symbols for each element or
         isotope.  The values will be `~numpy.ndarray` objects containing
@@ -441,7 +438,6 @@ class IonizationStateCollection:
             If ``inputs`` is not a `list`, `tuple`, or `dict` during
             instantiation, or if ``inputs`` is not a `dict` when it is
             being set.
-
         """
 
         # A potential problem is that using item assignment on the
@@ -644,10 +640,8 @@ class IonizationStateCollection:
         self._ionic_fractions = new_ionic_fractions
 
     def normalize(self) -> None:
-        """
-        Normalize the ionic fractions so that the sum for each element
-        equals one.
-        """
+        """Normalize the ionic fractions so that the sum for each element
+        equals one."""
         for particle in self.base_particles:
             tot = np.sum(self.ionic_fractions[particle])
             self.ionic_fractions[particle] = self.ionic_fractions[particle] / tot
@@ -655,7 +649,8 @@ class IonizationStateCollection:
     @property
     @validate_quantities
     def n_e(self) -> u.m ** -3:
-        """The electron number density under the assumption of quasineutrality."""
+        """The electron number density under the assumption of
+        quasineutrality."""
         number_densities = self.number_densities
         n_e = 0.0 * u.m ** -3
         for elem in self.base_particles:
@@ -687,10 +682,8 @@ class IonizationStateCollection:
 
     @property
     def number_densities(self) -> Dict[str, u.Quantity]:
-        """
-        A `dict` containing the number densities for the elements and/or
-        isotopes composing the collection.
-        """
+        """A `dict` containing the number densities for the elements and/or
+        isotopes composing the collection."""
         return {
             elem: self.n0 * self.abundances[elem] * self.ionic_fractions[elem]
             for elem in self.base_particles
@@ -704,9 +697,10 @@ class IonizationStateCollection:
     @abundances.setter
     def abundances(self, abundances_dict: Optional[Dict[ParticleLike, Real]]):
         """
-        Set the elemental (or isotopic) abundances.  The elements and
-        isotopes must be the same as or a superset of the elements whose
-        ionization states are being tracked.
+        Set the elemental (or isotopic) abundances.
+
+        The elements and isotopes must be the same as or a superset of
+        the elements whose ionization states are being tracked.
         """
         if abundances_dict is None:
             self._pars["abundances"] = {elem: np.nan for elem in self.base_particles}
@@ -760,10 +754,8 @@ class IonizationStateCollection:
 
     @property
     def log_abundances(self) -> Dict[str, Real]:
-        """
-        A `dict` with atomic or isotope symbols as keys and the base 10
-        logarithms of the relative abundances as the corresponding values.
-        """
+        """A `dict` with atomic or isotope symbols as keys and the base 10
+        logarithms of the relative abundances as the corresponding values."""
         log_abundances_dict = {}
         for key in self.abundances.keys():
             log_abundances_dict[key] = np.log10(self.abundances[key])
@@ -813,7 +805,6 @@ class IonizationStateCollection:
         have a valid distribution function.  If ``kappa`` equals
         `~numpy.inf`, then the distribution function reduces to a
         Maxwellian.
-
         """
         return self._pars["kappa"]
 
@@ -821,7 +812,9 @@ class IonizationStateCollection:
     def kappa(self, value: Real):
         """
         Set the kappa parameter for a kappa distribution function for
-        electrons.  The value must be between ``1.5`` and `~numpy.inf`.
+        electrons.
+
+        The value must be between ``1.5`` and `~numpy.inf`.
         """
         kappa_errmsg = "kappa must be a real number greater than 1.5"
         if not isinstance(value, Real):
@@ -832,10 +825,8 @@ class IonizationStateCollection:
 
     @property
     def base_particles(self) -> List[str]:
-        """
-        A `list` of the elements and isotopes whose ionization states
-        are being kept track of.
-        """
+        """A `list` of the elements and isotopes whose ionization states are
+        being kept track of."""
         return self._base_particles
 
     @property
@@ -861,8 +852,8 @@ class IonizationStateCollection:
         use_rms_mass: bool = False,
     ) -> CustomParticle:
         """
-        Return a |CustomParticle| representing the mean particle
-        included across all ionization states.
+        Return a |CustomParticle| representing the mean particle included
+        across all ionization states.
 
         By default, this method will use the weighted mean to calculate
         the properties of the |CustomParticle|, where the weights for
@@ -974,7 +965,6 @@ class IonizationStateCollection:
         T_e = 1.20e+04 K
         kappa = 3.40
         ----------------------------------------------------------------
-
         """
         separator_line = 64 * "-"
 

--- a/plasmapy/particles/isotopes.py
+++ b/plasmapy/particles/isotopes.py
@@ -1,8 +1,8 @@
 """
-Module for loading isotope data from :file:`plasmapy/particles/data/isotopes.json`.
+Module for loading isotope data from
+:file:`plasmapy/particles/data/isotopes.json`.
 
-.. attention::
-    This module is not part of PlasmaPy's public API.
+.. attention::     This module is not part of PlasmaPy's public API.
 """
 __all__ = []
 

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -74,8 +74,8 @@ def nuclear_binding_energy(
 @particle_input
 def mass_energy(particle: Particle, mass_numb: Optional[int] = None) -> u.Quantity:
     """
-    Return a particle's mass energy.  If the particle is an isotope or
-    nuclide, return the nuclear mass energy only.
+    Return a particle's mass energy.  If the particle is an isotope or nuclide,
+    return the nuclear mass energy only.
 
     Parameters
     ----------
@@ -194,11 +194,12 @@ def nuclear_reaction_energy(*args, **kwargs):
         unformatted_particles_list: List[Union[str, Particle]]
     ) -> List[Particle]:
         """
-        Take an unformatted list of particles and puts each
-        particle into standard form, while allowing an integer and
-        asterisk immediately preceding a particle to act as a
-        multiplier.  A string argument will be treated as a list
-        containing that string as its sole item.
+        Take an unformatted list of particles and puts each particle into
+        standard form, while allowing an integer and asterisk immediately
+        preceding a particle to act as a multiplier.
+
+        A string argument will be treated as a list containing that
+        string as its sole item.
         """
 
         if isinstance(unformatted_particles_list, str):
@@ -242,20 +243,16 @@ def nuclear_reaction_energy(*args, **kwargs):
         return particles
 
     def total_baryon_number(particles: List[Particle]) -> int:
-        """
-        Find the total number of baryons minus the number of
-        antibaryons in a list of particles.
-        """
+        """Find the total number of baryons minus the number of antibaryons in
+        a list of particles."""
         total_baryon_number = 0
         for particle in particles:
             total_baryon_number += particle.baryon_number
         return total_baryon_number
 
     def total_charge(particles: List[Particle]) -> int:
-        """
-        Find the total charge number in a list of nuclides
-        (excluding bound electrons) and other particles.
-        """
+        """Find the total charge number in a list of nuclides (excluding bound
+        electrons) and other particles."""
         total_charge = 0
         for particle in particles:
             if particle.isotope:
@@ -265,10 +262,8 @@ def nuclear_reaction_energy(*args, **kwargs):
         return total_charge
 
     def add_mass_energy(particles: List[Particle]) -> u.Quantity:
-        """
-        Find the total mass energy from a list of particles, while
-        taking the masses of the fully ionized isotopes.
-        """
+        """Find the total mass energy from a list of particles, while taking
+        the masses of the fully ionized isotopes."""
         total_mass_energy = 0.0 * u.J
         for particle in particles:
             total_mass_energy += particle.mass_energy

--- a/plasmapy/particles/parsing.py
+++ b/plasmapy/particles/parsing.py
@@ -1,9 +1,7 @@
 """
 Functionality to parse representations of particles into standard form.
 
-.. attention::
-    This module is not part of PlasmaPy's public API.
-
+.. attention::     This module is not part of PlasmaPy's public API.
 """
 __all__ = []
 
@@ -31,11 +29,11 @@ from plasmapy.utils import roman
 
 def _create_alias_dicts(Particles: dict) -> (Dict[str, str], Dict[str, str]):
     """
-    Create dictionaries for case sensitive aliases and case
-    insensitive aliases of special particles and antiparticles.
+    Create dictionaries for case sensitive aliases and case insensitive aliases
+    of special particles and antiparticles.
 
-    The keys of these dictionaries are the aliases, and the values
-    are the corresponding standardized symbol for the particle or
+    The keys of these dictionaries are the aliases, and the values are
+    the corresponding standardized symbol for the particle or
     antiparticle.
     """
 
@@ -116,11 +114,12 @@ _case_sensitive_aliases, _case_insensitive_aliases = _create_alias_dicts(_Partic
 
 def _dealias_particle_aliases(alias: Union[str, Integral]) -> str:
     """
-    Return the standard symbol for a particle or antiparticle
-    when the argument is a valid alias.  If the argument is not a
-    valid alias, then this function returns the original argument
-    (which will usually be a `str` but may be an `int` representing
-    atomic number).
+    Return the standard symbol for a particle or antiparticle when the argument
+    is a valid alias.
+
+    If the argument is not a valid alias, then this function returns the
+    original argument (which will usually be a `str` but may be an `int`
+    representing atomic number).
     """
     if not isinstance(alias, str):
         symbol = alias
@@ -139,10 +138,8 @@ def _dealias_particle_aliases(alias: Union[str, Integral]) -> str:
 
 
 def _invalid_particle_errmsg(argument, mass_numb=None, Z=None):
-    """
-    Return an appropriate error message for an
-    `~plasmapy.particles.exceptions.InvalidParticleError`.
-    """
+    """Return an appropriate error message for an
+    `~plasmapy.particles.exceptions.InvalidParticleError`."""
     errmsg = f"The argument {repr(argument)} "
     if mass_numb is not None or Z is not None:
         errmsg += "with "
@@ -160,8 +157,8 @@ def _parse_and_check_atomic_input(
     argument: Union[str, Integral], mass_numb: Integral = None, Z: Integral = None
 ):
     """
-    Parse information about a particle into a dictionary of standard
-    symbols, and check the validity of the particle.
+    Parse information about a particle into a dictionary of standard symbols,
+    and check the validity of the particle.
 
     Parameters
     ----------
@@ -204,12 +201,10 @@ def _parse_and_check_atomic_input(
     """
 
     def _atomic_number_to_symbol(atomic_numb: Integral):
-        """
-        Return the atomic symbol associated with an integer
-        representing an atomic number, or raises an
-        `~plasmapy.particles.exceptions.InvalidParticleError` if the atomic number does
-        not represent a known element.
-        """
+        """Return the atomic symbol associated with an integer representing an
+        atomic number, or raises an
+        `~plasmapy.particles.exceptions.InvalidParticleError` if the atomic
+        number does not represent a known element."""
         if atomic_numb in _atomic_numbers_to_symbols.keys():
             return _atomic_numbers_to_symbols[atomic_numb]
         else:
@@ -218,6 +213,7 @@ def _parse_and_check_atomic_input(
     def _extract_charge(arg: str):
         """
         Receive a `str` representing an element, isotope, or ion.
+
         Return a `tuple` containing a `str` that should represent an
         element or isotope, and either an `int` representing the
         charge or `None` if no charge information is provided.  Raise
@@ -276,6 +272,7 @@ def _parse_and_check_atomic_input(
     def _extract_mass_number(isotope_info: str):
         """
         Receives a string representing an element or isotope.
+
         Return a tuple containing a string that should represent
         an element, and either an integer representing the mass
         number or None if no mass number is available.  Raises an
@@ -306,10 +303,8 @@ def _parse_and_check_atomic_input(
         return element_info, mass_numb
 
     def _get_element(element_info: str) -> str:
-        """
-        Receive a `str` representing an element's symbol or
-        name, and returns a `str` representing the atomic symbol.
-        """
+        """Receive a `str` representing an element's symbol or name, and
+        returns a `str` representing the atomic symbol."""
         if element_info.lower() in _element_names_to_symbols.keys():
             element = _element_names_to_symbols[element_info.lower()]
         elif element_info in _atomic_numbers_to_symbols.values():
@@ -323,8 +318,10 @@ def _parse_and_check_atomic_input(
 
     def _reconstruct_isotope_symbol(element: str, mass_numb: Integral) -> str:
         """
-        Receive a `str` representing an atomic symbol and an
-        `int` representing a mass number.  Return the isotope symbol
+        Receive a `str` representing an atomic symbol and an `int` representing
+        a mass number.
+
+        Return the isotope symbol
         or `None` if no mass number information is available.  Raises an
         `~plasmapy.particles.exceptions.InvalidParticleError` for isotopes that have
         not yet been discovered.
@@ -353,10 +350,11 @@ def _parse_and_check_atomic_input(
         element: str, isotope: Integral = None, Z: Integral = None
     ):
         """
-        Receive a `str` representing an atomic symbol and/or a
-        string representing an isotope, and an `int` representing the
-        charge number.  Return a `str` representing the ion symbol,
-        or `None` if no charge information is available.
+        Receive a `str` representing an atomic symbol and/or a string
+        representing an isotope, and an `int` representing the charge number.
+
+        Return a `str` representing the ion symbol, or `None` if no
+        charge information is available.
         """
 
         if Z is not None:

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2311,7 +2311,7 @@ instances, are particle-like.
 * **Custom particles**
 
     `~plasmapy.particles.particle_class.CustomParticle` instances are
-    particle-like because particle properties are provided in physical units.
+    particle-like because particle properties are provided in physical units.k
 
 .. note::
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -95,12 +95,10 @@ _valid_categories = (
 
 
 def _category_errmsg(particle, category: str) -> str:
-    """
-    Return an error message when an attribute raises an
+    """Return an error message when an attribute raises an
     `~plasmapy.particles.exceptions.InvalidElementError`,
     `~plasmapy.particles.exceptions.InvalidIonError`, or
-    `~plasmapy.particles.exceptions.InvalidIsotopeError`.
-    """
+    `~plasmapy.particles.exceptions.InvalidIsotopeError`."""
     article = "an" if category[0] in "aeiouAEIOU" else "a"
     errmsg = (
         f"The particle {particle} is not {article} {category}, "
@@ -169,10 +167,8 @@ class AbstractParticle(ABC):
         return json_dictionary
 
     def __bool__(self):
-        """
-        Raise an `~plasmapy.particles.exceptions.ParticleError` because
-        particles do not have a truth value.
-        """
+        """Raise an `~plasmapy.particles.exceptions.ParticleError` because
+        particles do not have a truth value."""
         raise ParticleError("The truth value of a particle is not defined.")
 
     def json_dump(self, fp, **kwargs):
@@ -192,8 +188,8 @@ class AbstractParticle(ABC):
 
     def json_dumps(self, **kwargs) -> str:
         """
-        Serialize the particle's `json_dict` into a JSON formatted `str`
-        using `json.dumps`.
+        Serialize the particle's `json_dict` into a JSON formatted `str` using
+        `json.dumps`.
 
         Parameters
         ----------
@@ -679,18 +675,14 @@ class Particle(AbstractPhysicalParticle):
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        """
-        Allow use of `hash` so that a |Particle| instance may be used
-        as a key in a `dict`.
-        """
+        """Allow use of `hash` so that a |Particle| instance may be used as a
+        key in a `dict`."""
         return hash(self.__repr__())
 
     def __invert__(self) -> Particle:
-        """
-        Return the corresponding antiparticle, or raise an
-        `~plasmapy.particles.exceptions.ParticleError` if the particle
-        is not an elementary particle.
-        """
+        """Return the corresponding antiparticle, or raise an
+        `~plasmapy.particles.exceptions.ParticleError` if the particle is not
+        an elementary particle."""
         return self.antiparticle
 
     @property
@@ -776,8 +768,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def element(self) -> Optional[str]:
         """
-        The atomic symbol if the particle corresponds to an element, and
-        `None` otherwise.
+        The atomic symbol if the particle corresponds to an element, and `None`
+        otherwise.
 
         Examples
         --------
@@ -790,8 +782,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def isotope(self) -> Optional[str]:
         """
-        The isotope symbol if the particle corresponds to an isotope,
-        and `None` otherwise.
+        The isotope symbol if the particle corresponds to an isotope, and
+        `None` otherwise.
 
         Examples
         --------
@@ -804,8 +796,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def ionic_symbol(self) -> Optional[str]:
         """
-        The ionic symbol if the particle corresponds to an ion or
-        neutral atom, and `None` otherwise.
+        The ionic symbol if the particle corresponds to an ion or neutral atom,
+        and `None` otherwise.
 
         Examples
         --------
@@ -821,8 +813,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def roman_symbol(self) -> Optional[str]:
         """
-        The spectral name of the particle (i.e. the ionic symbol in
-        Roman numeral notation).
+        The spectral name of the particle (i.e. the ionic symbol in Roman
+        numeral notation).
 
         If the particle is not an ion or neutral atom, return `None`.
         The roman numeral represents one plus the charge number. Raise
@@ -875,8 +867,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def isotope_name(self) -> Optional[str]:
         """
-        The name of the element along with the isotope symbol if the
-        particle corresponds to an isotope, or `None` if it does not.
+        The name of the element along with the isotope symbol if the particle
+        corresponds to an isotope, or `None` if it does not.
 
         Raises
         ------
@@ -941,7 +933,8 @@ class Particle(AbstractPhysicalParticle):
         warning_type=PlasmaPyFutureWarning,
     )
     def integer_charge(self) -> Integral:
-        """The particle's electrical charge in units of the elementary charge."""
+        """The particle's electrical charge in units of the elementary
+        charge."""
         return self.charge_number
 
     @property
@@ -1439,8 +1432,8 @@ class Particle(AbstractPhysicalParticle):
     @property
     def periodic_table(self) -> namedtuple:
         """
-        A `~collections.namedtuple` that provides access to category,
-        period, group, and block information about an element.
+        A `~collections.namedtuple` that provides access to category, period,
+        group, and block information about an element.
 
         Raises
         ------
@@ -1476,7 +1469,6 @@ class Particle(AbstractPhysicalParticle):
         True
         >>> 'antilepton' in gold.categories
         False
-
         """
         return self._categories
 
@@ -1625,7 +1617,6 @@ class Particle(AbstractPhysicalParticle):
         True
         >>> Particle('e+').is_electron
         False
-
         """
         return self == "e-"
 
@@ -1642,13 +1633,13 @@ class Particle(AbstractPhysicalParticle):
         False
         >>> Particle('e+').is_ion
         False
-
         """
         return self.is_category("ion")
 
     def ionize(self, n: Integral = 1, inplace: bool = False):
         """
-        Create a new |Particle| instance corresponding to the current
+        Create a new |Particle| instance corresponding to the current.
+
         |Particle| after being ionized ``n`` times.
 
         If ``inplace`` is `False` (default), then return the ionized
@@ -1695,7 +1686,6 @@ class Particle(AbstractPhysicalParticle):
         >>> helium_particle.ionize(n=2, inplace=True)
         >>> helium_particle
         Particle("He-4 2+")
-
         """
         if not self.element:
             raise InvalidElementError(
@@ -1726,7 +1716,8 @@ class Particle(AbstractPhysicalParticle):
 
     def recombine(self, n: Integral = 1, inplace=False):
         """
-        Create a new |Particle| instance corresponding to the current
+        Create a new |Particle| instance corresponding to the current.
+
         |Particle| after undergoing recombination ``n`` times.
 
         If ``inplace`` is `False` (default), then return the |Particle|
@@ -1771,7 +1762,6 @@ class Particle(AbstractPhysicalParticle):
         >>> helium_particle.recombine(n=2, inplace=True)
         >>> helium_particle
         Particle("He-4 0+")
-
         """
 
         if not self.element:
@@ -1899,7 +1889,8 @@ class DimensionlessParticle(AbstractParticle):
     @property
     def json_dict(self) -> dict:
         """
-        A `json` friendly dictionary representation of the
+        A `json` friendly dictionary representation of the.
+
         |DimensionlessParticle|.
 
         See `~plasmapy.particles.particle_class.AbstractParticle.json_dict`
@@ -2212,7 +2203,8 @@ class CustomParticle(AbstractPhysicalParticle):
 
         This method will return `True` if ``other`` is an identical
         |CustomParticle| instance with the same mass charge and symbol,
-        and return `False` if ``other`` differs on any of these attributes.
+        and return `False` if ``other`` differs on any of these
+        attributes.
         """
 
         if not isinstance(other, self.__class__):
@@ -2231,16 +2223,14 @@ class CustomParticle(AbstractPhysicalParticle):
         Test whether or not two objects are different particles.
 
         This method will return `False` if ``other`` is an identical
-        |CustomParticle| instance, and return `True` if ``other`` is
-        a different |CustomParticle|.
+        |CustomParticle| instance, and return `True` if ``other`` is a
+        different |CustomParticle|.
         """
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        """
-        Allow use of `hash` so that a |CustomParticle| instance may be used
-        as a key in a `dict`.
-        """
+        """Allow use of `hash` so that a |CustomParticle| instance may be used
+        as a key in a `dict`."""
         return hash((self.__repr__(), self.symbol))
 
 

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -21,9 +21,8 @@ from plasmapy.particles.particle_class import (
 
 class ParticleList(collections.UserList):
     """
-    A `list` like collection of
-    `~plasmapy.particles.particle_class.Particle` and/or
-    `~plasmapy.particles.particle_class.CustomParticle` objects.
+    A `list` like collection of `~plasmapy.particles.particle_class.Particle`
+    and/or `~plasmapy.particles.particle_class.CustomParticle` objects.
 
     Parameters
     ----------
@@ -113,12 +112,10 @@ class ParticleList(collections.UserList):
     def _list_of_particles_and_custom_particles(
         particles: Optional[Iterable[ParticleLike]],
     ) -> List[Union[Particle, CustomParticle]]:  # TODO #687
-        """
-        Convert an iterable that provides
-        `~plasmapy.particles.particle_class.ParticleLike` objects into a
-        `list` containing `~plasmapy.particles.particle_class.Particle`
-        and `~plasmapy.particles.particle_class.CustomParticle` instances.
-        """
+        """Convert an iterable that provides
+        `~plasmapy.particles.particle_class.ParticleLike` objects into a `list`
+        containing `~plasmapy.particles.particle_class.Particle` and
+        `~plasmapy.particles.particle_class.CustomParticle` instances."""
         new_particles = list()
         if particles is None:
             return new_particles
@@ -206,16 +203,15 @@ class ParticleList(collections.UserList):
 
     @property
     def charge(self) -> u.C:
-        """
-        A `~astropy.units.Quantity` array of the electric charges
-        of the particles.
-        """
+        """A `~astropy.units.Quantity` array of the electric charges of the
+        particles."""
         return self._get_particle_attribute("charge", unit=u.C, default=np.nan * u.C)
 
     @property
     def data(self) -> List[Union[Particle, CustomParticle]]:
         """
-        A `list` containing the particles contained in the
+        A `list` containing the particles contained in the.
+
         |ParticleList| instance.
 
         The `~plasmapy.particles.particle_collections.ParticleList.data`
@@ -224,11 +220,9 @@ class ParticleList(collections.UserList):
         return self._data
 
     def extend(self, iterable: Iterable[ParticleLike]):
-        """
-        Extend the sequence by appending
+        """Extend the sequence by appending
         `~plasmapy.particles.particle_class.ParticleLike` elements from
-        ``iterable``.
-        """
+        ``iterable``."""
         if isinstance(iterable, ParticleList):
             self.data.extend(iterable)
         else:
@@ -237,10 +231,8 @@ class ParticleList(collections.UserList):
 
     @property
     def half_life(self) -> u.s:
-        """
-        A `~astropy.units.Quantity` array of the half-lives of the
-        particles.
-        """
+        """A `~astropy.units.Quantity` array of the half-lives of the
+        particles."""
         return self._get_particle_attribute("half_life", unit=u.s, default=np.nan * u.s)
 
     def insert(self, index, particle: ParticleLike):
@@ -252,10 +244,8 @@ class ParticleList(collections.UserList):
 
     @property
     def charge_number(self) -> np.array:
-        """
-        An array of the quantized charges of the particles, as
-        multiples of the elementary charge.
-        """
+        """An array of the quantized charges of the particles, as multiples of
+        the elementary charge."""
         return np.array(self._get_particle_attribute("charge_number", default=np.nan))
 
     @property
@@ -282,7 +272,8 @@ class ParticleList(collections.UserList):
         """
         Sort the |ParticleList| in-place.
 
-        For more information, refer to the documentation for `list.sort`.
+        For more information, refer to the documentation for
+        `list.sort`.
         """
         if key is None:
             raise TypeError("Unable to sort a ParticleList without a key.")
@@ -405,8 +396,8 @@ def ionic_levels(
     max_charge: Optional[Integral] = None,
 ) -> ParticleList:
     """
-    Return a |ParticleList| that includes different ionic levels of a
-    base atom.
+    Return a |ParticleList| that includes different ionic levels of a base
+    atom.
 
     Parameters
     ----------

--- a/plasmapy/particles/serialization.py
+++ b/plasmapy/particles/serialization.py
@@ -18,8 +18,8 @@ from plasmapy.particles.particle_class import (
 
 class ParticleJSONDecoder(json.JSONDecoder):
     """
-    A custom `~json.JSONDecoder` class to deserialize JSON objects into
-    the appropriate particle objects.
+    A custom `~json.JSONDecoder` class to deserialize JSON objects into the
+    appropriate particle objects.
 
     Parameters
     ----------

--- a/plasmapy/particles/special_particles.py
+++ b/plasmapy/particles/special_particles.py
@@ -1,7 +1,5 @@
-"""
-Classes, sets, and dictionaries to store data and taxonomy
-information for special particles.
-"""
+"""Classes, sets, and dictionaries to store data and taxonomy information for
+special particles."""
 __all__ = ["ParticleZoo", "_ParticleZooClass"]
 
 import astropy.constants as const
@@ -35,7 +33,6 @@ class _ParticleZooClass:
     False
     >>> 'mu+' in ParticleZoo.antiparticles
     True
-
     """
 
     def __init__(self):
@@ -130,9 +127,8 @@ ParticleZoo = _ParticleZooClass()
 
 def _create_Particles_dict() -> Dict[str, dict]:
     """
-    Create a dictionary of dictionaries that contains physical
-    information for particles and antiparticles that are not elements or
-    ions.
+    Create a dictionary of dictionaries that contains physical information for
+    particles and antiparticles that are not elements or ions.
 
     The keys of the top-level dictionary are the standard particle
     symbols. The values of the top-level dictionary are dictionaries for

--- a/plasmapy/particles/symbols.py
+++ b/plasmapy/particles/symbols.py
@@ -1,7 +1,5 @@
-"""
-Functions that deal with string representations of atomic symbols
-and numbers.
-"""
+"""Functions that deal with string representations of atomic symbols and
+numbers."""
 __all__ = [
     "atomic_symbol",
     "element_name",

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -514,8 +514,8 @@ def test_atomic_functions(inputs):
 
 
 def test_standard_atomic_weight_value_between():
-    """Test that `standard_atomic_weight` returns approximately the
-    correct value for phosphorus."""
+    """Test that `standard_atomic_weight` returns approximately the correct
+    value for phosphorus."""
     assert (
         30.973 < standard_atomic_weight("P").to(u.u).value < 30.974
     ), "Incorrect standard atomic weight for phosphorus."
@@ -529,10 +529,13 @@ def test_particle_mass_berkelium_249():
 
 
 def test_particle_mass_for_hydrogen_with_no_mass_number():
-    """Test that `particle_mass` does not return the proton mass when no
-    mass number is specified for hydrogen.  In this case, the
-    standard atomic weight should be used to account for the small
-    fraction of deuterium."""
+    """
+    Test that `particle_mass` does not return the proton mass when no mass
+    number is specified for hydrogen.
+
+    In this case, the standard atomic weight should be used to account
+    for the small fraction of deuterium.
+    """
     assert particle_mass("H", Z=1) > const.m_p
     assert particle_mass("hydrogen", Z=1) > const.m_p
 
@@ -570,8 +573,8 @@ equivalent_particle_mass_args = [
     "arg1, kwargs1, arg2, kwargs2, expected", equivalent_particle_mass_args
 )
 def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected):
-    """Test that `particle_mass` returns equivalent results for
-    equivalent positional and keyword arguments."""
+    """Test that `particle_mass` returns equivalent results for equivalent
+    positional and keyword arguments."""
 
     result1 = particle_mass(arg1, **kwargs1)
     result2 = particle_mass(arg2, **kwargs2)
@@ -592,8 +595,8 @@ def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected):
 
 @pytest.mark.slow
 def test_known_common_stable_isotopes():
-    """Test that `known_isotopes`, `common_isotopes`, and
-    `stable_isotopes` return the correct values for hydrogen."""
+    """Test that `known_isotopes`, `common_isotopes`, and `stable_isotopes`
+    return the correct values for hydrogen."""
 
     known_should_be = ["H-1", "D", "T", "H-4", "H-5", "H-6", "H-7"]
     common_should_be = ["H-1", "D"]
@@ -624,8 +627,8 @@ def test_half_life():
 
 
 def test_half_life_unstable_isotopes():
-    """Test that `half_life` returns `None` and raises an exception for
-    all isotopes that do not yet have half-life data."""
+    """Test that `half_life` returns `None` and raises an exception for all
+    isotopes that do not yet have half-life data."""
     for isotope in _isotopes.keys():
         if (
             "half_life" not in _isotopes[isotope].keys()
@@ -637,8 +640,8 @@ def test_half_life_unstable_isotopes():
 
 
 def test_half_life_u_220():
-    """Test that `half_life` returns `None` and issues a warning for an
-    isotope without half-life data."""
+    """Test that `half_life` returns `None` and issues a warning for an isotope
+    without half-life data."""
 
     isotope_without_half_life_data = "No-248"
 
@@ -653,8 +656,8 @@ def test_half_life_u_220():
 
 
 def test_known_common_stable_isotopes_cases():
-    """Test that known_isotopes, common_isotopes, and stable_isotopes
-    return certain isotopes that fall into these categories."""
+    """Test that known_isotopes, common_isotopes, and stable_isotopes return
+    certain isotopes that fall into these categories."""
     assert "H-1" in known_isotopes("H")
     assert "D" in known_isotopes("H")
     assert "T" in known_isotopes("H")
@@ -671,8 +674,9 @@ def test_known_common_stable_isotopes_cases():
 
 @pytest.mark.slow
 def test_known_common_stable_isotopes_len():
-    """Test that `known_isotopes`, `common_isotopes`, and
-    `stable_isotopes` each return a `list` of the expected length.
+    """
+    Test that `known_isotopes`, `common_isotopes`, and `stable_isotopes` each
+    return a `list` of the expected length.
 
     The number of common isotopes may change if isotopic composition
     data has any significant changes.
@@ -682,7 +686,6 @@ def test_known_common_stable_isotopes_len():
 
     The number of known isotopes will increase as new isotopes are
     discovered, so a buffer is included in the test.
-
     """
 
     assert len(common_isotopes()) == 288, (
@@ -703,17 +706,16 @@ def test_known_common_stable_isotopes_len():
 
 @pytest.mark.parametrize("func", [common_isotopes, stable_isotopes, known_isotopes])
 def test_known_common_stable_isotopes_error(func):
-    """Test that `known_isotopes`, `common_isotopes`, and
-    `stable_isotopes` raise an `~plasmapy.utils.InvalidElementError` for
-    neutrons."""
+    """Test that `known_isotopes`, `common_isotopes`, and `stable_isotopes`
+    raise an `~plasmapy.utils.InvalidElementError` for neutrons."""
     with pytest.raises(InvalidElementError):
         func("n")
         pytest.fail(f"{func} is not raising a ElementError for neutrons.")
 
 
 def test_isotopic_abundance():
-    """Test that `isotopic_abundance` returns the appropriate values or
-    raises appropriate errors for various isotopes."""
+    """Test that `isotopic_abundance` returns the appropriate values or raises
+    appropriate errors for various isotopes."""
     assert isotopic_abundance("H", 1) == isotopic_abundance("protium")
     assert np.isclose(isotopic_abundance("D"), 0.000115)
     assert isotopic_abundance("Be-8") == 0.0, "Be-8"
@@ -749,8 +751,8 @@ isotopic_abundance_sum_table = (
 
 @pytest.mark.parametrize("element, isotopes", isotopic_abundance_sum_table)
 def test_isotopic_abundances_sum(element, isotopes):
-    """Test that the sum of isotopic abundances for each element with
-    isotopic abundances is one."""
+    """Test that the sum of isotopic abundances for each element with isotopic
+    abundances is one."""
     sum_of_iso_abund = sum(isotopic_abundance(isotope) for isotope in isotopes)
     assert np.isclose(
         sum_of_iso_abund, 1, atol=1e-6

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -19,11 +19,8 @@ from ..particle_class import Particle
 def func_simple_noparens(
     a, particle: Particle, b=None, Z: int = None, mass_numb: int = None
 ) -> Particle:
-    """
-    A simple function that, when decorated with `@particle_input`,
-    returns the instance of the Particle class corresponding to the
-    inputs.
-    """
+    """A simple function that, when decorated with `@particle_input`, returns
+    the instance of the Particle class corresponding to the inputs."""
     if not isinstance(particle, Particle):
         raise TypeError(
             "The argument particle in func_simple_noparens is not a Particle"
@@ -35,11 +32,8 @@ def func_simple_noparens(
 def func_simple_parens(
     a, particle: Particle, b=None, Z: int = None, mass_numb: int = None
 ) -> Particle:
-    """
-    A simple function that, when decorated with `@particle_input()`,
-    returns the instance of the Particle class corresponding to the
-    inputs.
-    """
+    """A simple function that, when decorated with `@particle_input()`, returns
+    the instance of the Particle class corresponding to the inputs."""
     if not isinstance(particle, Particle):
         raise TypeError("The argument particle in func_simple_parens is not a Particle")
     return particle
@@ -59,10 +53,8 @@ particle_input_simple_table = [
 
 @pytest.mark.parametrize("func, args, kwargs, symbol", particle_input_simple_table)
 def test_particle_input_simple(func, args, kwargs, symbol):
-    """
-    Test that simple functions decorated by particle_input correctly
-    return the correct Particle object.
-    """
+    """Test that simple functions decorated by particle_input correctly return
+    the correct Particle object."""
     try:
         expected = Particle(symbol)
     except Exception as e:
@@ -95,10 +87,8 @@ particle_input_error_table = [
 
 @pytest.mark.parametrize("func, kwargs, expected_error", particle_input_error_table)
 def test_particle_input_errors(func, kwargs, expected_error):
-    """
-    Test that functions decorated with particle_input raise the
-    expected errors.
-    """
+    """Test that functions decorated with particle_input raise the expected
+    errors."""
     with pytest.raises(expected_error):
         func(**kwargs)
         pytest.fail(f"{func} did not raise {expected_error} with kwargs = {kwargs}")
@@ -106,7 +96,8 @@ def test_particle_input_errors(func, kwargs, expected_error):
 
 class Test_particle_input:
     """
-    A sample class with methods that will be used to check that
+    A sample class with methods that will be used to check that.
+
     @particle_input works both with and without parentheses.
     """
 
@@ -140,14 +131,14 @@ def test_particle_input_classes():
 
 @particle_input
 def function_with_no_annotations():
-    """A trivial function that is incorrectly decorated with
-    particle_input because no arguments are annotated with Particle."""
+    """A trivial function that is incorrectly decorated with particle_input
+    because no arguments are annotated with Particle."""
     pass
 
 
 def test_no_annotations_exception():
-    """Test that a function decorated with particle_input that has no
-    annotated arguments will raise an ParticleError."""
+    """Test that a function decorated with particle_input that has no annotated
+    arguments will raise an ParticleError."""
     with pytest.raises(ParticleError):
         function_with_no_annotations()
 
@@ -161,7 +152,7 @@ def ambiguous_keywords(p1: Particle, p2: Particle, Z=None, mass_numb=None):
 
 def test_function_with_ambiguity():
     """Test that a function decorated with particle_input that has two
-    annotated arguments"""
+    annotated arguments."""
     with pytest.raises(ParticleError):
         ambiguous_keywords("H", "He", Z=1, mass_numb=4)
     with pytest.raises(ParticleError):
@@ -174,9 +165,9 @@ def test_function_with_ambiguity():
 
 def function_to_test_annotations(particles: Union[Tuple, List], resulting_particles):
     """
-    Test that a function with an argument annotated with (Particle,
-    Particle, ...) or [Particle] returns a tuple of expected Particle
-    instances.
+    Test that a function with an argument annotated with (Particle, Particle,
+
+    ...) or [Particle] returns a tuple of expected Particle instances.
 
     Arguments
     =========
@@ -184,7 +175,6 @@ def function_to_test_annotations(particles: Union[Tuple, List], resulting_partic
         A collection containing many items, each of which may be a valid
         representation of a particle or a `~plasmapy.particles.Particle`
         instance
-
     """
 
     expected = [
@@ -399,9 +389,9 @@ decorator_categories_table = [
 )
 def test_decorator_categories(decorator_kwargs, particle, expected_exception):
     """Tests the require, any_of, and exclude categories lead to an
-    ParticleError being raised when an inputted particle does not meet
-    the required criteria, and do not lead to an ParticleError when the
-    inputted particle matches the criteria."""
+    ParticleError being raised when an inputted particle does not meet the
+    required criteria, and do not lead to an ParticleError when the inputted
+    particle matches the criteria."""
 
     @particle_input(**decorator_kwargs)
     def decorated_function(argument: Particle) -> Particle:
@@ -415,9 +405,12 @@ def test_decorator_categories(decorator_kwargs, particle, expected_exception):
 
 
 def test_none_shall_pass():
-    """Tests the `none_shall_pass` keyword argument in is_particle.
+    """
+    Tests the `none_shall_pass` keyword argument in is_particle.
+
     If `none_shall_pass=True`, then an annotated argument should allow
-    `None` to be passed through to the decorated function."""
+    `None` to be passed through to the decorated function.
+    """
 
     @particle_input(none_shall_pass=True)
     def func_none_shall_pass(particle: Particle) -> Optional[Particle]:
@@ -450,10 +443,13 @@ def test_none_shall_pass():
 
 
 def test_none_shall_not_pass():
-    """Tests the `none_shall_pass` keyword argument in is_particle.
+    """
+    Tests the `none_shall_pass` keyword argument in is_particle.
+
     If `none_shall_pass=False`, then particle_input should raise a
     `TypeError` if an annotated argument is assigned the value of
-    `None`."""
+    `None`.
+    """
 
     @particle_input(none_shall_pass=False)
     def func_none_shall_not_pass(particle: Particle) -> Particle:
@@ -530,8 +526,8 @@ def test_optional_particle_annotation_argname():
 
 def test_not_optional_particle_annotation_argname():
     """Tests the `Optional[Particle]` annotation argument in a function
-    decorated by `@particle_input` such that the annotated argument does
-    not allows `None` to be passed through to the decorated function."""
+    decorated by `@particle_input` such that the annotated argument does not
+    allows `None` to be passed through to the decorated function."""
 
     @particle_input
     def func_not_optional_particle_with_tuple(
@@ -576,55 +572,54 @@ not_ion = ["D", "T", "H-1", "He-4", "e-", "e+", "n"]
 
 @particle_input
 def function_with_element_argument(element: Particle) -> Particle:
-    """A function decorated with `~plasmapy.particles.particle_input`
-    where the argument annotated with `~plasmapy.particles.Particle`
-    is named `element`.  This function should raise an
-    `~plasmapy.utils.InvalidElementError` when the argument is not
-    an element, isotope, or ion."""
+    """
+    A function decorated with `~plasmapy.particles.particle_input` where the
+    argument annotated with `~plasmapy.particles.Particle` is named `element`.
+
+    This function should raise an `~plasmapy.utils.InvalidElementError`
+    when the argument is not an element, isotope, or ion.
+    """
     return element
 
 
 @particle_input
 def function_with_isotope_argument(isotope: Particle) -> Particle:
-    """A function decorated with `~plasmapy.particles.particle_input`
-    where the argument annotated with `~plasmapy.particles.Particle`
-    is named `isotope`.  This function should raise an
-    `~plasmapy.utils.InvalidIsotopeError` when the argument is not an
-    isotope or an ion of an isotope."""
+    """
+    A function decorated with `~plasmapy.particles.particle_input` where the
+    argument annotated with `~plasmapy.particles.Particle` is named `isotope`.
+
+    This function should raise an `~plasmapy.utils.InvalidIsotopeError`
+    when the argument is not an isotope or an ion of an isotope.
+    """
     return isotope
 
 
 @particle_input
 def function_with_ion_argument(ion: Particle) -> Particle:
     """
-    A function decorated with `~plasmapy.particles.particle_input`
-    where the argument annotated with `~plasmapy.particles.Particle`
-    is named `ion`.  This function should raise an
-    `~plasmapy.utils.InvalidIonError` when the argument is not an
-    ion.
+    A function decorated with `~plasmapy.particles.particle_input` where the
+    argument annotated with `~plasmapy.particles.Particle` is named `ion`.
+
+    This function should raise an `~plasmapy.utils.InvalidIonError` when
+    the argument is not an ion.
     """
     return ion
 
 
 @pytest.mark.parametrize("element", is_element)
 def test_is_element(element):
-    """
-    Test that particle_input will not raise an
-    `~plasmapy.utils.InvalidElementError` if the annotated argument is
-    named 'element' and is assigned values that are elements, isotopes,
-    or ions.
-    """
+    """Test that particle_input will not raise an
+    `~plasmapy.utils.InvalidElementError` if the annotated argument is named
+    'element' and is assigned values that are elements, isotopes, or ions."""
     function_with_element_argument(element)
 
 
 @pytest.mark.parametrize("particle", not_element)
 def test_not_element(particle):
-    """
-    Test that particle_input will raise an
+    """Test that particle_input will raise an
     `~plasmapy.utils.InvalidElementError` if an argument decorated with
     `~plasmapy.particles.Particle` is named 'element', but the annotated
-    argument ends up not being an element, isotope, or ion.
-    """
+    argument ends up not being an element, isotope, or ion."""
     with pytest.raises(InvalidElementError):
         function_with_element_argument(particle)
         pytest.fail(
@@ -636,22 +631,18 @@ def test_not_element(particle):
 
 @pytest.mark.parametrize("isotope", is_isotope)
 def test_is_isotope(isotope):
-    """
-    Test that particle_input will not raise an
-    `~plasmapy.utils.InvalidIsotopeError` if the annotated argument is
-    named 'isotope' and is assigned values that are isotopes or
-    ions of isotopes."""
+    """Test that particle_input will not raise an
+    `~plasmapy.utils.InvalidIsotopeError` if the annotated argument is named
+    'isotope' and is assigned values that are isotopes or ions of isotopes."""
     function_with_isotope_argument(isotope)
 
 
 @pytest.mark.parametrize("particle", not_isotope)
 def test_not_isotope(particle):
-    """
-    Test that particle_input will raise an
+    """Test that particle_input will raise an
     `~plasmapy.utils.InvalidIsotopeError` if an argument decorated with
     `~plasmapy.particles.Particle` is named 'isotope', but the annotated
-    argument ends up not being an isotope or an ion of an isotope.
-    """
+    argument ends up not being an isotope or an ion of an isotope."""
     with pytest.raises(InvalidIsotopeError):
         function_with_isotope_argument(particle)
         pytest.fail(
@@ -663,22 +654,17 @@ def test_not_isotope(particle):
 
 @pytest.mark.parametrize("ion", is_ion)
 def test_is_ion(ion):
-    """
-    Test that particle_input will not raise an
-    `~plasmapy.utils.InvalidIonError` if the annotated argument is
-    named 'ion' and is assigned values that are ions.
-    """
+    """Test that particle_input will not raise an
+    `~plasmapy.utils.InvalidIonError` if the annotated argument is named 'ion'
+    and is assigned values that are ions."""
     function_with_ion_argument(ion)
 
 
 @pytest.mark.parametrize("particle", not_ion)
 def test_not_ion(particle):
-    """
-    Test that particle_input will raise an
-    `~plasmapy.utils.InvalidIonError` if an argument decorated with
-    `~plasmapy.particles.Particle` is named 'ion', but the annotated
-    argument ends up not being an ion.
-    """
+    """Test that particle_input will raise an `~plasmapy.utils.InvalidIonError`
+    if an argument decorated with `~plasmapy.particles.Particle` is named
+    'ion', but the annotated argument ends up not being an ion."""
     with pytest.raises(InvalidIonError):
         function_with_ion_argument(particle)
         pytest.fail(

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -25,10 +25,8 @@ from plasmapy.utils.pytest_helpers import run_test
 def check_abundances_consistency(
     abundances: Dict[str, Real], log_abundances: Dict[str, Real]
 ):
-    """
-    Test that a set of abundances is consistent with a set of the base
-    10 logarithm of abundances.
-    """
+    """Test that a set of abundances is consistent with a set of the base 10
+    logarithm of abundances."""
     assert abundances.keys() == log_abundances.keys(), (
         f"Mismatch between keys from abundances and log_abundances.\n\n"
         f"abundances.keys():     {abundances.keys()}\n\n"
@@ -257,7 +255,7 @@ class TestIonizationStateCollection:
 
     @pytest.mark.parametrize("test_name", test_names)
     def test_getitem_element(self, test_name):
-        """Test that __get_item__ returns an IonizationState instance"""
+        """Test that __get_item__ returns an IonizationState instance."""
         instance = self.instances[test_name]
 
         for key in instance.base_particles:
@@ -360,9 +358,7 @@ def test_abundances_consistency():
 
 
 class TestIonizationStateCollectionItemAssignment:
-    """
-    Test IonizationStateCollection.__setitem__ and exceptions.
-    """
+    """Test IonizationStateCollection.__setitem__ and exceptions."""
 
     @classmethod
     def setup_class(cls):
@@ -537,11 +533,9 @@ class TestIonizationStateCollectionAttributes:
             pytest.fail(errmsg)
 
     def test_setting_ionic_fractions_for_single_element(self):
-        """
-        Test that __setitem__ correctly sets new ionic fractions when
-        used for just H, while not changing the ionic fractions for He
-        from the uninitialized default of an array of nans of length 3.
-        """
+        """Test that __setitem__ correctly sets new ionic fractions when used
+        for just H, while not changing the ionic fractions for He from the
+        uninitialized default of an array of nans of length 3."""
         self.new_fractions = [0.3, 0.7]
         self.instance["H"] = self.new_fractions
         resulting_fractions = self.instance.ionic_fractions["H"]
@@ -677,10 +671,8 @@ class TestIonizationStateCollectionAttributes:
             pytest.fail("Incorrect units for new number density.")
 
     def test_resetting_valid_densities(self):
-        """
-        Test that item assignment can be used to set number densities
-        that preserve the total element number density.
-        """
+        """Test that item assignment can be used to set number densities that
+        preserve the total element number density."""
 
         element = "H"
         valid_ionic_fractions = [0.54, 0.46]
@@ -701,10 +693,8 @@ class TestIonizationStateCollectionAttributes:
         ), "Item assignment of valid number densities did not yield correct number densities."
 
     def test_resetting_invalid_densities(self):
-        """
-        Test that item assignment with number densities that would
-        change the total element number density raises an exception.
-        """
+        """Test that item assignment with number densities that would change
+        the total element number density raises an exception."""
         element = "H"
         original_n_elem = np.sum(self.instance.number_densities[element])
         invalid_number_densities = np.array([1.0001, 0]) * original_n_elem
@@ -730,11 +720,8 @@ class TestIonizationStateCollectionAttributes:
         assert np.all(np.isnan(iron_fractions))
 
     def test_base_particles(self):
-        """
-        Test that the original base particles remain as the base
-        particles after performing a bunch of operations that should not
-        change them.
-        """
+        """Test that the original base particles remain as the base particles
+        after performing a bunch of operations that should not change them."""
         assert self.instance.base_particles == self.elements
 
     def test_base_particles_equal_ionic_fraction_particles(self):
@@ -801,10 +788,8 @@ tests_for_exceptions = {
 
 @pytest.mark.parametrize("test_name", tests_for_exceptions.keys())
 def test_exceptions_upon_instantiation(test_name):
-    """
-    Test that appropriate exceptions are raised for inappropriate inputs
-    to IonizationStateCollection when first instantiated.
-    """
+    """Test that appropriate exceptions are raised for inappropriate inputs to
+    IonizationStateCollection when first instantiated."""
     run_test(
         IonizationStateCollection,
         kwargs=tests_for_exceptions[test_name].inputs,
@@ -813,11 +798,9 @@ def test_exceptions_upon_instantiation(test_name):
 
 
 class TestIonizationStateCollectionDensityEqualities:
-    """
-    Test that IonizationStateCollection instances are equal or not equal to each
-    other as they should be for different combinations of inputs
-    related to ionic_fractions, number densities, and abundances.
-    """
+    """Test that IonizationStateCollection instances are equal or not equal to
+    each other as they should be for different combinations of inputs related
+    to ionic_fractions, number densities, and abundances."""
 
     @classmethod
     def setup_class(cls):
@@ -881,11 +864,13 @@ class TestIonizationStateCollectionDensityEqualities:
     def test_equality(self, this, that):
         """
         Test that the IonizationStateCollection instances that should provide
-        ``number_densities`` are all equal to each other.  Test that the
-        instances that should not provide ``number_densities`` are all
-        equal to each other.  Test that each instance that should
-        provide ``number_densities`` is not equal to each instance that
-        should not provide ``number_densities``.
+        ``number_densities`` are all equal to each other.
+
+        Test that the instances that should not provide
+        ``number_densities`` are all equal to each other.  Test that
+        each instance that should provide ``number_densities`` is not
+        equal to each instance that should not provide
+        ``number_densities``.
         """
         expect_equality = this[0:4] == that[0:4]
         are_equal = self.instances[this] == self.instances[that]
@@ -952,10 +937,9 @@ def test_average_ion_consistency(
     use_rms_charge,
     physical_type,
 ):
-    """
-    Make sure that the average ions returned from equivalent `IonizationState`
-    and `IonizationStateCollection` instances are consistent with each other.
-    """
+    """Make sure that the average ions returned from equivalent
+    `IonizationState` and `IonizationStateCollection` instances are consistent
+    with each other."""
     ionization_state = IonizationState(base_particle, ionic_fractions)
     ionization_state_collection = IonizationStateCollection(
         {base_particle: ionic_fractions}
@@ -988,11 +972,9 @@ def test_average_ion_consistency(
 def test_comparison_to_equivalent_particle_list(
     physical_property, use_rms, include_neutrals
 ):
-    """
-    Test that `IonizationState.average_ion` gives consistent results with
-    `ParticleList.average_particle` when the ratios of different particles
-    is the same between the `IonizationState` and the `ParticleList`.
-    """
+    """Test that `IonizationState.average_ion` gives consistent results with
+    `ParticleList.average_particle` when the ratios of different particles is
+    the same between the `IonizationState` and the `ParticleList`."""
 
     neutrals = 3 * ["H-1 0+"] + 2 * ["He-4 0+"] if include_neutrals else []
     ions = 2 * ["p+"] + 3 * ["He-4 1+"] + 5 * ["α"]
@@ -1021,11 +1003,9 @@ def test_comparison_to_equivalent_particle_list(
 
 
 def test_average_particle_exception():
-    """
-    Test that `IonizationStateCollection.average_ion` raises the
-    appropriate exception when abundances are undefined and there is more
-    than one base element or isotope.
-    """
+    """Test that `IonizationStateCollection.average_ion` raises the appropriate
+    exception when abundances are undefined and there is more than one base
+    element or isotope."""
     ionization_states = IonizationStateCollection({"H": [1, 0], "He": [1, 0, 0]})
 
     with pytest.raises(ParticleError):

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -56,30 +56,24 @@ def test_ionic_level_attributes(ion, ionic_fraction, number_density):
     [(-1e-9, ParticleError), (1.00000000001, ParticleError), ("...", ParticleError)],
 )
 def test_ionic_level_invalid_inputs(invalid_fraction, expected_exception):
-    """
-    Test that IonicLevel raises exceptions when the ionic fraction
-    is out of the interval [0,1] or otherwise invalid.
-    """
+    """Test that IonicLevel raises exceptions when the ionic fraction is out of
+    the interval [0,1] or otherwise invalid."""
     with pytest.raises(expected_exception):
         IonicLevel(ion="Fe 6+", ionic_fraction=invalid_fraction)
 
 
 @pytest.mark.parametrize("invalid_particle", ["H", "e-", "Fe-56"])
 def test_ionic_fraction_invalid_particles(invalid_particle):
-    """
-    Test that `~plasmapy.particles.IonicLevel` raises the appropriate
-    exception when passed a particle that isn't a neutral or ion.
-    """
+    """Test that `~plasmapy.particles.IonicLevel` raises the appropriate
+    exception when passed a particle that isn't a neutral or ion."""
     with pytest.raises(ParticleError):
         IonicLevel(invalid_particle, ionic_fraction=0)
 
 
 @pytest.mark.parametrize("ion1, ion2", [("Fe-56 6+", "Fe-56 5+"), ("H 1+", "D 1+")])
 def test_ionic_fraction_comparison_with_different_ions(ion1, ion2):
-    """
-    Test that a `TypeError` is raised when an `IonicLevel` object
-    is compared to an `IonicLevel` object of a different ion.
-    """
+    """Test that a `TypeError` is raised when an `IonicLevel` object is
+    compared to an `IonicLevel` object of a different ion."""
     fraction = 0.251
 
     ionic_fraction_1 = IonicLevel(ion=ion1, ionic_fraction=fraction)
@@ -89,11 +83,9 @@ def test_ionic_fraction_comparison_with_different_ions(ion1, ion2):
 
 
 def test_ionization_state_ion_input_error():
-    """
-    Test that `~plasmapy.particles.IonizationState` raises the appropriate
+    """Test that `~plasmapy.particles.IonizationState` raises the appropriate
     exception when an ion is the base particle and ionic fractions are
-    specified
-    """
+    specified."""
 
     ion = "He 1+"
     unnecessary_ionic_fractions = [0.0, 0.0, 1.0]
@@ -151,27 +143,21 @@ class Test_IonizationState:
 
     @pytest.mark.parametrize("test_name", test_names)
     def test_instantiation(self, test_name):
-        """
-        Test that each IonizationState test case can be instantiated.
-        """
+        """Test that each IonizationState test case can be instantiated."""
         self.instances[test_name] = IonizationState(**test_cases[test_name])
 
     @pytest.mark.parametrize("test_name", test_names)
     def test_charge_numbers(self, test_name):
-        """
-        Test that an `IonizationState` instance has the correct charge
-        numbers.
-        """
+        """Test that an `IonizationState` instance has the correct charge
+        numbers."""
         instance = self.instances[test_name]
         expected_charge_numbers = np.arange(instance.atomic_number + 1)
         assert np.allclose(instance.charge_numbers, expected_charge_numbers)
 
     @pytest.mark.parametrize("test_name", test_names)
     def test_integer_charges(self, test_name):
-        """
-        Test that `IonizationState.integer_charges` has the
-        correct charge numbers and issues a future warning.
-        """
+        """Test that `IonizationState.integer_charges` has the correct charge
+        numbers and issues a future warning."""
         # TODO: remove when IonizationState.integer_charge is removed
         instance = self.instances[test_name]
         expected_charge_numbers = np.arange(instance.atomic_number + 1)
@@ -184,10 +170,8 @@ class Test_IonizationState:
         [name for name in test_names if "ionic_fractions" in test_cases[name].keys()],
     )
     def test_ionic_fractions(self, test_name):
-        """
-        Test that each `IonizationState` instance has the expected
-        ionic fractions.
-        """
+        """Test that each `IonizationState` instance has the expected ionic
+        fractions."""
         instance = self.instances[test_name]
         inputted_fractions = test_cases[test_name]["ionic_fractions"]
         if isinstance(inputted_fractions, u.Quantity):
@@ -197,39 +181,31 @@ class Test_IonizationState:
             pytest.fail(f"Mismatch in ionic fractions for test {test_name}.")
 
     def test_equal_to_itself(self):
-        """
-        Test that `IonizationState.__eq__` returns `True for two identical
-        `IonizationState` instances.
-        """
+        """Test that `IonizationState.__eq__` returns `True for two identical
+        `IonizationState` instances."""
         assert (
             self.instances["Li"] == self.instances["Li"]
         ), "Identical IonizationState instances are not equal."
 
     def test_equal_to_within_tolerance(self):
-        """
-        Test that `IonizationState.__eq__` returns `True` for two
+        """Test that `IonizationState.__eq__` returns `True` for two
         `IonizationState` instances that differ within the inputted
-        tolerance.
-        """
+        tolerance."""
         assert self.instances["H"] == self.instances["H acceptable error"], (
             "Two IonizationState instances that are approximately the "
             "same to within the tolerance are not testing as equal."
         )
 
     def test_inequality(self):
-        """
-        Test that instances with different ionic fractions are not equal
-        to each other.
-        """
+        """Test that instances with different ionic fractions are not equal to
+        each other."""
         assert (
             self.instances["Li ground state"] != self.instances["Li"]
         ), "Different IonizationState instances are equal."
 
     def test_equality_no_more_exception(self):
-        """
-        Test that comparisons of `IonizationState` instances for
-        different elements does not fail.
-        """
+        """Test that comparisons of `IonizationState` instances for different
+        elements does not fail."""
         assert not (self.instances["Li"] == self.instances["H"])
 
     @pytest.mark.parametrize("test_name", test_names)
@@ -294,18 +270,14 @@ class Test_IonizationState:
 
     @pytest.mark.parametrize("index", [-1, 4, "Li"])
     def test_indexing_error(self, index):
-        """
-        Test that an `IonizationState` instance cannot be indexed
-        outside of the bounds of allowed charge numbers.
-        """
+        """Test that an `IonizationState` instance cannot be indexed outside of
+        the bounds of allowed charge numbers."""
         with pytest.raises(ParticleError):
             self.instances["Li"][index]
 
     def test_normalization(self):
-        """
-        Test that `_is_normalized` returns `False` when there is an
-        error greater than the tolerance, and `True` after normalizing.
-        """
+        """Test that `_is_normalized` returns `False` when there is an error
+        greater than the tolerance, and `True` after normalizing."""
         H = self.instances["H acceptable error"]
         assert not H._is_normalized(tol=1e-15)
         H.normalize()
@@ -313,11 +285,8 @@ class Test_IonizationState:
 
     @pytest.mark.parametrize("test_name", test_names)
     def test_identifications(self, test_name):
-        """
-        Test that the identification attributes for test
-        `IonizationState` instances match the expected values from the
-        `Particle` instance.
-        """
+        """Test that the identification attributes for test `IonizationState`
+        instances match the expected values from the `Particle` instance."""
 
         Identifications = collections.namedtuple(
             "Identifications", ["element", "isotope", "atomic_number"]
@@ -354,10 +323,8 @@ class Test_IonizationState:
 
     @pytest.mark.parametrize("test_name", test_cases.keys())
     def test_as_particle_list(self, test_name):
-        """
-        Test that `IonizationState` returns the correct `Particle`
-        instances.
-        """
+        """Test that `IonizationState` returns the correct `Particle`
+        instances."""
         instance = self.instances[test_name]
         atom = instance.base_particle
         nstates = instance.atomic_number + 1
@@ -390,9 +357,9 @@ class Test_IonizationState:
     @pytest.mark.parametrize("test_name", test_names)
     def test_getitem(self, test_name):
         """
-        Test that `IonizationState.__getitem__` returns the same value
-        when using equivalent keys (charge number, particle symbol, and
-        `Particle` instance).
+        Test that `IonizationState.__getitem__` returns the same value when
+        using equivalent keys (charge number, particle symbol, and `Particle`
+        instance).
 
         For example, if we create
 
@@ -401,7 +368,6 @@ class Test_IonizationState:
         then this checks to make sure that `He_states[2]`,
         `He_states['He 2+']`, and `He_states[Particle('He 2+')]` all
         return the same result.
-
         """
         instance = self.instances[test_name]
         particle_name = instance.base_particle
@@ -437,11 +403,8 @@ class Test_IonizationState:
         "attr", ["charge_number", "ionic_fraction", "ionic_symbol"]
     )
     def test_State_attrs(self, attr):
-        """
-        Test that an IonizationState instance returns something with the
-        correct attributes (be it a `collections.namedtuple` or a
-        `class`).
-        """
+        """Test that an IonizationState instance returns something with the
+        correct attributes (be it a `collections.namedtuple` or a `class`)."""
         test_name = "He"
         state = self.instances[test_name][1]
         assert hasattr(state, attr)
@@ -525,11 +488,9 @@ def test_IonizationState_ionfracs_from_ion_input(ion):
 
 @pytest.mark.parametrize("ion", ions)
 def test_IonizationState_base_particles_from_ion_input(ion):
-    """
-    Test that supplying an ion to IonizationState will result in the
-    base particle being the corresponding isotope or ion and that the
-    ionic fraction of the corresponding charge level is 100%.
-    """
+    """Test that supplying an ion to IonizationState will result in the base
+    particle being the corresponding isotope or ion and that the ionic fraction
+    of the corresponding charge level is 100%."""
 
     ionization_state = IonizationState(ion)
     ion_particle = Particle(ion)
@@ -548,10 +509,8 @@ def test_IonizationState_base_particles_from_ion_input(ion):
 
 @pytest.mark.parametrize("test", tests_for_exceptions.keys())
 def test_IonizationState_exceptions(test):
-    """
-    Test that appropriate exceptions are raised for inappropriate inputs
-    to `IonizationState`.
-    """
+    """Test that appropriate exceptions are raised for inappropriate inputs to
+    `IonizationState`."""
     run_test(
         IonizationState,
         kwargs=tests_for_exceptions[test].inputs,
@@ -593,10 +552,8 @@ def instance():
 
 @pytest.mark.parametrize("key", expected_properties)
 def test_IonizationState_attributes(instance, key):
-    """
-    Test a specific case that the `IonizationState` attributes are
-    working as expected.
-    """
+    """Test a specific case that the `IonizationState` attributes are working
+    as expected."""
     expected = expected_properties[key]
     actual = getattr(instance, key)
 
@@ -681,10 +638,8 @@ def test_len(instance):
 
 
 def test_nans():
-    """
-    Test that when no ionic fractions or temperature are inputted,
-    the result is an array full of `~numpy.nan` of the right size.
-    """
+    """Test that when no ionic fractions or temperature are inputted, the
+    result is an array full of `~numpy.nan` of the right size."""
     element = "He"
     nstates = atomic_number(element) + 1
     instance = IonizationState(element)
@@ -698,10 +653,8 @@ def test_nans():
 
 
 def test_setting_ionic_fractions():
-    """
-    Test the setter for the ``ionic_fractions`` attribute on
-    `~plasmapy.particles.IonizationState`.
-    """
+    """Test the setter for the ``ionic_fractions`` attribute on
+    `~plasmapy.particles.IonizationState`."""
     instance = IonizationState("He")
     new_ionic_fractions = [0.2, 0.5, 0.3]
     instance.ionic_fractions = new_ionic_fractions
@@ -813,11 +766,9 @@ particles_and_ionfracs = [
 @pytest.mark.parametrize("physical_property", physical_properties)
 @pytest.mark.parametrize("base_particle, ionic_fractions", particles_and_ionfracs)
 def test_weighted_mean_ion(base_particle, ionic_fractions, physical_property):
-    """
-    Test that `IonizationState.average_ion` gives a |CustomParticle|
-    instance with the expected mass or charge when calculating the
-    weighted mean.
-    """
+    """Test that `IonizationState.average_ion` gives a |CustomParticle|
+    instance with the expected mass or charge when calculating the weighted
+    mean."""
     ionization_state = IonizationState(base_particle, ionic_fractions)
     ions = ionic_levels(base_particle)
     physical_quantity = getattr(ions, physical_property)
@@ -830,11 +781,9 @@ def test_weighted_mean_ion(base_particle, ionic_fractions, physical_property):
 @pytest.mark.parametrize("physical_property", physical_properties)
 @pytest.mark.parametrize("base_particle, ionic_fractions", particles_and_ionfracs)
 def test_weighted_rms_ion(base_particle, ionic_fractions, physical_property):
-    """
-    Test that `IonizationState.average_ion` gives a |CustomParticle|
-    instances with the expected mass or charge when calculating the
-    weighted root mean square.
-    """
+    """Test that `IonizationState.average_ion` gives a |CustomParticle|
+    instances with the expected mass or charge when calculating the weighted
+    root mean square."""
     ionization_state = IonizationState(base_particle, ionic_fractions)
     ions = ionic_levels(base_particle)
     physical_quantity = getattr(ions, physical_property)
@@ -849,7 +798,8 @@ def test_weighted_rms_ion(base_particle, ionic_fractions, physical_property):
 
 def test_exclude_neutrals_from_average_ion():
     """
-    Test that the `IonizationState.average_ion` method returns a
+    Test that the `IonizationState.average_ion` method returns a.
+
     |CustomParticle| that does not include neutrals in the averaging
     when the ``include_neutrals`` keyword is `False`.
     """
@@ -866,11 +816,9 @@ def test_exclude_neutrals_from_average_ion():
 @pytest.mark.parametrize("physical_property", physical_properties)
 @pytest.mark.parametrize("use_rms", [True, False])
 def test_comparison_to_equivalent_particle_list(physical_property, use_rms):
-    """
-    Test that `IonizationState.average_ion` gives consistent results with
-    `ParticleList.average_particle` when the ratios of different particles
-    is the same between the `IonizationState` and the `ParticleList`.
-    """
+    """Test that `IonizationState.average_ion` gives consistent results with
+    `ParticleList.average_particle` when the ratios of different particles is
+    the same between the `IonizationState` and the `ParticleList`."""
     particles = ParticleList(2 * ["He-4 0+"] + 3 * ["He-4 1+"] + 5 * ["He-4 2+"])
     ionization_state = IonizationState("He-4", [0.2, 0.3, 0.5])
     kwargs = {f"use_rms_{physical_property}": True}

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -52,8 +52,8 @@ aliases_and_symbols = [
 @pytest.mark.parametrize("alias, symbol", aliases_and_symbols)
 def test_dealias_particle_aliases(alias, symbol):
     """Test that _dealias_particle_aliases correctly takes in aliases and
-    returns the corresponding symbols, and returns the original argument
-    if the argument does not correspond to an alias."""
+    returns the corresponding symbols, and returns the original argument if the
+    argument does not correspond to an alias."""
     result = _dealias_particle_aliases(alias)
     assert result == symbol, (
         f"_dealias_particle_aliases({alias}) returns '{result}', which "

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -468,10 +468,11 @@ test_Particle_table = [
 @pytest.mark.parametrize("arg, kwargs, expected_dict", test_Particle_table)
 def test_Particle_class(arg, kwargs, expected_dict):
     """
-    Test that `~plasmapy.particles.Particle` objects for different
-    subatomic particles, elements, isotopes, and ions return the
-    expected properties.  Provide a detailed error message that lists
-    all of the inconsistencies with the expected results.
+    Test that `~plasmapy.particles.Particle` objects for different subatomic
+    particles, elements, isotopes, and ions return the expected properties.
+
+    Provide a detailed error message that lists all of the
+    inconsistencies with the expected results.
     """
 
     call = call_string(Particle, arg, kwargs)
@@ -586,10 +587,8 @@ test_Particle_error_table = [
 
 @pytest.mark.parametrize("arg, kwargs, attribute, exception", test_Particle_error_table)
 def test_Particle_errors(arg, kwargs, attribute, exception):
-    """
-    Test that the appropriate exceptions are raised during the creation
-    and use of a `~plasmapy.particles.Particle` object.
-    """
+    """Test that the appropriate exceptions are raised during the creation and
+    use of a `~plasmapy.particles.Particle` object."""
     with pytest.raises(exception):
         exec(f"Particle(arg, **kwargs){attribute}")
         pytest.fail(
@@ -609,10 +608,8 @@ test_Particle_warning_table = [
 
 @pytest.mark.parametrize("arg, kwargs, attribute, warning", test_Particle_warning_table)
 def test_Particle_warnings(arg, kwargs, attribute, warning):
-    """
-    Test that the appropriate warnings are issued during the creation
-    and use of a `~plasmapy.particles.Particle` object.
-    """
+    """Test that the appropriate warnings are issued during the creation and
+    use of a `~plasmapy.particles.Particle` object."""
     with pytest.warns(warning) as record:
         exec(f"Particle(arg, **kwargs){attribute}")
         if not record:
@@ -652,12 +649,14 @@ nuclide_mass_and_mass_equiv_table = [
 @pytest.mark.parametrize("isotope, ion", nuclide_mass_and_mass_equiv_table)
 def test_particle_class_mass_nuclide_mass(isotope: str, ion: str):
     """
-    Test that the ``mass`` and ``nuclide_mass`` attributes return
-    equivalent values when appropriate.  The inputs should generally be
-    an isotope with no charge information, and a fully ionized ion of
-    that isotope, in order to make sure that the nuclide mass of the
-    isotope equals the mass of the fully ionized ion.  This method may
-    also check neutrons and protons.
+    Test that the ``mass`` and ``nuclide_mass`` attributes return equivalent
+    values when appropriate.
+
+    The inputs should generally be an isotope with no charge
+    information, and a fully ionized ion of that isotope, in order to
+    make sure that the nuclide mass of the isotope equals the mass of
+    the fully ionized ion.  This method may also check neutrons and
+    protons.
     """
 
     Isotope = Particle(isotope)
@@ -702,12 +701,10 @@ def test_particle_class_mass_nuclide_mass(isotope: str, ion: str):
 
 @pytest.mark.slow
 def test_particle_half_life_string():
-    """
-    Find the first isotope where the half-life is stored as a string
-    (because the uncertainties are too great), and tests that requesting
-    the half-life of that isotope causes a `MissingParticleDataWarning`
-    whilst returning a string.
-    """
+    """Find the first isotope where the half-life is stored as a string
+    (because the uncertainties are too great), and tests that requesting the
+    half-life of that isotope causes a `MissingParticleDataWarning` whilst
+    returning a string."""
 
     for isotope in known_isotopes():
         half_life = _isotopes[isotope].get("half-life", None)
@@ -781,46 +778,36 @@ def opposite(particle):
 
 
 class Test_antiparticle_properties_inversion:
-    """
-    Test particle and antiparticle inversion and properties for Particle
-    instances.
-    """
+    """Test particle and antiparticle inversion and properties for Particle
+    instances."""
 
     def test_inverted_inversion(self, particle):
-        """
-        Test that the antiparticle of the antiparticle of a particle is
-        the original particle.
-        """
+        """Test that the antiparticle of the antiparticle of a particle is the
+        original particle."""
         assert particle == ~~particle, (
             f"~~{repr(particle)} equals {repr(~~particle)} instead of "
             f"{repr(particle)}."
         )
 
     def test_opposite_charge(self, particle, opposite):
-        """
-        Test that a particle and its antiparticle have the opposite
-        charge.
-        """
+        """Test that a particle and its antiparticle have the opposite
+        charge."""
         assert particle.charge_number == -opposite.charge_number, (
             f"The charges of {particle} and {opposite} are not "
             f"opposites, as expected of a particle/antiparticle pair."
         )
 
     def test_equal_mass(self, particle, opposite):
-        """
-        Test that a particle and its antiparticle have the same mass.
-        """
+        """Test that a particle and its antiparticle have the same mass."""
         assert particle._attributes["mass"] == opposite._attributes["mass"], (
             f"The masses of {particle} and {opposite} are not equal, "
             f"as expected of a particle/antiparticle pair."
         )
 
     def test_antiparticle_attribute_and_operator(self, particle, opposite):
-        """
-        Test that the Particle.antiparticle attribute returns the same
-        value as the unary ~ (invert) operator acting on the same
-        Particle instance.
-        """
+        """Test that the Particle.antiparticle attribute returns the same value
+        as the unary ~ (invert) operator acting on the same Particle
+        instance."""
         assert particle.antiparticle == ~particle, (
             f"{repr(particle)}.antiparticle returned "
             f"{particle.antiparticle}, whereas ~{repr(particle)} "
@@ -830,10 +817,8 @@ class Test_antiparticle_properties_inversion:
 
 @pytest.mark.parametrize("arg", ["e-", "D+", "Fe 25+", "H-", "mu+"])
 def test_particleing_a_particle(arg):
-    """
-    Test that Particle(arg) is equal to Particle(Particle(arg)), but is
-    not the same object in memory.
-    """
+    """Test that Particle(arg) is equal to Particle(Particle(arg)), but is not
+    the same object in memory."""
     particle = Particle(arg)
 
     assert particle == Particle(
@@ -866,7 +851,6 @@ def test_that_object_can_be_dict_key(key):
 
     In most cases, objects that are mutable should not be hashable since
     they may change.
-
     """
     # TODO: I wrote this to be pretty general since I felt like
     # TODO: procrastinating other things, so we can probably put this
@@ -985,10 +969,8 @@ customized_particle_errors = [
 
 @pytest.mark.parametrize("cls, kwargs, exception", customized_particle_errors)
 def test_customized_particles_errors(cls, kwargs, exception):
-    """
-    Test that attempting to create invalid dimensionless or custom particles
-    results in an InvalidParticleError.
-    """
+    """Test that attempting to create invalid dimensionless or custom particles
+    results in an InvalidParticleError."""
     with pytest.raises(exception):
         cls(**kwargs)
         pytest.fail(f"{cls.__name__}(**{kwargs}) did not raise: {exception.__name__}.")
@@ -1010,7 +992,8 @@ customized_particle_repr_table = [
 
 @pytest.mark.parametrize("cls, kwargs, expected_repr", customized_particle_repr_table)
 def test_customized_particle_repr(cls, kwargs, expected_repr):
-    """Test the string representations of dimensionless and custom particles."""
+    """Test the string representations of dimensionless and custom
+    particles."""
     instance = cls(**kwargs)
     from_repr = repr(instance)
     from_str = str(instance)
@@ -1027,7 +1010,8 @@ def test_customized_particle_repr(cls, kwargs, expected_repr):
 @pytest.mark.parametrize("cls", [CustomParticle, DimensionlessParticle])
 @pytest.mark.parametrize("not_a_str", [1, u.kg])
 def test_typeerror_redefining_symbol(cls, not_a_str):
-    """Test that the symbol attribute cannot be set to something besides a string"""
+    """Test that the symbol attribute cannot be set to something besides a
+    string."""
     instance = cls()
     with pytest.raises(TypeError):
         instance.symbol = not_a_str
@@ -1125,7 +1109,7 @@ def test_custom_particles_from_json_string(
     cls, kwargs, json_string, expected_exception
 ):
     """Test the attributes of dimensionless and custom particles generated from
-    JSON representation"""
+    JSON representation."""
     if expected_exception is None:
         instance = cls(**kwargs)
         instance_from_json = json_loads_particle(json_string)
@@ -1155,7 +1139,7 @@ def test_custom_particles_from_json_string(
 )
 def test_custom_particles_from_json_file(cls, kwargs, json_string, expected_exception):
     """Test the attributes of dimensionless and custom particles generated from
-    JSON representation"""
+    JSON representation."""
     if expected_exception is None:
         instance = cls(**kwargs)
         test_file_object = io.StringIO(json_string)
@@ -1222,7 +1206,8 @@ particles_from_json_tests = [
     "cls, kwargs, json_string, expected_exception", particles_from_json_tests
 )
 def test_particles_from_json_string(cls, kwargs, json_string, expected_exception):
-    """Test the attributes of Particle objects created from JSON representation."""
+    """Test the attributes of Particle objects created from JSON
+    representation."""
     if expected_exception is None:
         instance = cls(**kwargs)
         instance_from_json = json_loads_particle(json_string)
@@ -1244,7 +1229,8 @@ def test_particles_from_json_string(cls, kwargs, json_string, expected_exception
     "cls, kwargs, json_string, expected_exception", particles_from_json_tests
 )
 def test_particles_from_json_file(cls, kwargs, json_string, expected_exception):
-    """Test the attributes of Particle objects created from JSON representation."""
+    """Test the attributes of Particle objects created from JSON
+    representation."""
     if expected_exception is None:
         instance = cls(**kwargs)
         test_file_object = io.StringIO(json_string)
@@ -1304,7 +1290,8 @@ particle_json_repr_table = [
 
 @pytest.mark.parametrize("cls, kwargs, expected_repr", particle_json_repr_table)
 def test_particle_to_json_string(cls, kwargs, expected_repr):
-    """Test the JSON representations of normal, dimensionless and custom particles."""
+    """Test the JSON representations of normal, dimensionless and custom
+    particles."""
     instance = cls(**kwargs)
     json_repr = instance.json_dumps()
     test_dict = json.loads(json_repr)["plasmapy_particle"]
@@ -1325,7 +1312,8 @@ def test_particle_to_json_string(cls, kwargs, expected_repr):
 
 @pytest.mark.parametrize("cls, kwargs, expected_repr", particle_json_repr_table)
 def test_particle_to_json_file(cls, kwargs, expected_repr):
-    """Test the JSON representations of normal, dimensionless and custom particles."""
+    """Test the JSON representations of normal, dimensionless and custom
+    particles."""
     instance = cls(**kwargs)
     test_file_object = io.StringIO("")
     instance.json_dump(test_file_object)

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -49,10 +49,8 @@ def various_particles():
 
 
 def _everything_is_particle_or_custom_particle(iterable):
-    """
-    Test that every object in an iterable is either a `Particle` instance
-    or a `CustomParticle` instance.
-    """
+    """Test that every object in an iterable is either a `Particle` instance or
+    a `CustomParticle` instance."""
     return all(isinstance(p, (Particle, CustomParticle)) for p in iterable)
 
 
@@ -70,10 +68,8 @@ def _everything_is_particle_or_custom_particle(iterable):
     ],
 )
 def test_particle_list_membership(args):
-    """
-    Test that the particles in the `ParticleList` match the particles
-    (or particle-like objects) that are passed to it.
-    """
+    """Test that the particles in the `ParticleList` match the particles (or
+    particle-like objects) that are passed to it."""
     particle_list = ParticleList(args)
     for arg, particle in zip(args, particle_list):
         assert particle == arg
@@ -84,8 +80,8 @@ def test_particle_list_membership(args):
 @pytest.mark.parametrize("attribute", attributes)
 def test_particle_list_attributes(attribute, various_particles):
     """
-    Test that the attributes of ParticleList correspond to the
-    attributes of the listed particles.
+    Test that the attributes of ParticleList correspond to the attributes of
+    the listed particles.
 
     This class does not test ParticleList instances that include
     CustomParticle instances inside of them.
@@ -103,23 +99,25 @@ def test_particle_list_no_redefining_attributes(various_particles, attribute):
     """
     Test that attributes of `ParticleList` cannot be manually redefined.
 
-    This test may fail if `@cached_property` is used instead of `@property`
-    because `@cached_property` allows reassignment while `@property` does
-    not.
+    This test may fail if `@cached_property` is used instead of
+    `@property` because `@cached_property` allows reassignment while
+    `@property` does not.
     """
     with pytest.raises(AttributeError):
         various_particles.__setattr__(attribute, 42)
 
 
 def test_particle_list_len():
-    """Test that using `len` on a `ParticleList` returns the expected number."""
+    """Test that using `len` on a `ParticleList` returns the expected
+    number."""
     original_list = ["n", "p", "e-"]
     particle_list = ParticleList(original_list)
     assert len(particle_list) == len(original_list)
 
 
 def test_particle_list_append(various_particles):
-    """Test that a particle-like object can get appended to a `ParticleList`."""
+    """Test that a particle-like object can get appended to a
+    `ParticleList`."""
     original_length = len(various_particles)
     various_particles.append("Li")
     appended_item = various_particles[-1]
@@ -130,7 +128,7 @@ def test_particle_list_append(various_particles):
 
 
 def test_particle_list_pop(various_particles):
-    """Test that the last item in the `ParticleList` is removed when"""
+    """Test that the last item in the `ParticleList` is removed when."""
     expected = various_particles[:-1]
     particle_that_should_be_removed = various_particles[-1]
     removed_particle = various_particles.pop()
@@ -139,10 +137,8 @@ def test_particle_list_pop(various_particles):
 
 
 def test_particle_list_extend(various_particles):
-    """
-    Test that a `ParticleList` can be extended when provided with an
-    iterable that yields particle-like objects.
-    """
+    """Test that a `ParticleList` can be extended when provided with an
+    iterable that yields particle-like objects."""
     new_particles = ["Fe", Particle("e-"), CustomParticle()]
     various_particles.extend(new_particles)
     assert _everything_is_particle_or_custom_particle(various_particles)
@@ -150,14 +146,15 @@ def test_particle_list_extend(various_particles):
 
 
 def test_particle_list_extended_with_particle_list(various_particles):
-    """Test that a `ParticleList` can be extended with another `ParticleList`."""
+    """Test that a `ParticleList` can be extended with another
+    `ParticleList`."""
     particle_list = ParticleList(["D", "T", CustomParticle()])
     various_particles.extend(particle_list)
     assert various_particles[-3:] == particle_list
 
 
 def test_particle_list_insert(various_particles):
-    """Test insertion of particle-like objects into"""
+    """Test insertion of particle-like objects into."""
     various_particles.insert(0, "tau neutrino")
     assert various_particles[0] == "tau neutrino"
     assert _everything_is_particle_or_custom_particle(various_particles)
@@ -167,48 +164,38 @@ invalid_particles = (0, "not a particle", DimensionlessParticle())
 
 
 def test_particle_list_instantiate_with_invalid_particles():
-    """
-    Test that a `ParticleList` instance cannot be created when it is
-    provided with invalid particles.
-    """
+    """Test that a `ParticleList` instance cannot be created when it is
+    provided with invalid particles."""
     with pytest.raises(InvalidParticleError):
         ParticleList(invalid_particles)
 
 
 @pytest.mark.parametrize("invalid_particle", invalid_particles)
 def test_particle_list_append_invalid_particle(various_particles, invalid_particle):
-    """
-    Test that objects that are not particle-like cannot be appended to
-    a `ParticleList` instance.
-    """
+    """Test that objects that are not particle-like cannot be appended to a
+    `ParticleList` instance."""
     with pytest.raises((InvalidParticleError, TypeError)):
         various_particles.append(invalid_particle)
 
 
 def test_particle_list_extend_with_invalid_particles(various_particles):
-    """
-    Test that a `ParticleList` instance cannot be extended with any
-    objects that are not particle-like.
-    """
+    """Test that a `ParticleList` instance cannot be extended with any objects
+    that are not particle-like."""
     with pytest.raises(InvalidParticleError):
         various_particles.extend(invalid_particles)
 
 
 @pytest.mark.parametrize("invalid_particle", invalid_particles)
 def test_particle_list_insert_invalid_particle(various_particles, invalid_particle):
-    """
-    Test that objects that are not particle-like cannot be inserted into
-    a `ParticleList` instance.
-    """
+    """Test that objects that are not particle-like cannot be inserted into a
+    `ParticleList` instance."""
     with pytest.raises((InvalidParticleError, TypeError)):
         various_particles.insert(1, invalid_particle)
 
 
 def test_particle_list_sort_with_key_and_reverse():
-    """
-    Test that a `ParticleList` instance can be sorted if a key is
-    provided, and that the ``reverse`` keyword argument works too.
-    """
+    """Test that a `ParticleList` instance can be sorted if a key is provided,
+    and that the ``reverse`` keyword argument works too."""
     elements = ["He", "H", "Fe", "U"]
     particle_list = ParticleList(elements)
     particle_list.sort(key=atomic_number, reverse=True)
@@ -222,10 +209,8 @@ def test_particle_list_sort_without_key(various_particles):
 
 
 def test_particle_list_dimensionless_particles():
-    """
-    Test that a `ParticleList` cannot be instantiated with a
-    `DimensionlessParticle`.
-    """
+    """Test that a `ParticleList` cannot be instantiated with a
+    `DimensionlessParticle`."""
     with pytest.raises(TypeError):
         ParticleList([DimensionlessParticle()])
 
@@ -239,10 +224,8 @@ def test_particle_list_adding_particle_list(various_particles):
 
 
 def test_add_particle_list_and_particle(various_particles):
-    """
-    Test that a `ParticleList` can be added to a `Particle` on the right
-    and then return a `ParticleList`.
-    """
+    """Test that a `ParticleList` can be added to a `Particle` on the right and
+    then return a `ParticleList`."""
     new_particle_list = various_particles + electron
     assert new_particle_list[-1] == electron
     assert new_particle_list[0:-1] == various_particles
@@ -250,10 +233,8 @@ def test_add_particle_list_and_particle(various_particles):
 
 
 def test_add_particle_and_particle_list(various_particles):
-    """
-    Test that a `Particle` can be added to a `ParticleList` on the right
-    and then return a `ParticleList`.
-    """
+    """Test that a `Particle` can be added to a `ParticleList` on the right and
+    then return a `ParticleList`."""
     new_particle_list = electron + various_particles
     assert new_particle_list[0] == electron
     assert new_particle_list[1:] == various_particles
@@ -261,10 +242,8 @@ def test_add_particle_and_particle_list(various_particles):
 
 
 def test_add_particle_and_particle_like():
-    """
-    Test that a `Particle` can be added to a particle-like object on the
-    right and then return a `ParticleList`.
-    """
+    """Test that a `Particle` can be added to a particle-like object on the
+    right and then return a `ParticleList`."""
     heavy_isotopes_of_hydrogen = Particle("D") + "T"
     assert isinstance(heavy_isotopes_of_hydrogen, ParticleList)
     assert heavy_isotopes_of_hydrogen[0] == "D"
@@ -272,10 +251,8 @@ def test_add_particle_and_particle_like():
 
 
 def test_add_particle_like_and_particle():
-    """
-    Test that a particle-like object on the left can be added to a
-    `Particle` instance on the right and then return a `ParticleList`.
-    """
+    """Test that a particle-like object on the left can be added to a
+    `Particle` instance on the right and then return a `ParticleList`."""
     heavy_isotopes_of_hydrogen = "D" + Particle("T")
     assert isinstance(heavy_isotopes_of_hydrogen, ParticleList)
     assert heavy_isotopes_of_hydrogen[0] == "D"
@@ -283,10 +260,8 @@ def test_add_particle_like_and_particle():
 
 
 def test_particle_list_gt_as_nuclear_reaction_energy():
-    """
-    Test that `ParticleList.__gt__` can be used to get the same result
-    as `nuclear_reaction_energy`.
-    """
+    """Test that `ParticleList.__gt__` can be used to get the same result as
+    `nuclear_reaction_energy`."""
     reactants = ParticleList(["D+", "T+"])
     products = ParticleList(["alpha", "n"])
     expected_energy = nuclear_reaction_energy("D + T --> alpha + n")
@@ -295,10 +270,8 @@ def test_particle_list_gt_as_nuclear_reaction_energy():
 
 
 def test_particle_gt_as_radioactive_decay():
-    """
-    Test a nuclear reaction where a `Particle` instance is the sole
-    reactant on the left side.
-    """
+    """Test a nuclear reaction where a `Particle` instance is the sole reactant
+    on the left side."""
     tritium = Particle("T")
     expected_energy = nuclear_reaction_energy("T -> He-3 + e")
     actual_energy = tritium > Particle("He-3") + "e"
@@ -308,10 +281,8 @@ def test_particle_gt_as_radioactive_decay():
 @pytest.mark.parametrize("method", ["append", "__add__", "__radd__"])
 @pytest.mark.parametrize("invalid_particle", invalid_particles)
 def test_particle_list_invalid_ops(various_particles, invalid_particle, method):
-    """
-    Test that operations with invalid particles raise the appropriate
-    exceptions.
-    """
+    """Test that operations with invalid particles raise the appropriate
+    exceptions."""
     with pytest.raises((InvalidParticleError, TypeError)):
         getattr(various_particles, method)(invalid_particle)
 
@@ -319,19 +290,15 @@ def test_particle_list_invalid_ops(various_particles, invalid_particle, method):
 @pytest.mark.parametrize("particle", [electron, CustomParticle()])
 @pytest.mark.parametrize("method", ["__mul__", "__rmul__"])
 def test_particle_multiplication(method, particle):
-    """
-    Test that multiplying a `Particle` or `CustomParticle` with an
-    integer returns a `ParticleList` that contains the correct values.
-    """
+    """Test that multiplying a `Particle` or `CustomParticle` with an integer
+    returns a `ParticleList` that contains the correct values."""
     particle_list = getattr(particle, method)(3)
     assert particle_list == [particle, particle, particle]
 
 
 def test_mean_particle():
-    """
-    Test that ``ParticleList.average_particle()`` returns a particle with
-    the mean mass and mean charge of a |ParticleList|.
-    """
+    """Test that ``ParticleList.average_particle()`` returns a particle with
+    the mean mass and mean charge of a |ParticleList|."""
     massless_uncharged_particle = CustomParticle(mass=0 * u.kg, charge=0 * u.C)
     particle_list = ParticleList([proton, electron, alpha, massless_uncharged_particle])
     expected_mass = (proton.mass + electron.mass + alpha.mass) / 4
@@ -342,10 +309,8 @@ def test_mean_particle():
 
 
 def test_weighted_mean_particle():
-    """
-    Test that ``ParticleList.average_particle()`` returns a particle with
-    the weighted mean.
-    """
+    """Test that ``ParticleList.average_particle()`` returns a particle with
+    the weighted mean."""
     custom_proton = CustomParticle(mass=proton.mass, charge=proton.charge)
     particle_list = ParticleList([proton, electron, alpha, custom_proton])
     abundances = [1, 2, 0, 1]
@@ -361,10 +326,8 @@ boolean_pairs = [(False, False), (True, False), (False, True), (True, True)]
 
 @pytest.mark.parametrize("use_rms_charge, use_rms_mass", boolean_pairs)
 def test_root_mean_square_particle(use_rms_charge, use_rms_mass):
-    """
-    Test that ``ParticleList.average_particle`` returns the mean or root
-    mean square of the charge and mass, as appropriate.
-    """
+    """Test that ``ParticleList.average_particle`` returns the mean or root
+    mean square of the charge and mass, as appropriate."""
 
     particle_list = ParticleList(["p+", "e-"])
     average_particle = particle_list.average_particle(

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -14,9 +14,7 @@ from plasmapy.particles.particle_class import (
 
 
 class TestPickling:
-    """
-    Test that different objects in `plasmapy.particles` can be pickled.
-    """
+    """Test that different objects in `plasmapy.particles` can be pickled."""
 
     @pytest.mark.parametrize(
         "instance",
@@ -30,10 +28,8 @@ class TestPickling:
         ],
     )
     def test_pickling(self, instance, tmp_path):
-        """
-        Test that different objects contained within `plasmapy.particles`
-        can be pickled and unpickled.
-        """
+        """Test that different objects contained within `plasmapy.particles`
+        can be pickled and unpickled."""
         filename = tmp_path / "pickled_particles.p"
         with open(filename, "wb") as pickle_file:
             pickle.dump(instance, pickle_file)

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -16,8 +16,8 @@ particle_antiparticle_pairs = [
 
 @pytest.mark.parametrize("particle,antiparticle", particle_antiparticle_pairs)
 def test_particle_antiparticle_pairs(particle, antiparticle):
-    """Test that particles and antiparticles have the same or exact
-    opposite properties in the _Particles dictionary."""
+    """Test that particles and antiparticles have the same or exact opposite
+    properties in the _Particles dictionary."""
 
     assert not _Particles[particle][
         "antimatter"

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -1,6 +1,4 @@
-"""
-Module for defining the base framework of the plasma classes.
-"""
+"""Module for defining the base framework of the plasma classes."""
 __all__ = ["BasePlasma", "GenericPlasma"]
 
 from abc import ABC, abstractmethod
@@ -8,12 +6,12 @@ from abc import ABC, abstractmethod
 
 class BasePlasma(ABC):
     """
-    Registration class for `~plasmapy.plasma.GenericPlasma` and declares
-    some abstract methods for data common in different kinds of plasmas.
+    Registration class for `~plasmapy.plasma.GenericPlasma` and declares some
+    abstract methods for data common in different kinds of plasmas.
 
-    This class checks for the existence of a method named ``is_datasource_for``
-    when a subclass of `GenericPlasma` is defined. If it exists it will add that
-    class to the registry.
+    This class checks for the existence of a method named
+    ``is_datasource_for`` when a subclass of `GenericPlasma` is defined.
+    If it exists it will add that class to the registry.
     """
 
     # GenericPlasma subclass registry
@@ -62,8 +60,10 @@ class BasePlasma(ABC):
 
 class GenericPlasma(BasePlasma):
     """
-    A Generic Plasma class. This class contains definitions for abstract
-    methods declared in the `BasePlasma`.
+    A Generic Plasma class.
+
+    This class contains definitions for abstract methods declared in the
+    `BasePlasma`.
     """
 
     def __init__(self, **kwargs):

--- a/plasmapy/plasma/plasma_factory.py
+++ b/plasmapy/plasma/plasma_factory.py
@@ -1,6 +1,4 @@
-"""
-Module for defining the framework around the plasma factory.
-"""
+"""Module for defining the framework around the plasma factory."""
 __all__ = ["PlasmaFactory", "Plasma"]
 
 from plasmapy.plasma.plasma_base import GenericPlasma
@@ -9,9 +7,10 @@ from plasmapy.utils.datatype_factory_base import BasicRegistrationFactory
 
 class PlasmaFactory(BasicRegistrationFactory):
     """
-    Plasma factory class. Used to create a variety of Plasma objects.
-    Valid plasma structures are specified by registering them with the
-    factory.
+    Plasma factory class.
+
+    Used to create a variety of Plasma objects. Valid plasma structures
+    are specified by registering them with the factory.
     """
 
     pass

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -50,7 +50,6 @@ class HDF5Reader(GenericPlasma):
 
     **kwargs
         Any keyword accepted by `GenericPlasma`.
-
     """
 
     def __init__(self, hdf5, **kwargs):
@@ -103,8 +102,9 @@ class HDF5Reader(GenericPlasma):
     @property
     def electric_field(self):
         """
-        An (x, y, z) array containing electric field data.  (Returned as an astropy
-        `~astropy.units.Quantity`.)
+        An (x, y, z) array containing electric field data.
+
+        (Returned as an astropy `~astropy.units.Quantity`.)
         """
         path = f"data/{self.subname}/fields/E"
         if path in self.h5:
@@ -117,8 +117,9 @@ class HDF5Reader(GenericPlasma):
     @property
     def charge_density(self):
         """
-        An array containing charge density data.  (Returned as an astropy
-        `~astropy.units.Quantity`.)
+        An array containing charge density data.
+
+        (Returned as an astropy `~astropy.units.Quantity`.)
         """
         path = f"data/{self.subname}/fields/rho"
         if path in self.h5:

--- a/plasmapy/plasma/sources/plasma3d.py
+++ b/plasmapy/plasma/sources/plasma3d.py
@@ -1,6 +1,5 @@
-"""
-Defines the core Plasma class used by PlasmaPy to represent plasma properties.
-"""
+"""Defines the core Plasma class used by PlasmaPy to represent plasma
+properties."""
 __all__ = ["Plasma3D"]
 
 import astropy.units as u
@@ -16,8 +15,8 @@ from plasmapy.utils.decorators import validate_quantities
 
 class Plasma3D(GenericPlasma):
     """
-    Core class for describing and calculating plasma parameters with
-    spatial dimensions.
+    Core class for describing and calculating plasma parameters with spatial
+    dimensions.
 
     Parameters
     ----------
@@ -59,33 +58,34 @@ class Plasma3D(GenericPlasma):
     @property
     def x(self):
         """
-        (`~astropy.units.Quantity`) x-coordinates within the plasma domain. Equal to
-        the `domain_x` input parameter.
+        (`~astropy.units.Quantity`) x-coordinates within the plasma domain.
+
+        Equal to the `domain_x` input parameter.
         """
         return self._x
 
     @property
     def y(self):
         """
-        (`~astropy.units.Quantity`) y-coordinates within the plasma domain. Equal
-        to the `domain_y` input parameter.
+        (`~astropy.units.Quantity`) y-coordinates within the plasma domain.
+
+        Equal to the `domain_y` input parameter.
         """
         return self._y
 
     @property
     def z(self):
         """
-        (`~astropy.units.Quantity`) z-coordinates within the plasma domain. Equal
-        to the `domain_z` input parameter.
+        (`~astropy.units.Quantity`) z-coordinates within the plasma domain.
+
+        Equal to the `domain_z` input parameter.
         """
         return self._z
 
     @property
     def grid(self):
-        """
-        (`~astropy.units.Quantity`) (3, x, y, z) array containing the values of each
-        coordinate at every point in the domain.
-        """
+        """(`~astropy.units.Quantity`) (3, x, y, z) array containing the values
+        of each coordinate at every point in the domain."""
         return self._grid
 
     @property
@@ -95,50 +95,38 @@ class Plasma3D(GenericPlasma):
 
     @property
     def density(self):
-        """
-        (`~astropy.units.Quantity`) (x, y, z) array of mass density at every
-        point in the domain.
-        """
+        """(`~astropy.units.Quantity`) (x, y, z) array of mass density at every
+        point in the domain."""
         return self._density
 
     @property
     def momentum(self):
-        """
-        (`~astropy.units.Quantity`) (3, x, y, z) array of the momentum vector at
-        every point in the domain.
-        """
+        """(`~astropy.units.Quantity`) (3, x, y, z) array of the momentum
+        vector at every point in the domain."""
         return self._momentum
 
     @property
     def pressure(self):
-        """
-        (`~astropy.units.Quantity`) (x, y, z) array of pressure at every point
-        in the domain.
-        """
+        """(`~astropy.units.Quantity`) (x, y, z) array of pressure at every
+        point in the domain."""
         return self._pressure
 
     @property
     def magnetic_field(self):
-        """
-        (`~astropy.units.Quantity`) (3, x, y, z) array of the magnetic field vector
-        at every point in the domain.
-        """
+        """(`~astropy.units.Quantity`) (3, x, y, z) array of the magnetic field
+        vector at every point in the domain."""
         return self._magnetic_field
 
     @property
     def electric_field(self):
-        """
-        (`~astropy.units.Quantity`) (3, x, y, z) array of the magnetic field vector
-        at every point in the domain.
-        """
+        """(`~astropy.units.Quantity`) (3, x, y, z) array of the magnetic field
+        vector at every point in the domain."""
         return self._electric_field
 
     @property
     def velocity(self):
-        """
-        (`~astropy.units.Quantity`) (3, x, y, z) array of the fluid velocity vector at
-        every point in the domain.
-        """
+        """(`~astropy.units.Quantity`) (3, x, y, z) array of the fluid velocity
+        vector at every point in the domain."""
         return self.momentum / self.density
 
     @property
@@ -146,9 +134,7 @@ class Plasma3D(GenericPlasma):
         """
         Total field strength.
 
-        .. math::
-            \\sqrt{ \\sum{ B^2 }}
-
+        .. math::     \\sqrt{ \\sum{ B^2 }}
         """
         B = self.magnetic_field
         return np.sqrt(np.sum(B * B, axis=0))
@@ -158,19 +144,15 @@ class Plasma3D(GenericPlasma):
         """
         Total field strength.
 
-        .. math::
-            \\sqrt{ \\sum{ E^2 }}
-
+        .. math::     \\sqrt{ \\sum{ E^2 }}
         """
         E = self.electric_field
         return np.sqrt(np.sum(E * E, axis=0))
 
     @property
     def alfven_speed(self):
-        """
-        (`~astropy.units.Quantity`) (x, y, z) array of the Alfvén speed at
-        every point in the domain.
-        """
+        """(`~astropy.units.Quantity`) (x, y, z) array of the Alfvén speed at
+        every point in the domain."""
         B = self.magnetic_field
         rho = self.density
         return np.sqrt(np.sum(B * B, axis=0) / (mu0 * rho))

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -1,6 +1,5 @@
-"""
-Defines the core Plasma class used by PlasmaPy to represent plasma properties.
-"""
+"""Defines the core Plasma class used by PlasmaPy to represent plasma
+properties."""
 __all__ = ["PlasmaBlob"]
 
 import astropy.units as u
@@ -17,15 +16,14 @@ from plasmapy.utils.exceptions import CouplingWarning
 
 
 class PlasmaBlob(GenericPlasma):
-    """
-    Class for describing and calculating plasma parameters without
-    spatial/temporal description.
-    """
+    """Class for describing and calculating plasma parameters without
+    spatial/temporal description."""
 
     @validate_quantities(T_e=u.K, n_e=u.m ** -3)
     def __init__(self, T_e, n_e, Z=None, particle="p"):
         """
         Initialize plasma parameters.
+
         The most basic description is composition (ion), temperature,
         density, and ionization.
         """
@@ -46,7 +44,6 @@ class PlasmaBlob(GenericPlasma):
         PlasmaBlob(T_e=10000.0*u.K, n_e=1e+20*u.m**-3, particle='p', Z=1)
         Intermediate coupling regime: Gamma = 0.01250283...
         Thermal kinetic energy dominant: Theta = 109690.5...
-
         """
         return self.__repr__() + "\n" + "\n".join(self.regimes())
 
@@ -89,10 +86,8 @@ class PlasmaBlob(GenericPlasma):
         return self.particle
 
     def regimes(self):
-        """
-        Generate a comprehensive description of the plasma regimes
-        based on plasma properties and consequent plasma parameters.
-        """
+        """Generate a comprehensive description of the plasma regimes based on
+        plasma properties and consequent plasma parameters."""
         # getting dimensionless parameters
         coupling = self.coupling()
         quantum_theta = self.quantum_theta()
@@ -131,9 +126,11 @@ class PlasmaBlob(GenericPlasma):
 
     def coupling(self):
         """
-        Ion-ion coupling parameter to determine if quantum/coupling effects
-        are important. This compares Coulomb potential energy to thermal
-        kinetic energy.
+        Ion-ion coupling parameter to determine if quantum/coupling effects are
+        important.
+
+        This compares Coulomb potential energy to thermal kinetic
+        energy.
         """
         couple = coupling_parameter(
             self.T_e, self.n_e, (self.particle, self.particle), self.Z
@@ -147,10 +144,8 @@ class PlasmaBlob(GenericPlasma):
         return couple
 
     def quantum_theta(self):
-        """
-        Quantum theta parameter, which compares Fermi kinetic energy to
-        thermal kinetic energy to check if quantum effects are important.
-        """
+        """Quantum theta parameter, which compares Fermi kinetic energy to
+        thermal kinetic energy to check if quantum effects are important."""
         theta = quantum_theta(self.T_e, self.n_e)
         return theta
 

--- a/plasmapy/plasma/sources/tests/test_plasmablob.py
+++ b/plasmapy/plasma/sources/tests/test_plasmablob.py
@@ -292,7 +292,7 @@ class Test_PlasmaBlobRegimes:
 class Test_PlasmaBlob:
     @classmethod
     def setup_class(self):
-        """initializing parameters for tests"""
+        """initializing parameters for tests."""
         self.T_e = 5 * 11e3 * u.K
         self.n_e = 1e23 * u.cm ** -3
         self.Z = 2.5
@@ -304,16 +304,14 @@ class Test_PlasmaBlob:
         self.thetaVal = 0.6032979246923964
 
     def test_invalid_particle(self):
-        """
-        Checks if function raises error for invalid particle.
-        """
+        """Checks if function raises error for invalid particle."""
         with pytest.raises(InvalidParticleError):
             plasmablob.PlasmaBlob(
                 T_e=self.T_e, n_e=self.n_e, Z=self.Z, particle="cupcakes"
             )
 
     def test_electron_temperature(self):
-        """Testing if we get the same electron temperature we put in"""
+        """Testing if we get the same electron temperature we put in."""
         testTrue = self.T_e == self.blob.electron_temperature
         errStr = (
             f"Input electron temperature {self.T_e} should be equal to "
@@ -323,7 +321,7 @@ class Test_PlasmaBlob:
         assert testTrue, errStr
 
     def test_electron_density(self):
-        """Testing if we get the same electron density we put in"""
+        """Testing if we get the same electron density we put in."""
         testTrue = self.n_e == self.blob.electron_density
         errStr = (
             f"Input electron density {self.n_e} should be equal to "
@@ -333,7 +331,7 @@ class Test_PlasmaBlob:
         assert testTrue, errStr
 
     def test_ionization(self):
-        """Testing if we get the same ionization we put in"""
+        """Testing if we get the same ionization we put in."""
         testTrue = self.Z == self.blob.ionization
         errStr = (
             f"Input ionization {self.Z} should be equal to "
@@ -343,7 +341,7 @@ class Test_PlasmaBlob:
         assert testTrue, errStr
 
     def test_composition(self):
-        """Testing if we get the same composition (particle) we put in"""
+        """Testing if we get the same composition (particle) we put in."""
         testTrue = self.particle == self.blob.composition
         errStr = (
             f"Input particle {self.particle} should be equal to "
@@ -353,9 +351,7 @@ class Test_PlasmaBlob:
         assert testTrue, errStr
 
     def test_coupling(self):
-        """
-        Tests if coupling  method value meets expected value.
-        """
+        """Tests if coupling  method value meets expected value."""
         methodVal = self.blob.coupling()
         errStr = (
             f"Coupling parameter should be {self.couplingVal} "
@@ -365,9 +361,7 @@ class Test_PlasmaBlob:
         assert testTrue, errStr
 
     def test_quantum_theta(self):
-        """
-        Tests if degeneracy parameter method value meets expected value.
-        """
+        """Tests if degeneracy parameter method value meets expected value."""
         methodVal = self.blob.quantum_theta()
         errStr = (
             f"Degeneracy parameter should be {self.thetaVal} "

--- a/plasmapy/plasma/tests/test_plasma_base.py
+++ b/plasmapy/plasma/tests/test_plasma_base.py
@@ -22,17 +22,13 @@ class IsNotDataSource(BasePlasma):
 
 class TestRegistrar:
     def test_no_data_source(self):
-        """
-        NoDataSource class should not be registered since it has
-        no method named ``is_datasource_for``.
-        """
+        """NoDataSource class should not be registered since it has no method
+        named ``is_datasource_for``."""
         assert not BasePlasma._registry.get(NoDataSource)
 
     def test_is_data_source(self):
-        """
-        IsDataSource class should be registered since it has a
-        method named ``is_datasource_for`` and must return True.
-        """
+        """IsDataSource class should be registered since it has a method named
+        ``is_datasource_for`` and must return True."""
         assert BasePlasma._registry.get(IsDataSource)
         assert BasePlasma._registry[IsDataSource]()
         # Delete the class from _registry once test is done
@@ -40,10 +36,8 @@ class TestRegistrar:
         del BasePlasma._registry[IsDataSource]
 
     def test_is_not_data_source(self):
-        """
-        IsNotDataSource class should be registered since it has a
-        method named ``is_datasource_for`` but must return False.
-        """
+        """IsNotDataSource class should be registered since it has a method
+        named ``is_datasource_for`` but must return False."""
         assert BasePlasma._registry.get(IsNotDataSource)
         assert not BasePlasma._registry[IsNotDataSource]()
         del BasePlasma._registry[IsNotDataSource]

--- a/plasmapy/simulation/abstractions.py
+++ b/plasmapy/simulation/abstractions.py
@@ -16,15 +16,12 @@ class AbstractSimulation(ABC):
     """
     A prototype abstract interface for numerical simulations.
 
-    .. warning::
-        This interface is unstable and subject to change.
+    .. warning::     This interface is unstable and subject to change.
     """
 
     @abstractmethod
     def summarize(self):
-        """
-        Print a summary of the simulation parameters and status.
-        """
+        """Print a summary of the simulation parameters and status."""
         ...
 
     @abstractmethod
@@ -47,8 +44,8 @@ class AbstractTimeDependentSimulation(AbstractSimulation):
     """
     A prototype abstract interface for time-dependent numerical simulations.
 
-    .. warning::
-        This interface is unstable and is subject to change.
+    .. warning::     This interface is unstable and is subject to
+    change.
     """
 
     ...
@@ -56,11 +53,11 @@ class AbstractTimeDependentSimulation(AbstractSimulation):
 
 class AbstractNormalizations(ABC):
     """
-    An abstract base class to represent the normalization constants for
-    systems of equations describing plasmas.
+    An abstract base class to represent the normalization constants for systems
+    of equations describing plasmas.
 
-    .. warning::
-        This interface is unstable and is subject to change.
+    .. warning::     This interface is unstable and is subject to
+    change.
     """
 
     @property
@@ -177,7 +174,7 @@ class AbstractNormalizations(ABC):
         """
         The normalization for a volumetric rate.
 
-        This normalization is applicable to, for example, the number
-        of collisions per unit volume per unit time.
+        This normalization is applicable to, for example, the number of
+        collisions per unit volume per unit time.
         """
         ...

--- a/plasmapy/tests/helpers/exceptions.py
+++ b/plasmapy/tests/helpers/exceptions.py
@@ -30,76 +30,58 @@ class TestFailed(Failed):
 
 
 class TypeMismatchFail(TestFailed):
-    """
-    Exception for when the type of the actual result differs from the
-    type of the expected result.
-    """
+    """Exception for when the type of the actual result differs from the type
+    of the expected result."""
 
     pass
 
 
 class MissingExceptionFail(TestFailed):
-    """
-    Exception for when the expected exception is not raised.
-    """
+    """Exception for when the expected exception is not raised."""
 
     pass
 
 
 class UnexpectedExceptionFail(TestFailed):
-    """
-    Exception for when an exception is raised unexpectedly.
-    """
+    """Exception for when an exception is raised unexpectedly."""
 
     pass
 
 
 class ExceptionMismatchFail(UnexpectedExceptionFail, MissingExceptionFail):
-    """
-    Exception for when an exception is expected, but a different
-    exception is raised.
-    """
+    """Exception for when an exception is expected, but a different exception
+    is raised."""
 
     pass
 
 
 class UnexpectedWarningFail(TestFailed):
-    """
-    Exception for when a warning is issued unexpectedly.
-    """
+    """Exception for when a warning is issued unexpectedly."""
 
     pass
 
 
 class MissingWarningFail(TestFailed):
-    """
-    Exception for when an expected warning is not issued.
-    """
+    """Exception for when an expected warning is not issued."""
 
     pass
 
 
 class WarningMismatchFail(UnexpectedWarningFail, MissingWarningFail):
-    """
-    Exception for when a warning is expected, but one or more
-    different warnings were issued instead.
-    """
+    """Exception for when a warning is expected, but one or more different
+    warnings were issued instead."""
 
     pass
 
 
 class UnexpectedResultFail(TestFailed):
-    """
-    Exception for when the returned value does not match the value that
-    was expected.
-    """
+    """Exception for when the returned value does not match the value that was
+    expected."""
 
     pass
 
 
 class InvalidTestError(Exception):
-    """
-    Exception for when the inputs to a test are not valid.
-    """
+    """Exception for when the inputs to a test are not valid."""
 
     pass

--- a/plasmapy/tests/helpers/tests/sample_functions.py
+++ b/plasmapy/tests/helpers/tests/sample_functions.py
@@ -1,7 +1,5 @@
-"""
-Sample functions and classes to be used for testing the test helper
-functionality.
-"""
+"""Sample functions and classes to be used for testing the test helper
+functionality."""
 
 import astropy.units as u
 import numpy as np
@@ -17,9 +15,7 @@ class SampleException(Exception):
 
 
 class SampleExceptionSubclass(SampleException):
-    """
-    The subclass of `SampleException` to used for testing purposes.
-    """
+    """The subclass of `SampleException` to used for testing purposes."""
 
     pass
 
@@ -31,9 +27,7 @@ class SampleWarning(Warning):
 
 
 class SampleWarningSubclass(SampleWarning):
-    """
-    The subclass of `SampleWarning` to be used for testing purposes.
-    """
+    """The subclass of `SampleWarning` to be used for testing purposes."""
 
     pass
 
@@ -45,10 +39,8 @@ def return_42() -> int:
 
 
 def return_42_meters() -> u.Quantity:
-    """
-    A sample function for testing purposes that returns an
-    `~astropy.units.Quantity` with a value of ``42.0 m``.
-    """
+    """A sample function for testing purposes that returns an
+    `~astropy.units.Quantity` with a value of ``42.0 m``."""
 
     return 42.0 * u.m
 
@@ -66,26 +58,23 @@ def issue_warning() -> NoReturn:
 
 
 def issue_warning_return_42() -> int:
-    """
-    A sample function for testing purposes that issues a `SampleWarning`
-    and returns ``42``.
-    """
+    """A sample function for testing purposes that issues a `SampleWarning` and
+    returns ``42``."""
 
     warnings.warn("warning message", SampleWarning)
     return 42
 
 
 def raise_exception():
-    """A sample function for testing purposes that raises a `SampleException`."""
+    """A sample function for testing purposes that raises a
+    `SampleException`."""
 
     raise SampleException("exception message")
 
 
 def sum_of_args_and_kwargs(arg1, arg2, *, kw1, kw2):
-    """
-    A sample function for testing purposes that returns the sum of
-    two positional arguments and two keyword arguments.
-    """
+    """A sample function for testing purposes that returns the sum of two
+    positional arguments and two keyword arguments."""
 
     return arg1 + arg2 + kw1 + kw2
 
@@ -105,10 +94,8 @@ class SampleClass1:
 
     @classmethod
     def arg_plus_kwarg(self, arg, *, kwarg):
-        """
-        A sample method that returns the sum of a positional argument
-        and a keyword argument.
-        """
+        """A sample method that returns the sum of a positional argument and a
+        keyword argument."""
 
         return arg + kwarg
 
@@ -140,11 +127,9 @@ class SampleClass2:
         self.cls_kwarg2 = cls_kwarg2
 
     def method(self, method_arg1, method_arg2, *, method_kwarg1, method_kwarg2):
-        """
-        Return the sum of the positional and keyword arguments supplied
-        to the class upon instantiation plus the sum of the positional
-        and keyword arguments supplied to the method when it is called.
-        """
+        """Return the sum of the positional and keyword arguments supplied to
+        the class upon instantiation plus the sum of the positional and keyword
+        arguments supplied to the method when it is called."""
 
         return sum(
             [
@@ -161,9 +146,7 @@ class SampleClass2:
 
     @property
     def attr(self):
-        """
-        Return the sum of the positional and keyword arguments supplied
-        to the class upon instantiation.
-        """
+        """Return the sum of the positional and keyword arguments supplied to
+        the class upon instantiation."""
 
         return self.cls_arg1 + self.cls_arg2 + self.cls_kwarg1 + self.cls_kwarg2

--- a/plasmapy/utils/code_repr.py
+++ b/plasmapy/utils/code_repr.py
@@ -12,8 +12,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 def _code_repr_of_ndarray(array: np.ndarray, max_items=np.inf) -> str:
     """
-    Transform a `~numpy.ndarray` into a format as would appear in a
-    function call, after having done ``import numpy as np``.
+    Transform a `~numpy.ndarray` into a format as would appear in a function
+    call, after having done ``import numpy as np``.
 
     If ``max_items`` is less than ``array.size``, then include only the
     first ``max_items`` elements of the array in the resulting string
@@ -49,10 +49,8 @@ def _code_repr_of_ndarray(array: np.ndarray, max_items=np.inf) -> str:
 
 
 def _code_repr_of_quantity(arg: u.Quantity, max_items=np.inf) -> str:
-    """
-    Transform a `~astropy.units.Quantity` into a format as would appear
-    in a function call.
-    """
+    """Transform a `~astropy.units.Quantity` into a format as would appear in a
+    function call."""
     if isinstance(arg.value, np.ndarray):
         formatted = _code_repr_of_ndarray(arg.value, max_items=max_items)
     else:
@@ -73,7 +71,8 @@ def _code_repr_of_quantity(arg: u.Quantity, max_items=np.inf) -> str:
 
 
 def _code_repr_of_arg(arg, max_items=np.inf) -> str:
-    """Transform an argument into a format as would appear in a function call."""
+    """Transform an argument into a format as would appear in a function
+    call."""
     if hasattr(arg, "__name__"):
         return arg.__name__
     function_for_type = {
@@ -90,10 +89,8 @@ def _code_repr_of_arg(arg, max_items=np.inf) -> str:
 def _code_repr_of_args_and_kwargs(
     args: Any = None, kwargs: Dict = None, max_items=np.inf
 ) -> str:
-    """
-    Take positional and keyword arguments, and format them into a
-    string as they would appear in a function call (excluding parentheses).
-    """
+    """Take positional and keyword arguments, and format them into a string as
+    they would appear in a function call (excluding parentheses)."""
     args = tuple() if args is None else args
     kwargs = dict() if kwargs is None else kwargs
 
@@ -115,8 +112,8 @@ def _code_repr_of_args_and_kwargs(
 
 def _name_with_article(ex: Exception) -> str:
     """
-    Return a string with an indefinite article and the name of
-    the exception ``ex`` (e.g. ``Exception`` -> ``'an Exception'``).
+    Return a string with an indefinite article and the name of the exception
+    ``ex`` (e.g. ``Exception`` -> ``'an Exception'``).
 
     Notes
     -----
@@ -172,11 +169,9 @@ def _object_name(obj: Any, showmodule=False) -> str:
 def _string_together_warnings_for_printing(
     warning_types: List[Warning], warning_messages: List[str]
 ):
-    """
-    Take a list of warning types with a list of corresponding warning
-    messages, and create a string that prints out each warning type
-    followed by the corresponding message, separated by a full line.
-    """
+    """Take a list of warning types with a list of corresponding warning
+    messages, and create a string that prints out each warning type followed by
+    the corresponding message, separated by a full line."""
     warnings_with_messages = [
         _object_name(warning, showmodule=False) + ": " + message
         for warning, message in zip(warning_types, warning_messages)
@@ -191,8 +186,8 @@ def call_string(
     max_items: Integral = 12,
 ) -> str:
     """
-    Approximate a call of a function or class with positional and
-    keyword arguments.
+    Approximate a call of a function or class with positional and keyword
+    arguments.
 
     Parameters
     ----------
@@ -253,8 +248,8 @@ def attribute_call_string(
     max_items: Integral = 12,
 ) -> str:
     """
-    Approximate the command to instantiate a class, and access an
-    attribute of the resulting class instance.
+    Approximate the command to instantiate a class, and access an attribute of
+    the resulting class instance.
 
     Parameters
     ----------
@@ -329,8 +324,8 @@ def method_call_string(
     max_items: Integral = 12,
 ) -> str:
     """
-    Approximate the command to instantiate a class, and then call a
-    method in the resulting class instance.
+    Approximate the command to instantiate a class, and then call a method in
+    the resulting class instance.
 
     Parameters
     ----------

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -142,7 +142,8 @@ class BasicRegistrationFactory:
         return WidgetType(*args, **kwargs)
 
     def register(self, WidgetType, validation_function=None, is_default=False):
-        """Register a widget with the factory.
+        """
+        Register a widget with the factory.
 
         If `validation_function` is not specified, tests `WidgetType` for
         existence of any function in in the list `self.validation_functions`,
@@ -159,7 +160,6 @@ class BasicRegistrationFactory:
 
         is_default : `bool`, optional
             Sets WidgetType to be the default widget.
-
         """
         if is_default:
             self.default_widget_type = WidgetType

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -1,6 +1,4 @@
-"""
-Decorator for checking input/output arguments of functions.
-"""
+"""Decorator for checking input/output arguments of functions."""
 __all__ = [
     "check_values",
     "check_units",
@@ -58,17 +56,15 @@ class CheckBase:
 
     @property
     def checks(self):
-        """
-        Requested checks on the decorated function's input arguments
-        and/or return.
-        """
+        """Requested checks on the decorated function's input arguments and/or
+        return."""
         return self._checks
 
 
 class CheckValues(CheckBase):
     """
-    A decorator class to 'check' -- limit/control -- the values of input and return
-    arguments to a function or method.
+    A decorator class to 'check' -- limit/control -- the values of input and
+    return arguments to a function or method.
 
     Parameters
     ----------
@@ -197,9 +193,9 @@ class CheckValues(CheckBase):
         self, bound_args: inspect.BoundArguments
     ) -> Dict[str, Dict[str, bool]]:
         """
-        Review :attr:`checks` and function bound arguments to build a complete 'checks'
-        dictionary.  If a check key is omitted from the argument checks, then a default
-        value is assumed (see `check values`_).
+        Review :attr:`checks` and function bound arguments to build a complete
+        'checks' dictionary.  If a check key is omitted from the argument
+        checks, then a default value is assumed (see `check values`_).
 
         Parameters
         ----------
@@ -295,7 +291,6 @@ class CheckValues(CheckBase):
         ------
         ValueError
             raised if a check fails
-
         """
         if arg_name == "checks_on_return":
             valueerror_msg = "The return value "
@@ -338,8 +333,8 @@ class CheckValues(CheckBase):
 
 class CheckUnits(CheckBase):
     """
-    A decorator class to 'check' -- limit/control -- the units of input and return
-    arguments to a function or method.
+    A decorator class to 'check' -- limit/control -- the units of input and
+    return arguments to a function or method.
 
     Parameters
     ----------
@@ -529,9 +524,9 @@ class CheckUnits(CheckBase):
         self, bound_args: inspect.BoundArguments
     ) -> Dict[str, Dict[str, Any]]:
         """
-        Review :attr:`checks` and function bound arguments to build a complete 'checks'
-        dictionary.  If a check key is omitted from the argument checks, then a default
-        value is assumed (see `check units`_)
+        Review :attr:`checks` and function bound arguments to build a complete
+        'checks' dictionary.  If a check key is omitted from the argument
+        checks, then a default value is assumed (see `check units`_)
 
         Parameters
         ----------
@@ -1020,8 +1015,7 @@ class CheckUnits(CheckBase):
 
     def _flatten_equivalencies_list(self, elist):
         """
-        Given a list of equivalencies, flatten out any sub-element lists
-
+        Given a list of equivalencies, flatten out any sub-element lists.
 
         Parameters
         ----------
@@ -1032,7 +1026,6 @@ class CheckUnits(CheckBase):
         -------
         list
             a flattened list of astropy :mod:`~astropy.units.equivalencies`
-
         """
         new_list = []
         for el in elist:

--- a/plasmapy/utils/decorators/deprecation.py
+++ b/plasmapy/utils/decorators/deprecation.py
@@ -10,10 +10,9 @@ from plasmapy.utils.exceptions import PlasmaPyDeprecationWarning
 
 
 def deprecated(*args, warning_type=PlasmaPyDeprecationWarning, **kwargs):
-    """
-    A wrapper of `astropy.utils.decorators.deprecated` that by default assumes
-    a warning type of `~plasmapy.utils.exceptions.PlasmaPyDeprecationWarning`.
-    """
+    """A wrapper of `astropy.utils.decorators.deprecated` that by default
+    assumes a warning type of
+    `~plasmapy.utils.exceptions.PlasmaPyDeprecationWarning`."""
     return astropy_deprecated(*args, warning_type=warning_type, **kwargs)
 
 

--- a/plasmapy/utils/decorators/tests/test_checks.py
+++ b/plasmapy/utils/decorators/tests/test_checks.py
@@ -1,7 +1,5 @@
-"""
-Tests for 'check` decorators (i.e. decorators that only check objects but do not
-change them).
-"""
+"""Tests for 'check` decorators (i.e. decorators that only check objects but do
+not change them)."""
 import inspect
 import numpy as np
 import pytest
@@ -32,9 +30,8 @@ from plasmapy.utils.exceptions import (
 # Test Decorator class `CheckBase`
 # ----------------------------------------------------------------------------------------
 class TestCheckBase:
-    """
-    Test for decorator class :class:`~plasmapy.utils.decorators.checks.CheckBase`.
-    """
+    """Test for decorator class
+    :class:`~plasmapy.utils.decorators.checks.CheckBase`."""
 
     def test_for_members(self):
         assert hasattr(CheckUnits, "checks")
@@ -56,10 +53,9 @@ class TestCheckBase:
 # Test Decorator class `CheckValues` and decorator `check_values`
 # ----------------------------------------------------------------------------------------
 class TestCheckUnits:
-    """
-    Tests for decorator :func:`~plasmapy.utils.decorators.checks.check_units` and
-    decorator class :class:`~plasmapy.utils.decorators.checks.CheckUnits`.
-    """
+    """Tests for decorator
+    :func:`~plasmapy.utils.decorators.checks.check_units` and decorator class
+    :class:`~plasmapy.utils.decorators.checks.CheckUnits`."""
 
     check_defaults = CheckUnits._CheckUnits__check_defaults  # type: Dict[str, Any]
 
@@ -182,9 +178,11 @@ class TestCheckUnits:
 
     def test_cu_method__get_unit_checks(self):
         """
-        Test functionality/behavior of the method `_get_unit_checks` on `CheckUnits`.
-        This method reviews the decorator `checks` arguments and wrapped function
-        annotations to build a complete checks dictionary.
+        Test functionality/behavior of the method `_get_unit_checks` on
+        `CheckUnits`.
+
+        This method reviews the decorator `checks` arguments and wrapped
+        function annotations to build a complete checks dictionary.
         """
         # methods must exist
         assert hasattr(CheckUnits, "_get_unit_checks")
@@ -435,9 +433,11 @@ class TestCheckUnits:
 
     def test_cu_method__check_unit(self):
         """
-        Test functionality/behavior of the methods `_check_unit` and `_check_unit_core`
-        on `CheckUnits`.  These methods do the actual checking of the argument units
-        and should be called by `CheckUnits.__call__()`.
+        Test functionality/behavior of the methods `_check_unit` and
+        `_check_unit_core` on `CheckUnits`.
+
+        These methods do the actual checking of the argument units and
+        should be called by `CheckUnits.__call__()`.
         """
         # methods must exist
         assert hasattr(CheckUnits, "_check_unit")
@@ -554,9 +554,8 @@ class TestCheckUnits:
                     cu._check_unit(arg, arg_name, arg_checks)
 
     def test_cu_called_as_decorator(self):
-        """
-        Test behavior of `CheckUnits.__call__` (i.e. used as a decorator).
-        """
+        """Test behavior of `CheckUnits.__call__` (i.e. used as a
+        decorator)."""
         # setup test cases
         # 'setup' = arguments for `CheckUnits` and wrapped function
         # 'output' = expected return from wrapped function
@@ -636,10 +635,8 @@ class TestCheckUnits:
         autospec=True,
     )
     def test_decorator_func_def(self, mock_cu_class):
-        """
-        Test that :func:`~plasmapy.utils.decorators.checks.check_units` is
-        properly defined.
-        """
+        """Test that :func:`~plasmapy.utils.decorators.checks.check_units` is
+        properly defined."""
         # create mock function (mock_foo) from function to mock (self.foo_no_anno)
         mock_foo = mock.Mock(
             side_effect=self.foo_no_anno, name="mock_foo", autospec=True
@@ -715,10 +712,9 @@ class TestCheckUnits:
 # Test Decorator class `CheckValues` and decorator `check_values`
 # ----------------------------------------------------------------------------------------
 class TestCheckValues:
-    """
-    Tests for decorator :func:`~plasmapy.utils.decorators.checks.check_values` and
-    decorator class :class:`~plasmapy.utils.decorators.checks.CheckValues`.
-    """
+    """Tests for decorator
+    :func:`~plasmapy.utils.decorators.checks.check_values` and decorator class
+    :class:`~plasmapy.utils.decorators.checks.CheckValues`."""
 
     check_defaults = CheckValues._CheckValues__check_defaults  # type: Dict[str, bool]
 
@@ -734,7 +730,7 @@ class TestCheckValues:
         assert issubclass(CheckValues, CheckBase)
 
     def test_cv_default_check_values(self):
-        """Test the default check dictionary for CheckValues"""
+        """Test the default check dictionary for CheckValues."""
         cv = CheckValues()
         assert hasattr(cv, "_CheckValues__check_defaults")
         assert isinstance(cv._CheckValues__check_defaults, dict)
@@ -751,9 +747,11 @@ class TestCheckValues:
 
     def test_cv_method__get_value_checks(self):
         """
-        Test functionality/behavior of the method `_get_value_checks` on `CheckValues`.
-        This method reviews the decorator `checks` arguments to build a complete
-        checks dictionary.
+        Test functionality/behavior of the method `_get_value_checks` on
+        `CheckValues`.
+
+        This method reviews the decorator `checks` arguments to build a
+        complete checks dictionary.
         """
         # methods must exist
         assert hasattr(CheckValues, "_get_value_checks")
@@ -858,9 +856,11 @@ class TestCheckValues:
 
     def test_cv_method__check_value(self):
         """
-        Test functionality/behavior of the `_check_value` method on `CheckValues`.
-        This method does the actual checking of the argument values and should be
-        called by `CheckValues.__call__()`.
+        Test functionality/behavior of the `_check_value` method on
+        `CheckValues`.
+
+        This method does the actual checking of the argument values and
+        should be called by `CheckValues.__call__()`.
         """
         # setup wrapped function
         cv = CheckValues()
@@ -1038,9 +1038,8 @@ class TestCheckValues:
                     assert cv._check_value(arg, arg_name, checks) is None
 
     def test_cv_called_as_decorator(self):
-        """
-        Test behavior of `CheckValues.__call__` (i.e. used as a decorator).
-        """
+        """Test behavior of `CheckValues.__call__` (i.e. used as a
+        decorator)."""
         # setup test cases
         # 'setup' = arguments for `CheckUnits` and wrapped function
         # 'output' = expected return from wrapped function
@@ -1136,10 +1135,8 @@ class TestCheckValues:
         autospec=True,
     )
     def test_decorator_func_def(self, mock_cv_class):
-        """
-        Test that :func:`~plasmapy.utils.decorators.checks.check_values` is
-        properly defined.
-        """
+        """Test that :func:`~plasmapy.utils.decorators.checks.check_values` is
+        properly defined."""
         # create mock function (mock_foo) from function to mock (self.foo)
         mock_foo = mock.Mock(side_effect=self.foo, name="mock_foo", autospec=True)
         mock_foo.__name__ = "mock_foo"

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -1,7 +1,5 @@
-"""
-Tests for 'validate` decorators (i.e. decorators that check objects and change them
-when possible).
-"""
+"""Tests for 'validate` decorators (i.e. decorators that check objects and
+change them when possible)."""
 import inspect
 import pytest
 
@@ -340,7 +338,8 @@ class TestValidateQuantities:
             assert mock_cv_checks.called
 
     def test_vq_preserves_signature(self):
-        """Test `ValidateQuantities` preserves signature of wrapped function."""
+        """Test `ValidateQuantities` preserves signature of wrapped
+        function."""
         # I'd like to directly test the @preserve_signature is used (??)
 
         wfoo = ValidateQuantities()(self.foo_anno)
@@ -348,9 +347,8 @@ class TestValidateQuantities:
         assert wfoo.__signature__ == inspect.signature(self.foo_anno)
 
     def test_vq_called_as_decorator(self):
-        """
-        Test behavior of `ValidateQuantities.__call__` (i.e. used as a decorator).
-        """
+        """Test behavior of `ValidateQuantities.__call__` (i.e. used as a
+        decorator)."""
         # setup test cases
         # 'setup' = arguments for `CheckUnits` and wrapped function
         # 'output' = expected return from wrapped function
@@ -478,10 +476,9 @@ class TestValidateQuantities:
         autospec=True,
     )
     def test_decorator_func_def(self, mock_vq_class):
-        """
-        Test that :func:`~plasmapy.utils.decorators.validators.validate_quantities` is
-        properly defined.
-        """
+        """Test that
+        :func:`~plasmapy.utils.decorators.validators.validate_quantities` is
+        properly defined."""
         # create mock function (mock_foo) from function to mock (self.foo)
         mock_foo = mock.Mock(side_effect=self.foo, name="mock_foo", autospec=True)
         mock_foo.__name__ = "mock_foo"

--- a/plasmapy/utils/exceptions.py
+++ b/plasmapy/utils/exceptions.py
@@ -32,9 +32,7 @@ class PlasmaPyError(Exception):
 
 
 class PhysicsError(PlasmaPyError, ValueError):
-    """
-    The base exception for physics-related errors.
-    """
+    """The base exception for physics-related errors."""
 
     pass
 
@@ -49,27 +47,21 @@ class RomanError(PlasmaPyError):
 
 
 class RelativityError(PhysicsError):
-    """
-    An exception for speeds greater than the speed of light.
-    """
+    """An exception for speeds greater than the speed of light."""
 
     pass
 
 
 class OutOfRangeError(RomanError):
-    """
-    An exception to be raised for integers that outside of the range
-    that can be converted to Roman numerals.
-    """
+    """An exception to be raised for integers that outside of the range that
+    can be converted to Roman numerals."""
 
     pass
 
 
 class InvalidRomanNumeralError(RomanError):
-    """
-    An exception to be raised when the input is not a valid Roman
-    numeral.
-    """
+    """An exception to be raised when the input is not a valid Roman
+    numeral."""
 
     pass
 
@@ -103,36 +95,28 @@ class PhysicsWarning(PlasmaPyWarning):
 
 
 class RelativityWarning(PhysicsWarning):
-    """
-    A warning for when relativistic velocities are being used in or are
-    returned by non-relativistic functionality.
-    """
+    """A warning for when relativistic velocities are being used in or are
+    returned by non-relativistic functionality."""
 
     pass
 
 
 class CouplingWarning(PhysicsWarning):
-    """
-    A warning for functions that rely on a particular coupling regime to
-    be valid.
-    """
+    """A warning for functions that rely on a particular coupling regime to be
+    valid."""
 
     pass
 
 
 class PlasmaPyDeprecationWarning(PlasmaPyWarning, DeprecationWarning):
-    """
-    A warning for deprecated features when the warning is intended for
-    other Python developers.
-    """
+    """A warning for deprecated features when the warning is intended for other
+    Python developers."""
 
     pass
 
 
 class PlasmaPyFutureWarning(PlasmaPyWarning, FutureWarning):
-    """
-    A warning for deprecated features when the warning is intended for
-    end users of PlasmaPy.
-    """
+    """A warning for deprecated features when the warning is intended for end
+    users of PlasmaPy."""
 
     pass

--- a/plasmapy/utils/pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers/pytest_helpers.py
@@ -32,11 +32,12 @@ from plasmapy.utils.exceptions import PlasmaPyWarning
 
 def _process_input(wrapped_function: Callable):  # coverage: ignore
     """
-    Allow `run_test` to take a single positional argument that is a
-    `list` or `tuple` in lieu of using multiple positional/keyword
-    arguments as usual.  If `len` of this argument returns `3`, then
-    it assumes that `kwargs` is an empty `dict` and that the expected
-    result/outcome is the last item.
+    Allow `run_test` to take a single positional argument that is a `list` or
+    `tuple` in lieu of using multiple positional/keyword arguments as usual.
+
+    If `len` of this argument returns `3`, then it assumes that `kwargs`
+    is an empty `dict` and that the expected result/outcome is the last
+    item.
     """
 
     def decorator(wrapped_function: Callable):
@@ -77,9 +78,9 @@ def run_test(
     atol: float = 0.0,
 ):  # coverage: ignore
     """
-    Test that a function or class returns the expected result, raises
-    the expected exception, or issues an expected warning for the
-    supplied positional and keyword arguments.
+    Test that a function or class returns the expected result, raises the
+    expected exception, or issues an expected warning for the supplied
+    positional and keyword arguments.
 
     Parameters
     ----------
@@ -212,7 +213,6 @@ def run_test(
         @pytest.mark.parametrize('inputs', inputs_table)
         def test_func(inputs):
             run_test(inputs)
-
     """
 
     if kwargs is None:
@@ -492,7 +492,6 @@ def run_test_equivalent_calls(*test_inputs, require_same_type: bool = True):
     raised if the results are of different types.
 
     >>> run_test_equivalent_calls(f, -1, 1.0, require_same_type=False)
-
     """
 
     if len(test_inputs) == 1:
@@ -681,9 +680,8 @@ def assert_can_handle_nparray(
     def _prepare_input(
         param_name, param_default, insert_some_nans, insert_all_nans, kwargs
     ):
-        """
-        Parse parameter names and set up values to input for 0d, 1d, and 2d array tests.
-        """
+        """Parse parameter names and set up values to input for 0d, 1d, and 2d
+        array tests."""
         # first things first: let any passed in kwarg right through (VIP access)
         if param_name in kwargs.keys():
             return (kwargs[param_name],) * 4

--- a/plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py
@@ -131,7 +131,6 @@ def test_run_test(f, args, kwargs, expected, whaterror):
         The type of exception that the test helper function is supposed
         to raise, or `None` if the test helper function is not supposed
         to raise an exception.
-
     """
 
     try:

--- a/plasmapy/utils/roman.py
+++ b/plasmapy/utils/roman.py
@@ -9,7 +9,6 @@ Copyright (c) 2001 Mark Pilgrim
 This program is free software; you can redistribute it and/or modify
 it under the terms of the Python 2.1.1 license, available at
 https://www.python.org/download/releases/2.1.1/license/
-
 """
 __all__ = [
     "to_roman",
@@ -92,7 +91,6 @@ def to_roman(n: Union[Integral, np.integer]) -> str:
     'V'
     >>> to_roman(2525)
     'MMDXXV'
-
     """
     if not isinstance(n, (Integral, np.integer)):
         raise TypeError(f"{n} cannot be converted to a Roman numeral.")
@@ -139,7 +137,6 @@ def from_roman(s: str) -> Integral:
     5
     >>> from_roman('MMMMCCCLXVII')
     4367
-
     """
     if not isinstance(s, str):
         raise TypeError("The argument to from_roman must be a string.")
@@ -186,7 +183,6 @@ def is_roman_numeral(s: str) -> bool:
     True
     >>> is_roman_numeral("42")
     False
-
     """
     if not isinstance(s, str):
         raise TypeError("Only strings may be tested ")

--- a/plasmapy/utils/tests/test_code_repr.py
+++ b/plasmapy/utils/tests/test_code_repr.py
@@ -121,10 +121,8 @@ function_case = namedtuple("function_case", ("func", "args", "kwargs", "expected
     ],
 )
 def test_call_string(func, args, kwargs, expected):
-    """
-    Tests that call_string returns a string that is equivalent to the
-    function call.
-    """
+    """Tests that call_string returns a string that is equivalent to the
+    function call."""
     actual = call_string(func, args, kwargs, max_items=8)
     assert actual == expected, (
         "When call_string is called with:\n"
@@ -309,9 +307,10 @@ ndarray_case = namedtuple("ndarray_case", ("array_inputs", "max_items", "expecte
 )
 def test__code_repr_of_ndarray(array_inputs, max_items, expected):
     """
-    Test that `numpy.ndarray` objects get converted into a string as
-    expected.  Subsequently, test that evaluating the code representation
-    of an ndarray returns an array equal to the array created from
+    Test that `numpy.ndarray` objects get converted into a string as expected.
+
+    Subsequently, test that evaluating the code representation of an
+    ndarray returns an array equal to the array created from
     `array_inputs`.
     """
     array = np.array(array_inputs)
@@ -353,10 +352,8 @@ quantity_case = namedtuple("QuantityTestCases", ("quantity", "expected"))
     ],
 )
 def test__code_repr_of_quantity(quantity, expected):
-    """
-    Test that `astropy.units.Quantity` objects get converted into a
-    string as expected.
-    """
+    """Test that `astropy.units.Quantity` objects get converted into a string
+    as expected."""
     actual = _code_repr_of_quantity(quantity)
     assert actual == expected, (
         f"_code_repr_of_quantity for {quantity} is not producing the "
@@ -394,10 +391,8 @@ def test__string_together_warnings_for_printing():
     ],
 )
 def test__code_repr_of_arg(arg, expected):
-    """
-    Test that _code_repr_of_arg correctly transforms arguments into a
-    `str` the represents how the arg would appear in code.
-    """
+    """Test that _code_repr_of_arg correctly transforms arguments into a `str`
+    the represents how the arg would appear in code."""
     code_repr_of_arg = _code_repr_of_arg(arg)
     assert code_repr_of_arg == expected, (
         f"_code_repr_of_arg is not returning the expected result.\n"
@@ -418,11 +413,9 @@ def test__code_repr_of_arg(arg, expected):
     ],
 )
 def test__code_repr_of_args_and_kwargs(args, kwargs, expected):
-    """
-    Test that `_code_repr_of_args_and_kwargs` returns a string containing
-    the positional and keyword arguments, as they would appear in a
-    function call.
-    """
+    """Test that `_code_repr_of_args_and_kwargs` returns a string containing
+    the positional and keyword arguments, as they would appear in a function
+    call."""
     args_and_kwargs = _code_repr_of_args_and_kwargs(args, kwargs)
     assert args_and_kwargs == expected, (
         f"_code_repr_of_args_and_kwargs with the following arguments:\n"
@@ -447,10 +440,8 @@ def test__code_repr_of_args_and_kwargs(args, kwargs, expected):
     ],
 )
 def test__name_with_article(obj, expected):
-    """
-    Test that `_name_with_article` returns the expected string, which
-    contains ``"a "`` or ``"an "`` followed by the name of ``obj``.
-    """
+    """Test that `_name_with_article` returns the expected string, which
+    contains ``"a "`` or ``"an "`` followed by the name of ``obj``."""
     name_with_article = _name_with_article(obj)
     assert name_with_article == expected, (
         f"When calling _name_with_article for {obj}, expecting "

--- a/plasmapy/utils/tests/test_roman.py
+++ b/plasmapy/utils/tests/test_roman.py
@@ -155,37 +155,29 @@ fromRoman_exceptions_table = [
 
 @pytest.mark.parametrize("integer, roman_numeral", ints_and_roman_numerals)
 def test_to_roman(integer, roman_numeral):
-    """
-    Test that `~plasmapy.utils.roman.to_roman` correctly converts
-    integers to Roman numerals.
-    """
+    """Test that `~plasmapy.utils.roman.to_roman` correctly converts integers
+    to Roman numerals."""
     run_test(func=roman.to_roman, args=integer, expected_outcome=roman_numeral)
 
 
 @pytest.mark.parametrize("integer, roman_numeral", ints_and_roman_numerals)
 def test_from_roman(integer, roman_numeral):
-    """
-    Test that `~plasmapy.utils.roman.from_roman` correctly converts
-    Roman numerals to integers.
-    """
+    """Test that `~plasmapy.utils.roman.from_roman` correctly converts Roman
+    numerals to integers."""
     run_test(func=roman.from_roman, args=roman_numeral, expected_outcome=int(integer))
 
 
 @pytest.mark.parametrize("input, expected_exception", toRoman_exceptions_table)
 def test_to_roman_exceptions(input, expected_exception):
-    """
-    Test that `~plasmapy.utils.roman.to_roman` raises the correct
-    exceptions when necessary.
-    """
+    """Test that `~plasmapy.utils.roman.to_roman` raises the correct exceptions
+    when necessary."""
     run_test(func=roman.to_roman, args=input, expected_outcome=expected_exception)
 
 
 @pytest.mark.parametrize("input, expected_exception", fromRoman_exceptions_table)
 def test_from_roman_exceptions(input, expected_exception):
-    """
-    Test that `~plasmapy.utils.roman.from_roman` raises the correct
-    exceptions when necessary.
-    """
+    """Test that `~plasmapy.utils.roman.from_roman` raises the correct
+    exceptions when necessary."""
     run_test(func=roman.from_roman, args=input, expected_outcome=expected_exception)
 
 


### PR DESCRIPTION
This PR installs a pre-commit hook for [docformatter](https://github.com/myint/docformatter), which we can use to auto-format docstrings.  

Applying the changes all at once would probably lead to merge conflicts, so for now my intention is to make these changes only for files that are not being touched by any pull requests.  The rest of the formatting changes will get applied gradually and we touch files.

The only substantive change is in `.pre-commit-config.yaml`.  All of the other changes are being automatically applied.