### PR TITLE
Enable sphinx-hoverxref for documentation

### DIFF
--- a/changelog/1353.doc.rst
+++ b/changelog/1353.doc.rst
@@ -1,0 +1,2 @@
+Enabled the `sphinx-hoverxref <https://sphinx-hoverxref.readthedocs.io>`_
+extension to Sphinx.

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -156,3 +156,6 @@
 
 .. _`sphinx_changelog`: https://sphinx-changelog.readthedocs.io
 .. |sphinx_changelog| replace:: `sphinx_changelog`
+
+.. _`sphinx-hoverxref`: https://sphinx-hoverxref.readthedocs.io
+.. |sphinx-hoverxref| replace:: `sphinx-hoverxref`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ extensions = [
     "sphinx_changelog",
     "plasmapy_sphinx",
     "sphinxcontrib.bibtex",
+    "sphinx-hoverxref",
 ]
 
 bibtex_bibfiles = ["bibliography.bib"]
@@ -185,6 +186,8 @@ linkcheck_anchors_ignore = [
 
 # Use a code highlighting style that meets the WCAG AA contrast standard
 pygments_style = "xcode"
+
+hoverxref_auto_ref = True
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ extensions = [
     "sphinx_changelog",
     "plasmapy_sphinx",
     "sphinxcontrib.bibtex",
-    "sphinx-hoverxref",
+    "hoverxref.extension",
 ]
 
 bibtex_bibfiles = ["bibliography.bib"]

--- a/docs/development/doc_guide.rst
+++ b/docs/development/doc_guide.rst
@@ -360,6 +360,8 @@ extensions:
 * |sphinx_gallery.load_style|_ for using sphinx-gallery styles.
 * |IPython.sphinxext.ipython_console_highlighting|_.
 * |sphinx_changelog|_ for rendering `towncrier`_ changelogs.
+* |sphinx-hoverxref|_ for showing floating windows on cross references
+  of the documentation.
 * `plasmapy_sphinx` for customizations created for use in PlasmaPy and
   affiliated packages. Note that `plasmapy_sphinx` is expected to be
   broken out into its own package in the future.

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,6 +12,7 @@ sphinx >= 3.2.0
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery
+sphinx-hoverxref >= 1.0.0
 sphinx_rtd_theme >= 1.0.0
 sphinxcontrib-bibtex
 towncrier >= 19.2.0

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - pygments >= 2.4.1
   - sphinx >= 3.2.0
   - sphinx-gallery
+  - sphinx-hoverxref >= 1.0.0
   - sphinx_rtd_theme >= 1.0.0
   - towncrier >= 19.2.0
   - pytest-regressions

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,7 @@ docs =
   sphinx-changelog
   sphinx-copybutton
   sphinx-gallery
+  sphinx-hoverxref >= 1.0.0
   sphinxcontrib-bibtex
   sphinx_rtd_theme >= 1.0.0
   towncrier >= 19.2.0


### PR DESCRIPTION
This PR enables [sphinx-hoverxref](https://sphinx-hoverxref.readthedocs.io/en/latest/) for our docs.  From their documentation:

> sphinx-hoverxref is a Sphinx extension to show a floating window (tooltips or modal dialogues) on the cross references of the documentation embedding the content of the linked section on them. With sphinx-hoverxref, you don’t need to click a link to see what’s in there.

Many thanks to @StanczakDominik for bringing this up in the chat!