### PR TITLE
Drop scipy-dev tests for now

### DIFF
--- a/.github/workflows/fortnightly.yml
+++ b/.github/workflows/fortnightly.yml
@@ -30,11 +30,6 @@ jobs:
           python: 3.8
           toxenv: py38-numpydev
 
-        - name: Python 3.8 with SciPy dev
-          os: ubuntu-latest
-          python: 3.8
-          toxenv: py38-scipydev
-
         - name: Documentation with Sphinx dev
           os: ubuntu-latest
           python: 3.8

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps =
     astropydev: git+https://github.com/astropy/astropy
     matplotlibdev: git+https://github.com/matplotlib/matplotlib
     numpydev: :NIGHTLY:numpy
-    scipydev: :NIGHTLY:scipy
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
     cov: pytest-cov
@@ -32,7 +31,6 @@ description =
     astropydev: with the development version of astropy
     matplotlibdev: with the development version of matplotlib
     numpydev: with the development version of numpy
-    scipydev: with the development version of scipy
     sphinxdev: with the development version of sphinx
     xarraydev: with the development version of xarray
     minimal: with minimal versions of dependencies


### PR DESCRIPTION
Drops the failing scipy-dev cron job test from #1341.