### PR TITLE
Use extract function refactoring pattern for `@particle_input`

### DIFF
--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -72,7 +72,23 @@ def _category_errmsg(particle, require, exclude, any_of, funcname) -> str:
     return category_errmsg
 
 
-def _get_args_to_become_particles(arguments, annotations: Dict[str, Any]):
+def _get_args_to_become_particles(
+    arguments: Dict[str, Any], annotations: Dict[str, Any]
+) -> List[str]:
+    """
+    Return a `list` that contains the arguments that need to be
+    processed by `~plasmapy.particles.decorators.particle_input`.
+
+    Parameters
+    ----------
+    arguments : `dict`
+        A `dict` with argument names as keys the arguments themselves as
+        values.k
+
+    annotations : `dict`
+        A `dict` with argument names as keys and the corresponding
+        annotations as values for a function.
+    """
     args_to_become_particles = []
     for argname in annotations.keys():
         if isinstance(annotations[argname], tuple):


### PR DESCRIPTION
`@particle_input` is a long function that does multiple things, and I've been finding it hard to modify it.  This PR is to extract functionality from `@particle_input` into distinct functions, so that high-level functions call medium-level functions, and medium-level functions call low-level functions.  Ultimately, I'd like to fully separate the decorator logic from the logic that processes arguments.  This PR should be strictly refactoring without any actual changes to the functionality, which I'm saving for a future PR.  I might also split up the refactoring into multiple PRs to make code review easier.