### PR TITLE
Create helper function to sort an iterable into a `dict` with `PhysicalType` objects as keys

### DIFF
--- a/changelog/1360.trivial.rst
+++ b/changelog/1360.trivial.rst
@@ -1,0 +1,3 @@
+Added a helper function that takes an iterable and creates a `dict` with
+physical types as keys and the corresponding objects from that iterable
+as values.

--- a/changelog/1360.trivial.rst
+++ b/changelog/1360.trivial.rst
@@ -1,3 +1,4 @@
 Added a helper function that takes an iterable and creates a `dict` with
 physical types as keys and the corresponding objects from that iterable
-as values.
+as values. This change updates the minimum required version of Astropy
+to 4.3.1.

--- a/plasmapy/utils/tests/test_units_helpers.py
+++ b/plasmapy/utils/tests/test_units_helpers.py
@@ -1,3 +1,5 @@
+"""Tests of `plasmapy.utils.units_helpers`."""
+
 import astropy.units as u
 import pytest
 

--- a/plasmapy/utils/tests/test_units_helpers.py
+++ b/plasmapy/utils/tests/test_units_helpers.py
@@ -1,17 +1,72 @@
 import astropy.units as u
-import astropy.units.physical as physical
 import pytest
+
+from astropy.constants import c, m_e
+from collections import namedtuple
 
 from plasmapy.utils.units_helpers import get_physical_type_dict
 
 
-@pytest.fixture
-def pre_physical_type_dict():
-    units = (u.m, u.m ** -3, u.m * u.s)
-    return {unit.physical_type: 5 * unit for unit in units}
+def test_get_physical_type_dict_specific_example():
+    units = [u.m, u.m ** -3, u.m * u.s]
+    quantities = [5 * unit for unit in units]
+    expected = {quantity.unit.physical_type: quantity for quantity in quantities}
+    new_physical_type_dict = get_physical_type_dict(quantities)
+    assert new_physical_type_dict == expected
 
 
-def test_get_physical_type(pre_physical_type_dict):
-    units = pre_physical_type_dict.values()
-    new_physical_type_dict = get_physical_type_dict(units)
-    assert pre_physical_type_dict == new_physical_type_dict
+velocity = u.get_physical_type("velocity")
+mass = u.get_physical_type("mass")
+dimensionless = u.get_physical_type(1)
+
+test_case = namedtuple("case", ["collection", "kwargs", "expected"])
+
+
+test_cases = [
+    test_case(
+        collection=(c, m_e),
+        kwargs={},
+        expected={velocity: c, mass: m_e},
+    ),
+    test_case(
+        collection=(c, 5),
+        kwargs={"only_quantities": True, "numbers_become_quantities": True},
+        expected={velocity: c, dimensionless: u.Quantity(5)},
+    ),
+    test_case(
+        collection=(c, 5),
+        kwargs={"only_quantities": False, "numbers_become_quantities": True},
+        expected={velocity: c, dimensionless: u.Quantity(5)},
+    ),
+    test_case(
+        collection=(c, 5),
+        kwargs={"only_quantities": True, "numbers_become_quantities": False},
+        expected={velocity: c},
+    ),
+    test_case(
+        collection=(c, 5),
+        kwargs={"only_quantities": False, "numbers_become_quantities": False},
+        expected={velocity: c, dimensionless: 5},
+    ),
+]
+
+
+@pytest.mark.parametrize("collection, kwargs, expected", test_cases)
+def test_get_physical_type_dict(collection, kwargs, expected):
+    physical_type_dict = get_physical_type_dict(collection, **kwargs)
+    assert physical_type_dict == expected
+
+
+test_cases_exceptions = [
+    test_case(
+        collection=(u.m, 5 * u.m),
+        kwargs={},
+        expected=ValueError,
+    ),
+]
+
+
+@pytest.mark.parametrize("collection, kwargs, expected", test_cases_exceptions)
+def test_get_physical_type_dict_exceptions(collection, kwargs, expected):
+    with pytest.raises(expected):
+        get_physical_type_dict(collection, **kwargs)

--- a/plasmapy/utils/tests/test_units_helpers.py
+++ b/plasmapy/utils/tests/test_units_helpers.py
@@ -1,0 +1,17 @@
+import astropy.units as u
+import astropy.units.physical as physical
+import pytest
+
+from plasmapy.utils.units_helpers import get_physical_type_dict
+
+
+@pytest.fixture
+def pre_physical_type_dict():
+    units = (u.m, u.m ** -3, u.m * u.s)
+    return {unit.physical_type: 5 * unit for unit in units}
+
+
+def test_get_physical_type(pre_physical_type_dict):
+    units = pre_physical_type_dict.values()
+    new_physical_type_dict = get_physical_type_dict(units)
+    assert pre_physical_type_dict == new_physical_type_dict

--- a/plasmapy/utils/tests/test_units_helpers.py
+++ b/plasmapy/utils/tests/test_units_helpers.py
@@ -50,6 +50,11 @@ test_cases = [
         kwargs={"only_quantities": False, "numbers_become_quantities": False},
         expected={velocity: c, dimensionless: 5},
     ),
+    test_case(
+        collection=("...", "....", set()),
+        kwargs={"only_quantities": False, "numbers_become_quantities": False},
+        expected={},
+    ),
 ]
 
 

--- a/plasmapy/utils/tests/test_units_helpers.py
+++ b/plasmapy/utils/tests/test_units_helpers.py
@@ -4,14 +4,14 @@ import pytest
 from astropy.constants import c, m_e
 from collections import namedtuple
 
-from plasmapy.utils.units_helpers import get_physical_type_dict
+from plasmapy.utils.units_helpers import _get_physical_type_dict
 
 
 def test_get_physical_type_dict_specific_example():
     units = [u.m, u.m ** -3, u.m * u.s]
     quantities = [5 * unit for unit in units]
     expected = {quantity.unit.physical_type: quantity for quantity in quantities}
-    new_physical_type_dict = get_physical_type_dict(quantities)
+    new_physical_type_dict = _get_physical_type_dict(quantities)
     assert new_physical_type_dict == expected
 
 
@@ -53,7 +53,7 @@ test_cases = [
 
 @pytest.mark.parametrize("collection, kwargs, expected", test_cases)
 def test_get_physical_type_dict(collection, kwargs, expected):
-    physical_type_dict = get_physical_type_dict(collection, **kwargs)
+    physical_type_dict = _get_physical_type_dict(collection, **kwargs)
     assert physical_type_dict == expected
 
 
@@ -69,4 +69,4 @@ test_cases_exceptions = [
 @pytest.mark.parametrize("collection, kwargs, expected", test_cases_exceptions)
 def test_get_physical_type_dict_exceptions(collection, kwargs, expected):
     with pytest.raises(expected):
-        get_physical_type_dict(collection, **kwargs)
+        _get_physical_type_dict(collection, **kwargs)

--- a/plasmapy/utils/units_helpers.py
+++ b/plasmapy/utils/units_helpers.py
@@ -31,8 +31,10 @@ def _get_physical_type_dict(
 
     only_quantities : `bool`, keyword-only, optional
         If `True`, only `~astropy.units.Quantity` instances in
-        ``iterable`` will be passed into the resulting `dict`.
-        Defaults to `False`.
+        ``iterable`` will be passed into the resulting `dict`. If
+        `False`, then any unit, |PhysicalType|, or object that can be
+        converted to a |Quantity| or that has a physical type will be
+        included in the `dict`. Defaults to `False`.
 
     numbers_become_quantities : `bool`, keyword-only, optional
         If `True`, `~numbers.Number` objects will be converted into
@@ -65,7 +67,7 @@ def _get_physical_type_dict(
 
         try:
             physical_type = u.get_physical_type(obj)
-        except TypeError:
+        except (TypeError, ValueError):
             pass
         else:
             if physical_type in physical_types:

--- a/plasmapy/utils/units_helpers.py
+++ b/plasmapy/utils/units_helpers.py
@@ -1,0 +1,54 @@
+"""Helper functionality for `astropy.units`."""
+
+from astropy.units.physical import get_physical_type
+
+
+def get_physical_type_dict(quantities, *, quantities_only: bool = True):
+    """
+    Return a `dict` that contains physical types as keys and
+    ``quantities`` as the values.
+
+    Parameters
+    ----------
+    quantities : iterable of `~astropy.units.Quantity`
+        An
+
+    quantities_only : bool
+        If `True` (default), allow only `~astropy.units.Quantity`
+        instances. If `False`, allow any `object` that has a valid
+        physical type.
+
+    Returns
+    -------
+
+    Raises
+    ------
+    `TypeError`
+        If ``quantities`` contains something other than a |Quantity| and
+        ``quantities_only`` is `True`.  T
+
+    `ValueError`
+        If a `~astropy.units.Quantity` is
+
+    """
+
+    if quantities_only:
+        all_are_quantities = all(isinstance(quantity) for quantity in quantities)
+        if not all_are_quantities:
+            raise TypeError("Not all values in iterable are Quantity instances.")
+
+    physical_types = [get_physical_type(quantity) for quantity in quantities]
+
+    return {
+        physical_type: quantity
+        for physical_type, quantity in zip(physical_types, quantities)
+    }
+
+    physical_type_dict = {}
+    for value in values:
+        physical_type = get_physical_type(value)
+        if physical_type in physical_type_dict:
+            raise ValueError(f"Duplicate physical type: {physical_type}")
+        physical_type_dict[physical_type] = value
+
+    return physical_type_dict

--- a/plasmapy/utils/units_helpers.py
+++ b/plasmapy/utils/units_helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["_get_physical_type_dict"]
+__all__ = []
 
 import astropy.units as u
 
@@ -11,39 +11,39 @@ from typing import Dict, Iterable
 
 
 def _get_physical_type_dict(
-    collection: Iterable,
+    iterable: Iterable,
     *,
     only_quantities=False,
     numbers_become_quantities=False,
 ) -> Dict[u.PhysicalType, u.Quantity]:
     """
     Return a `dict` that contains `~astropy.units.PhysicalType` objects
-    as keys and the corresponding objects in ``collection`` as values.
+    as keys and the corresponding objects in ``iterable`` as values.
 
-    Objects in ``collection`` that do not correspond to a |PhysicalType|
+    Objects in ``iterable`` that do not correspond to a |PhysicalType|
     are skipped.
 
     Parameters
     ----------
-    collection : iterable
-        A collection that is expected to contain objects with physical
+    iterable : iterable
+        A iterable that is expected to contain objects with physical
         types.
 
-    only_quantities : bool, keyword-only, optional
+    only_quantities : `bool`, keyword-only, optional
         If `True`, only `~astropy.units.Quantity` instances in
-        ``collection`` will be passed into the resulting `dict`.
+        ``iterable`` will be passed into the resulting `dict`.
         Defaults to `False`.
 
-    numbers_become_quantities : bool, keyword-only, optional
+    numbers_become_quantities : `bool`, keyword-only, optional
         If `True`, `~numbers.Number` objects will be converted into
         dimensionless |Quantity| instances. If `False`,
         `~numbers.Number` objects will be skipped. Defaults to `False`.
 
     Returns
     -------
-    physical_types : dict
+    physical_types : `dict`
         A mapping from |PhysicalType| instances to the corresponding
-        objects in ``collection``.
+        objects in ``iterable``.
 
     Examples
     --------
@@ -55,7 +55,7 @@ def _get_physical_type_dict(
     """
     physical_types = {}
 
-    for obj in collection:
+    for obj in iterable:
 
         if isinstance(obj, Number) and numbers_become_quantities:
             obj = u.Quantity(obj, u.dimensionless_unscaled)

--- a/plasmapy/utils/units_helpers.py
+++ b/plasmapy/utils/units_helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["get_physical_type_dict"]
+__all__ = ["_get_physical_type_dict"]
 
 import astropy.units as u
 
@@ -10,7 +10,7 @@ from numbers import Number
 from typing import Dict, Iterable
 
 
-def get_physical_type_dict(
+def _get_physical_type_dict(
     collection: Iterable,
     *,
     only_quantities=False,
@@ -48,9 +48,9 @@ def get_physical_type_dict(
     Examples
     --------
     >>> import astropy.units as u
-    >>> from plasmapy.utils.units_helpers import get_physical_type_dict
+    >>> from plasmapy.utils.units_helpers import _get_physical_type_dict
     >>> quantities = [1 * u.m, 2 * u.kg]
-    >>> get_physical_type_dict(quantities)
+    >>> _get_physical_type_dict(quantities)
     {PhysicalType('length'): <Quantity 1. m>, PhysicalType('mass'): <Quantity 2. kg>}
     """
     physical_types = {}

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -5,10 +5,10 @@ channels:
 - conda-forge
 
 dependencies:
-- python=3.7
+- python=3.9
 - numpy
 - scipy
-- astropy
+- astropy >= 4.3.1
 - h5py
 - matplotlib >= 3.3.0
 - mpmath

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,6 +1,6 @@
 # these are dependencies required to use the package
 # ought to mirror 'install_requires' under 'options' in setup.cfg
-astropy >= 4.0
+astropy >= 4.3.1
 cached-property >= 1.5.2
 matplotlib >= 3.3.0
 numpy >= 1.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ setup_requires =
   # build dependencies...they should be defined under build-system.requires
 install_requires =
   # ought to mirror requirements/install.txt
-  astropy >= 4.0
+  astropy >= 4.3.1
   cached-property >= 1.5.2
   matplotlib >= 3.3.0
   numpy >= 1.18.1

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps =
 conda_deps =
   numpy>=1.18.1
   scipy>=1.2
-  astropy>=4.0
+  astropy>=4.3.1
   pytest>=5.1
   h5py
   matplotlib
@@ -92,7 +92,7 @@ deps =
   pytest-cov
   numpy==1.18.1
   scipy==1.2
-  astropy==4.0
+  astropy==4.3.1
   h5py==2.8
   matplotlib==3.3.0
   pytest==5.1


### PR DESCRIPTION
This PR adds the module named `plasmapy.utils.units_helpers` (though we could change this) which contains a function `get_physical_type_dict`.  This function takes a `list` or `tuple` that is expected to contain `Quantity` instances and possibly other objects, and then create a `dict` that has `astropy.units.PhysicalType` instances as keys and the corresponding `Quantity` instances (or other objects with a physical type) as keys.  

I'm planning to use this for a `Normalizations` class, and it could also be used for perhaps a `UniformPlasma` class or our `PlasmaBlob` class.  An application could look vaguely like this:

```Python
class Normalizations:
    def __init__(self, *args):  # allow users to input a bunch of quantities of different physical types in arbitrary order
        physical_type_dict = get_physical_type_dict(args)
        # store normalizations coming from args here
```

We could possibly make this a private function, at least temporarily.  The implementation and interface for this will probably change whilst working on the normalizations classes in future PRs.