### PR TITLE
Update `gyroradius` FutureWarning and tests

### DIFF
--- a/changelog/1430.bugfix.rst
+++ b/changelog/1430.bugfix.rst
@@ -1,0 +1,5 @@
+For `~plasmapy.formulary.parameters.gyroradius`, updated the default
+keyword arguments and conditional for issuing the
+`~plasmapy.utils.exceptions.PlasmaPyFutureWarning`.  This addresses the
+incorrect behavior where a `ValueError` is raised if an array is passed
+to the deprecated keyword ``T_i``.

--- a/changelog/1430.trivial.rst
+++ b/changelog/1430.trivial.rst
@@ -1,2 +1,2 @@
-Refactor tests (consolidate and parametrize) associated with
+Refactored tests (consolidate and parametrize) associated with
 `~plasmapy.formulary.parameters.gyroradius`.

--- a/changelog/1430.trivial.rst
+++ b/changelog/1430.trivial.rst
@@ -1,2 +1,2 @@
-Refactored tests (consolidate and parametrize) associated with
+Consolidated and parametrized tests associated with
 `~plasmapy.formulary.parameters.gyroradius`.

--- a/changelog/1430.trivial.rst
+++ b/changelog/1430.trivial.rst
@@ -1,0 +1,2 @@
+Refactor tests (consolidate and parametrize) associated with
+`~plasmapy.formulary.parameters.gyroradius`.

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1299,8 +1299,16 @@ wc_ = gyrofrequency
 
 @validate_quantities(
     Vperp={"can_be_nan": True},
-    T_i={"can_be_nan": True, "equivalencies": u.temperature_energy()},
-    T={"can_be_nan": True, "equivalencies": u.temperature_energy()},
+    T_i={
+        "can_be_nan": True,
+        "equivalencies": u.temperature_energy(),
+        "none_shall_pass": True,
+    },
+    T={
+        "can_be_nan": True,
+        "equivalencies": u.temperature_energy(),
+        "none_shall_pass": True,
+    },
     validations_on_return={"equivalencies": u.dimensionless_angles()},
 )
 def gyroradius(
@@ -1308,8 +1316,8 @@ def gyroradius(
     particle: Particle,
     *,
     Vperp: u.m / u.s = np.nan * u.m / u.s,
-    T_i: u.K = np.nan * u.K,
-    T: u.K = np.nan * u.K,
+    T_i: u.K = None,
+    T: u.K = None,
 ) -> u.m:
     r"""Return the particle gyroradius.
 
@@ -1406,13 +1414,21 @@ def gyroradius(
     """
 
     # Backwards Compatibility and Deprecation check for keyword T_i
-    if not np.isnan(T_i):
+    if T_i is not None:
         warnings.warn(
             "Keyword T_i is deprecated, use T instead.",
             PlasmaPyFutureWarning,
         )
-        if np.isnan(T):
+        if T is None:
             T = T_i
+        else:
+            raise ValueError(
+                "Keywords T_i and T are both given.  T_i is deprecated, "
+                "please use T only."
+            )
+
+    if T is None:
+        T = np.nan * u.K
 
     isfinite_T = np.isfinite(T)
     isfinite_Vperp = np.isfinite(Vperp)

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -869,7 +869,9 @@ class TestGyroradius:
 
         vperp = thermal_speed(T, particle=particle, method="most_probable", ndim=3)
 
-        assert gyroradius(B, particle=particle, T=T) == gyroradius(B, particle=particle, Vperp=vperp)
+        assert gyroradius(B, particle=particle, T=T) == gyroradius(
+            B, particle=particle, Vperp=vperp
+        )
 
 
 def test_Debye_length():

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -645,17 +645,6 @@ def test_gyrofrequency():
     assert_can_handle_nparray(gyrofrequency, kwargs={"signed": False})
 
 
-def test_gyroradius():
-    r"""Test the gyroradius function in parameters.py."""
-
-    T2 = 1.2 * u.MK
-    B2 = 123 * u.G
-    particle2 = "alpha"
-    Vperp2 = thermal_speed(T2, particle=particle2)
-    gyro_by_vperp = gyroradius(B2, particle="alpha", Vperp=Vperp2)
-    assert gyro_by_vperp == gyroradius(B2, particle="alpha", T=T2)
-
-
 class TestGyroradius:
     """Tests for `plasmapy.formulary.parameters.gyroradius`."""
 
@@ -868,6 +857,19 @@ class TestGyroradius:
         gyroradius(B_arr, "e-", Vperp=Vperp1, T=T)
 
         assert_quantity_allclose(Vperp1, Vperp2)
+
+    def test_correct_thermal_speed_used(self):
+        """
+        Test the correct version of thermal_speed is used when
+        temperature is given.
+        """
+        B = 123 * u.G
+        T = 1.2 * u.MK
+        particle = "alpha"
+
+        vperp = thermal_speed(T, particle=particle, method="most_probable", ndim=3)
+
+        assert gyroradius(B, particle=particle, T=T) == gyroradius(B, particle=particle, Vperp=vperp)
 
 
 def test_Debye_length():

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -834,6 +834,12 @@ class TestGyroradius:
                 [0.03130334, 0.02213481] * u.m,
                 None,
             ),
+            (
+                ([0.4, 0.6, 0.8] * u.T,),
+                {"particle": "e-", "T": [6, 4, 2] * u.eV},
+                [2.06499941e-05, 1.12404331e-05, 5.96113984e-06] * u.m,
+                None,
+            ),
         ],
     )
     def test_values(self, args, kwargs, expected, atol):

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -677,14 +677,6 @@ class Test_gyroradius:
         assert np.all(np.isfinite(gyroradius(B_arr, "e-", Vperp=V, T=T_allnanarr)))
         assert np.all(np.isfinite(gyroradius(B_arr, "e-", Vperp=V_allnanarr, T=T_i)))
 
-    def test_keeps_arguments_unchanged(self):
-        Vperp1 = u.Quantity([np.nan, 1], unit=u.m / u.s)
-        Vperp2 = u.Quantity([np.nan, 1], unit=u.m / u.s)  # an exact copy
-        T_i = u.Quantity([1, np.nan], unit=u.K)
-
-        gyroradius(B_arr, "e-", Vperp=Vperp1, T=T_i)
-        assert_quantity_allclose(Vperp1, Vperp2)
-
 
 class TestGyroradius:
     """Tests for `plasmapy.formulary.parameters.gyroradius`."""
@@ -865,6 +857,15 @@ class TestGyroradius:
             rc = gyroradius(*args, **kwargs)
             if expected is not None:
                 assert np.allclose(rc, expected)
+
+    def test_keeps_arguments_unchanged(self):
+        Vperp1 = u.Quantity([np.nan, 1], unit=u.m / u.s)
+        Vperp2 = Vperp1.copy()
+        T = u.Quantity([1, np.nan], unit=u.K)
+
+        gyroradius(B_arr, "e-", Vperp=Vperp1, T=T)
+
+        assert_quantity_allclose(Vperp1, Vperp2)
 
 
 def test_Debye_length():

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -648,12 +648,6 @@ def test_gyrofrequency():
 def test_gyroradius():
     r"""Test the gyroradius function in parameters.py."""
 
-    assert gyroradius(B, "e-", T=T_e).unit.is_equivalent(u.m)
-    assert gyroradius(B, particle="p", T=T_i).unit.is_equivalent(u.m)
-
-    assert gyroradius(B, "e-", Vperp=25 * u.m / u.s).unit.is_equivalent(u.m)
-    assert gyroradius(B, particle="p", Vperp=25 * u.m / u.s).unit.is_equivalent(u.m)
-
     T2 = 1.2 * u.MK
     B2 = 123 * u.G
     particle2 = "alpha"

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -656,15 +656,6 @@ def test_gyroradius():
     assert gyro_by_vperp == gyroradius(B2, particle="alpha", T=T2)
 
 
-class Test_gyroradius:
-
-    def test_scalar_and_nan_qarray(self):
-        # If either Vperp or T is a valid scalar and the other is a Qarray of all nans,
-        # should do something valid and not raise a ValueError
-        assert np.all(np.isfinite(gyroradius(B_arr, "e-", Vperp=V, T=T_allnanarr)))
-        assert np.all(np.isfinite(gyroradius(B_arr, "e-", Vperp=V_allnanarr, T=T_i)))
-
-
 class TestGyroradius:
     """Tests for `plasmapy.formulary.parameters.gyroradius`."""
 
@@ -811,6 +802,21 @@ class TestGyroradius:
                 ([0.001, 0.002] * u.T, "e-"),
                 {"Vperp": [25, np.nan] * u.m / u.s, "T": [np.nan, 2e6] * u.K},
                 [1.42140753e-07, 2.21348073e-02] * u.m,
+                None,
+            ),
+            #
+            # If either Vperp or T is a valid scalar and the other is a Qarray of
+            # all nans, then the Qarray of nans should be ignored
+            (
+                ([0.001, 0.002] * u.T, "e-"),
+                {"Vperp": 25.2 * u.m / u.s, "T": [np.nan, np.nan] * u.K},
+                [1.43277879e-07, 7.16389393e-08] * u.m,
+                None,
+            ),
+            (
+                ([0.001, 0.002] * u.T, "e-"),
+                {"Vperp": [np.nan, np.nan] * u.m / u.s, "T": 1e6 * u.K},
+                [0.03130334, 0.01565167] * u.m,
                 None,
             ),
         ],

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -658,13 +658,6 @@ def test_gyroradius():
 
 class Test_gyroradius:
 
-    def test_handle_mixed_Qarrays(self):
-        # If both Vperp or T are input as Qarrays, but only one of the two is valid
-        # at each element, then that's fine, the function should work:
-        assert gyroradius(B_arr, "e-", Vperp=V_nanarr, T=T_nanarr2)[0] == gyroradius(
-            B_arr[0], "e-", Vperp=V_nanarr[0], T=T_nanarr2[0]
-        )
-
     def test_scalar_and_nan_qarray(self):
         # If either Vperp or T is a valid scalar and the other is a Qarray of all nans,
         # should do something valid and not raise a ValueError
@@ -809,6 +802,15 @@ class TestGyroradius:
                 (0.4 * u.T, "p"),
                 {"T": (5800 * u.K).to(u.eV, equivalencies=u.temperature_energy())},
                 0.00025539 * u.m,
+                None,
+            ),
+            #
+            # If both Vperp or T are given, but only one of the two is valid
+            # at each element, then the valid union is taken
+            (
+                ([0.001, 0.002] * u.T, "e-"),
+                {"Vperp": [25, np.nan] * u.m / u.s, "T": [np.nan, 2e6] * u.K},
+                [1.42140753e-07, 2.21348073e-02] * u.m,
                 None,
             ),
         ],

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -687,7 +687,7 @@ class TestGyroradius:
         ],
     )
     def test_raises(self, args, kwargs, _error):
-        """Test scenarios that rais an exception."""
+        """Test scenarios that raise an exception."""
 
         with warnings.catch_warnings(), pytest.raises(_error):
             # we don't care about warnings for these tests

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -683,6 +683,7 @@ class TestGyroradius:
             ((B_arr, "e-"), {"Vperp": V_arr, "T": T_i}, ValueError),
             ((B_arr, "e-"), {"Vperp": V, "T": T_nanarr}, ValueError),
             ((B_arr, "e-"), {"Vperp": V_nanarr, "T": T_i}, ValueError),
+            ((0.4 * u.T, "e-"), {"T": 5 * u.eV, "T_i": 7 * u.eV}, ValueError),
         ],
     )
     def test_raises(self, args, kwargs, _error):

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -832,7 +832,9 @@ class TestGyroradius:
             atol = 1e-8
 
         # note allclose() checks values and units
-        assert np.allclose(gyroradius(*args, **kwargs), expected, atol=atol)
+        rc = gyroradius(*args, **kwargs)
+        assert np.allclose(rc, expected, atol=atol)
+        assert rc.unit == u.m
 
     @pytest.mark.parametrize(
         "args, kwargs, expected, _warns",

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -797,7 +797,7 @@ class TestGyroradius:
             ((B_arr, "e-"), {"Vperp": V_nanarr, "T": T_i}, ValueError),
         ],
     )
-    def test_riases(self, args, kwargs, _error):
+    def test_raises(self, args, kwargs, _error):
         """Test scenarios that rais an exception."""
 
         with warnings.catch_warnings(), pytest.raises(_error):

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -818,6 +818,13 @@ class TestGyroradius:
                 [2.06499941e-05, 1.12404331e-05, 5.96113984e-06] * u.m,
                 None,
             ),
+            ((0.4 * u.T, "p"), {"T": 5800 * u.K}, 0.00025539 * u.m, None),
+            (
+                (0.4 * u.T, "p"),
+                {"T": (5800 * u.K).to(u.eV, equivalencies=u.temperature_energy())},
+                0.00025539 * u.m,
+                None,
+            ),
         ],
     )
     def test_values(self, args, kwargs, expected, atol):


### PR DESCRIPTION
This PR focuses on...

1. Updating the conditional for generating the `PlasmaPyFutureWarning` to resolve issue #1420.
2. Refactors the tests for `gyroradius` by combining the existing test function and test class into one test class, as well as parametrizing all tests.

closes #1420 