### PR TITLE
Two stages of tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -105,10 +105,48 @@ jobs:
       uses: codecov/codecov-action@v2.1.0
       with:
         file: ./coverage.xml
+  documentation:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    needs: initial-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+        - name: Documentation
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: build_docs
+          toxposargs: -q
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2.3.0
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install Python dependencies
+      run: python -m pip install --progress-bar off --upgrade tox codecov
+    - name: Install language-pack-fr and tzdata
+      if: startsWith(matrix.name, 'Documentation')
+      run: sudo apt-get install graphviz pandoc
+    - name: Run tests
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+    - name: Upload coverage to codecov
+      if: ${{ contains(matrix.toxenv,'-cov') }}
+      uses: codecov/codecov-action@v2.1.0
+      with:
+        file: ./coverage.xml
   build-n-publish:
     name: Packaging
     runs-on: ubuntu-18.04
-    needs: comprehensive-tests
+    needs:
+    - comprehensive-tests
+    - documentation
     steps:
     - uses: actions/checkout@v2.4.0
     - name: Get history and tags for SCM versioning to work

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -108,7 +108,6 @@ jobs:
   documentation:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    needs: initial-tests
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,9 +12,41 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests:
+  initial-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+        - name: Python 3.9
+          os: ubuntu-latest
+          python: 3.9
+          toxenv: py39
+
+        - name: Linters
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: linters
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2.3.0
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install Python dependencies
+      run: python -m pip install --progress-bar off --upgrade tox codecov
+    - name: Run tests
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+  comprehensive-tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    needs: initial-tests
     strategy:
       fail-fast: false
       matrix:
@@ -23,49 +55,34 @@ jobs:
         - name: Python 3.7 with minimal dependencies
           os: ubuntu-latest
           python: 3.7
-          toxenv: py37-minimal
+          toxenv: py37-all-minimal
 
         - name: Python 3.7
           os: ubuntu-latest
           python: 3.7
-          toxenv: py37
+          toxenv: py37-all
 
-        - name: Python 3.8 with code coverage
+        - name: Python 3.8, all tests, code coverage
           os: ubuntu-latest
           python: 3.8
-          toxenv: py38-cov
-
-        - name: Python 3.8, slow tests with code coverage
-          os: ubuntu-latest
-          python: 3.8
-          toxenv: py38-slow-cov
-
-        - name: Python 3.9
-          os: ubuntu-latest
-          python: 3.9
-          toxenv: py39
+          toxenv: py38-all-cov
 
         - name: Python 3.8 (Windows)
           os: windows-latest
           python: 3.8
-          toxenv: py38
+          toxenv: py38-all
           toxposargs: --durations=50
 
         - name: Python 3.8 (MacOS X)
           os: macos-latest
           python: 3.8
-          toxenv: py38
+          toxenv: py38-all
 
         - name: Documentation
           os: ubuntu-latest
           python: 3.8
           toxenv: build_docs
           toxposargs: -q
-
-        - name: Linters
-          os: ubuntu-latest
-          python: 3.8
-          toxenv: linters
 
     steps:
     - name: Checkout code
@@ -91,7 +108,7 @@ jobs:
   build-n-publish:
     name: Packaging
     runs-on: ubuntu-18.04
-    needs: tests
+    needs: comprehensive-tests
     steps:
     - uses: actions/checkout@v2.4.0
     - name: Get history and tags for SCM versioning to work

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --upgrade tox codecov
+      run: python -m pip install --progress-bar off --upgrade tox codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc
@@ -104,8 +104,8 @@ jobs:
         python-version: 3.7
     - name: Install requirements
       run: |
-        pip install --upgrade pip
-        pip install setuptools numpy wheel setuptools_scm twine
+        pip install --progress-bar off --upgrade pip
+        pip install --progress-bar off setuptools numpy wheel setuptools_scm twine
     - name: Build a binary wheel
       run: python setup.py bdist_wheel
     - name: Build a source tarball
@@ -115,7 +115,7 @@ jobs:
     - name: Install PlasmaPy in all variants
       run: |
         pip install --progress-bar off .[all,dev]
-        pip install -e .[all,dev]
+        pip install --progress-bar off -e .[all,dev]
         python setup.py develop
     - name: Publish distribution, if tagged, 📦 to PyPI
       if: ${{ startsWith(github.ref, 'refs/tags') && !endsWith(github.ref, 'dev') }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -114,9 +114,8 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox codecov
+      run: python -m pip install --progress-bar off --upgrade tox
     - name: Install language-pack-fr and tzdata
-      if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc
     - name: Run tests
       run: tox  -e build_docs -- -q

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,12 +78,6 @@ jobs:
           python: 3.8
           toxenv: py38-all
 
-        - name: Documentation
-          os: ubuntu-latest
-          python: 3.8
-          toxenv: build_docs
-          toxposargs: -q
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v2.4.0
@@ -106,19 +100,10 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+    name: Documentation
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-
-        - name: Documentation
-          os: ubuntu-latest
-          python: 3.8
-          toxenv: build_docs
-          toxposargs: -q
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v2.4.0
@@ -127,19 +112,14 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2.3.0
       with:
-        python-version: ${{ matrix.python }}
+        python-version: 3.8
     - name: Install Python dependencies
       run: python -m pip install --progress-bar off --upgrade tox codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc
     - name: Run tests
-      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
-    - name: Upload coverage to codecov
-      if: ${{ contains(matrix.toxenv,'-cov') }}
-      uses: codecov/codecov-action@v2.1.0
-      with:
-        file: ./coverage.xml
+      run: tox  -e build_docs -- -q
   build-n-publish:
     name: Packaging
     runs-on: ubuntu-18.04

--- a/changelog/1350.trivial.rst
+++ b/changelog/1350.trivial.rst
@@ -1,0 +1,1 @@
+Split the tests running on PRs into multiple stages. The various Pytest test environments, including code coverage, now run conditionally given succesful execution of a basic test env and the linter checks. This also prevents code coverage prompts from appearing twice, with incomplete information on the first time.

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ conda_deps =
   sphinx_rtd_theme
 
 # This env tests minimal versions of each dependency.
-[testenv:py37-minimal]
+[testenv:py37-all-minimal]
 basepython = python3.7
 extras =
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ deps =
     pytest-github-actions-annotate-failures
 commands =
     !cov: {env:PYTEST_COMMAND} {posargs} -m 'not slow'
-    cov: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml -m 'not slow'
-    cov-slow: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml -m 'slow'
+    all: {env:PYTEST_COMMAND} {posargs}
+    cov-all: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml
 description =
     run tests
     astropydev: with the development version of astropy


### PR DESCRIPTION
What this does can be best seen in the [Checks tab](https://github.com/PlasmaPy/PlasmaPy/pull/1350/checks). I split tests into two groups, one happening after the other, and moved code coverage to a single run in the latter. If I got it right, the second stage should run conditionally on the first one (linters and one quick run of tests, except the slow ones), and codecov should only trigger once.