### PR TITLE
Add `ParticleList.is_category`

### DIFF
--- a/changelog/1378.feature.rst
+++ b/changelog/1378.feature.rst
@@ -1,5 +1,4 @@
 Added the `~plasmapy.particles.particle_collections.ParticleList.is_category`
-for |ParticleList| objects.  This method is analogous to the
-method that is analogous to the
-`~plasmapy.particles.particle_class.Particle.is_category` for |Particle|
-objects.
+method for |ParticleList| objects.  This method is analogous to the
+`~plasmapy.particles.particle_class.Particle.is_category` method for
+|Particle| objects.

--- a/changelog/1378.feature.rst
+++ b/changelog/1378.feature.rst
@@ -1,0 +1,5 @@
+Added the `~plasmapy.particles.particle_collections.ParticleList.is_category`
+for |ParticleList| objects.  This method is analogous to the
+method that is analogous to the
+`~plasmapy.particles.particle_class.Particle.is_category` for |Particle|
+objects.

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -250,6 +250,46 @@ class ParticleList(collections.UserList):
             particle = Particle(particle)
         self.data.insert(index, particle)
 
+    def is_category(
+        self,
+        *category_tuple,
+        require: Union[str, Iterable[str]] = None,
+        any_of: Union[str, Iterable[str]] = None,
+        exclude: Union[str, Iterable[str]] = None,
+    ) -> List[bool]:
+        """
+        Determine element-wise if the particles in the |ParticleList|
+        meet categorization criteria.
+
+        Return a `list` in which each element will be `True` if the
+        corresponding particle is consistent with the categoziation
+        criteria, and `False` otherwise.
+
+        Please refer to the documentation of
+        `~plasmapy.particles.particle_class.Particle.is_category`
+        for information on the parameters, categories, and more
+        extensive examples.
+
+        Examples
+        --------
+        >>> particles = ParticleList(["proton", "electron", "tau neutrino"])
+        >>> particles.is_category("lepton")
+        [False, True, True]
+        >>> particles.is_category(require="lepton", exclude="neutrino")
+        [False, True, False]
+        >>> particles.is_category(any_of=["lepton", "charged"])
+        [True, True, True]
+        """
+        return [
+            particle.is_category(
+                *category_tuple,
+                require=require,
+                any_of=any_of,
+                exclude=exclude,
+            )
+            for particle in self
+        ]
+
     @property
     def charge_number(self) -> np.array:
         """

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -267,8 +267,8 @@ class ParticleList(collections.UserList):
 
         Please refer to the documentation of
         `~plasmapy.particles.particle_class.Particle.is_category`
-        for information on the parameters, categories, and more
-        extensive examples.
+        for information on the parameters and categories, as well as
+        more extensive examples.
 
         Examples
         --------

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -327,6 +327,43 @@ def test_particle_multiplication(method, particle):
     assert particle_list == [particle, particle, particle]
 
 
+@pytest.mark.parametrize(
+    "particles, args, kwargs, expected",
+    [
+        [
+            ["electron", "proton", "neutron"],
+            ["lepton"],
+            {},
+            [True, False, False],
+        ],
+        [
+            ["electron", "proton", "neutron"],
+            [],
+            {"require": "lepton"},
+            [True, False, False],
+        ],
+        [
+            ["electron", "proton", "neutron"],
+            [],
+            {"exclude": "lepton"},
+            [False, True, True],
+        ],
+        [
+            ["electron", "proton", "neutron"],
+            [],
+            {"any_of": {"lepton", "charged"}},
+            [True, True, False],
+        ],
+    ],
+)
+def test_particle_list_is_category(particles, args, kwargs, expected):
+    """
+    Test that ``ParticleList.is_category()`` behaves as expected.
+    """
+    sample_list = ParticleList(particles)
+    assert sample_list.is_category(*args, **kwargs) == expected
+
+
 def test_mean_particle():
     """
     Test that ``ParticleList.average_particle()`` returns a particle with


### PR DESCRIPTION
This PR adds the `ParticleList.is_category` method that is analogous to `Particle.is_category`.  I realized the need for this while figuring out how to make `@particle_input` work with `ParticleList` instances.

Currently the docstring for the method refers to the `Particle.is_category` docstring.  I did this to make the docstring for `Particle.is_category` the definitive one, and to avoid the possibility that the docstrings for the two methods could diverge.  I'm open to including the parameters list in the docstring of the new method if preferred.
