### PR TITLE
Fix linter errors

### DIFF
--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -29,6 +29,16 @@ class AbstractFitFunction(ABC):
     """
     Abstract class for defining fit functions :math:`f(x)` and the tools for
     fitting the function to a set of data.
+
+    Parameters
+    ----------
+    params: Tuple[float, ...], optional
+        Tuple of values for the function parameters. Equal in size to
+        :attr:`param_names`.
+
+    param_errors: Tuple[float, ...], optional
+        Tuple of values for the errors associated with the function
+        parameters.  Equal in size to :attr:`param_names`.
     """
 
     _param_names = NotImplemented  # type: Tuple[str, ...]
@@ -38,19 +48,6 @@ class AbstractFitFunction(ABC):
         params: Tuple[float, ...] = None,
         param_errors: Tuple[float, ...] = None,
     ):
-        """
-        Create an instance of the class.
-
-        Parameters
-        ----------
-        params: Tuple[float, ...], optional
-            Tuple of values for the function parameters. Equal in size to
-            :attr:`param_names`.
-
-        param_errors: Tuple[float, ...], optional
-            Tuple of values for the errors associated with the function
-            parameters.  Equal in size to :attr:`param_names`.
-        """
 
         self._FitParamTuple = namedtuple("FitParamTuple", self._param_names)
 

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -48,7 +48,6 @@ class AbstractFitFunction(ABC):
         param_errors: Tuple[float, ...], optional
             Tuple of values for the errors associated with the function
             parameters.  Equal in size to :attr:`param_names`.
-
         """
 
         self._FitParamTuple = namedtuple("FitParamTuple", self._param_names)
@@ -203,7 +202,6 @@ class AbstractFitFunction(ABC):
             J. R. Taylor.  *An Introduction to Error Analysis: The Study of
             Uncertainties in Physical Measurements.* University Science Books,
             second edition, August 1996 (ISBN: 093570275X)
-
         """
         ...
 

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -29,16 +29,6 @@ class AbstractFitFunction(ABC):
     """
     Abstract class for defining fit functions :math:`f(x)` and the tools for
     fitting the function to a set of data.
-
-    Parameters
-    ----------
-    params: Tuple[float, ...], optional
-        Tuple of values for the function parameters. Equal in size to
-        :attr:`param_names`.
-
-    param_errors: Tuple[float, ...], optional
-        Tuple of values for the errors associated with the function
-        parameters.  Equal in size to :attr:`param_names`.
     """
 
     _param_names = NotImplemented  # type: Tuple[str, ...]
@@ -48,6 +38,18 @@ class AbstractFitFunction(ABC):
         params: Tuple[float, ...] = None,
         param_errors: Tuple[float, ...] = None,
     ):
+        """
+        Parameters
+        ----------
+        params: Tuple[float, ...], optional
+            Tuple of values for the function parameters. Equal in size to
+            :attr:`param_names`.
+
+        param_errors: Tuple[float, ...], optional
+            Tuple of values for the errors associated with the function
+            parameters.  Equal in size to :attr:`param_names`.
+
+        """
 
         self._FitParamTuple = namedtuple("FitParamTuple", self._param_names)
 
@@ -171,9 +173,6 @@ class AbstractFitFunction(ABC):
     )
     def func_err(self, x, x_err=None, rety=False):
         """
-        Return calculated uncertainties of the independent variables and
-        the associated dependent variables.
-
         Parameters
         ----------
         x: array_like
@@ -204,6 +203,7 @@ class AbstractFitFunction(ABC):
             J. R. Taylor.  *An Introduction to Error Analysis: The Study of
             Uncertainties in Physical Measurements.* University Science Books,
             second edition, August 1996 (ISBN: 093570275X)
+
         """
         ...
 

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -39,6 +39,8 @@ class AbstractFitFunction(ABC):
         param_errors: Tuple[float, ...] = None,
     ):
         """
+        Create an instance of the class.
+
         Parameters
         ----------
         params: Tuple[float, ...], optional

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -172,6 +172,9 @@ class AbstractFitFunction(ABC):
     )
     def func_err(self, x, x_err=None, rety=False):
         """
+        Return calculated uncertainties of the independent variables and
+        the associated dependent variables.
+
         Parameters
         ----------
         x: array_like

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -1196,7 +1196,6 @@ class CartesianGrid(AbstractGrid):
 
         Notes
         -----
-
         This interpolator approximates the value of a quantity at a given
         interpolation point using a weighted sum of the values at the eight grid
         vertices that surround the point. The weighting factors are calculated by

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -52,6 +52,7 @@ class PlasmaBlob(GenericPlasma):
 
     def __repr__(self):
         """
+        Return a string representation of this instance.
 
         Returns
         -------

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -146,7 +146,7 @@ class CheckValues(CheckBase):
 
     def __call__(self, f):
         """
-        Wrap the function.
+        Decorate a function.
 
         Parameters
         ----------
@@ -480,7 +480,7 @@ class CheckUnits(CheckBase):
 
     def __call__(self, f):
         """
-        Wrap the function.
+        Decorate a function.
 
         Parameters
         ----------

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -146,6 +146,8 @@ class CheckValues(CheckBase):
 
     def __call__(self, f):
         """
+        Wrap the function.
+
         Parameters
         ----------
         f
@@ -478,6 +480,8 @@ class CheckUnits(CheckBase):
 
     def __call__(self, f):
         """
+        Wrap the function.
+
         Parameters
         ----------
         f

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -165,7 +165,7 @@ class ValidateQuantities(CheckUnits, CheckValues):
 
     def __call__(self, f):
         """
-        Wrap the function.
+        Decorate a function.
 
         Parameters
         ----------

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -165,6 +165,8 @@ class ValidateQuantities(CheckUnits, CheckValues):
 
     def __call__(self, f):
         """
+        Wrap the function.
+
         Parameters
         ----------
         f

--- a/setup.cfg
+++ b/setup.cfg
@@ -214,6 +214,7 @@ per-file-ignores =
     plasmapy/formulary/__init__.py:F403
     plasmapy/__init__.py:FS003
     plasmapy/diagnostics/charged_particle_radiography.py:FS003
+    plasmapy/analysis/fit_functions.py:RST499
 
 [coverage:run]
 omit =


### PR DESCRIPTION
This is to fix some linter errors that showed up from an update of `pyflakes rst-docstrings`.  Closes #1355.

 - [ ] Check that modified docstrings in `__call__` methods are displaying correctly in the docs.
 - [ ] Check that modified docstrings in `__call__` methods contain correct information