### PR TITLE
Update docstring for `molecule`

### DIFF
--- a/changelog/1455.doc.rst
+++ b/changelog/1455.doc.rst
@@ -1,0 +1,1 @@
+Updated the docstring for `plasmapy.particles.particle_class.molecule`.

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -477,34 +477,33 @@ def parse_and_check_molecule_input(argument: str, Z: Integral = None):
 
     Parameters
     ----------
-    argument : 'str'
+    argument : `str`
         The molecule symbol to be parsed.
 
-    Z : 'Integral', optional
+    Z : integer, optional
         The provided charge number.
 
     Returns
     -------
-    elements_dict : 'dict'
-        A dictionary with identified element symbols as keys and amount of each as values.
-        The molecule symbol stripped of the charge.
-        The integer charge.
+    elements_dict : `dict`
+        A dictionary with identified element symbols as keys and amount
+        of each as values.
 
-    molecule_info : 'str'
+    molecule_info : `str`
         The molecule symbol stripped of its charge.
 
-    Z : 'int'
-        The molecule charge.
+    Z : `int`
+        The charge number of the molecule.
 
     Raises
     ------
-    'InvalidParticleError'
-        If the Symbol couldn't be parsed.
+    `InvalidParticleError`
+        If the symbol couldn't be parsed.
 
     Warns
     -----
-    `ParticleWarning`
-        If The charge is given both as an argument and in the symbol.
+    : `ParticleWarning`
+        If the charge is given both as an argument and in the symbol.
     """
     molecule_info, z_from_arg = extract_charge(argument)
     if not re.fullmatch(r"(?:[A-Z][a-z]?\d*)+", molecule_info):

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -498,7 +498,7 @@ def parse_and_check_molecule_input(argument: str, Z: Integral = None):
     Raises
     ------
     `InvalidParticleError`
-        If the symbol couldn't be parsed.
+        If ``argument`` could not be parsed as a molecule.
 
     Warns
     -----

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -486,8 +486,10 @@ def parse_and_check_molecule_input(argument: str, Z: Integral = None):
     Returns
     -------
     elements_dict : `dict`
-        A dictionary with identified element symbols as keys and the number
-        of elements that make up the molecule as values.
+        A dictionary with identified element symbols as keys and the
+        number of each element that make up the molecule as values. For
+        example, ``argument="CO2"`` would lead to ``elements_dict``
+        being ``{"C": 1, "O": 2}``.
 
     molecule_info : `str`
         The molecule symbol stripped of its charge.

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -486,8 +486,8 @@ def parse_and_check_molecule_input(argument: str, Z: Integral = None):
     Returns
     -------
     elements_dict : `dict`
-        A dictionary with identified element symbols as keys and amount
-        of each as values.
+        A dictionary with identified element symbols as keys and the number
+        of elements that make up the molecule as values.
 
     molecule_info : `str`
         The molecule symbol stripped of its charge.

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -480,7 +480,7 @@ def parse_and_check_molecule_input(argument: str, Z: Integral = None):
     argument : `str`
         The molecule symbol to be parsed.
 
-    Z : integer, optional
+    Z : `int`, optional
         The provided charge number.
 
     Returns

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2269,7 +2269,12 @@ def molecule(
     Parameters
     ----------
     symbol : `str`
-        Symbol of the molecule to be parsed.
+        Symbol of the molecule to be parsed. This argument should be a
+        string representing the chemical formula where the subscript
+        numbers are not given as subscripts, followed by charge
+        information. For example, CO\ :sub:`2` can be represented as
+        ``"CO2"`` and CO\ :sup:`+` can be represented as ``"CO 1+"``,
+        ``"CO +1"``, or ``"CO+"``.
 
     Z : integer, optional
         The charge number if not present in the symbol.
@@ -2290,6 +2295,13 @@ def molecule(
     -----
     : `~plasmapy.particles.exceptions.ParticleWarning`
         If the charge is given both as an argument and in the symbol.
+
+    Notes
+    -----
+    ``symbol`` should be a string that
+
+    ``symbol`` should be a string that contains a series of atomic
+    symbols optionally followed by a number representing the
 
     Examples
     --------
@@ -2318,7 +2330,7 @@ def molecule(
     """
     try:
         return Particle(symbol, Z=Z)
-    except ParticleError:
+    except ParticleError as exc:
         element_dict, bare_symbol, Z = _parsing.parse_and_check_molecule_input(
             symbol, Z
         )
@@ -2326,14 +2338,15 @@ def molecule(
         for element_symbol, amount in element_dict.items():
             try:
                 element = Particle(element_symbol)
-            except ParticleError as e:
+            except ParticleError as exc:
                 raise InvalidParticleError(
                     f"Could not identify {element_symbol}."
-                ) from e
+                ) from exc
             if not element.is_category("element"):
                 raise InvalidParticleError(
                     f"Molecule symbol contains a particle that is not an element: {element.symbol}"
-                )
+                ) from exc
+
             mass += amount * element.mass
 
         if Z is None:

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2271,23 +2271,23 @@ def molecule(
     symbol : 'str'
         Symbol of the molecule to be parsed.
 
-    Z : 'Integral', optional
+    Z : integer, optional
         Charge number if not present in symbol.
 
     Returns
     -------
-        A |Particle| object if the input could be parsed as such,
-        or a |CustomParticle| with the provided symbol, charge,
-        and a mass corresponding to the sum of the molecule elements.
+    A |Particle| object if the input could be parsed as such, or a
+    |CustomParticle| with the provided symbol, charge, and a mass
+    corresponding to the sum of the molecule elements.
 
     Raises
     ------
-    'InvalidParticleError'
+    `InvalidParticleError`
         If ``symbol`` couldn't be parsed.
 
     Warns
     -----
-    `ParticleWarning`
+    : `ParticleWarning`
         If the charge is given both as an argument and in the symbol.
 
     Examples

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2331,14 +2331,14 @@ def molecule(
         for element_symbol, amount in element_dict.items():
             try:
                 element = Particle(element_symbol)
-            except ParticleError as exc:
+            except ParticleError as exc2:
                 raise InvalidParticleError(
                     f"Could not identify {element_symbol}."
                 ) from exc
             if not element.is_category("element"):
                 raise InvalidParticleError(
                     f"Molecule symbol contains a particle that is not an element: {element.symbol}"
-                ) from exc
+                ) from exc2
 
             mass += amount * element.mass
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2268,7 +2268,7 @@ def molecule(
 
     Parameters
     ----------
-    symbol : 'str'
+    symbol : `str`
         Symbol of the molecule to be parsed.
 
     Z : integer, optional

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2272,7 +2272,7 @@ def molecule(
         Symbol of the molecule to be parsed.
 
     Z : integer, optional
-        Charge number if not present in symbol.
+        The charge number if not present in the symbol.
 
     Returns
     -------
@@ -2288,7 +2288,7 @@ def molecule(
 
     Warns
     -----
-    : `ParticleWarning`
+    : `~plasmapy.particles.exceptions.ParticleWarning`
         If the charge is given both as an argument and in the symbol.
 
     Examples

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2296,13 +2296,6 @@ def molecule(
     : `~plasmapy.particles.exceptions.ParticleWarning`
         If the charge is given both as an argument and in the symbol.
 
-    Notes
-    -----
-    ``symbol`` should be a string that
-
-    ``symbol`` should be a string that contains a series of atomic
-    symbols optionally followed by a number representing the
-
     Examples
     --------
     >>> from plasmapy.particles import molecule

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2334,11 +2334,11 @@ def molecule(
             except ParticleError as exc2:
                 raise InvalidParticleError(
                     f"Could not identify {element_symbol}."
-                ) from exc
+                ) from exc2
             if not element.is_category("element"):
                 raise InvalidParticleError(
                     f"Molecule symbol contains a particle that is not an element: {element.symbol}"
-                ) from exc2
+                ) from exc
 
             mass += amount * element.mass
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2276,7 +2276,7 @@ def molecule(
         ``"CO2"`` and CO\ :sup:`+` can be represented as ``"CO 1+"``,
         ``"CO +1"``, or ``"CO+"``.
 
-    Z : integer, optional
+    Z : `int`, optional
         The charge number if not present in the symbol.
 
     Returns

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2276,9 +2276,10 @@ def molecule(
 
     Returns
     -------
-    A |Particle| object if the input could be parsed as such, or a
-    |CustomParticle| with the provided symbol, charge, and a mass
-    corresponding to the sum of the molecule elements.
+    |Particle| or |CustomParticle|
+        A |Particle| object if the input could be parsed as such, or a
+        |CustomParticle| with the provided symbol, charge, and a mass
+        corresponding to the sum of the molecule elements.
 
     Raises
     ------


### PR DESCRIPTION
This PR updates the docstrings for `plasmapy.particles.particle_class.molecule` and associated private functions.  In particular, this expands/edits some parameter descriptions, and makes a few reST edits.  

I also adopted a minor refactoring suggested by Sourcery, which was to explicitly raise an exception from another exception.