### PR TITLE
Reformat docstrings in collisions.py

### DIFF
--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -469,9 +469,8 @@ def Coulomb_logarithm(
 
     See Also
     --------
-    ~plasmapy.formulary.collisions.impact_parameter :
-        Computes :math:`b_{min}` and :math:`b_{max}`.
-
+    ~plasmapy.formulary.collisions.impact_parameter : Computes
+        :math:`b_{min}` and :math:`b_{max}`.
     """
     # fetching impact min and max impact parameters
     bmin, bmax = impact_parameter(
@@ -622,14 +621,14 @@ def impact_parameter_perp(
 
     Raises
     ------
-    ValueError
+    `ValueError`
         If the mass or charge of either particle cannot be found, or
         any of the inputs contain incorrect values.
 
-    UnitConversionError
+    `~astropy.units.UnitConversionError`
         If the units on any of the inputs are incorrect.
 
-    TypeError
+    `TypeError`
         If either of ``T`` or ``V`` is not a `~astropy.units.Quantity`.
 
     `~plasmapy.utils.exceptions.RelativityError`
@@ -665,7 +664,6 @@ def impact_parameter_perp(
     ----------
     .. [1] Francis, F. Chen. Introduction to plasma physics and controlled
        fusion 3rd edition. Ch 5 (Springer 2015).
-
     """
     # boiler plate checks
     T, masses, charges, reduced_mass, V = _boilerPlate(T=T, species=species, V=V)
@@ -741,14 +739,14 @@ def impact_parameter(
 
     Raises
     ------
-    ValueError
+    `ValueError`
         If the mass or charge of either particle cannot be found, or any
         of the inputs contain incorrect values.
 
-    UnitConversionError
+    `~astropy.units.UnitConversionError`
         If the units on any of the inputs are incorrect.
 
-    TypeError
+    `TypeError`
         If any of ``n_e``, ``T``, or ``V`` is not a
         `~astropy.units.Quantity`.
 
@@ -978,7 +976,7 @@ def collision_frequency(
         of the inputs contain incorrect values.
 
     `~astropy.units.UnitConversionError`
-        If the units on any of the inputs are incorrect
+        If the units on any of the inputs are incorrect.
 
     `TypeError`
         If any of ``n_e``, ``T``, or ``V`` is not a


### PR DESCRIPTION
There were several docstrings in `collisions.py` with very long lines.  This PR wraps those lines to 72ish characters, and makes a few more stylistic changes.  There shouldn't be any substantive changes in this PR.  

I looked into a few auto-formatting tools for docstrings and reST files but I haven't found one that works well enough that we could run it on all of our files without running into any problems, unfortunately.