### PR TITLE
Remove warnings from `CustomParticle` and `DimensionlessParticle` for `nan` attributes

### DIFF
--- a/changelog/1399.trivial.rst
+++ b/changelog/1399.trivial.rst
@@ -1,0 +1,3 @@
+|CustomParticle| and |DimensionlessParticle| no longer emit a warning
+when the charge and/or mass is not provided and got assigned a value of
+|nan| in the appropriate units.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1956,10 +1956,6 @@ class DimensionlessParticle(AbstractParticle):
                 f"The mass of a dimensionless particle must be a real "
                 f"number that is greater than or equal to zero, not: {m}"
             ) from None
-        if self._mass is np.nan:
-            warnings.warn(
-                "DimensionlessParticle mass set to NaN", MissingParticleDataWarning
-            )
 
     @charge.setter
     def charge(self, q: Optional[Union[Real, u.Quantity]]):
@@ -1970,10 +1966,6 @@ class DimensionlessParticle(AbstractParticle):
                 f"The charge of a dimensionless particle must be a real "
                 f"number, not: {q}"
             ) from None
-        if self._charge is np.nan:
-            warnings.warn(
-                "DimensionlessParticle charge set to NaN", MissingParticleDataWarning
-            )
 
     @property
     def symbol(self) -> str:
@@ -2118,9 +2110,6 @@ class CustomParticle(AbstractPhysicalParticle):
     def charge(self, q: Optional[Union[u.Quantity, Real]]):
         if q is None:
             q = np.nan * u.C
-            warnings.warn(
-                "CustomParticle charge set to NaN C", MissingParticleDataWarning
-            )
         elif isinstance(q, str):
             q = u.Quantity(q)
 
@@ -2162,9 +2151,6 @@ class CustomParticle(AbstractPhysicalParticle):
     def mass(self, m: u.kg):
         if m is None:
             m = np.nan * u.kg
-            warnings.warn(
-                "CustomParticle mass set to NaN kg", MissingParticleDataWarning
-            )
         elif isinstance(m, str):
             m = u.Quantity(m)
         elif not isinstance(m, u.Quantity):

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1921,7 +1921,7 @@ class DimensionlessParticle(AbstractParticle):
             '__init__': {'args': (), 'kwargs': {'mass': 1.0, 'charge': -1.0,
             'symbol': 'DimensionlessParticle(mass=1.0, charge=-1.0)'}}}}
         >>> import pytest
-        >>> with pytest.warns(MissingParticleDataWarning): dimensionless_particle = DimensionlessParticle(mass=1.0)
+        >>> dimensionless_particle = DimensionlessParticle(mass=1.0)
         >>> dimensionless_particle.json_dict
         {'plasmapy_particle': {'type': 'DimensionlessParticle',
             'module': 'plasmapy.particles.particle_class',
@@ -2085,7 +2085,7 @@ class CustomParticle(AbstractPhysicalParticle):
             '__init__': {'args': (), 'kwargs': {'mass': '5.12 kg', 'charge': '6.2 C',
             'symbol': 'ξ'}}}}
         >>> import pytest
-        >>> with pytest.warns(MissingParticleDataWarning): custom_particle = CustomParticle(mass=1.5e-26 * u.kg)
+        >>> custom_particle = CustomParticle(mass=1.5e-26 * u.kg)
         >>> custom_particle.json_dict
         {'plasmapy_particle': {'type': 'CustomParticle',
             'module': 'plasmapy.particles.particle_class',

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -940,9 +940,8 @@ def test_customized_particles(cls, kwargs, attr, expected):
     ],
 )
 def test_custom_particle_symbol(cls, symbol, expected):
-    with pytest.warns(MissingParticleDataWarning):
-        instance = cls(symbol=symbol)
-        assert instance.symbol == expected
+    instance = cls(symbol=symbol)
+    assert instance.symbol == expected
 
 
 customized_particle_errors = [

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1031,8 +1031,7 @@ def test_customized_particle_repr(cls, kwargs, expected_repr):
 @pytest.mark.parametrize("not_a_str", [1, u.kg])
 def test_typeerror_redefining_symbol(cls, not_a_str):
     """Test that the symbol attribute cannot be set to something besides a string"""
-    with pytest.warns(MissingParticleDataWarning):
-        instance = cls()
+    instance = cls()
     with pytest.raises(TypeError):
         instance.symbol = not_a_str
 
@@ -1132,8 +1131,7 @@ def test_custom_particles_from_json_string(
     JSON representation"""
     if expected_exception is None:
         if "mass" not in kwargs or "charge" not in kwargs:
-            with pytest.warns(MissingParticleDataWarning):
-                instance = cls(**kwargs)
+            instance = cls(**kwargs)
         else:
             instance = cls(**kwargs)
         instance_from_json = json_loads_particle(json_string)
@@ -1165,11 +1163,7 @@ def test_custom_particles_from_json_file(cls, kwargs, json_string, expected_exce
     """Test the attributes of dimensionless and custom particles generated from
     JSON representation"""
     if expected_exception is None:
-        if "mass" not in kwargs or "charge" not in kwargs:
-            with pytest.warns(MissingParticleDataWarning):
-                instance = cls(**kwargs)
-        else:
-            instance = cls(**kwargs)
+        instance = cls(**kwargs)
         test_file_object = io.StringIO(json_string)
         instance_from_json = json_load_particle(test_file_object)
         assert u.isclose(

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -921,14 +921,8 @@ customized_particle_tests = [
 @pytest.mark.parametrize("cls, kwargs, attr, expected", customized_particle_tests)
 def test_customized_particles(cls, kwargs, attr, expected):
     """Test the attributes of dimensionless and custom particles."""
-
-    if "mass" not in kwargs or "charge" not in kwargs:
-        with pytest.warns(MissingParticleDataWarning):
-            instance = cls(**kwargs)
-    else:
-        instance = cls(**kwargs)
+    instance = cls(**kwargs)
     value = getattr(instance, attr)
-
     if not u.isclose(value, expected, equal_nan=True):
         pytest.fail(
             f"{call_string(cls, kwargs=kwargs)}.{attr} should return a value "


### PR DESCRIPTION
This PR changes `CustomParticle` and `DimensionlessParticle` so that they no longer emit a warning when they are instantiated without either a charge or a mass.  The warnings had stated that that particular attribute was not provided and thus was given a value of `numpy.nan` in the appropriate units.

I'm removing this since it's not uncommon for me to only need to define either a mass or a charge, and the warnings are getting kind of annoying.  If the warnings do end up being helpful to others, though, I'm open to keeping them.  

I'm not quite sure what sort of changelog entry makes the most sense, but I'm going to go with `trivial` for now.