### PR TITLE
Update cron tests

### DIFF
--- a/.github/workflows/fortnightly.yml
+++ b/.github/workflows/fortnightly.yml
@@ -1,8 +1,8 @@
-name: monthly tests
+name: fortnightly tests
 
 on:
   schedule:
-  - cron: 17 7 1 * *
+  - cron: 17 7 1,15 * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fortnightly.yml
+++ b/.github/workflows/fortnightly.yml
@@ -20,31 +20,31 @@ jobs:
           python: 3.8
           toxenv: py38-astropydev
 
+        - name: Python 3.8 with matplotlib dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-matplotlibdev
+
         - name: Python 3.8 with NumPy dev
           os: ubuntu-latest
           python: 3.8
           toxenv: py38-numpydev
 
-        - name: Python 3.8 with xarray dev
-          os: ubuntu-latest
-          python: 3.8
-          toxenv: py38-xarraydev
-
         - name: Python 3.8 with SciPy dev
           os: ubuntu-latest
           python: 3.8
-          toxenv: py38-dev
-
-        - name: Python 3.8 with matplotlib dev
-          os: ubuntu-latest
-          python: 3.8
-          toxenv: py38-matplotlibdev
+          toxenv: py38-scipydev
 
         - name: Documentation with Sphinx dev
           os: ubuntu-latest
           python: 3.8
           toxenv: build_docs-sphinxdev
           toxposargs: -q
+
+        - name: Python 3.8 with xarray dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-xarraydev
 
     steps:
     - name: Checkout code

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,8 +1,8 @@
-name: weekly tests
+name: monthly tests
 
 on:
   schedule:
-  - cron: 17 7 * * 1
+  - cron: 17 7 1 * *
   workflow_dispatch:
 
 jobs:
@@ -29,6 +29,16 @@ jobs:
           os: ubuntu-latest
           python: 3.8
           toxenv: py38-xarraydev
+
+        - name: Python 3.8 with SciPy dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-dev
+
+        - name: Python 3.8 with matplotlib dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-matplotlibdev
 
         - name: Documentation with Sphinx dev
           os: ubuntu-latest

--- a/changelog/1333.trivial.rst
+++ b/changelog/1333.trivial.rst
@@ -1,0 +1,3 @@
+Added cron tests of the development versions of matplotlib and SciPy,
+while changing the cadence of cron tests to be run approxiately
+fortnightly.

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,12 @@ setenv =
     PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 -n=auto --dist=loadfile
 extras = tests
 deps =
-    numpydev: git+https://github.com/numpy/numpy
     astropydev: git+https://github.com/astropy/astropy
-    xarraydev: git+https://github.com/pydata/xarray
-    sphinxdev: git+https://github.com/sphinx-doc/sphinx
     matplotlibdev: git+https://github.com/matplotlib/matplotlib
+    numpydev: git+https://github.com/numpy/numpy
     scipydev: git+https://github.com/matplotlib/matplotlib
+    sphinxdev: git+https://github.com/sphinx-doc/sphinx
+    xarraydev: git+https://github.com/pydata/xarray
     cov: pytest-cov
     !minimal: pytest-xdist
     pytest-github-actions-annotate-failures
@@ -27,12 +27,12 @@ commands =
     cov-slow: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml -m 'slow'
 description =
     run tests
-    numpydev: with the development version of numpy
     astropydev: with the development version of astropy
-    xarraydev: with the development version of xarray
-    sphinxdev: with the development version of sphinx
     matplotlibdev: with the development version of matplotlib
+    numpydev: with the development version of numpy
     scipydev: with the development version of scipy
+    sphinxdev: with the development version of sphinx
+    xarraydev: with the development version of xarray
     minimal: with minimal versions of dependencies
     cov: with code coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = clean,py37,build_docs
 isolated_build = True
+indexserver =
+    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
 whitelist_externals=
@@ -14,8 +16,8 @@ extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
     matplotlibdev: git+https://github.com/matplotlib/matplotlib
-    numpydev: git+https://github.com/numpy/numpy
-    scipydev: git+https://github.com/matplotlib/matplotlib
+    numpydev: :NIGHTLY:numpy
+    scipydev: :NIGHTLY:scipy
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
     cov: pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     astropydev: git+https://github.com/astropy/astropy
     xarraydev: git+https://github.com/pydata/xarray
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
+    matplotlibdev: git+https://github.com/matplotlib/matplotlib
+    scipydev: git+https://github.com/matplotlib/matplotlib
     cov: pytest-cov
     !minimal: pytest-xdist
     pytest-github-actions-annotate-failures
@@ -25,9 +27,12 @@ commands =
     cov-slow: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml -m 'slow'
 description =
     run tests
-    numpydev: with the git main version of numpy
-    astropydev: with the git main version of astropy
-    xarraydev: with the git master version of xarray
+    numpydev: with the development version of numpy
+    astropydev: with the development version of astropy
+    xarraydev: with the development version of xarray
+    sphinxdev: with the development version of sphinx
+    matplotlibdev: with the development version of matplotlib
+    scipydev: with the development version of scipy
     minimal: with minimal versions of dependencies
     cov: with code coverage
 


### PR DESCRIPTION
 - I changed weekly tests to approximately fortnightly since that seemed a more appropriate cadence, and because it's an excuse to use the word "fortnightly".  
 - I added tests of the development versions of matplotlib (inspired by #1330) and SciPy so that we can catch any API changes before official releases.