### PR TITLE
Patch for PR #1453 (`plasmapy.formulary.misc`)

### DIFF
--- a/changelog/1471.bugfix.rst
+++ b/changelog/1471.bugfix.rst
@@ -1,0 +1,1 @@
+Exposed `plasmapy.formulary.misc` to the `plasmapy.formulary` namespace.

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -17,6 +17,7 @@ from plasmapy.formulary.ionization import *
 from plasmapy.formulary.lengths import *
 from plasmapy.formulary.magnetostatics import *
 from plasmapy.formulary.mathematics import *
+from plasmapy.formulary.misc import *
 from plasmapy.formulary.quantum import *
 from plasmapy.formulary.relativity import *
 from plasmapy.formulary.speeds import *
@@ -40,6 +41,7 @@ for modname in (
     "lengths",
     "magnetostatics",
     "mathematics",
+    "misc",
     "parameters",
     "quantum",
     "relativity",

--- a/plasmapy/formulary/misc.py
+++ b/plasmapy/formulary/misc.py
@@ -20,6 +20,8 @@ from plasmapy import particles
 from plasmapy.particles import Particle
 from plasmapy.utils.decorators import validate_quantities
 
+__all__ += __aliases__
+
 
 def _grab_charge(ion: Particle, z_mean=None):
     """


### PR DESCRIPTION
This is patch for PR #1453 .

1. In `plasmapy.formulary.misc` add `__aliases__` to `__all__`.
2. Expose `plasmapy.formulary.misc` to the `plasmapy.formulary` name space

For some reason the checks for PR #1453 passed with these issues.  These issues only came to my attention when I started seeing documentation build errors for PR #1252 .