### PR TITLE
Create and populate `plasmapy.formulary.misc`

### DIFF
--- a/changelog/1453.feature.rst
+++ b/changelog/1453.feature.rst
@@ -1,7 +1,7 @@
 Created `plasmapy.formulary.misc` to contain functionality for
 miscellaneous plasma parameters, and migrated
-`~plasmapy.formulary.misc._grab_charge`,
-`~plasmapy.formulary.misc.Bohm_diffusions`,
+``~plasmapy.formulary.misc._grab_charge``,
+`~plasmapy.formulary.misc.Bohm_diffusion`,
 `~plasmapy.formulary.misc.magnetic_energy_density`,
 `~plasmapy.formulary.misc.magnetic_pressure`,
 `~plasmapy.formulary.misc.mass_density`, and

--- a/changelog/1453.feature.rst
+++ b/changelog/1453.feature.rst
@@ -1,0 +1,10 @@
+Created `plasmapy.formulary.misc` to contain functionality for
+miscellaneous plasma parameters, and migrated
+`~plasmapy.formulary.misc._grab_charge`,
+`~plasmapy.formulary.misc.Bohm_diffusions`,
+`~plasmapy.formulary.misc.magnetic_energy_density`,
+`~plasmapy.formulary.misc.magnetic_pressure`,
+`~plasmapy.formulary.misc.mass_density`, and
+`~plasmapy.formulary.misc.thermal_pressure` from
+`plasmapy.formulary.parameters` to the new module.  Related aliases were
+also migrated.

--- a/changelog/1453.removal.rst
+++ b/changelog/1453.removal.rst
@@ -1,2 +1,2 @@
-Officially deprecating `plasmapy.formulary.parameters` and scheduling its
-permanent removal for the `v0.9.0` release.
+Officially deprecated `plasmapy.formulary.parameters` and scheduled its
+permanent removal for the ``v0.9.0`` release.

--- a/changelog/1453.removal.rst
+++ b/changelog/1453.removal.rst
@@ -1,0 +1,2 @@
+Officially deprecating `plasmapy.formulary.parameters` and scheduling its
+permanent removal for the `v0.9.0` release.

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -41,8 +41,8 @@ multiple software components work together as intended.
 PlasmaPy's tests are set up using the pytest_ framework. The tests for
 a subpackage are located in its :file:`tests` subdirectory in files with
 names of the form :file:`test_*.py`. For example, tests for
-`plasmapy.formulary.parameters` are located at
-:file:`plasmapy/formulary/tests/test_parameters.py` relative to the top
+`plasmapy.formulary.speeds` are located at
+:file:`plasmapy/formulary/tests/test_speeds.py` relative to the top
 of the package. Example code contained within docstrings is tested to
 make sure that the actual printed output matches what is in the
 docstring.

--- a/docs/formulary/index.rst
+++ b/docs/formulary/index.rst
@@ -1,4 +1,4 @@
-.. _formulary:
+.. _formular:
 
 ********************************
 Formulary (`plasmapy.formulary`)

--- a/docs/formulary/index.rst
+++ b/docs/formulary/index.rst
@@ -44,6 +44,9 @@ physical quantities helpful for plasma physics.
    | .. toctree:: Mathematics <mathematics>                 | `plasmapy.formulary.mathematics`        |
    |    :maxdepth: 1                                        |                                         |
    +--------------------------------------------------------+-----------------------------------------+
+   | .. toctree:: Miscellaneous Parameters <misc>           | `plasmapy.formulary.misc`               |
+   |    :maxdepth: 1                                        |                                         |
+   +--------------------------------------------------------+-----------------------------------------+
    | .. toctree:: Plasma Parameters <parameters>            | `plasmapy.formulary.parameters`         |
    |    :maxdepth: 1                                        |                                         |
    +--------------------------------------------------------+-----------------------------------------+
@@ -54,6 +57,9 @@ physical quantities helpful for plasma physics.
    |    :maxdepth: 1                                        |                                         |
    +--------------------------------------------------------+-----------------------------------------+
    | .. toctree:: Relativistic Relations <relativity>       | `plasmapy.formulary.relativity`         |
+   |    :maxdepth: 1                                        |                                         |
+   +--------------------------------------------------------+-----------------------------------------+
+   | .. toctree:: Speeds <speeds>                           | `plasmapy.formulary.speeds`             |
    |    :maxdepth: 1                                        |                                         |
    +--------------------------------------------------------+-----------------------------------------+
 

--- a/docs/formulary/index.rst
+++ b/docs/formulary/index.rst
@@ -1,4 +1,4 @@
-.. _formular:
+.. _formulary:
 
 ********************************
 Formulary (`plasmapy.formulary`)

--- a/docs/formulary/misc.rst
+++ b/docs/formulary/misc.rst
@@ -1,0 +1,7 @@
+.. _formulary_misc:
+
+***********************************************************
+Miscellaneous Plasma Parameters (`plasmapy.formulary.misc`)
+***********************************************************
+
+.. automodapi:: plasmapy.formulary.misc

--- a/docs/formulary/speeds.rst
+++ b/docs/formulary/speeds.rst
@@ -1,0 +1,13 @@
+.. _speeds:
+
+*****************************************************
+Speed Plasma Parameters (`plasmapy.formulary.speeds`)
+*****************************************************
+
+.. automodapi:: plasmapy.formulary.speeds
+
+.. nbgallery::
+    :caption: Examples
+
+    /notebooks/distribution
+    /notebooks/formulary/thermal_speed

--- a/docs/plasmapy_sphinx/automodsumm/core.py
+++ b/docs/plasmapy_sphinx/automodsumm/core.py
@@ -171,15 +171,15 @@ below relate to the behavior of the :rst:dir:`automodsumm` directive.
     object names just like ``__all__``.  The :rst:dir:`automodapi` and
     :rst:dir:`automodsumm` directives will used this defined dunder to identify
     the objects associated with the custom group.  Using
-    `plasmapy.formulary.parameters` as an example, the **aliases** group can
+    `plasmapy.formulary.speeds` as an example, the **aliases** group can
     now be collected and displayed like
 
     .. code-block:: rst
 
-        .. automodsumm:: plasmapy.formulary.parameters
+        .. automodsumm:: plasmapy.formulary.speeds
            :groups: aliases
 
-    .. automodsumm:: plasmapy.formulary.parameters
+    .. automodsumm:: plasmapy.formulary.speeds
            :groups: aliases
 
 .. confval:: automodapi_generate_module_stub_files

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -6,9 +6,6 @@ __all__ = []
 __aliases__ = []
 __lite_funcs__ = []
 
-# parameters import must remain first so other imports can override
-# TODO: remove parameters import when issue #1433 is closed
-from plasmapy.formulary.parameters import *  # noqa
 from plasmapy.formulary.braginskii import *
 from plasmapy.formulary.collisions import *
 from plasmapy.formulary.dielectric import *

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -132,7 +132,7 @@ from plasmapy.formulary.collisions import (
     fundamental_ion_collision_freq,
 )
 from plasmapy.formulary.dimensionless import Hall_parameter
-from plasmapy.formulary.parameters import _grab_charge
+from plasmapy.formulary.misc import _grab_charge
 from plasmapy.particles.atomic import _is_electron
 from plasmapy.utils import PhysicsError
 from plasmapy.utils.decorators import validate_quantities

--- a/plasmapy/formulary/dimensionless.py
+++ b/plasmapy/formulary/dimensionless.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from astropy.constants.si import k_B, mu0
 
-from plasmapy.formulary import frequencies, lengths, parameters, quantum
+from plasmapy.formulary import frequencies, lengths, misc, quantum
 from plasmapy.particles import Particle
 from plasmapy.utils.decorators import validate_quantities
 
@@ -330,11 +330,11 @@ def beta(T: u.K, n: u.m ** -3, B: u.T) -> u.dimensionless_unscaled:
 
     See Also
     --------
-    ~plasmapy.formulary.parameters.thermal_pressure
-    ~plasmapy.formulary.parameters.magnetic_pressure
+    ~plasmapy.formulary.misc.thermal_pressure
+    ~plasmapy.formulary.misc.magnetic_pressure
     """
-    thermal_pressure = parameters.thermal_pressure(T, n)
-    magnetic_pressure = parameters.magnetic_pressure(B)
+    thermal_pressure = misc.thermal_pressure(T, n)
+    magnetic_pressure = misc.magnetic_pressure(B)
     return thermal_pressure / magnetic_pressure
 
 

--- a/plasmapy/formulary/frequencies.py
+++ b/plasmapy/formulary/frequencies.py
@@ -16,6 +16,7 @@ from astropy.constants.si import e, eps0
 from numba import njit
 
 from plasmapy import particles
+from plasmapy.formulary import misc
 from plasmapy.particles import Particle
 from plasmapy.utils.decorators import (
     angular_freq_to_hz,
@@ -131,10 +132,8 @@ def gyrofrequency(B: u.T, particle: Particle, signed=False, Z=None) -> u.rad / u
     279924... Hz
 
     """
-    from plasmapy.formulary.parameters import _grab_charge
-
     m = particles.particle_mass(particle)
-    Z = _grab_charge(particle, Z)
+    Z = misc._grab_charge(particle, Z)
     if not signed:
         Z = abs(Z)
 

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -1,12 +1,13 @@
 """Functions to for miscellaneous plasma parameter calculations."""
 
-__all__ = ["mass_density"]
-__aliases__ = ["rho_"]
+__all__ = ["mass_density", "thermal_pressure"]
+__aliases__ = ["rho_", "pth_"]
 
 import astropy.units as u
 import numbers
 import numpy as np
 
+from astropy.constants.si import k_B
 from typing import Optional, Union
 
 from plasmapy import particles
@@ -148,3 +149,57 @@ def mass_density(
 
 rho_ = mass_density
 """Alias to `~plasmapy.formulary.misc.mass_density`."""
+
+
+@validate_quantities(
+    T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
+    n={"can_be_negative": False},
+)
+def thermal_pressure(T: u.K, n: u.m ** -3) -> u.Pa:
+    r"""
+    Return the thermal pressure for a Maxwellian distribution.
+
+    **Aliases:** `pth_`
+
+    Parameters
+    ----------
+    T : `~astropy.units.Quantity`
+        The particle temperature in either kelvin or energy per particle.
+
+    n : `~astropy.units.Quantity`
+        The particle number density in units convertible to m\ :sup:`-3`\ .
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> thermal_pressure(1*u.eV, 1e20/u.m**3)
+    <Quantity 16.021... Pa>
+    >>> thermal_pressure(10*u.eV, 1e20/u.m**3)
+    <Quantity 160.21... Pa>
+
+    Returns
+    -------
+    p_th : `~astropy.units.Quantity`
+        Thermal pressure.
+
+    Raises
+    ------
+    `TypeError`
+        The temperature or number density is not a `~astropy.units.Quantity`.
+
+    `~astropy.units.UnitConversionError`
+        If the particle temperature is not in units of temperature or
+        energy per particle.
+
+    Notes
+    -----
+    The thermal pressure is given by:
+
+    .. math::
+        T_{th} = n k_B T
+    """
+    return n * k_B * T
+
+
+pth_ = thermal_pressure
+"""Alias to `~plasmapy.formulary.misc.thermal_pressure`."""

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -149,7 +149,7 @@ def magnetic_energy_density(B: u.T) -> u.J / u.m ** 3:
         If the input is not in units convertible to tesla.
 
     `ValueError`
-        If the magnetic field strength does not have an appropriate.
+        If the magnetic field strength does not have an appropriate
         value.
 
     Warns

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -1,13 +1,13 @@
 """Functions to for miscellaneous plasma parameter calculations."""
 
-__all__ = ["mass_density", "thermal_pressure"]
-__aliases__ = ["rho_", "pth_"]
+__all__ = ["Bohm_diffusion", "mass_density", "thermal_pressure"]
+__aliases__ = ["DB_", "rho_", "pth_"]
 
 import astropy.units as u
 import numbers
 import numpy as np
 
-from astropy.constants.si import k_B
+from astropy.constants.si import e, k_B
 from typing import Optional, Union
 
 from plasmapy import particles
@@ -43,6 +43,78 @@ def _grab_charge(ion: Particle, z_mean=None):
         # using average ionization provided by user
         Z = z_mean
     return Z
+
+
+@validate_quantities(
+    T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
+    B={"can_be_negative": False},
+)
+def Bohm_diffusion(T_e: u.K, B: u.T) -> u.m ** 2 / u.s:
+    r"""
+    Return the Bohm diffusion coefficient.
+
+    The Bohm diffusion coefficient was conjectured to follow Bohm model
+    of the diffusion of plasma across a magnetic field and describe the
+    diffusion of early fusion energy machines :cite:p:`bohm:1949`. The
+    rate predicted by Bohm diffusion is much higher than classical
+    diffusion, and if there were no exceptions, magnetically confined
+    fusion would be impractical.
+
+    .. math::
+
+        D_B = \frac{1}{16} \frac{k_B T}{e B}
+
+    where :math:`k_B` is the Boltzmann constant
+    and :math:`e` is the fundamental charge.
+
+    **Aliases:** `DB_`
+
+    Parameters
+    ----------
+    T_e : `~astropy.units.Quantity`
+        The electron temperature.
+
+    B : `~astropy.units.Quantity`
+        The magnitude of the magnetic field in the plasma.
+
+    Warns
+    -----
+    : `~astropy.units.UnitsWarning`
+        If units are not provided, SI units are assumed.
+
+    Raises
+    ------
+    `TypeError`
+        ``T_e`` is not a `~astropy.units.Quantity` and cannot be
+        converted into one.
+
+    `~astropy.units.UnitConversionError`
+        If ``T_e`` is not in appropriate units.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> T_e = 5000 * u.K
+    >>> B = 10 * u.T
+    >>> Bohm_diffusion(T_e, B)
+    <Quantity 0.00269292 m2 / s>
+    >>> T_e = 50 * u.eV
+    >>> B = 10 * u.T
+    >>> Bohm_diffusion(T_e, B)
+    <Quantity 0.3125 m2 / s>
+
+    Returns
+    -------
+    D_B : `~astropy.units.Quantity`
+        The Bohm diffusion coefficient in meters squared per second.
+
+    """
+    D_B = k_B * T_e / (16 * e * B)
+    return D_B
+
+
+DB_ = Bohm_diffusion
+"""Alias to `~plasmapy.formulary.misc.Bohm_diffusion`."""
 
 
 @validate_quantities(

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -1,7 +1,12 @@
 """Functions to for miscellaneous plasma parameter calculations."""
 
-__all__ = ["Bohm_diffusion", "mass_density", "thermal_pressure"]
-__aliases__ = ["DB_", "rho_", "pth_"]
+__all__ = [
+    "Bohm_diffusion",
+    "magnetic_energy_density",
+    "mass_density",
+    "thermal_pressure",
+]
+__aliases__ = ["DB_", "pth_", "rho_", "ub_"]
 
 import astropy.units as u
 import numbers
@@ -115,6 +120,71 @@ def Bohm_diffusion(T_e: u.K, B: u.T) -> u.m ** 2 / u.s:
 
 DB_ = Bohm_diffusion
 """Alias to `~plasmapy.formulary.misc.Bohm_diffusion`."""
+
+
+@validate_quantities
+def magnetic_energy_density(B: u.T) -> u.J / u.m ** 3:
+    r"""
+    Calculate the magnetic energy density.
+
+    **Aliases:** `ub_`
+
+    Parameters
+    ----------
+    B : `~astropy.units.Quantity`
+        The magnetic field in units convertible to tesla.
+
+    Returns
+    -------
+    E_B : `~astropy.units.Quantity`
+        The magnetic energy density in units of joules per cubic meter.
+
+    Raises
+    ------
+    `TypeError`
+        If the input is not a `~astropy.units.Quantity`.
+
+    `~astropy.units.UnitConversionError`
+        If the input is not in units convertible to tesla.
+
+    `ValueError`
+        If the magnetic field strength does not have an appropriate.
+        value.
+
+    Warns
+    -----
+    : `~astropy.units.UnitsWarning`
+        If units are not provided, SI units are assumed
+
+    Notes
+    -----
+    The magnetic energy density is given by:
+
+    .. math::
+        E_B = \frac{B^2}{2 μ_0}
+
+    The motivation behind having two separate functions for magnetic
+    pressure and magnetic energy density is that it allows greater
+    insight into the physics that are being considered by the user and
+    thus more readable code.
+
+    See Also
+    --------
+    magnetic_pressure : Returns an equivalent `~astropy.units.Quantity`,
+        except in units of pascals.
+
+    Examples
+    --------
+    >>> from astropy import units as u
+    >>> magnetic_energy_density(0.1*u.T)
+    <Quantity 3978.87... J / m3>
+
+    """
+    return magnetic_pressure(B)
+
+
+ub_ = magnetic_energy_density
+"""Alias to `~plasmapy.formulary.misc.magnetic_energy_density`."""
 
 
 @validate_quantities(

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -1,0 +1,2 @@
+"""Functions to for miscellaneous plasma parameter calculations."""
+

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -1,2 +1,38 @@
 """Functions to for miscellaneous plasma parameter calculations."""
 
+__all__ = []
+__aliases__ = []
+
+from plasmapy import particles
+from plasmapy.particles import Particle
+
+
+def _grab_charge(ion: Particle, z_mean=None):
+    """
+    Merge two possible inputs for particle charge.
+
+    Parameters
+    ----------
+    ion : `~plasmapy.particles.particle_class.Particle`
+        a string representing a charged particle, or a Particle object.
+
+    z_mean : `float`
+        An optional float describing the average ionization of a particle
+        species.
+
+    Returns
+    -------
+    float
+        if ``z_mean`` was passed, ``z_mean``, otherwise, the charge number
+        of ``ion``.
+
+    """
+    if z_mean is None:
+        # warnings.warn("No z_mean given, defaulting to atomic charge",
+        #               PhysicsWarning)
+        Z = particles.charge_number(ion)
+    else:
+        # using average ionization provided by user
+        Z = z_mean
+    return Z
+

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -1,10 +1,17 @@
 """Functions to for miscellaneous plasma parameter calculations."""
 
-__all__ = []
-__aliases__ = []
+__all__ = ["mass_density"]
+__aliases__ = ["rho_"]
+
+import astropy.units as u
+import numbers
+import numpy as np
+
+from typing import Optional, Union
 
 from plasmapy import particles
 from plasmapy.particles import Particle
+from plasmapy.utils.decorators import validate_quantities
 
 
 def _grab_charge(ion: Particle, z_mean=None):
@@ -36,3 +43,108 @@ def _grab_charge(ion: Particle, z_mean=None):
         Z = z_mean
     return Z
 
+
+@validate_quantities(
+    density={"can_be_negative": False}, validations_on_return={"can_be_negative": False}
+)
+def mass_density(
+    density: (u.m ** -3, u.kg / (u.m ** 3)),
+    particle: Union[Particle, str],
+    z_ratio: Optional[numbers.Real] = 1,
+) -> u.kg / u.m ** 3:
+    r"""
+    Calculate the mass density from a number density.
+
+    .. math::
+
+        \rho = \left| \frac{Z_{s}}{Z_{particle}} \right| n_{s} m_{particle}
+              = | Z_{ratio} | n_{s} m_{particle}
+
+    where :math:`m_{particle}` is the particle mass, :math:`n_{s}` is a number
+    density for plasma species :math:`s`, :math:`Z_{s}` is the charge number of
+    species :math:`s`, and :math:`Z_{particle}` is the charge number of
+    ``particle``.  For example, if the electron density is given for :math:`n_s`
+    and ``particle`` is a doubly ionized atom, then :math:`Z_{ratio} = -1 / 2`\ .
+
+    **Aliases:** `rho_`
+
+    Parameters
+    ----------
+    density : `~astropy.units.Quantity`
+        Either a particle number density (in units of m\ :sup:`-3` or
+        equivalent) or a mass density (in units of kg / m\ :sup:`3` or
+        equivalent).  If ``density`` is a mass density, then it will be passed
+        through and returned without modification.
+
+    particle : `~plasmapy.particles.particle_class.Particle`
+        The particle for which the mass density is being calculated for.  Must
+        be a `~plasmapy.particles.particle_class.Particle` or a value convertible to
+        a `~plasmapy.particles.particle_class.Particle` (e.g., ``'p'`` for protons,
+        ``'D+'`` for deuterium, or ``'He-4 +1'`` for singly ionized helium-4).
+
+    z_ratio : `int`, `float`, optional
+        The ratio of the charge numbers corresponding to the plasma species
+        represented by ``density`` and the ``particle``.  For example, if the
+        given ``density`` is and electron density and ``particle`` is doubly
+        ionized ``He``, then ``z_ratio = -0.5``.  Default is ``1``.
+
+    Raises
+    ------
+    `~astropy.units.UnitTypeError`
+        If the ``density`` does not have units equivalent to a number density
+        or mass density.
+
+    `TypeError`
+        If ``density`` is not of type `~astropy.units.Quantity`, or convertible.
+
+    `TypeError`
+        If ``particle`` is not of type or convertible to
+        `~plasmapy.particles.particle_class.Particle`.
+
+    `TypeError`
+        If ``z_ratio`` is not of type `int` or `float`.
+
+    `ValueError`
+        If ``density`` is negative.
+
+    Returns
+    -------
+    `~astropy.units.Quantity`
+        The mass density for the plasma species represented by ``particle``.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> mass_density(1 * u.m ** -3, 'p')
+    <Quantity 1.67262...e-27 kg / m3>
+    >>> mass_density(4 * u.m ** -3, 'D+')
+    <Quantity 1.33743...e-26 kg / m3>
+    >>> mass_density(2.e12 * u.cm ** -3, 'He')
+    <Quantity 1.32929...e-08 kg / m3>
+    >>> mass_density(2.e12 * u.cm ** -3, 'He', z_ratio=0.5)
+    <Quantity 6.64647...e-09 kg / m3>
+    >>> mass_density(1.0 * u.g * u.m ** -3, "")
+    <Quantity 0.001 kg / m3>
+    """
+    if density.unit.is_equivalent(u.kg / u.m ** 3):
+        return density
+
+    if not isinstance(particle, Particle):
+        try:
+            particle = Particle(particle)
+        except TypeError:
+            raise TypeError(
+                f"If passing a number density, you must pass a plasmapy Particle "
+                f"(not type {type(particle)}) to calculate the mass density!"
+            )
+
+    if not isinstance(z_ratio, (float, np.floating, int, np.integer)):
+        raise TypeError(
+            f"Expected type int or float for keyword z_ratio, got type {type(z_ratio)}."
+        )
+
+    return abs(z_ratio) * density * particle.mass
+
+
+rho_ = mass_density
+"""Alias to `~plasmapy.formulary.misc.mass_density`."""

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -1,4 +1,4 @@
-"""Functions to for miscellaneous plasma parameter calculations."""
+"""Functions for miscellaneous plasma parameter calculations."""
 
 __all__ = [
     "Bohm_diffusion",

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -3,16 +3,17 @@
 __all__ = [
     "Bohm_diffusion",
     "magnetic_energy_density",
+    "magnetic_pressure",
     "mass_density",
     "thermal_pressure",
 ]
-__aliases__ = ["DB_", "pth_", "rho_", "ub_"]
+__aliases__ = ["DB_", "pmag_", "pth_", "rho_", "ub_"]
 
 import astropy.units as u
 import numbers
 import numpy as np
 
-from astropy.constants.si import e, k_B
+from astropy.constants.si import e, k_B, mu0
 from typing import Optional, Union
 
 from plasmapy import particles
@@ -185,6 +186,71 @@ def magnetic_energy_density(B: u.T) -> u.J / u.m ** 3:
 
 ub_ = magnetic_energy_density
 """Alias to `~plasmapy.formulary.misc.magnetic_energy_density`."""
+
+
+@validate_quantities
+def magnetic_pressure(B: u.T) -> u.Pa:
+    r"""
+    Calculate the magnetic pressure.
+
+    **Aliases:** `pmag_`
+
+    Parameters
+    ----------
+    B : `~astropy.units.Quantity`
+        The magnetic field in units convertible to tesla.
+
+    Returns
+    -------
+    p_B : `~astropy.units.Quantity`
+        The magnetic pressure in units in pascals (newtons per square meter).
+
+    Raises
+    ------
+    `TypeError`
+        If the input is not a `~astropy.units.Quantity`.
+
+    `~astropy.units.UnitConversionError`
+        If the input is not in units convertible to tesla.
+
+    `ValueError`
+        If the magnetic field strength is not a real number between
+        :math:`±∞`\ .
+
+    Warns
+    -----
+    : `~astropy.units.UnitsWarning`
+        If units are not provided, SI units are assumed.
+
+    Notes
+    -----
+    The magnetic pressure is given by:
+
+    .. math::
+        p_B = \frac{B^2}{2 μ_0}
+
+    The motivation behind having two separate functions for magnetic
+    pressure and magnetic energy density is that it allows greater
+    insight into the physics that are being considered by the user and
+    thus more readable code.
+
+    See Also
+    --------
+    magnetic_energy_density : returns an equivalent `~astropy.units.Quantity`,
+        except in units of joules per cubic meter.
+
+    Examples
+    --------
+    >>> from astropy import units as u
+    >>> magnetic_pressure(0.1*u.T).to(u.Pa)
+    <Quantity 3978.87... Pa>
+
+    """
+    return (B ** 2) / (2 * mu0)
+
+
+pmag_ = magnetic_pressure
+"""Alias to `~plasmapy.formulary.misc.magnetic_pressure`."""
 
 
 @validate_quantities(

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1,13 +1,7 @@
 """Functions to calculate fundamental plasma parameters."""
 
-__all__ = [
-    "magnetic_energy_density",
-    "magnetic_pressure",
-]
-__aliases__ = [
-    "pmag_",
-    "ub_",
-]
+__all__ = ["magnetic_pressure"]
+__aliases__ = ["pmag_"]
 __lite_funcs__ = []
 
 import astropy.units as u
@@ -92,6 +86,8 @@ funcs_to_deprecate_wrap = [  # (module_name, func_name)
     ("misc", "_grab_charge"),
     ("misc", "Bohm_diffusion"),
     ("misc", "DB_"),
+    ("misc", "magnetic_energy_density"),
+    ("misc", "ub_"),
     ("misc", "mass_density"),
     ("misc", "rho_"),
     ("misc", "thermal_pressure"),
@@ -119,7 +115,7 @@ for modname, name in funcs_to_deprecate_wrap:
         ),
     )(getattr(globals()[f"{modname}"], name))
 
-del modname, name
+del funcs_to_deprecate_wrap, modname, name
 
 
 @validate_quantities
@@ -185,68 +181,3 @@ def magnetic_pressure(B: u.T) -> u.Pa:
 
 pmag_ = magnetic_pressure
 """Alias to `~plasmapy.formulary.parameters.magnetic_pressure`."""
-
-
-@validate_quantities
-def magnetic_energy_density(B: u.T) -> u.J / u.m ** 3:
-    r"""
-    Calculate the magnetic energy density.
-
-    **Aliases:** `ub_`
-
-    Parameters
-    ----------
-    B : `~astropy.units.Quantity`
-        The magnetic field in units convertible to tesla.
-
-    Returns
-    -------
-    E_B : `~astropy.units.Quantity`
-        The magnetic energy density in units of joules per cubic meter.
-
-    Raises
-    ------
-    `TypeError`
-        If the input is not a `~astropy.units.Quantity`.
-
-    `~astropy.units.UnitConversionError`
-        If the input is not in units convertible to tesla.
-
-    `ValueError`
-        If the magnetic field strength does not have an appropriate.
-        value.
-
-    Warns
-    -----
-    : `~astropy.units.UnitsWarning`
-        If units are not provided, SI units are assumed
-
-    Notes
-    -----
-    The magnetic energy density is given by:
-
-    .. math::
-        E_B = \frac{B^2}{2 μ_0}
-
-    The motivation behind having two separate functions for magnetic
-    pressure and magnetic energy density is that it allows greater
-    insight into the physics that are being considered by the user and
-    thus more readable code.
-
-    See Also
-    --------
-    magnetic_pressure : Returns an equivalent `~astropy.units.Quantity`,
-        except in units of pascals.
-
-    Examples
-    --------
-    >>> from astropy import units as u
-    >>> magnetic_energy_density(0.1*u.T)
-    <Quantity 3978.87... J / m3>
-
-    """
-    return magnetic_pressure(B)
-
-
-ub_ = magnetic_energy_density
-"""Alias to `~plasmapy.formulary.parameters.magnetic_energy_density`."""

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1,14 +1,10 @@
 """Functions to calculate fundamental plasma parameters."""
 
-__all__ = ["magnetic_pressure"]
-__aliases__ = ["pmag_"]
-__lite_funcs__ = []
+__all__ = []
 
-import astropy.units as u
+from astropy.constants.si import e, eps0, k_B
 
-from astropy.constants.si import e, eps0, k_B, mu0
-
-from plasmapy.utils.decorators import deprecated, validate_quantities
+from plasmapy.utils.decorators import deprecated
 from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
 from plasmapy.formulary import dimensionless, frequencies, lengths, misc, speeds  # noqa
@@ -20,11 +16,9 @@ __all__ += (
     + lengths.__all__.copy()
     + misc.__all__.copy()
     + speeds.__all__.copy()
-    + __aliases__
-    + __lite_funcs__
 )
 
-__aliases__ += (
+__aliases__ = (
     dimensionless.__aliases__.copy()
     + frequencies.__aliases__.copy()
     + lengths.__aliases__.copy()
@@ -32,7 +26,7 @@ __aliases__ += (
     + speeds.__aliases__.copy()
 )
 
-__lite_funcs__ += frequencies.__lite_funcs__.copy() + speeds.__lite_funcs__.copy()
+__lite_funcs__ = frequencies.__lite_funcs__.copy() + speeds.__lite_funcs__.copy()
 
 # remove from __all__ and __aliases__ added functionality names that are not
 # actually in this file
@@ -88,6 +82,8 @@ funcs_to_deprecate_wrap = [  # (module_name, func_name)
     ("misc", "DB_"),
     ("misc", "magnetic_energy_density"),
     ("misc", "ub_"),
+    ("misc", "magnetic_pressure"),
+    ("misc", "pmag_"),
     ("misc", "mass_density"),
     ("misc", "rho_"),
     ("misc", "thermal_pressure"),
@@ -116,68 +112,3 @@ for modname, name in funcs_to_deprecate_wrap:
     )(getattr(globals()[f"{modname}"], name))
 
 del funcs_to_deprecate_wrap, modname, name
-
-
-@validate_quantities
-def magnetic_pressure(B: u.T) -> u.Pa:
-    r"""
-    Calculate the magnetic pressure.
-
-    **Aliases:** `pmag_`
-
-    Parameters
-    ----------
-    B : `~astropy.units.Quantity`
-        The magnetic field in units convertible to tesla.
-
-    Returns
-    -------
-    p_B : `~astropy.units.Quantity`
-        The magnetic pressure in units in pascals (newtons per square meter).
-
-    Raises
-    ------
-    `TypeError`
-        If the input is not a `~astropy.units.Quantity`.
-
-    `~astropy.units.UnitConversionError`
-        If the input is not in units convertible to tesla.
-
-    `ValueError`
-        If the magnetic field strength is not a real number between
-        :math:`±∞`\ .
-
-    Warns
-    -----
-    : `~astropy.units.UnitsWarning`
-        If units are not provided, SI units are assumed.
-
-    Notes
-    -----
-    The magnetic pressure is given by:
-
-    .. math::
-        p_B = \frac{B^2}{2 μ_0}
-
-    The motivation behind having two separate functions for magnetic
-    pressure and magnetic energy density is that it allows greater
-    insight into the physics that are being considered by the user and
-    thus more readable code.
-
-    See Also
-    --------
-    magnetic_energy_density : returns an equivalent `~astropy.units.Quantity`,
-        except in units of joules per cubic meter.
-
-    Examples
-    --------
-    >>> from astropy import units as u
-    >>> magnetic_pressure(0.1*u.T).to(u.Pa)
-    <Quantity 3978.87... Pa>
-
-    """
-    return (B ** 2) / (2 * mu0)
-
-
-pmag_ = magnetic_pressure
-"""Alias to `~plasmapy.formulary.parameters.magnetic_pressure`."""

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1,15 +1,11 @@
 """Functions to calculate fundamental plasma parameters."""
 
 __all__ = [
-    "Bohm_diffusion",
     "magnetic_energy_density",
     "magnetic_pressure",
 ]
 __aliases__ = [
-    "DB_",
     "pmag_",
-    "pth_",
-    "rho_",
     "ub_",
 ]
 __lite_funcs__ = []
@@ -94,6 +90,8 @@ funcs_to_deprecate_wrap = [  # (module_name, func_name)
     ("lengths", "inertial_length"),
     ("lengths", "cwp_"),
     ("misc", "_grab_charge"),
+    ("misc", "Bohm_diffusion"),
+    ("misc", "DB_"),
     ("misc", "mass_density"),
     ("misc", "rho_"),
     ("misc", "thermal_pressure"),
@@ -252,75 +250,3 @@ def magnetic_energy_density(B: u.T) -> u.J / u.m ** 3:
 
 ub_ = magnetic_energy_density
 """Alias to `~plasmapy.formulary.parameters.magnetic_energy_density`."""
-
-
-@validate_quantities(
-    T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
-    B={"can_be_negative": False},
-)
-def Bohm_diffusion(T_e: u.K, B: u.T) -> u.m ** 2 / u.s:
-    r"""
-    Return the Bohm diffusion coefficient.
-
-    The Bohm diffusion coefficient was conjectured to follow Bohm model
-    of the diffusion of plasma across a magnetic field and describe the
-    diffusion of early fusion energy machines :cite:p:`bohm:1949`. The
-    rate predicted by Bohm diffusion is much higher than classical
-    diffusion, and if there were no exceptions, magnetically confined
-    fusion would be impractical.
-
-    .. math::
-
-        D_B = \frac{1}{16} \frac{k_B T}{e B}
-
-    where :math:`k_B` is the Boltzmann constant
-    and :math:`e` is the fundamental charge.
-
-    **Aliases:** `DB_`
-
-    Parameters
-    ----------
-    T_e : `~astropy.units.Quantity`
-        The electron temperature.
-
-    B : `~astropy.units.Quantity`
-        The magnitude of the magnetic field in the plasma.
-
-    Warns
-    -----
-    : `~astropy.units.UnitsWarning`
-        If units are not provided, SI units are assumed.
-
-    Raises
-    ------
-    `TypeError`
-        ``T_e`` is not a `~astropy.units.Quantity` and cannot be
-        converted into one.
-
-    `~astropy.units.UnitConversionError`
-        If ``T_e`` is not in appropriate units.
-
-    Examples
-    --------
-    >>> import astropy.units as u
-    >>> T_e = 5000 * u.K
-    >>> B = 10 * u.T
-    >>> Bohm_diffusion(T_e, B)
-    <Quantity 0.00269292 m2 / s>
-    >>> T_e = 50 * u.eV
-    >>> B = 10 * u.T
-    >>> Bohm_diffusion(T_e, B)
-    <Quantity 0.3125 m2 / s>
-
-    Returns
-    -------
-    D_B : `~astropy.units.Quantity`
-        The Bohm diffusion coefficient in meters squared per second.
-
-    """
-    D_B = k_B * T_e / (16 * e * B)
-    return D_B
-
-
-DB_ = Bohm_diffusion
-"""Alias to `~plasmapy.formulary.parameters.Bohm_diffusion`."""

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -23,18 +23,18 @@ import numpy as np
 from astropy.constants.si import e, eps0, k_B, mu0
 from typing import Optional, Union
 
-from plasmapy import particles
 from plasmapy.particles import Particle
 from plasmapy.utils.decorators import deprecated, validate_quantities
 from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
-from plasmapy.formulary import dimensionless, frequencies, lengths, speeds  # noqa
+from plasmapy.formulary import dimensionless, frequencies, lengths, misc, speeds  # noqa
 
 
 __all__ += (
     dimensionless.__all__.copy()
     + frequencies.__all__.copy()
     + lengths.__all__.copy()
+    + misc.__all__.copy()
     + speeds.__all__.copy()
     + __aliases__
     + __lite_funcs__
@@ -44,6 +44,7 @@ __aliases__ += (
     dimensionless.__aliases__.copy()
     + frequencies.__aliases__.copy()
     + lengths.__aliases__.copy()
+    + misc.__aliases__.copy()
     + speeds.__aliases__.copy()
 )
 
@@ -98,6 +99,7 @@ funcs_to_deprecate_wrap = [  # (module_name, func_name)
     ("lengths", "rhoc_"),
     ("lengths", "inertial_length"),
     ("lengths", "cwp_"),
+    ("misc", "_grab_charge"),
     ("speeds", "Alfven_speed"),
     ("speeds", "va_"),
     ("speeds", "ion_sound_speed"),
@@ -122,36 +124,6 @@ for modname, name in funcs_to_deprecate_wrap:
     )(getattr(globals()[f"{modname}"], name))
 
 del modname, name
-
-
-def _grab_charge(ion: Particle, z_mean=None):
-    """
-    Merge two possible inputs for particle charge.
-
-    Parameters
-    ----------
-    ion : `~plasmapy.particles.particle_class.Particle`
-        a string representing a charged particle, or a Particle object.
-
-    z_mean : `float`
-        An optional float describing the average ionization of a particle
-        species.
-
-    Returns
-    -------
-    float
-        if ``z_mean`` was passed, ``z_mean``, otherwise, the charge number
-        of ``ion``.
-
-    """
-    if z_mean is None:
-        # warnings.warn("No z_mean given, defaulting to atomic charge",
-        #               PhysicsWarning)
-        Z = particles.charge_number(ion)
-    else:
-        # using average ionization provided by user
-        Z = z_mean
-    return Z
 
 
 @validate_quantities(

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -2,8 +2,6 @@
 
 __all__ = []
 
-from astropy.constants.si import e, eps0, k_B
-
 from plasmapy.utils.decorators import deprecated
 from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
@@ -50,10 +48,6 @@ for name in (
     except ValueError:
         # name was not in __all__
         pass
-
-e_si_unitless = e.value
-eps0_si_unitless = eps0.value
-k_B_si_unitless = k_B.value
 
 funcs_to_deprecate_wrap = [  # (module_name, func_name)
     ("dimensionless", "Debye_number"),

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -4,7 +4,6 @@ __all__ = [
     "Bohm_diffusion",
     "magnetic_energy_density",
     "magnetic_pressure",
-    "thermal_pressure",
 ]
 __aliases__ = [
     "DB_",
@@ -97,6 +96,8 @@ funcs_to_deprecate_wrap = [  # (module_name, func_name)
     ("misc", "_grab_charge"),
     ("misc", "mass_density"),
     ("misc", "rho_"),
+    ("misc", "thermal_pressure"),
+    ("misc", "pth_"),
     ("speeds", "Alfven_speed"),
     ("speeds", "va_"),
     ("speeds", "ion_sound_speed"),
@@ -121,60 +122,6 @@ for modname, name in funcs_to_deprecate_wrap:
     )(getattr(globals()[f"{modname}"], name))
 
 del modname, name
-
-
-@validate_quantities(
-    T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
-    n={"can_be_negative": False},
-)
-def thermal_pressure(T: u.K, n: u.m ** -3) -> u.Pa:
-    r"""
-    Return the thermal pressure for a Maxwellian distribution.
-
-    **Aliases:** `pth_`
-
-    Parameters
-    ----------
-    T : `~astropy.units.Quantity`
-        The particle temperature in either kelvin or energy per particle.
-
-    n : `~astropy.units.Quantity`
-        The particle number density in units convertible to m\ :sup:`-3`\ .
-
-    Examples
-    --------
-    >>> import astropy.units as u
-    >>> thermal_pressure(1*u.eV, 1e20/u.m**3)
-    <Quantity 16.021... Pa>
-    >>> thermal_pressure(10*u.eV, 1e20/u.m**3)
-    <Quantity 160.21... Pa>
-
-    Returns
-    -------
-    p_th : `~astropy.units.Quantity`
-        Thermal pressure.
-
-    Raises
-    ------
-    `TypeError`
-        The temperature or number density is not a `~astropy.units.Quantity`.
-
-    `~astropy.units.UnitConversionError`
-        If the particle temperature is not in units of temperature or
-        energy per particle.
-
-    Notes
-    -----
-    The thermal pressure is given by:
-
-    .. math::
-        T_{th} = n k_B T
-    """
-    return n * k_B * T
-
-
-pth_ = thermal_pressure
-"""Alias to `~plasmapy.formulary.parameters.thermal_pressure`."""
 
 
 @validate_quantities

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -4,7 +4,6 @@ __all__ = [
     "Bohm_diffusion",
     "magnetic_energy_density",
     "magnetic_pressure",
-    "mass_density",
     "thermal_pressure",
 ]
 __aliases__ = [
@@ -17,13 +16,9 @@ __aliases__ = [
 __lite_funcs__ = []
 
 import astropy.units as u
-import numbers
-import numpy as np
 
 from astropy.constants.si import e, eps0, k_B, mu0
-from typing import Optional, Union
 
-from plasmapy.particles import Particle
 from plasmapy.utils.decorators import deprecated, validate_quantities
 from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
@@ -100,6 +95,8 @@ funcs_to_deprecate_wrap = [  # (module_name, func_name)
     ("lengths", "inertial_length"),
     ("lengths", "cwp_"),
     ("misc", "_grab_charge"),
+    ("misc", "mass_density"),
+    ("misc", "rho_"),
     ("speeds", "Alfven_speed"),
     ("speeds", "va_"),
     ("speeds", "ion_sound_speed"),
@@ -124,112 +121,6 @@ for modname, name in funcs_to_deprecate_wrap:
     )(getattr(globals()[f"{modname}"], name))
 
 del modname, name
-
-
-@validate_quantities(
-    density={"can_be_negative": False}, validations_on_return={"can_be_negative": False}
-)
-def mass_density(
-    density: (u.m ** -3, u.kg / (u.m ** 3)),
-    particle: Union[Particle, str],
-    z_ratio: Optional[numbers.Real] = 1,
-) -> u.kg / u.m ** 3:
-    r"""
-    Calculate the mass density from a number density.
-
-    .. math::
-
-        \rho = \left| \frac{Z_{s}}{Z_{particle}} \right| n_{s} m_{particle}
-              = | Z_{ratio} | n_{s} m_{particle}
-
-    where :math:`m_{particle}` is the particle mass, :math:`n_{s}` is a number
-    density for plasma species :math:`s`, :math:`Z_{s}` is the charge number of
-    species :math:`s`, and :math:`Z_{particle}` is the charge number of
-    ``particle``.  For example, if the electron density is given for :math:`n_s`
-    and ``particle`` is a doubly ionized atom, then :math:`Z_{ratio} = -1 / 2`\ .
-
-    **Aliases:** `rho_`
-
-    Parameters
-    ----------
-    density : `~astropy.units.Quantity`
-        Either a particle number density (in units of m\ :sup:`-3` or
-        equivalent) or a mass density (in units of kg / m\ :sup:`3` or
-        equivalent).  If ``density`` is a mass density, then it will be passed
-        through and returned without modification.
-
-    particle : `~plasmapy.particles.particle_class.Particle`
-        The particle for which the mass density is being calculated for.  Must
-        be a `~plasmapy.particles.particle_class.Particle` or a value convertible to
-        a `~plasmapy.particles.particle_class.Particle` (e.g., ``'p'`` for protons,
-        ``'D+'`` for deuterium, or ``'He-4 +1'`` for singly ionized helium-4).
-
-    z_ratio : `int`, `float`, optional
-        The ratio of the charge numbers corresponding to the plasma species
-        represented by ``density`` and the ``particle``.  For example, if the
-        given ``density`` is and electron density and ``particle`` is doubly
-        ionized ``He``, then ``z_ratio = -0.5``.  Default is ``1``.
-
-    Raises
-    ------
-    `~astropy.units.UnitTypeError`
-        If the ``density`` does not have units equivalent to a number density
-        or mass density.
-
-    `TypeError`
-        If ``density`` is not of type `~astropy.units.Quantity`, or convertible.
-
-    `TypeError`
-        If ``particle`` is not of type or convertible to
-        `~plasmapy.particles.particle_class.Particle`.
-
-    `TypeError`
-        If ``z_ratio`` is not of type `int` or `float`.
-
-    `ValueError`
-        If ``density`` is negative.
-
-    Returns
-    -------
-    `~astropy.units.Quantity`
-        The mass density for the plasma species represented by ``particle``.
-
-    Examples
-    --------
-    >>> import astropy.units as u
-    >>> mass_density(1 * u.m ** -3, 'p')
-    <Quantity 1.67262...e-27 kg / m3>
-    >>> mass_density(4 * u.m ** -3, 'D+')
-    <Quantity 1.33743...e-26 kg / m3>
-    >>> mass_density(2.e12 * u.cm ** -3, 'He')
-    <Quantity 1.32929...e-08 kg / m3>
-    >>> mass_density(2.e12 * u.cm ** -3, 'He', z_ratio=0.5)
-    <Quantity 6.64647...e-09 kg / m3>
-    >>> mass_density(1.0 * u.g * u.m ** -3, "")
-    <Quantity 0.001 kg / m3>
-    """
-    if density.unit.is_equivalent(u.kg / u.m ** 3):
-        return density
-
-    if not isinstance(particle, Particle):
-        try:
-            particle = Particle(particle)
-        except TypeError:
-            raise TypeError(
-                f"If passing a number density, you must pass a plasmapy Particle "
-                f"(not type {type(particle)}) to calculate the mass density!"
-            )
-
-    if not isinstance(z_ratio, (float, np.floating, int, np.integer)):
-        raise TypeError(
-            f"Expected type int or float for keyword z_ratio, got type {type(z_ratio)}."
-        )
-
-    return abs(z_ratio) * density * particle.mass
-
-
-rho_ = mass_density
-"""Alias to `~plasmapy.formulary.parameters.mass_density`."""
 
 
 @validate_quantities(

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1,4 +1,20 @@
-"""Functions to calculate fundamental plasma parameters."""
+"""
+.. attention::
+   The `plasmapy.formulary.parameters` module is deprecated and will be
+   removed in the release of ``v0.9.0``.  Please update your code to
+   import directly from `plasmapy.formulary` or the specific submodule
+   the functionality is defined in.  For example,
+
+   .. code-block:: python
+
+      from plasmapy.formulary import Alfven_speed
+
+      # or
+
+      from plasmapy.formulary.speeds import Alfven_speed
+
+Functions to calculate fundamental plasma parameters.
+"""
 
 __all__ = []
 

--- a/plasmapy/formulary/parameters.py
+++ b/plasmapy/formulary/parameters.py
@@ -1,5 +1,6 @@
 """
 .. attention::
+
    The `plasmapy.formulary.parameters` module is deprecated and will be
    removed in the release of ``v0.9.0``.  Please update your code to
    import directly from `plasmapy.formulary` or the specific submodule

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -19,7 +19,7 @@ from astropy.constants.si import k_B, mu0
 from numba import njit
 from typing import Optional
 
-from plasmapy.formulary import lengths
+from plasmapy.formulary import lengths, misc
 from plasmapy.particles import Particle, particle_input, particle_mass
 from plasmapy.particles.exceptions import ChargeError
 from plasmapy.utils.decorators import (
@@ -151,8 +151,6 @@ def Alfven_speed(
     >>> Alfven_speed(B, n, ion="He", z_mean=1.8)
     <Quantity 21661.51... m / s>
     """
-    # TODO: remove mass_density import when migrated to plasmapy.formulary.misc
-    from plasmapy.formulary.parameters import mass_density
 
     if density.unit.is_equivalent(u.kg / u.m ** 3):
         rho = density
@@ -172,7 +170,10 @@ def Alfven_speed(
                 z_mean = 1
 
         z_mean = abs(z_mean)
-        rho = mass_density(density, ion) + mass_density(density, "e", z_ratio=z_mean)
+        rho = (
+            misc.mass_density(density, ion)
+            + misc.mass_density(density, "e", z_ratio=z_mean)
+        )
 
     V_A = np.abs(B) / np.sqrt(mu0 * rho)
     return V_A

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -170,9 +170,8 @@ def Alfven_speed(
                 z_mean = 1
 
         z_mean = abs(z_mean)
-        rho = (
-            misc.mass_density(density, ion)
-            + misc.mass_density(density, "e", z_ratio=z_mean)
+        rho = misc.mass_density(density, ion) + misc.mass_density(
+            density, "e", z_ratio=z_mean
         )
 
     V_A = np.abs(B) / np.sqrt(mu0 * rho)

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -328,11 +328,9 @@ def ion_sound_speed(
     <Quantity 229585... m / s>
 
     """
-    # TODO: remove import of _grab_charge when it's moved to plasmapy.formulary.misc
-    from plasmapy.formulary.parameters import _grab_charge
 
     m_i = particle_mass(ion)
-    Z = _grab_charge(ion, z_mean)
+    Z = misc._grab_charge(ion, z_mean)
 
     for gamma, species in zip([gamma_e, gamma_i], ["electrons", "ions"]):
         if not isinstance(gamma, (numbers.Real, numbers.Integral)):

--- a/plasmapy/formulary/tests/test_dimensionless.py
+++ b/plasmapy/formulary/tests/test_dimensionless.py
@@ -38,8 +38,8 @@ T_e = 1e6 * u.K
         (Rm_, Mag_Reynolds),
     ],
 )
-def test_parameters_aliases(alias, parent):
-    """Test all aliases defined in parameters.py"""
+def test_aliases(alias, parent):
+    """Test all aliases defined in dimensionless.py"""
     assert alias is parent
 
 
@@ -100,7 +100,7 @@ def test_Mag_Reynolds():
 
 
 def test_Debye_number():
-    r"""Test the Debye_number function in parameters.py."""
+    r"""Test the Debye_number function in dimensionless.py."""
 
     assert Debye_number(T_e, n_e).unit.is_equivalent(u.dimensionless_unscaled)
 

--- a/plasmapy/formulary/tests/test_frequencies.py
+++ b/plasmapy/formulary/tests/test_frequencies.py
@@ -34,13 +34,13 @@ B_nanarr = np.array([0.001, np.nan]) * u.T
         (wuh_, upper_hybrid_frequency),
     ],
 )
-def test_parameters_aliases(alias, parent):
-    """Test all aliases defined in parameters.py"""
+def test_aliases(alias, parent):
+    """Test all aliases defined in frequencies.py"""
     assert alias is parent
 
 
 def test_gyrofrequency():
-    r"""Test the gyrofrequency function in parameters.py."""
+    r"""Test the gyrofrequency function in frequencies.py."""
 
     assert gyrofrequency(B, "e-").unit.is_equivalent(u.rad / u.s)
 
@@ -120,7 +120,7 @@ def test_gyrofrequency():
 
 
 def test_lower_hybrid_frequency():
-    r"""Test the lower_hybrid_frequency function in parameters.py."""
+    r"""Test the lower_hybrid_frequency function in frequencies.py."""
 
     ion = "He-4 1+"
     omega_ci = gyrofrequency(B, particle=ion)
@@ -157,7 +157,7 @@ def test_lower_hybrid_frequency():
 
 
 def test_upper_hybrid_frequency():
-    r"""Test the upper_hybrid_frequency function in parameters.py."""
+    r"""Test the upper_hybrid_frequency function in frequencies.py."""
 
     omega_uh = upper_hybrid_frequency(B, n_e=n_e)
     omega_uh_hz = upper_hybrid_frequency(B, n_e=n_e, to_hz=True)

--- a/plasmapy/formulary/tests/test_lengths.py
+++ b/plasmapy/formulary/tests/test_lengths.py
@@ -41,7 +41,7 @@ mu = m_p.to(u.u).value
 
 
 def test_Debye_length():
-    r"""Test the Debye_length function in parameters.py."""
+    r"""Test the Debye_length function in lengths.py."""
 
     assert Debye_length(T_e, n_e).unit.is_equivalent(u.m)
 
@@ -304,7 +304,7 @@ class TestGyroradius:
 
 
 def test_inertial_length():
-    r"""Test the inertial_length function in parameters.py."""
+    r"""Test the inertial_length function in lengths.py."""
 
     assert inertial_length(n_i, particle="p").unit.is_equivalent(u.m)
 
@@ -367,6 +367,6 @@ def test_inertial_length():
         (rhoc_, gyroradius),
     ],
 )
-def test_parameters_aliases(alias, parent):
-    """Test all aliases defined in parameters.py"""
+def test_aliases(alias, parent):
+    """Test all aliases defined in lengths.py"""
     assert alias is parent

--- a/plasmapy/formulary/tests/test_misc.py
+++ b/plasmapy/formulary/tests/test_misc.py
@@ -1,6 +1,10 @@
 """Tests for functionality contained in `plasmapy.formulary.misc`."""
 
+import astropy.units as u
+import numpy as np
 import pytest
+
+from astropy.tests.helper import assert_quantity_allclose
 
 from plasmapy.formulary.misc import (
     Bohm_diffusion,
@@ -14,6 +18,16 @@ from plasmapy.formulary.misc import (
     thermal_pressure,
     ub_,
 )
+from plasmapy.particles import Particle
+from plasmapy.utils.pytest_helpers import assert_can_handle_nparray
+
+B = 1.0 * u.T
+B_arr = np.array([0.001, 0.002]) * u.T
+B_nanarr = np.array([0.001, np.nan]) * u.T
+
+n_i = 5e19 * u.m ** -3
+
+T_e = 1e6 * u.K
 
 
 @pytest.mark.parametrize(
@@ -29,3 +43,152 @@ from plasmapy.formulary.misc import (
 def test_parameters_aliases(alias, parent):
     """Test all aliases defined in parameters.py"""
     assert alias is parent
+
+
+class Test_mass_density:
+    r"""Test the mass_density function in misc.py."""
+
+    @pytest.mark.parametrize(
+        "args, kwargs, conditional",
+        [
+            ((-1 * u.kg * u.m ** -3, "He"), {}, pytest.raises(ValueError)),
+            ((-1 * u.m ** -3, "He"), {}, pytest.raises(ValueError)),
+            (("not a Quantity", "He"), {}, pytest.raises(TypeError)),
+            ((1 * u.m ** -3,), {}, pytest.raises(TypeError)),
+            ((1 * u.J, "He"), {}, pytest.raises(u.UnitTypeError)),
+            ((1 * u.m ** -3, None), {}, pytest.raises(TypeError)),
+            (
+                (1 * u.m ** -3, "He"),
+                {"z_ratio": "not a ratio"},
+                pytest.raises(TypeError),
+            ),
+        ],
+    )
+    def test_raises(self, args, kwargs, conditional):
+        with conditional:
+            mass_density(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "args, kwargs, expected",
+        [
+            ((1.0 * u.g * u.m ** -3, ""), {}, 1.0e-3 * u.kg * u.m ** -3),
+            ((5.0e12 * u.cm ** -3, "He"), {}, 3.32323849e-8 * u.kg * u.m ** -3),
+            (
+                (5.0e12 * u.cm ** -3, Particle("He")),
+                {},
+                3.32323849e-8 * u.kg * u.m ** -3,
+            ),
+            (
+                (5.0e12 * u.cm ** -3, "He"),
+                {"z_ratio": 0.5},
+                1.66161925e-08 * u.kg * u.m ** -3,
+            ),
+            (
+                (5.0e12 * u.cm ** -3, "He"),
+                {"z_ratio": -0.5},
+                1.66161925e-08 * u.kg * u.m ** -3,
+            ),
+        ],
+    )
+    def test_values(self, args, kwargs, expected):
+        assert np.isclose(mass_density(*args, **kwargs), expected)
+
+    def test_handle_nparrays(self):
+        """Test for ability to handle numpy array quantities"""
+        assert_can_handle_nparray(mass_density)
+
+
+def test_thermal_pressure():
+    assert thermal_pressure(T_e, n_i).unit.is_equivalent(u.Pa)
+
+    # TODO: may be array issues with arg "mass"
+    assert_can_handle_nparray(thermal_pressure)
+
+
+def test_magnetic_pressure():
+    r"""Test the magnetic_pressure function in misc.py."""
+
+    assert magnetic_pressure(B_arr).unit.is_equivalent(u.Pa)
+
+    assert magnetic_pressure(B).unit.is_equivalent(u.Pa)
+
+    assert magnetic_pressure(B).unit.name == "Pa"
+
+    assert magnetic_pressure(B).value == magnetic_energy_density(B).value
+
+    assert magnetic_pressure(B) == magnetic_energy_density(B.to(u.G))
+
+    assert np.isclose(magnetic_pressure(B).value, 397887.35772973835)
+
+    with pytest.warns(u.UnitsWarning):
+        magnetic_pressure(5)
+
+    with pytest.raises(u.UnitTypeError):
+        magnetic_pressure(5 * u.m)
+
+    assert np.isnan(magnetic_pressure(np.nan * u.T))
+
+    with pytest.raises(ValueError):
+        magnetic_pressure(5j * u.T)
+
+    assert np.isnan(magnetic_pressure(B_nanarr)[-1])
+
+    with pytest.warns(u.UnitsWarning):
+        assert magnetic_pressure(22.2) == magnetic_pressure(22.2 * u.T)
+
+    assert_can_handle_nparray(magnetic_pressure)
+
+
+def test_magnetic_energy_density():
+    r"""Test the magnetic_energy_density function in misc.py."""
+
+    assert magnetic_energy_density(B_arr).unit.is_equivalent(u.J / u.m ** 3)
+
+    assert magnetic_energy_density(B).unit.is_equivalent("J / m3")
+
+    assert magnetic_energy_density(B).value == magnetic_pressure(B).value
+
+    assert_quantity_allclose(
+        magnetic_energy_density(2 * B), 4 * magnetic_energy_density(B)
+    )
+
+    assert_quantity_allclose(magnetic_energy_density(B).value, 397887.35772973835)
+
+    assert_quantity_allclose(
+        magnetic_energy_density(B), magnetic_energy_density(B.to(u.G))
+    )
+
+    assert isinstance(magnetic_energy_density(B_arr), u.Quantity)
+
+    with pytest.warns(u.UnitsWarning):
+        magnetic_energy_density(5)
+
+    with pytest.raises(u.UnitTypeError):
+        magnetic_energy_density(5 * u.m)
+
+    assert np.isnan(magnetic_energy_density(np.nan * u.T))
+
+    with pytest.raises(ValueError):
+        magnetic_energy_density(5j * u.T)
+
+    assert np.isnan(magnetic_energy_density(B_nanarr)[-1])
+
+    with pytest.warns(u.UnitsWarning):
+        assert magnetic_energy_density(22.2) == magnetic_energy_density(22.2 * u.T)
+
+    assert_can_handle_nparray(magnetic_energy_density)
+
+
+def test_Bohm_diffusion():
+    r"""Test Mag_Reynolds in dimensionless.py"""
+
+    T_e = 5000 * u.K
+    B = 10 * u.T
+
+    assert (Bohm_diffusion(T_e, B)).unit == u.m ** 2 / u.s
+
+    with pytest.warns(u.UnitsWarning):
+        Bohm_diffusion(5000, B)
+
+    with pytest.raises(u.UnitTypeError):
+        Bohm_diffusion(2.2 * u.kg, B)

--- a/plasmapy/formulary/tests/test_misc.py
+++ b/plasmapy/formulary/tests/test_misc.py
@@ -1,0 +1,1 @@
+"""Tests for functionality contained in `plasmapy.formulary.misc`."""

--- a/plasmapy/formulary/tests/test_misc.py
+++ b/plasmapy/formulary/tests/test_misc.py
@@ -1,1 +1,31 @@
 """Tests for functionality contained in `plasmapy.formulary.misc`."""
+
+import pytest
+
+from plasmapy.formulary.misc import (
+    Bohm_diffusion,
+    DB_,
+    magnetic_energy_density,
+    magnetic_pressure,
+    mass_density,
+    pmag_,
+    pth_,
+    rho_,
+    thermal_pressure,
+    ub_,
+)
+
+
+@pytest.mark.parametrize(
+    "alias, parent",
+    [
+        (DB_, Bohm_diffusion),
+        (ub_, magnetic_energy_density),
+        (pmag_, magnetic_pressure),
+        (rho_, mass_density),
+        (pth_, thermal_pressure),
+    ],
+)
+def test_parameters_aliases(alias, parent):
+    """Test all aliases defined in parameters.py"""
+    assert alias is parent

--- a/plasmapy/formulary/tests/test_misc.py
+++ b/plasmapy/formulary/tests/test_misc.py
@@ -40,8 +40,8 @@ T_e = 1e6 * u.K
         (pth_, thermal_pressure),
     ],
 )
-def test_parameters_aliases(alias, parent):
-    """Test all aliases defined in parameters.py"""
+def test_aliases(alias, parent):
+    """Test all aliases defined in misc.py"""
     assert alias is parent
 
 

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -5,7 +5,6 @@ import pytest
 
 from astropy import units as u
 from astropy.constants import m_e, m_p
-from astropy.tests.helper import assert_quantity_allclose
 
 from plasmapy.formulary import dimensionless, frequencies, lengths, speeds
 from plasmapy.formulary.parameters import (
@@ -51,9 +50,7 @@ from plasmapy.formulary.parameters import (
     wp_,
     wuh_,
 )
-from plasmapy.particles import Particle
 from plasmapy.utils.exceptions import PlasmaPyFutureWarning
-from plasmapy.utils.pytest_helpers import assert_can_handle_nparray
 
 B = 1.0 * u.T
 Z = 1
@@ -87,159 +84,6 @@ V_nanarr = np.array([25, np.nan]) * u.m / u.s
 V_allnanarr = np.array([np.nan, np.nan]) * u.m / u.s
 
 mu = m_p.to(u.u).value
-
-
-class Test_mass_density:
-    r"""Test the mass_density function in parameters.py."""
-
-    @pytest.mark.parametrize(
-        "args, kwargs, conditional",
-        [
-            ((-1 * u.kg * u.m ** -3, "He"), {}, pytest.raises(ValueError)),
-            ((-1 * u.m ** -3, "He"), {}, pytest.raises(ValueError)),
-            (("not a Quantity", "He"), {}, pytest.raises(TypeError)),
-            ((1 * u.m ** -3,), {}, pytest.raises(TypeError)),
-            ((1 * u.J, "He"), {}, pytest.raises(u.UnitTypeError)),
-            ((1 * u.m ** -3, None), {}, pytest.raises(TypeError)),
-            (
-                (1 * u.m ** -3, "He"),
-                {"z_ratio": "not a ratio"},
-                pytest.raises(TypeError),
-            ),
-        ],
-    )
-    def test_raises(self, args, kwargs, conditional):
-        with conditional:
-            mass_density(*args, **kwargs)
-
-    @pytest.mark.parametrize(
-        "args, kwargs, expected",
-        [
-            ((1.0 * u.g * u.m ** -3, ""), {}, 1.0e-3 * u.kg * u.m ** -3),
-            ((5.0e12 * u.cm ** -3, "He"), {}, 3.32323849e-8 * u.kg * u.m ** -3),
-            (
-                (5.0e12 * u.cm ** -3, Particle("He")),
-                {},
-                3.32323849e-8 * u.kg * u.m ** -3,
-            ),
-            (
-                (5.0e12 * u.cm ** -3, "He"),
-                {"z_ratio": 0.5},
-                1.66161925e-08 * u.kg * u.m ** -3,
-            ),
-            (
-                (5.0e12 * u.cm ** -3, "He"),
-                {"z_ratio": -0.5},
-                1.66161925e-08 * u.kg * u.m ** -3,
-            ),
-        ],
-    )
-    def test_values(self, args, kwargs, expected):
-        assert np.isclose(mass_density(*args, **kwargs), expected)
-
-    def test_handle_nparrays(self):
-        """Test for ability to handle numpy array quantities"""
-        assert_can_handle_nparray(mass_density)
-
-
-# Assertions below that are in CGS units with 2-3 significant digits
-# are generally from the NRL Plasma Formulary.
-
-
-def test_thermal_pressure():
-    assert thermal_pressure(T_e, n_i).unit.is_equivalent(u.Pa)
-
-    # TODO: may be array issues with arg "mass"
-    assert_can_handle_nparray(thermal_pressure)
-
-
-def test_magnetic_pressure():
-    r"""Test the magnetic_pressure function in parameters.py."""
-
-    assert magnetic_pressure(B_arr).unit.is_equivalent(u.Pa)
-
-    assert magnetic_pressure(B).unit.is_equivalent(u.Pa)
-
-    assert magnetic_pressure(B).unit.name == "Pa"
-
-    assert magnetic_pressure(B).value == magnetic_energy_density(B).value
-
-    assert magnetic_pressure(B) == magnetic_energy_density(B.to(u.G))
-
-    assert np.isclose(magnetic_pressure(B).value, 397887.35772973835)
-
-    with pytest.warns(u.UnitsWarning):
-        magnetic_pressure(5)
-
-    with pytest.raises(u.UnitTypeError):
-        magnetic_pressure(5 * u.m)
-
-    assert np.isnan(magnetic_pressure(np.nan * u.T))
-
-    with pytest.raises(ValueError):
-        magnetic_pressure(5j * u.T)
-
-    assert np.isnan(magnetic_pressure(B_nanarr)[-1])
-
-    with pytest.warns(u.UnitsWarning):
-        assert magnetic_pressure(22.2) == magnetic_pressure(22.2 * u.T)
-
-    assert_can_handle_nparray(magnetic_pressure)
-
-
-def test_magnetic_energy_density():
-    r"""Test the magnetic_energy_density function in parameters.py."""
-
-    assert magnetic_energy_density(B_arr).unit.is_equivalent(u.J / u.m ** 3)
-
-    assert magnetic_energy_density(B).unit.is_equivalent("J / m3")
-
-    assert magnetic_energy_density(B).value == magnetic_pressure(B).value
-
-    assert_quantity_allclose(
-        magnetic_energy_density(2 * B), 4 * magnetic_energy_density(B)
-    )
-
-    assert_quantity_allclose(magnetic_energy_density(B).value, 397887.35772973835)
-
-    assert_quantity_allclose(
-        magnetic_energy_density(B), magnetic_energy_density(B.to(u.G))
-    )
-
-    assert isinstance(magnetic_energy_density(B_arr), u.Quantity)
-
-    with pytest.warns(u.UnitsWarning):
-        magnetic_energy_density(5)
-
-    with pytest.raises(u.UnitTypeError):
-        magnetic_energy_density(5 * u.m)
-
-    assert np.isnan(magnetic_energy_density(np.nan * u.T))
-
-    with pytest.raises(ValueError):
-        magnetic_energy_density(5j * u.T)
-
-    assert np.isnan(magnetic_energy_density(B_nanarr)[-1])
-
-    with pytest.warns(u.UnitsWarning):
-        assert magnetic_energy_density(22.2) == magnetic_energy_density(22.2 * u.T)
-
-    assert_can_handle_nparray(magnetic_energy_density)
-
-
-def test_Bohm_diffusion():
-    r"""Test Mag_Reynolds in dimensionless.py"""
-
-    T_e = 5000 * u.K
-    B = 10 * u.T
-
-    assert (Bohm_diffusion(T_e, B)).unit == u.m ** 2 / u.s
-
-    with pytest.warns(u.UnitsWarning):
-        Bohm_diffusion(5000, B)
-
-    with pytest.raises(u.UnitTypeError):
-        Bohm_diffusion(2.2 * u.kg, B)
 
 
 @pytest.mark.parametrize(

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -6,8 +6,9 @@ import pytest
 from astropy import units as u
 from astropy.constants import m_e, m_p
 
-from plasmapy.formulary import dimensionless, frequencies, lengths, speeds
+from plasmapy.formulary import dimensionless, frequencies, lengths, misc, speeds
 from plasmapy.formulary.parameters import (
+    _grab_charge,
     Alfven_speed,
     betaH_,
     Bohm_diffusion,
@@ -206,6 +207,28 @@ mu = m_p.to(u.u).value
             rhoc_,
             lengths.rhoc_,
         ),
+        #
+        # misc
+        #
+        ({"ion": "He+", "z_mean": 1.32}, _grab_charge, misc._grab_charge),
+        ({"T_e": 58000 * u.K, "B": 0.4 * u.T}, Bohm_diffusion, misc.Bohm_diffusion),
+        ({"T_e": 58000 * u.K, "B": 0.4 * u.T}, DB_, misc.DB_),
+        ({"B": 0.4 * u.T}, magnetic_energy_density, misc.magnetic_energy_density),
+        ({"B": 0.4 * u.T}, ub_, misc.ub_),
+        ({"B": 0.4 * u.T}, magnetic_pressure, misc.magnetic_pressure),
+        ({"B": 0.4 * u.T}, pmag_, misc.pmag_),
+        (
+            {"density": 1e18 * u.m ** -3, "particle": "He+"},
+            mass_density,
+            misc.mass_density,
+        ),
+        ({"density": 1e18 * u.m ** -3, "particle": "He+"}, rho_, misc.rho_),
+        (
+            {"T": 5800 * u.K, "n": 1e18 * u.m ** -3},
+            thermal_pressure,
+            misc.thermal_pressure,
+        ),
+        ({"T": 5800 * u.K, "n": 1e18 * u.m ** -3}, pth_, misc.pth_),
         #
         # speeds
         #

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -1,10 +1,7 @@
 """Tests for functions that calculate plasma parameters."""
 
-import numpy as np
+import astropy.units as u
 import pytest
-
-from astropy import units as u
-from astropy.constants import m_e, m_p
 
 from plasmapy.formulary import dimensionless, frequencies, lengths, misc, speeds
 from plasmapy.formulary.parameters import (
@@ -52,39 +49,6 @@ from plasmapy.formulary.parameters import (
     wuh_,
 )
 from plasmapy.utils.exceptions import PlasmaPyFutureWarning
-
-B = 1.0 * u.T
-Z = 1
-ion = "p"
-m_i = m_p
-n_i = 5e19 * u.m ** -3
-n_e = Z * 5e19 * u.m ** -3
-rho = n_i * m_i + n_e * m_e
-T_e = 1e6 * u.K
-T_i = 1e6 * u.K
-k_1 = 3e1 * u.m ** -1
-k_2 = 3e7 * u.m ** -1
-
-B_arr = np.array([0.001, 0.002]) * u.T
-B_nanarr = np.array([0.001, np.nan]) * u.T
-B_allnanarr = np.array([np.nan, np.nan]) * u.T
-
-rho_arr = np.array([5e-10, 2e-10]) * u.kg / u.m ** 3
-rho_infarr = np.array([np.inf, 5e19]) * u.m ** -3
-rho_negarr = np.array([-5e19, 6e19]) * u.m ** -3
-
-T_arr = np.array([1e6, 2e6]) * u.K
-T_nanarr = np.array([1e6, np.nan]) * u.K
-T_nanarr2 = np.array([np.nan, 2e6]) * u.K
-T_allnanarr = np.array([np.nan, np.nan]) * u.K
-T_negarr = np.array([1e6, -5151.0]) * u.K
-
-V = 25.2 * u.m / u.s
-V_arr = np.array([25, 50]) * u.m / u.s
-V_nanarr = np.array([25, np.nan]) * u.m / u.s
-V_allnanarr = np.array([np.nan, np.nan]) * u.m / u.s
-
-mu = m_p.to(u.u).value
 
 
 @pytest.mark.parametrize(

--- a/plasmapy/formulary/tests/test_parameters.py
+++ b/plasmapy/formulary/tests/test_parameters.py
@@ -243,21 +243,6 @@ def test_Bohm_diffusion():
 
 
 @pytest.mark.parametrize(
-    "alias, parent",
-    [
-        (rho_, mass_density),
-        (pth_, thermal_pressure),
-        (pmag_, magnetic_pressure),
-        (ub_, magnetic_energy_density),
-        (DB_, Bohm_diffusion),
-    ],
-)
-def test_parameters_aliases(alias, parent):
-    """Test all aliases defined in parameters.py"""
-    assert alias is parent
-
-
-@pytest.mark.parametrize(
     "kwargs, deprecated_func, parent",
     [
         # dimensionless

--- a/plasmapy/formulary/tests/test_speeds.py
+++ b/plasmapy/formulary/tests/test_speeds.py
@@ -35,8 +35,8 @@ T_negarr = np.array([1e6, -5151.0]) * u.K
         (cs_, ion_sound_speed),
     ],
 )
-def test_parameters_aliases(alias, parent):
-    """Test all aliases defined in parameters.py"""
+def test_aliases(alias, parent):
+    """Test all aliases defined in speeds.py"""
     assert alias is parent
 
 

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -8,7 +8,7 @@ import warnings
 
 from plasmapy.formulary.collisions import coupling_parameter
 from plasmapy.formulary.dimensionless import quantum_theta
-from plasmapy.formulary.parameters import _grab_charge
+from plasmapy.formulary.misc import _grab_charge
 from plasmapy.particles import particle_mass
 from plasmapy.plasma.plasma_base import GenericPlasma
 from plasmapy.utils import code_repr


### PR DESCRIPTION
This PR moves miscellaneous plasma parameters from `plasmapy.formulary.parameters` to `plasmapy.formulary.misc` in accordance with issue #1433.