### PR TITLE
 Refactored test_validators and test_checks with parametrize

### DIFF
--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -83,7 +83,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Antoine Tavant <https://github.com/antoinetavant>`__
 * `Thomas Ulrich <https://github.com/Elfhelm>`__
 * `Thomas Varnish <https://github.com/tvarnish>`__
-* `Anthony Vo <https://github.com/anthony-vo>`__
+* `Tien Vo <https://github.com/tien-vo>`__
 * `Sixue Xu <https://github.com/hzxusx>`__
 * `Carol Zhang <https://github.com/carolyz>`__
 * `Cody Skinner <https://github.com/cskinner74>`__

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -404,7 +404,7 @@ class TestValidateQuantities:
                 "output": (2 * u.kg * u.m / u.s ** 2).to(u.N),
                 "extra assert": lambda x: x.unit.to_string() == u.N.to_string(),
             },
-        ]
+        ],
     )
     def test_vq_called_as_decorator(self, case):
         """
@@ -507,7 +507,7 @@ class TestValidateQuantities:
                 },
                 "output": -3 * u.cm,
             },
-        ]
+        ],
     )
     def test_decorator_func_def(self, mock_vq_class, case):
         """


### PR DESCRIPTION
Closes #1001 and #1002. All test functions are parameterized. foo and foo_anno are put outside of the test class to make them callable.