### PR TITLE
Discuss parametrization with argument unpacking in testing guide

### DIFF
--- a/changelog/1316.doc.rst
+++ b/changelog/1316.doc.rst
@@ -1,0 +1,2 @@
+Added a discussion of test parametrization with argument unpacking to
+the testing guide in the contributor guide.

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -466,7 +466,10 @@ functions or pass in tuples containing inputs and expected values.
 Parametrizing with argument unpacking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose we want to test a function called ``add``:
+When the number of arguments passed to a function varies, we can use
+argument unpacking_ along with test parametrization.  Suppose we want to
+test a function called ``add`` that accepts two positional arguments
+(``x`` and ``y``) and one optional keyword argument (``reverse_order``).
 
 .. code-block:: python
 
@@ -475,12 +478,18 @@ Suppose we want to test a function called ``add``:
            return y + x
        return x + y
 
-This function accepts ``x`` and ``y`` as positional arguments and
-``reverse_order`` as an optional keyword argument. We want to test
-`add`` while *specifying* or *not specifying* ``reverse_order``.
+We want to test ``add`` for three cases:
+
+* ``reverse_order`` is `True`,
+* ``reverse_order`` is `False`, and
+* `` reverse_order`` is *not specified*.
+
+To pass different styles
 
 When the number of arguments passed to a function varies, we can use
 argument unpacking_ in conjunction with test parametrization.
+Positional arguments are given in a `tuple` or `list` named ``args`` and
+keyword arguments are given in a `dict` named ``kwargs``.
 
 .. code-block:: python
 

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -467,29 +467,39 @@ Parametrizing with argument unpacking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the number of arguments passed to a function varies, we can use
-argument unpacking_ along with test parametrization.  Suppose we want to
-test a function called ``add`` that accepts two positional arguments
-(``x`` and ``y``) and one optional keyword argument (``reverse_order``).
+argument unpacking_ in conjunction with test parametrization.
+
+Suppose we want to test a function called ``add`` that accepts two
+positional arguments (``a`` and ``b``) and one optional keyword argument
+(``reverse_order``).
 
 .. code-block:: python
 
-   def add(x, y, reverse_order = False):
+   def add(a, b, reverse_order = False):
        if reverse_order:
-           return y + x
-       return x + y
+           return a + b
+       return a + b
+
+Argument unpacking_ lets us provide positional arguments in a `tuple` or
+`list` (commonly named :term:`args`) and keyword arguments in a `dict`
+(commonly named :term:`kwargs`). Unpacking_ occurs when ``args`` is
+preceded by ``*`` and ``kwargs`` is preceded by ``**``.
+
+.. code-block:: pycon
+
+   >>> args = ("1", "2")
+   >>> kwargs = {"reverse_order": True}
+   >>> add(*args, **kwargs)  # equivalent to add("1", "2", reverse_order=True)
+   '21'
 
 We want to test ``add`` for three cases:
 
 * ``reverse_order`` is `True`,
 * ``reverse_order`` is `False`, and
-* `` reverse_order`` is *not specified*.
+* ``reverse_order`` is *not specified*.
 
-To pass different styles
-
-When the number of arguments passed to a function varies, we can use
-argument unpacking_ in conjunction with test parametrization.
-Positional arguments are given in a `tuple` or `list` named ``args`` and
-keyword arguments are given in a `dict` named ``kwargs``.
+We can do this by parametrizing the test over ``args`` and ``kwargs``,
+and unpacking_ them inside of the test function.
 
 .. code-block:: python
 

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -481,9 +481,9 @@ positional arguments (``a`` and ``b``) and one optional keyword argument
        return a + b
 
 Argument unpacking_ lets us provide positional arguments in a `tuple` or
-`list` (commonly named :term:`args`) and keyword arguments in a `dict`
-(commonly named :term:`kwargs`). Unpacking_ occurs when ``args`` is
-preceded by ``*`` and ``kwargs`` is preceded by ``**``.
+`list` (commonly referred to as :term:`args`) and keyword arguments in a
+`dict` (commonly referred to as :term:`kwargs`). Unpacking_ occurs when
+``args`` is preceded by ``*`` and ``kwargs`` is preceded by ``**``.
 
 .. code-block:: pycon
 

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -100,10 +100,10 @@ The following checks are performed with each pull request.
 
   .. tip::
 
-    `Python 3.10 <https://docs.python.org/3.10/whatsnew/3.10.html>`__ and
-    `Python 3.11 <https://docs.python.org/3.11/whatsnew/3.11.html>`__
-    include (or will include) significant improvements to common error
-    messages.
+     `Python 3.10 <https://docs.python.org/3.10/whatsnew/3.10.html>`__ and
+     `Python 3.11 <https://docs.python.org/3.11/whatsnew/3.11.html>`__
+     include (or will include) significant improvements to common error
+     messages.
 
 * Checks with labels like **CI / Python 3.x with NumPy dev (pull
   request)** verify that PlasmaPy works the version of NumPy that is
@@ -333,10 +333,10 @@ to help us find the cause of a particular test failure.
 
 .. code-block:: python
 
-  def test_addition():
-      result = 2 + 2
-      expected = 4
-      assert result == expected, f"2 + 2 returns {result} instead of {expected}."
+   def test_addition():
+       result = 2 + 2
+       expected = 4
+       assert result == expected, f"2 + 2 returns {result} instead of {expected}."
 
 .. tip::
 
@@ -347,9 +347,9 @@ Floating point comparisons
 
 .. caution::
 
-  Using ``==`` to compare floating point numbers can lead to brittle
-  tests because of slight differences due to limited precision, rounding
-  errors, and revisions to fundamental constants.
+   Using ``==`` to compare floating point numbers can lead to brittle
+   tests because of slight differences due to limited precision,
+   rounding errors, and revisions to fundamental constants.
 
 In order to avoid these difficulties, use `numpy.testing.assert_allclose`
 when comparing floating point numbers and arrays, and
@@ -375,14 +375,14 @@ To test that a function issues an appropriate warning, use
 
 .. code-block:: python
 
-  import pytest, warnings
+   import pytest, warnings
 
-  def issue_warning():
-      warnings.warn("warning message", UserWarning)
+   def issue_warning():
+       warnings.warn("warning message", UserWarning)
 
-  def test_that_a_warning_is_issued():
-      with pytest.warns(UserWarning):
-          issue_warning()
+   def test_that_a_warning_is_issued():
+       with pytest.warns(UserWarning):
+           issue_warning()
 
 To test that a function raises an appropriate exception, use
 `pytest.raises`.
@@ -391,12 +391,12 @@ To test that a function raises an appropriate exception, use
 
   import pytest
 
-  def raise_exception():
-      raise Exception
+   def raise_exception():
+       raise Exception
 
-  def test_that_an_exception_is_raised():
-      with pytest.raises(Exception):
-          raise_exception()
+   def test_that_an_exception_is_raised():
+       with pytest.raises(Exception):
+           raise_exception()
 
 Test independence and parametrization
 -------------------------------------
@@ -420,9 +420,9 @@ function.
 
 .. code-block:: python
 
-  def test_proof_by_riemann_hypothesis():
-       assert proof_by_riemann(False)
-       assert proof_by_riemann(True)  # will only be run if the previous test passes
+   def test_proof_by_riemann_hypothesis():
+        assert proof_by_riemann(False)
+        assert proof_by_riemann(True)  # will only be run if the previous test passes
 
 If the first test were to fail, then the second test would never be run.
 We would therefore not know the potentially useful results of the second
@@ -431,11 +431,11 @@ both will be run.
 
 .. code-block:: python
 
-  def test_proof_if_riemann_false():
-       assert proof_by_riemann(False)
+   def test_proof_if_riemann_false():
+        assert proof_by_riemann(False)
 
-  def test_proof_if_riemann_true():
-       assert proof_by_riemann(True)
+   def test_proof_if_riemann_true():
+        assert proof_by_riemann(True)
 
 However, this approach can lead to cumbersome, repeated code if you are
 calling the same function over and over. If you wish to run multiple
@@ -444,9 +444,9 @@ tests for the same function, the preferred method is to use the
 
 .. code-block:: python
 
-  @pytest.mark.parametrize("truth_value", [True, False])
-  def test_proof_if_riemann(truth_value):
-       assert proof_by_riemann(truth_value)
+   @pytest.mark.parametrize("truth_value", [True, False])
+   def test_proof_if_riemann(truth_value):
+        assert proof_by_riemann(truth_value)
 
 This code snippet will run ``proof_by_riemann(truth_value)`` for each
 ``truth_value`` in ``[True, False]``. Both of the above

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -463,8 +463,8 @@ functions or pass in tuples containing inputs and expected values.
    def test_proof_if_riemann(truth_value, expected):
        assert proof_by_riemann(truth_value) == expected
 
-Parametrizing with argument unpacking
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Test parametrization with argument unpacking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the number of arguments passed to a function varies, we can use
 argument unpacking_ in conjunction with test parametrization.

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -459,9 +459,44 @@ functions or pass in tuples containing inputs and expected values.
 
 .. code-block:: python
 
-  @pytest.mark.parametrize("truth_value, expected", [(True, True), (False, True)])
-  def test_proof_if_riemann(truth_value, expected):
+   @pytest.mark.parametrize("truth_value, expected", [(True, True), (False, True)])
+   def test_proof_if_riemann(truth_value, expected):
        assert proof_by_riemann(truth_value) == expected
+
+Parametrizing with argument unpacking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Suppose we want to test a function called ``add``:
+
+.. code-block:: python
+
+   def add(x, y, reverse_order = False):
+       if reverse_order:
+           return y + x
+       return x + y
+
+This function accepts ``x`` and ``y`` as positional arguments and
+``reverse_order`` as an optional keyword argument. We want to test
+`add`` while *specifying* or *not specifying* ``reverse_order``.
+
+When the number of arguments passed to a function varies, we can use
+argument unpacking_ in conjunction with test parametrization.
+
+.. code-block:: python
+
+   @pytest.mark.parametrize(
+       "args, kwargs, expected",
+       [
+           # test that add("1", "2", reverse_order=False) == "12"
+           (["1", "2"], {"reverse_order": False}, "12"),
+           # test that add("1", "2", reverse_order=True) == "21"
+           (["1", "2"], {"reverse_order": True}, "21"),
+           # test that add("1", "2") == "12"
+           (["1", "2"], {}, "12"),  # if no keyword arguments, use an empty dict
+       ]
+   )
+   def test_add(args, kwargs, expected):
+       assert add(*args, **kwargs) == expected
 
 Fixtures
 --------
@@ -682,4 +717,5 @@ should be balanced with each other rather than absolute principles.
 .. _`test warnings`: https://docs.pytest.org/en/latest/warnings.html#warns
 .. _`test exceptions`: https://docs.pytest.org/en/latest/assert.html#assertions-about-expected-exceptions
 .. _`tox environments`: https://tox.readthedocs.io/en/latest/config.html?highlight=py37#tox-environments
+.. _unpacking: https://docs.python.org/3/tutorial/controlflow.html#unpacking-argument-lists
 .. _`Visual Studio`: https://visualstudio.microsoft.com/


### PR DESCRIPTION
This PR expands the testing guide to include an example where we want to test a function both with and without a keyword argument so that we use argument unpacking. 

I still need to briefly mention what `*args` and `**kwargs` do in this example.