### PR TITLE
Minor docstring fixes in `plasmapy.formulary`

### DIFF
--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -166,8 +166,8 @@ class ClassicalTransport:
     ion : `str`
         Representation of the ion species (e.g., ``'p'`` for protons,
         ``'e'`` for electrons, ``'D+'`` for deuterium, or ``'He-4 +1'``
-        ionized helium-4). If no charge state information is provided,
-        then the particles are assumed to be singly charged.
+        for singly ionized helium-4). If no charge state information is
+        provided, then the particles are assumed to be singly charged.
 
     Z : `int` or `numpy.inf`, optional
         The ion charge state. Overrides particle charge state if included.

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -164,16 +164,16 @@ class ClassicalTransport:
         The ion number density in units convertible to per cubic meter.
 
     ion : `str`
-        Representation of the ion species (e.g., 'p' for protons,
-        'e' for electrons, 'D+' for deuterium, or 'He-4 +1' for singly
+        Representation of the ion species (e.g., ``'p'`` for protons,
+        ``'e'`` for electrons, ``'D+'`` for deuterium, or ``'He-4 +1'``
         ionized helium-4). If no charge state information is provided,
         then the particles are assumed to be singly charged.
 
-    Z : `int` or `np.inf`, optional
+    Z : `int` or `numpy.inf`, optional
         The ion charge state. Overrides particle charge state if included.
-        Different theories support different values of `Z`. For the original
-        Braginskii model, `Z` can be any of [1, 2, 3, 4, infinity]. The Ji-Held
-        model supports arbitrary `Z`. Average ionization states `Z_mean` can be
+        Different theories support different values of ``Z``. For the original
+        Braginskii model, ``Z`` can be any of [1, 2, 3, 4, infinity]. The Ji-Held
+        model supports arbitrary ``Z``. Average ionization states ``Z_mean`` can be
         input using this input and the Ji-Held model, although doing so may
         neglect effects caused by multiple ion populations.
 
@@ -202,7 +202,8 @@ class ClassicalTransport:
     coulomb_log_ei : `float` or dimensionless `~astropy.units.Quantity`, optional
         Force a particular value to be used for the electron-ion Coulomb
         logarithm (test electrons on field ions). If `None`,
-        `Coulomb_logarithm` will be used. Useful for comparing calculations.
+        `~plasmapy.formulary.collisions.Coulomb_logarithm` will be used.
+        Useful for comparing calculations.
 
     V_ei : `~astropy.units.Quantity`, optional
        The relative velocity between particles.  Supplied to `Coulomb_logarithm`
@@ -212,22 +213,24 @@ class ClassicalTransport:
     coulomb_log_ii : `float` or dimensionless `~astropy.units.Quantity`, optional
         Force a particular value to be used for the ion-ion Coulomb logarithm
         (test ions on field ions). If `None`, the PlasmaPy function
-        `Coulomb_logarithm` will be used. Useful for comparing calculations.
+        `~plasmapy.formulary.collisions.Coulomb_logarithm` will be used.
+        Useful for comparing calculations.
 
     V_ii : `~astropy.units.Quantity`, optional
        The relative velocity between particles.  Supplied to
-       `Coulomb_logarithm` function, not otherwise used. If not provided,
-       thermal velocity is assumed: :math:`μ V^2 \sim 2 k_B T`
-       where :math`μ` is the reduced mass.
+       `~plasmapy.formulary.collisions.Coulomb_logarithm` function, not
+       otherwise used. If not provided, thermal velocity is assumed:
+       :math:`μ V^2 \sim 2 k_B T` where :math`μ` is the reduced mass.
 
     hall_e : `float` or dimensionless `~astropy.units.Quantity`, optional
-        Force a particular value to be used for the electron Hall parameter. If
-        `None`, `Hall_parameter` will be used. Useful for comparing calculations.
+        Force a particular value to be used for the electron Hall parameter.
+        If `None`, `~plasmapy.formulary.parameters.Hall_parameter` will
+        be used. Useful for comparing calculations.
 
     hall_i : `float` or dimensionless `~astropy.units.Quantity`, optional
         Force a particular value to be used for the ion Hall parameter. If
-        `None`, `Hall_parameter` will be used. Useful for comparing
-        calculations.
+        `None`, `~plasmapy.formulary.parameters.Hall_parameter` will be
+        used. Useful for comparing calculations.
 
     mu : `float` or dimensionless `~astropy.units.Quantity`, optional
         Ji-Held model only, may be used to include ion-electron effects
@@ -450,10 +453,11 @@ class ClassicalTransport:
         cross-sectional area), you could calculate a DC resistance of the
         plasma in ohms as resistivity × length / cross-sectional area.
 
-        Experimentalists with plasma discharges may observe different V = IR
-        Ohm's law behavior than suggested by the resistance calculated here,
-        for reasons such as the occurrence of plasma sheath layers at the
-        electrodes or the plasma not satisfying the classical assumptions.
+        Experimentalists with plasma discharges may observe different
+        :math:`V = IR` Ohm's law behavior than suggested by the
+        resistance calculated here, for reasons such as the occurrence
+        of plasma sheath layers at the electrodes or the plasma not
+        satisfying the classical assumptions.
 
         Returns
         -------
@@ -623,9 +627,9 @@ class ClassicalTransport:
         -----
         This is the dynamic viscosity that you find for ions in the classical
         plasma, similar to the viscosity of air or water or honey. The big
-        effect is the :math:`T^{5/2}` dependence, so as classical plasmas get hotter they
-        become dramatically more viscous. The ion viscosity typically dominates
-        over the electron viscosity.
+        effect is the :math:`T^{5/2}` dependence, so as classical plasmas
+        get hotter they become dramatically more viscous. The ion
+        viscosity typically dominates over the electron viscosity.
 
         Returns
         -------
@@ -671,9 +675,9 @@ class ClassicalTransport:
         -----
         This is the dynamic viscosity that you find for electrons in the
         classical plasma, similar to the viscosity of air or water or honey.
-        The big effect is the :math:`T^{5/2}` dependence, so as classical plasmas get
-        hotter they become dramatically more viscous. The ion viscosity
-        typically dominates over the electron viscosity.
+        The big effect is the :math:`T^{5/2}` dependence, so as classical
+        plasmas get hotter they become dramatically more viscous. The
+        ion viscosity typically dominates over the electron viscosity.
 
         Returns
         -------
@@ -681,8 +685,7 @@ class ClassicalTransport:
 
         See Also
         --------
-        ion_viscosity
-
+        ~plasmapy.formulary.braginskii.ClassicalTransport.ion_viscosity
         """
         eta_hat = _nondim_viscosity(
             self.hall_e,
@@ -790,10 +793,11 @@ def resistivity(
     cross-sectional area), you could calculate a DC resistance of the
     plasma in ohms as resistivity × length / cross-sectional area.
 
-    Experimentalists with plasma discharges may observe different V = IR
-    Ohm's law behavior than suggested by the resistance calculated here,
-    for reasons such as the occurrence of plasma sheath layers at the
-    electrodes or the plasma not satisfying the classical assumptions.
+    Experimentalists with plasma discharges may observe different
+    :math:`V = IR` Ohm's law behavior than suggested by the resistance
+    calculated here, for reasons such as the occurrence of plasma sheath
+    layers at the electrodes or the plasma not satisfying the classical
+    assumptions.
 
     Returns
     -------
@@ -953,12 +957,13 @@ def electron_thermal_conductivity(
 
         κ = \hat{κ} \frac{n_e k_B^2 T_e τ_e}{m_e}
 
-    where :math:`\hat{κ}` is the non-dimensional electron thermal conductivity of the plasma,
+    where :math:`\hat{κ}` is the non-dimensional electron thermal
+    conductivity of the plasma,
     :math:`n_e` is the electron number density of the plasma,
     :math:`k_B` is the Boltzmann constant,
     :math:`T_e` is the electron temperature of the plasma,
-    :math:`τ_e` is the fundamental electron collision period of the plasma,
-    and :math:`m_e` is the mass of an electron.
+    :math:`τ_e` is the fundamental electron collision period of the
+    plasma, and :math:`m_e` is the mass of an electron.
 
     Notes
     -----
@@ -990,7 +995,6 @@ def electron_thermal_conductivity(
     See Also
     --------
     ion_thermal_conductivity
-
     """
     ct = ClassicalTransport(
         T_e,

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -59,8 +59,7 @@ def Fermi_integral(
     Warnings
     --------
     At present this function is limited to relatively small arguments
-    due to limitations in the `mpmath` package's implementation of
-    `~mpmath.polylog`.
+    due to limitations in `mpmath` implementation of `~mpmath.polylog`.
 
     Examples
     --------

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -36,7 +36,7 @@ def Fermi_integral(
         If the argument is a `~astropy.units.Quantity` but is not
         dimensionless.
 
-    ValueError
+    `ValueError`
         If the argument is not entirely finite.
 
     Notes
@@ -56,9 +56,11 @@ def Fermi_integral(
     .. math::
         F_j (x) = -Li_{j+1}\left(-e^{x}\right)
 
-    Warning: at present this function is limited to relatively small
-    arguments due to limitations in the `~mpmath` package's
-    implementation of `~mpmath.polylog`.
+    Warnings
+    --------
+    At present this function is limited to relatively small arguments
+    due to limitations in the `mpmath` package's implementation of
+    `~mpmath.polylog`.
 
     Examples
     --------
@@ -68,7 +70,6 @@ def Fermi_integral(
     (1.3132616875182228-0j)
     >>> Fermi_integral(1, 1)
     (1.8062860704447743-0j)
-
     """
     try:
         from mpmath import polylog
@@ -146,7 +147,6 @@ def rot_a_to_b(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     -------
     R : `~numpy.ndarray`, shape (3,3)
         The rotation matrix that will rotate vector ``a`` onto vector ``b``.
-
     """
 
     # Normalize and validate both vectors

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -75,7 +75,7 @@ def _grab_charge(ion: Particle, z_mean=None):
 
     Parameters
     ----------
-    ion : `~plasmapy.particles.Particle`
+    ion : `~plasmapy.particles.particle_class.Particle`
         a string representing a charged particle, or a Particle object.
 
     z_mean : `float`
@@ -131,10 +131,10 @@ def mass_density(
         equivalent).  If ``density`` is a mass density, then it will be passed
         through and returned without modification.
 
-    particle : `~plasmapy.particles.Particle`
+    particle : `~plasmapy.particles.particle_class.Particle`
         The particle for which the mass density is being calculated for.  Must
-        be a `~plasmapy.particles.Particle` or a value convertible to
-        a `~plasmapy.particles.Particle` (e.g., ``'p'`` for protons,
+        be a `~plasmapy.particles.particle_class.Particle` or a value convertible to
+        a `~plasmapy.particles.particle_class.Particle` (e.g., ``'p'`` for protons,
         ``'D+'`` for deuterium, or ``'He-4 +1'`` for singly ionized helium-4).
 
     z_ratio : `int`, `float`, optional
@@ -154,7 +154,7 @@ def mass_density(
 
     `TypeError`
         If ``particle`` is not of type or convertible to
-        `~plasmapy.particles.Particle`.
+        `~plasmapy.particles.particle_class.Particle`.
 
     `TypeError`
         If ``z_ratio`` is not of type `int` or `float`.
@@ -240,7 +240,7 @@ def Alfven_speed(
         m\ :sup:`-3` or the total mass density :math:`ρ` in units
         convertible to kg m\ :sup:`-3`\ .
 
-    ion : `~plasmapy.particles.Particle`, optional
+    ion : `~plasmapy.particles.particle_class.Particle`, optional
         Representation of the ion species (e.g., `'p'` for protons, `'D+'` for
         deuterium, `'He-4 +1'` for singly ionized helium-4, etc.). If no charge
         state information is provided, then the ions are assumed to be singly
@@ -269,7 +269,7 @@ def Alfven_speed(
         or convertible.
 
     `TypeError`
-        If ``ion`` is not of type or convertible to `~plasmapy.particles.Particle`.
+        If ``ion`` is not of type or convertible to `~plasmapy.particles.particle_class.Particle`.
 
     `TypeError`
         If ``z_mean`` is not of type `int` or `float`.
@@ -383,7 +383,7 @@ def ion_sound_speed(
         particle.  If this is not given, then the ion temperature is
         assumed to be zero.
 
-    ion : `~plasmapy.particles.Particle`
+    ion : `~plasmapy.particles.particle_class.Particle`
         Representation of the ion species (e.g., `'p'` for protons,
         `'D+'` for deuterium, or 'He-4 +1' for singly ionized
         helium-4). If no charge state information is provided, then the
@@ -571,7 +571,7 @@ def thermal_speed(
     T : `~astropy.units.Quantity`
         The particle temperature in either kelvin or energy per particle
 
-    particle : `~plasmapy.particles.Particle`
+    particle : `~plasmapy.particles.particle_class.Particle`
         Representation of the particle species (e.g., ``'p'`` for protons, ``'D+'``
         for deuterium, or ``'He-4 +1'`` for singly ionized helium-4). If no
         charge state information is provided, then the particles are
@@ -767,7 +767,7 @@ def kappa_thermal_speed(
         of the Kappa velocity distribution function. ``kappa`` must be greater
         than 3/2.
 
-    particle : `~plasmapy.particles.Particle`
+    particle : `~plasmapy.particles.particle_class.Particle`
         Representation of the particle species (e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for singly ionized helium-4). If no
         charge state information is provided, then the particles are
@@ -895,10 +895,10 @@ def Hall_parameter(
     B : `~astropy.units.quantity.Quantity`
         The magnetic field.
 
-    ion : `~plasmapy.particles.Particle`
+    ion : `~plasmapy.particles.particle_class.Particle`
         The type of ion ``particle`` is colliding with.
 
-    particle : `~plasmapy.particles.Particle`
+    particle : `~plasmapy.particles.particle_class.Particle`
         The particle species for which the Hall parameter is calculated for.
         Representation of the particle species (e.g., ``'p'`` for protons,
         ``'D+'`` for deuterium, or ``'He-4 +1'`` for singly ionized helium-4).
@@ -992,7 +992,7 @@ def gyrofrequency(B: u.T, particle: Particle, signed=False, Z=None) -> u.rad / u
     B : `~astropy.units.Quantity`
         The magnetic field magnitude in units convertible to tesla.
 
-    particle : `~plasmapy.particles.Particle`
+    particle : `~plasmapy.particles.particle_class.Particle`
         Representation of the particle species (e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for singly ionized helium-4). If no
         charge state information is provided, then the particles are assumed
@@ -1115,7 +1115,7 @@ def gyroradius(
     B : `~astropy.units.Quantity`
         The magnetic field magnitude in units convertible to tesla.
 
-    particle : `~plasmapy.particles.Particle`
+    particle : `~plasmapy.particles.particle_class.Particle`
         Representation of the particle species (e.g., `'p'` for protons, `'D+'`
         for deuterium, or `'He-4 +1'` for singly ionized helium-4).  If no
         charge state information is provided, then the particles are assumed
@@ -1285,7 +1285,7 @@ def plasma_frequency(n: u.m ** -3, particle: Particle, z_mean=None) -> u.rad / u
     n : `~astropy.units.Quantity`
         Particle number density in units convertible to per cubic meter.
 
-    particle : `~plasmapy.particles.Particle`
+    particle : `~plasmapy.particles.particle_class.Particle`
         Representation of the particle species (e.g., 'p' for protons, 'D+'
         for deuterium, or 'He-4 +1' for singly ionized helium-4). If no
         charge state information is provided, then the particles are assumed
@@ -1540,7 +1540,7 @@ def inertial_length(n: u.m ** -3, particle: Particle) -> u.m:
     n : `~astropy.units.Quantity`
         Particle number density in units convertible to m\ :sup:`-3`\ .
 
-    particle : `~plasmapy.particles.Particle`
+    particle : `~plasmapy.particles.particle_class.Particle`
         Representation of the particle species (e.g., 'p+' for protons,
         'D+' for deuterium, or 'He-4 +1' for singly ionized helium-4).
 
@@ -1837,7 +1837,7 @@ def lower_hybrid_frequency(B: u.T, n_i: u.m ** -3, ion: Particle) -> u.rad / u.s
     n_i : `~astropy.units.Quantity`
         Ion number density.
 
-    ion : `~plasmapy.particles.Particle`
+    ion : `~plasmapy.particles.particle_class.Particle`
         Representation of the ion species (e.g., ``'p'`` for protons, ``'D+'``
         for deuterium, or ``'He-4 +1'`` for singly ionized helium-4). If no
         charge state information is provided, then the ions are assumed to

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -53,7 +53,7 @@ def deBroglie_wavelength(V: u.m / u.s, particle) -> u.m:
     V : `~astropy.units.Quantity`
         Particle velocity in units convertible to meters per second.
 
-    particle : `str`, `~plasmapy.particles.Particle`, or `~astropy.units.Quantity`
+    particle : `str`, `~plasmapy.particles.particle_class.Particle`, or `~astropy.units.Quantity`
         An instance of `~plasmapy.particles.particle_class.Particle`, or
         an equvalent representation (e.g., ``'e'``, ``'p'``, ``'D+'``, or
         ``'He-4 1+'``), for the particle of interest, or the particle
@@ -320,8 +320,8 @@ def Thomas_Fermi_length(n_e: u.m ** -3) -> u.m:
 
     See Also
     --------
-    Fermi_energy
-    plasmapy.formulary.Debye_length
+    ~plasmapy.formulary.quantum.Fermi_energy
+    ~plasmapy.formulary.parameters.Debye_length
 
     Examples
     --------
@@ -363,7 +363,7 @@ def Wigner_Seitz_radius(n: u.m ** -3) -> u.m:
     Raises
     ------
     `TypeError`
-        If argument is not a ~astropy.units.Quantity.
+        If argument is not a `~astropy.units.Quantity`.
 
     `~astropy.units.UnitConversionError`
         If argument is in incorrect units.
@@ -387,7 +387,7 @@ def Wigner_Seitz_radius(n: u.m ** -3) -> u.m:
 
     See Also
     --------
-    Fermi_energy
+    ~plasmapy.formulary.quantum.Fermi_energy
 
     Examples
     --------
@@ -416,7 +416,7 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
     n_e : `~astropy.units.Quantity`
         Electron number density.
 
-    T : ~astropy.units.Quantity
+    T : `~astropy.units.Quantity`
         The temperature.
 
     Returns
@@ -456,25 +456,26 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
     The definition for the ideal chemical potential is implicit, so it must
     be obtained numerically by solving for the Fermi integral for values
     of chemical potential approaching the degeneracy parameter. Since values
-    returned from the Fermi_integral are complex, a nonlinear
-    Levenberg-Marquardt least squares method is used to iteratively approach
-    a value of :math:`μ` which minimizes
+    returned from the `~plasmapy.formulary.mathematics.Fermi_integral`
+    are complex, a nonlinear Levenberg-Marquardt least squares method is
+    used to iteratively approach a value of :math:`μ` which minimizes
     :math:`I_{1/2}(β μ_a^{ideal}) - χ_a`
 
     This function returns :math:`β μ^{ideal}` the dimensionless
     ideal chemical potential.
 
-    Warning: at present this function is limited to relatively small
-    arguments due to limitations in the `~mpmath` package's implementation
-    of `~mpmath.polylog`, which PlasmaPy uses in calculating the Fermi
-    integral.
+    .. warning::
+
+       At present this function is limited to relatively small arguments
+       due to limitations in the `~mpmath` package's implementation of
+       `~mpmath.polylog`, which PlasmaPy uses in calculating the Fermi
+       integral.
 
     Examples
     --------
     >>> from astropy import units as u
     >>> chemical_potential(n_e=1e21*u.cm**-3,T=11000*u.K)  # doctest: +SKIP
     <Quantity 2.00039985e-12>
-
     """
 
     raise NotImplementedError(

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -464,12 +464,12 @@ def chemical_potential(n_e: u.m ** -3, T: u.K) -> u.dimensionless_unscaled:
     This function returns :math:`β μ^{ideal}` the dimensionless
     ideal chemical potential.
 
-    .. warning::
-
-       At present this function is limited to relatively small arguments
-       due to limitations in the `~mpmath` package's implementation of
-       `~mpmath.polylog`, which PlasmaPy uses in calculating the Fermi
-       integral.
+    Warnings
+    --------
+    At present this function is limited to relatively small arguments
+    due to limitations in the `mpmath` implementation of
+    `~mpmath.polylog`, which PlasmaPy uses in calculating the Fermi
+    integral.
 
     Examples
     --------

--- a/plasmapy/formulary/radiation.py
+++ b/plasmapy/formulary/radiation.py
@@ -76,9 +76,9 @@ def thermal_bremsstrahlung(
         Ion number density in the plasma (convertible to m\ :sup:`-3`\ ). Defaults
         to the quasi-neutral condition :math:`n_i = n_e / Z`\ .
 
-    ion : `str` or `~plasmapy.particles.Particle`, optional
-        An instance of `~plasmapy.particles.Particle`, or a string
-        convertible to `~plasmapy.particles.Particle`.
+    ion : `str` or `~plasmapy.particles.particle_class.Particle`, optional
+        An instance of `~plasmapy.particles.particle_class.Particle`, or a string
+        convertible to `~plasmapy.particles.particle_class.Particle`.
 
     kmax :  `~astropy.units.Quantity`
         Cutoff wavenumber (convertible to radians per meter). Defaults


### PR DESCRIPTION
This follows up on #1375 with some more minor reST and other docstring fixes in a few files in `plasmapy.formulary`.  Again, I don't think that there's anything substantive here.

 - [ ] Check the modified docstrings to see that they render okay