### PR TITLE
Testing `sphinx-hoverxref` on dev version

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,41 @@ PlasmaPy Documentation
 PlasmaPy_ is an open source community-developed core Python_ 3.7+
 package for plasma physics currently under development.
 
+Testing `sphinx-hoverxref` linking
+----------------------------------
+
+Testing the following syntax...
+
+.. code-block:: rst
+
+   .. Originally no tooltip generated
+
+   `astropy.units.Quantity`
+   `~astropy.units.Quantity`
+   `Quantity <astropy.units.Quantity>`
+
+   .. Originally tooltip generated
+
+   :class:`astropy.units.Quantity`
+   :class:`~astropy.units.Quantity`
+   :class:`Quantity <astropy.units.Quantity>`
+   :py:class:`Quantity <astropy.units.Quantity>`
+
+Here are the links...
+
+.. Originally no tooltip generated
+
+`astropy.units.Quantity`
+`~astropy.units.Quantity`
+`Quantity <astropy.units.Quantity>`
+
+.. Originally tooltip generated
+
+:class:`astropy.units.Quantity`
+:class:`~astropy.units.Quantity`
+:class:`Quantity <astropy.units.Quantity>`
+:py:class:`Quantity <astropy.units.Quantity>`
+
 Example highlights
 ------------------
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,7 +12,8 @@ sphinx >= 3.2.0
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery
-sphinx-hoverxref >= 1.0.0
+# sphinx-hoverxref >= 1.0.0
+git+https://github.com/readthedocs/sphinx-hoverxref/tree/humitos/improve-intersphinx#egg=sphinx-hoverxref
 sphinx_rtd_theme >= 1.0.0
 sphinxcontrib-bibtex
 towncrier >= 19.2.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -13,7 +13,7 @@ sphinx-changelog
 sphinx-copybutton
 sphinx-gallery
 # sphinx-hoverxref >= 1.0.0
-git+https://github.com/readthedocs/sphinx-hoverxref/tree/humitos/improve-intersphinx#egg=sphinx-hoverxref
+git+https://github.com/readthedocs/sphinx-hoverxref/@humitos/improve-intersphinx#egg=sphinx-hoverxref
 sphinx_rtd_theme >= 1.0.0
 sphinxcontrib-bibtex
 towncrier >= 19.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,8 @@ install_requires =
   tqdm >= 4.41.0
   xarray >= 0.14.0
   voila >= 0.2.15
+dependency_links =
+  git+https://github.com/readthedocs/sphinx-hoverxref/tree/humitos/improve-intersphinx#egg=sphinx-hoverxref
 
 [options.extras_require]
 # a weird "bug" since python 2 allows extras to depend on extras
@@ -91,6 +93,7 @@ docs =
   sphinx-changelog
   sphinx-copybutton
   sphinx-gallery
+  # GitHub link provided in 'dependency_links' config variable
   sphinx-hoverxref >= 1.0.0
   sphinxcontrib-bibtex
   sphinx_rtd_theme >= 1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
   xarray >= 0.14.0
   voila >= 0.2.15
 dependency_links =
-  git+https://github.com/readthedocs/sphinx-hoverxref/tree/humitos/improve-intersphinx#egg=sphinx-hoverxref
+  git+https://github.com/readthedocs/sphinx-hoverxref/@humitos/improve-intersphinx#egg=sphinx-hoverxref
 
 [options.extras_require]
 # a weird "bug" since python 2 allows extras to depend on extras


### PR DESCRIPTION
Testing if https://github.com/readthedocs/sphinx-hoverxref/pull/171 is providing a more robust tooltip to address issue https://github.com/readthedocs/sphinx-hoverxref/issues/170.