### PR TITLE
Use extract method refactoring pattern on `Particle.__init__`

### DIFF
--- a/changelog/1368.trivial.rst
+++ b/changelog/1368.trivial.rst
@@ -1,0 +1,2 @@
+Used the extract method refactoring pattern on the initialization of
+|Particle| objects.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -475,6 +475,9 @@ class Particle(AbstractPhysicalParticle):
                     f"use:  Particle({repr(attributes['particle'])})"
                 )
 
+    def _initialize_atom(self, special_particle, Z, mass_numb):
+        pass
+
     def __init__(
         self,
         argument: ParticleLike,
@@ -505,6 +508,8 @@ class Particle(AbstractPhysicalParticle):
         if particle_symbol in _Particles.keys():  # special particles
             self._initialize_special_particle(particle_symbol, Z, mass_numb)
         else:  # elements, isotopes, and ions (besides protons)
+            self._initialize_atom(argument, mass_numb, Z)
+
             try:
                 nomenclature = _parse_and_check_atomic_input(
                     argument, mass_numb=mass_numb, Z=Z

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -553,7 +553,7 @@ class Particle(AbstractPhysicalParticle):
             self._attributes["charge"] = const.e.si
         elif self._attributes["charge number"] is not None:
             self._attributes["charge"] = self._attributes["charge number"] * const.e.si
-            
+
         if self._attributes["charge number"]:
             self._categories.add("charged")
         elif self._attributes["charge number"] == 0:

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -421,6 +421,25 @@ class Particle(AbstractPhysicalParticle):
     ``'transition metal'``, ``'uncharged'``, and ``'unstable'``.
     """
 
+    @staticmethod
+    def _validate_arguments(argument, Z, mass_numb):
+        if not isinstance(argument, (Integral, np.integer, str)):
+            raise TypeError(
+                "The first positional argument when creating a "
+                "Particle object must be either an integer, string, or "
+                "another Particle object."
+            )
+
+        if mass_numb is not None and not isinstance(mass_numb, Integral):
+            raise TypeError("mass_numb is not an integer")
+
+        if Z is not None and not isinstance(Z, Integral):
+            raise TypeError("Z is not an integer.")
+
+    def _initialize_attrs_categories(self):
+        self._attributes = defaultdict(type(None))
+        self._categories = set()
+
     def __init__(
         self,
         argument: ParticleLike,
@@ -429,13 +448,6 @@ class Particle(AbstractPhysicalParticle):
     ):
         """Instantiate a |Particle| object and set private attributes."""
 
-        if not isinstance(argument, (Integral, np.integer, str, Particle)):
-            raise TypeError(
-                "The first positional argument when creating a "
-                "Particle object must be either an integer, string, or "
-                "another Particle object."
-            )
-
         # If argument is a Particle instance, then we will construct a
         # new Particle instance for the same Particle (essentially a
         # copy).
@@ -443,20 +455,10 @@ class Particle(AbstractPhysicalParticle):
         if isinstance(argument, Particle):
             argument = argument.symbol
 
-        if mass_numb is not None and not isinstance(mass_numb, Integral):
-            raise TypeError("mass_numb is not an integer")
+        self._validate_arguments(argument, Z, mass_numb)
+        self._initialize_attrs_categories()
 
-        if Z is not None and not isinstance(Z, Integral):
-            raise TypeError("Z is not an integer.")
-
-        # For Python 3.10, change `type(None)` to `types.NoneType`
-        self._attributes = defaultdict(type(None))
         attributes = self._attributes
-
-        # Use this set to keep track of particle categories such as
-        # 'lepton' for use with the is_category method later on.
-
-        self._categories = set()
         categories = self._categories
 
         # If the argument corresponds to one of the case-sensitive or

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -553,6 +553,7 @@ class Particle(AbstractPhysicalParticle):
             self._attributes["charge"] = const.e.si
         elif self._attributes["charge number"] is not None:
             self._attributes["charge"] = self._attributes["charge number"] * const.e.si
+            
         if self._attributes["charge number"]:
             self._categories.add("charged")
         elif self._attributes["charge number"] == 0:

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -423,7 +423,8 @@ class Particle(AbstractPhysicalParticle):
 
     @staticmethod
     def _validate_arguments(argument, Z, mass_numb):
-        if not isinstance(argument, (Integral, np.integer, str)):
+        """Raise appropriate exceptions when inputs are invalid."""
+        if not isinstance(argument, (Integral, np.integer, str, Particle)):
             raise TypeError(
                 "The first positional argument when creating a "
                 "Particle object must be either an integer, string, or "
@@ -437,10 +438,13 @@ class Particle(AbstractPhysicalParticle):
             raise TypeError("Z is not an integer.")
 
     def _initialize_attrs_categories(self):
+        """Create empty collections for attributes & categories."""
+
         self._attributes = defaultdict(type(None))
         self._categories = set()
 
     def _initialize_special_particle(self, particle_symbol, Z, mass_numb):
+        """Initialize special particles."""
         attributes = self._attributes
         categories = self._categories
 
@@ -476,7 +480,7 @@ class Particle(AbstractPhysicalParticle):
                 )
 
     def _initialize_atom(self, argument, Z, mass_numb):
-
+        """Assign attributes and categories to atoms."""
         attributes = self._attributes
         categories = self._categories
 
@@ -544,6 +548,7 @@ class Particle(AbstractPhysicalParticle):
         categories.add(Element["category"])
 
     def _add_charge_information(self):
+        """Assign attributes and categories related to charge information."""
         if self._attributes["charge number"] == 1:
             self._attributes["charge"] = const.e.si
         elif self._attributes["charge number"] is not None:
@@ -554,6 +559,7 @@ class Particle(AbstractPhysicalParticle):
             self._categories.add("uncharged")
 
     def _add_half_life_information(self):
+        """Assign categories related to stability."""
         if self._attributes["half-life"] is not None:
             if isinstance(self._attributes["half-life"], str):
                 self._categories.add("unstable")
@@ -582,16 +588,12 @@ class Particle(AbstractPhysicalParticle):
 
         particle_symbol = _dealias_particle_aliases(argument)
 
-        #        is_special_particle = particle_symbol not in _Particles.keys()
-        #        should_be_atom = not is_special_particle
+        is_special_particle = particle_symbol in _Particles.keys()
 
-        #        if should_be_atom:
-        #            self._initialize_atom(argument, Z=Z, mass_numb=mass_numb)
-
-        if particle_symbol in _Particles.keys():
+        if is_special_particle:
             self._initialize_special_particle(particle_symbol, Z=Z, mass_numb=mass_numb)
         else:
-            self._initialize_atom(argument, Z=Z, mass_numb=mass_numb)
+            self._initialize_atom(particle_symbol, Z=Z, mass_numb=mass_numb)
 
         self._add_charge_information()
         self._add_half_life_information()


### PR DESCRIPTION
Whilst working on #1366, I discovered that dealing with special cases in `Particle.__init__` was becoming a pain since the method is very long with lots of conditionals, etc.  This PR is to put the functionality in `Particle.__init__` into private methods to make it easier to understand and maintain. 