### PR TITLE
Add temperature to glossary

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -86,6 +86,18 @@ Glossary
       dimensional |Quantity| and a real number is provided, then the
       real number is often assumed to have the appropriate SI units.
 
+   temperature
+      Most functions in PlasmaPy accept temperature :math:`T` as a
+      `~astropy.units.Quantity` with units of temperature (e.g., kelvin)
+      or energy (e.g., electron-volts).
+
+Most functions in PlasmaPy accept temperature either in units of
+      temperature (e.g., kelvin) or energy (e.g., electron-volts). When
+
+
+When
+      the temperature is provided as an energy,
+
    unit test
       A **unit test** verifies a single unit of behavior, does it
       quickly, and does it in isolation from other tests

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -87,16 +87,11 @@ Glossary
       real number is often assumed to have the appropriate SI units.
 
    temperature
-      Most functions in PlasmaPy accept temperature :math:`T` as a
+      Most functions in PlasmaPy accept temperature, :math:`T`, as a
       `~astropy.units.Quantity` with units of temperature (e.g., kelvin)
-      or energy (e.g., electron-volts).
-
-Most functions in PlasmaPy accept temperature either in units of
-      temperature (e.g., kelvin) or energy (e.g., electron-volts). When
-
-
-When
-      the temperature is provided as an energy,
+      or energy (e.g., electron-volts). A value for energy that is
+      provided will be divided by the Boltzmann constant, :math:`k_B`,
+      to be converted into units of temperature.
 
    unit test
       A **unit test** verifies a single unit of behavior, does it


### PR DESCRIPTION
Because of the nuances with how we accept temperature as an argument to formulary functions, I was thinking that it'd be helpful to have a description of temperature that we could easily link to in docstrings by using ``` :term:`temperature` ```.  I chose the glossary since it seems the most sensible place to define a term, but I'm open to putting this elsewhere as long as there's an easy way to link to the information.  I want to think about the wording a little more carefully since using eV as a unit of temperature is a point of confusion for newcomers to the field (at least it was for me back in the day).  
