### PR TITLE
[Docs] Refactor `version`, `release`, and `revision` definitions in `conf.py`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,16 +149,13 @@ copyright = f"2015–{datetime.utcnow().year}, {author}"
 #        However, release needs to be a semantic style version number, so set
 #        the 'unknown' case to ''.
 release = "" if release == "unknown" else release
-if release == "unknown":
-    release = version = revision = ""
+pv = parse_version(release)
+release = pv.public
+version = ".".join(release.split(".")[:2])  # short X.Y version
+if pv.local is not None:
+    revision = pv.local[1:]  # revision number w/o the leading g
 else:
-    pv = parse_version(release)
-    release = pv.public
-    version = ".".join(release.split(".")[:2])  # short X.Y version
-    if pv.local is not None:
-        revision = pv.local[1:]  # revision number w/o the leading g
-    else:
-        revision = ""
+    revision = ""
 
 # This is added to the end of RST files — a good place to put substitutions to
 # be used globally.


### PR DESCRIPTION
Refactor the if-else clause that defines the `release`, `version`, and `revision` configuration variables in `docs/conf.py`.

Closes #1406.