### PR TITLE
Patch for #1444

### DIFF
--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -73,7 +73,7 @@ for name in (
     "Re_",
     "Reynolds_number",
     "Rm_",
-):
+):  # coverage: ignore
     try:
         __aliases__.remove(name)
     except ValueError:

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -47,11 +47,43 @@ from plasmapy.utils.decorators import (
 )
 from plasmapy.utils.exceptions import PhysicsWarning, PlasmaPyFutureWarning
 
-from plasmapy.formulary import dimensionless, frequencies, lengths  # noqa
+__all__ += (
+    dimensionless.__all__.copy()
+    + frequencies.__all__.copy()
+    + lengths.__all__.copy()
+    + __aliases__
+    + __lite_funcs__
+)
 
-__aliases__ += frequencies.__aliases__ + lengths.__aliases__
-__lite_funcs__ += frequencies.__lite_funcs__
-__all__ += frequencies.__all__ + lengths.__all__ + __aliases__ + __lite_funcs__
+__aliases__ += (
+    dimensionless.__aliases__.copy()
+    + frequencies.__aliases__.copy()
+    + lengths.__aliases__.copy()
+)
+
+__lite_funcs__ += frequencies.__lite_funcs__.copy()
+
+# remove from __all__ added functionality that was not originally contained in parameters
+for name in (
+    "beta",
+    "betaH_",
+    "Mag_Reynolds",
+    "quantum_theta",
+    "Re_",
+    "Reynolds_number",
+    "Rm_",
+):
+    try:
+        __aliases__.remove(name)
+    except ValueError:
+        # name was not in __aliases__
+        pass
+
+    try:
+        __all__.remove(name)
+    except ValueError:
+        # name was not in __all__
+        pass
 
 e_si_unitless = e.value
 eps0_si_unitless = eps0.value

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -65,8 +65,8 @@ __aliases__ += (
 
 __lite_funcs__ += frequencies.__lite_funcs__.copy()
 
-# remove from __all__ and __aliases__ added functionality that was not originally
-# contained in parameters
+# remove from __all__ and __aliases__ added functionality names that are not
+# actually in this file
 for name in (
     "beta",
     "betaH_",

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -63,7 +63,8 @@ __aliases__ += (
 
 __lite_funcs__ += frequencies.__lite_funcs__.copy()
 
-# remove from __all__ added functionality that was not originally contained in parameters
+# remove from __all__ and __aliases__ added functionality that was not originally
+# contained in parameters
 for name in (
     "beta",
     "betaH_",

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -47,6 +47,8 @@ from plasmapy.utils.decorators import (
 )
 from plasmapy.utils.exceptions import PhysicsWarning, PlasmaPyFutureWarning
 
+from plasmapy.formulary import dimensionless, frequencies, lengths  # noqa
+
 __all__ += (
     dimensionless.__all__.copy()
     + frequencies.__all__.copy()


### PR DESCRIPTION
After merging PR #1444 we started getting an `ImportError` from `plasampy.formulary`.  This was coming from the import of `from plasmapy.formulary.parameters import *`.  The reason for this is two fold: (1) the `plasmapy.formulary.dimensionless` pkg existed before the functionality migration done in PR #1444 and thus it contained functionality not originally contained in `plasmapy.formulary.parameters`; and (2) the auto-population scheme of `__all__`, `__aliases__`, and `__lite_funcs__` was adding the names of these "non-parameters" functions to the `parameters` dunders.  This resulted in `from plasmapy.formulary.parameters import *` trying to import functionality not contained in the namespace.

<img width="1404" alt="image" src="https://user-images.githubusercontent.com/29869348/155858338-ff82c340-0fe9-4652-ad28-406b7b29bfe9.png">
