### PR TITLE
Create generic decorator that can be adapted to process arguments based on annotations

### DIFF
--- a/plasmapy/utils/decorators/__init__.py
+++ b/plasmapy/utils/decorators/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "CheckUnits",
     "CheckValues",
     "ValidateQuantities",
+    "GenericDecorator",
 ]
 
 from plasmapy.utils.decorators.checks import (
@@ -26,5 +27,6 @@ from plasmapy.utils.decorators.checks import (
 )
 from plasmapy.utils.decorators.converter import angular_freq_to_hz
 from plasmapy.utils.decorators.deprecation import deprecated
+from plasmapy.utils.decorators.generic import GenericDecorator
 from plasmapy.utils.decorators.helpers import modify_docstring, preserve_signature
 from plasmapy.utils.decorators.validators import validate_quantities, ValidateQuantities

--- a/plasmapy/utils/decorators/generic.py
+++ b/plasmapy/utils/decorators/generic.py
@@ -1,0 +1,13 @@
+"""
+Generic classes for decorators that process arguments based on
+annotations.
+"""
+
+__all__ = ["GenericDecorator"]
+
+from abc import ABC, abstractmethod
+
+
+class GenericDecorator(ABC):
+    def __init__(self):
+        pass

--- a/plasmapy/utils/decorators/generic.py
+++ b/plasmapy/utils/decorators/generic.py
@@ -5,9 +5,126 @@ annotations.
 
 __all__ = ["GenericDecorator"]
 
-from abc import ABC, abstractmethod
+import collections
+import functools
+import inspect
+
+from typing import AbstractSet, Any, Callable, Mapping, NoReturn, Optional, Tuple
 
 
-class GenericDecorator(ABC):
-    def __init__(self):
-        pass
+class GenericDecorator:
+    @classmethod
+    def as_decorator(cls, func: Callable = None, **kwargs_to_decorator):
+        print("calling as_decorator")
+        try:
+            self = cls(**kwargs_to_decorator)
+        except KeyError:
+            raise RuntimeError("Incorrect argument to decorator")  # add test for this
+        return self if func is None or kwargs_to_decorator else self(func)
+
+    def __init__(self, func=None, **kwargs_to_init):
+        print("calling __init__")
+        self._data = collections.defaultdict(lambda: None)
+        self._data["new_kwargs"] = {}
+
+    def __call__(self, wrapped_function: Callable):
+        self._data["new_kwargs"] = {}
+        self.wrapped_function = wrapped_function
+        # TODO: give better name to assigned since I don't know what it means
+        assigned = list(functools.WRAPPER_ASSIGNMENTS)
+        assigned.append("__signature__")
+
+        @functools.wraps(wrapped_function, assigned=assigned)
+        def wrapper(*original_args_to_func, **original_kwargs_to_func):
+            print("Inside wrapper")
+            self.original_args_to_func = original_args_to_func
+            self.original_kwargs_to_func = original_kwargs_to_func
+            self.process_arguments()
+            return wrapped_function(**self.new_kwargs)
+
+        return wrapper
+
+    @property
+    def wrapped_function(self) -> Optional[Callable]:
+        """The function that is being decorated."""
+        return self._data["wrapped_function"]
+
+    @wrapped_function.setter
+    def wrapped_function(self, function: Callable):
+        self._data["wrapped_function"] = function
+        self._data["wrapped_signature"] = inspect.signature(function)
+        self._data["annotations"] = getattr(function, "__annotations__", {}).copy()
+        if "return" in self._data["annotations"]:
+            del self._data["annotations"]["return"]
+
+    @property
+    def annotations(self) -> Optional[Mapping[str, Any]]:
+        """
+        Annotations for arguments in the decorated function.
+        The keys are the arguments to the decorated function that have
+        annotations.  The associated values are the annotations themselves.
+        Only arguments with annotations are included.
+        """
+        return self._data["annotations"]
+
+    @property
+    def wrapped_signature(self) -> Optional[inspect.Signature]:
+        return self._data["wrapped_signature"]
+
+    @property
+    def bound_args(self) -> Optional[inspect.BoundArguments]:
+        bound_args_ = self.wrapped_signature.bind(
+            *self.original_args_to_func, **self.original_kwargs_to_func
+        )
+        bound_args_.apply_defaults()
+        return bound_args_
+
+    @property
+    def default_arguments(self) -> Mapping[str, inspect.Parameter]:
+        return self.bound_args.signature.parameters
+
+    @property
+    def new_kwargs(self) -> Optional[Mapping[str, Any]]:
+        """The revised keyword arguments to be supplied to the decorated function."""
+        return self._data["new_kwargs"]
+
+    @new_kwargs.setter
+    def new_kwargs(self, kwargs: Mapping[str, Any]) -> NoReturn:
+        if isinstance(kwargs, collections.abc.Mapping):
+            self._data["new_kwargs"] = kwargs
+        else:
+            raise TypeError("new_kwargs must be a mapping such as a dictionary")
+
+    @property
+    def original_args_to_func(self) -> Optional[Tuple]:
+        """Positional arguments as originally supplied to the decorated function."""
+        return self._data["original_args_to_func"]
+
+    @original_args_to_func.setter
+    def original_args_to_func(self, value: Tuple):
+        self._data["original_args_to_func"] = value
+
+    @property
+    def original_kwargs_to_func(self) -> Optional[Mapping[str, Any]]:
+        """Keyword arguments as originally supplied to the decorated function."""
+        return self._data["original_kwargs_to_func"]
+
+    @original_kwargs_to_func.setter
+    def original_kwargs_to_func(self, value: Mapping[str, Any]):
+        self._data["original_kwargs_to_func"] = value
+
+    @property
+    def original_values(self) -> Mapping[str, Any]:
+        """
+        The values that were originally passed as positional and keyword
+        arguments to the decorated function.
+        """
+        return self.bound_args.arguments
+
+    @property
+    def argument_names(self) -> AbstractSet:
+        """The names of the arguments to the original function."""
+        return self.bound_args.signature.parameters.keys()
+
+    def process_arguments(self) -> NoReturn:
+        self.new_kwargs = self.original_values

--- a/plasmapy/utils/decorators/tests/test_generic.py
+++ b/plasmapy/utils/decorators/tests/test_generic.py
@@ -1,0 +1,7 @@
+"""Tests of generic decorator functionality."""
+
+from plasmapy.utils.decorators.generic import GenericDecorator
+
+
+def test_generic_decorator():
+    GenericDecorator()

--- a/plasmapy/utils/decorators/tests/test_generic.py
+++ b/plasmapy/utils/decorators/tests/test_generic.py
@@ -2,6 +2,13 @@
 
 from plasmapy.utils.decorators.generic import GenericDecorator
 
+generic_decorator = GenericDecorator().as_decorator
 
-def test_generic_decorator():
-    GenericDecorator()
+
+@generic_decorator
+def decorated_function(x, *, y, z=5):
+    return x, y, z
+
+
+def test_decorated_function():
+    assert decorated_function(2, y=3) == (2, 3, 5)


### PR DESCRIPTION
This PR is to create a generic class-based decorator that can be subclassed into different decorators that process arguments based on annotations.  My plan is to subclass this in the refactoring of `@particle_input` in #1057, and actually much of the content within it has been extracted from #1057.  There was also inspiration from `@astropy.units.quantity_input`.  I'd still like to compare this to the implementation of our other decorators. I haven't been able to find an equivalent to this in the pythoniverse, but I'm still wondering if there's something out there.

So far I'm working on this as a prototype.  I'm not sure if this should ultimately go in PlasmaPy, but if this is implemented cleanly and documented well, then this could simplify the creation of new decorators and perhaps the implementation of some of our existing decorators.  

My hope is that this and #1365 will make refactoring `@particle_input` a lot more straightforward.  It'd be great if there was something out there in the pythoniverse already like this, but haven't been able to find what I was looking for.

I'm also wondering about an implementation like...

```Python
def process_arguments_based_on_annotations(args, kwargs, annotations):
    return new_args, new_kwargs, new_annotations

def create_decorator(process_arguments):
    ...
```
Closes #1079.