### PR TITLE
Bump minimum version of matplotlib and enable matplotlib 3.5.0

### DIFF
--- a/changelog/1334.trivial.rst
+++ b/changelog/1334.trivial.rst
@@ -1,2 +1,3 @@
-Increased the minimum version of matplotlib to 3.3.0 and enabled
-compatibility with matplotlib 3.5.0.
+Increased the minimum version of matplotlib to 3.3.0 and updated
+`plasmapy.diagnostics.langmuir.swept_probe_analysis` to be compatible
+with matplotlib 3.5.0.

--- a/changelog/1334.trivial.rst
+++ b/changelog/1334.trivial.rst
@@ -1,0 +1,2 @@
+Increased the minimum version of matplotlib to 3.3.0 and enabled
+compatibility with matplotlib 3.5.0.

--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -415,7 +415,7 @@ def swept_probe_analysis(
                 c="c",
             )
             ax2.plot(tot_current.bias, np.abs(tot_current.current), c="g")
-            ax2.set_yscale("log", nonposy="clip")
+            ax2.set_yscale("log", nonpositive="clip")
             ax1.legend(loc="best")
             ax2.legend(loc="best")
 

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - scipy
 - astropy
 - h5py
-- matplotlib
+- matplotlib >= 3.3.0
 - mpmath
 - pandas
 - pillow

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -2,7 +2,7 @@
 # ought to mirror 'install_requires' under 'options' in setup.cfg
 astropy >= 4.0
 cached-property >= 1.5.2
-matplotlib >= 3.2
+matplotlib >= 3.3.0
 numpy >= 1.18.1
 packaging
 pandas >= 1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
   # ought to mirror requirements/install.txt
   astropy >= 4.0
   cached-property >= 1.5.2
-  matplotlib >= 3.2
+  matplotlib >= 3.3.0
   numpy >= 1.18.1
   packaging
   pandas >= 1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -93,6 +93,7 @@ deps =
   pytest==5.1
   mpmath==1.0
   tqdm==4.41.0
+  xarray==0.14.0
   pillow
   hypothesis
   pytest-regressions

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ deps =
   scipy==1.2
   astropy==4.0
   h5py==2.8
-  matplotlib==2.0
+  matplotlib==3.3.0
   pytest==5.1
   mpmath==1.0
   tqdm==4.41.0


### PR DESCRIPTION
The `nonposy` keyword was removed from matplotlib 3.5.0, and replaced with `nonpositive` which was added in matplotlib 3.3.0.  The easiest fix was to replace `nonposy` with `nonpositive` and bump the minimum version of matplotlib from 3.2.0 to 3.3.0.  

If we wanted to stay compatible with matplotlib 3.2.0, an alternative would be to put a `try`/`except` clause to catch the `TypeError`.  I don't prefer that approach because that fix is less permanent.