### PR TITLE
Add a fortnightly test for a nitpicky documentation build

### DIFF
--- a/.github/workflows/fortnightly.yml
+++ b/.github/workflows/fortnightly.yml
@@ -41,6 +41,11 @@ jobs:
           python: 3.8
           toxenv: py38-xarraydev
 
+        - name: Documentation build (nitpicky)
+          os: ubunti-latest
+          python: 3.9
+          toxenv: build_docs_nitpicky
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2.4.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![YouTube](https://img.shields.io/badge/YouTube%20-subscribe-red?style=flat&logo=youtube)](https://www.youtube.com/channel/UCSH6qzslhqIZKTAJmHPxIxw)
 
 [![GitHub Actions — CI](https://github.com/PlasmaPy/PlasmaPy/workflows/CI/badge.svg)](https://github.com/PlasmaPy/PlasmaPy/actions?query=workflow%3ACI+branch%3Amain)
-[![weekly tests](https://github.com/PlasmaPy/PlasmaPy/actions/workflows/weekly.yml/badge.svg?branch=main)](https://github.com/PlasmaPy/PlasmaPy/actions/workflows/weekly.yml)
+[![fortnightly tests](https://github.com/PlasmaPy/PlasmaPy/actions/workflows/weekly.yml/badge.svg?branch=main)](https://github.com/PlasmaPy/PlasmaPy/actions/workflows/fortnightly.yml)
 [![Style linters](https://github.com/PlasmaPy/PlasmaPy/actions/workflows/linters.yml/badge.svg)](https://github.com/PlasmaPy/PlasmaPy/actions/workflows/linters.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/PlasmaPy/PlasmaPy/main.svg)](https://results.pre-commit.ci/latest/github/PlasmaPy/PlasmaPy/main)
 [![codecov](https://codecov.io/gh/PlasmaPy/PlasmaPy/branch/main/graph/badge.svg)](https://codecov.io/gh/PlasmaPy/PlasmaPy)


### PR DESCRIPTION
This adds a cron test that uses the [nitpicky](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpicky) option for our documentation build.  This will make Sphinx warn about all references where the target cannot be found.  The warnings will be turned into failures because  the `-W` flag for `sphinx-build` is being used too.  

This test currently fails because we have numerous references that are missing targets, for example in-line code snippets that have single back ticks but should have double back ticks. Once we do get this to pass, I'd like to turn on this option for our regular CI to catch missing targets right away.  

I think we might need to merge this before we can check that it's set up correctly.