### PR TITLE
Revert pygments style to `"default"` and set minimum version of pygments to 2.11.0

### DIFF
--- a/changelog/1361.doc.rst
+++ b/changelog/1361.doc.rst
@@ -1,0 +1,4 @@
+Reverted the code syntax highlighting style back to the pygments_
+default. The minimum version of pygments_ was set to ``2.11.0`` because
+the default style was changed to meet accessibility guidelines for
+contrast in this release.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,7 +185,7 @@ linkcheck_anchors_ignore = [
 ]
 
 # Use a code highlighting style that meets the WCAG AA contrast standard
-pygments_style = "xcode"
+pygments_style = "default"
 
 hoverxref_auto_ref = True
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,7 +7,7 @@ ipywidgets
 nbsphinx
 numpydoc
 pillow
-pygments >= 2.4.1
+pygments >= 2.11.0
 sphinx >= 3.2.0
 sphinx-changelog
 sphinx-copybutton

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - numpydoc
   - pytest
   - lmfit
-  - pygments >= 2.4.1
+  - pygments >= 2.11.0
   - sphinx >= 3.2.0
   - sphinx-gallery
   - sphinx-hoverxref >= 1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ docs =
   nbsphinx
   numpydoc
   pillow
-  pygments >= 2.4.1
+  pygments >= 2.11.0
   sphinx >= 3.2.0
   sphinx-changelog
   sphinx-copybutton


### PR DESCRIPTION
The default style for pygments has recently been updated to meet web accessibility standards for contrast (https://github.com/pygments/pygments/pull/1940).  This PR reverts #1287 to change the pygments style to `"default"` and sets the minimum version of pygments to 2.11.0.  This PR will need to wait to be merged until pygments 2.11.0 is officially released.

There are a few other styles at the top of the [pygments website](https://pygments.org/styles/) that meet the web accessibility standard for contrast.  Among these, I like `"default"` the best, but we do have a few alternatives if we'd prefer.


