### PR TITLE
Use short type hints in documented signatures

### DIFF
--- a/changelog/1488.doc.1.rst
+++ b/changelog/1488.doc.1.rst
@@ -1,2 +1,2 @@
 Defined ``autodoc_typehints_format="short"`` so signature type hints
-are displayed in short form,  i.e. without the leading module names.
+are displayed in short form, i.e. without the leading module names.

--- a/changelog/1488.doc.1.rst
+++ b/changelog/1488.doc.1.rst
@@ -1,0 +1,2 @@
+Defined ``autodoc_typehints_format="short"`` so signature type hints
+are displayed in short form,  i.e. without the leading module names.

--- a/changelog/1488.doc.2.rst
+++ b/changelog/1488.doc.2.rst
@@ -1,0 +1,1 @@
+Set minimum version of `sphinx` to ``v4.4``".

--- a/changelog/1488.doc.2.rst
+++ b/changelog/1488.doc.2.rst
@@ -1,1 +1,1 @@
-Set minimum version of `sphinx` to ``v4.4``".
+Set minimum version of `sphinx` to ``v4.4``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,6 @@ sys.path.insert(0, os.path.abspath("."))
 from plasmapy import __version__ as release  # noqa
 
 # -- General configuration ------------------------------------------------
-
 autosummary_generate = True
 automodapi_custom_groups = {
     "aliases": {
@@ -135,6 +134,7 @@ hoverxref_intersphinx = [
 ]
 
 autoclass_content = "both"
+autodoc_typehints_format = "short"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ nbsphinx
 numpydoc
 pillow
 pygments >= 2.11.0
-sphinx >= 3.2.0
+sphinx >= 4.4
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ docs =
   numpydoc
   pillow
   pygments >= 2.11.0
-  sphinx >= 3.2.0
+  sphinx >= 4.4
   sphinx-changelog
   sphinx-copybutton
   sphinx-gallery


### PR DESCRIPTION
Currently documented signatures use the long form name like `plasmapy.particles.particle_class.Particle` instead of the short form like `Particle`.  While I can see the benefit of the long form, I do think it makes the signature unreadable very quick with the addition of multiple type hints.  This PR sets the [sphinx configuration variable `autodoc_typehints_format="short"`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints_format), which will generate the short form type hints.  This also becomes the default behavior in `sphinx>=5.0`.   All the `intersphinx` linking still works as expected.

Long form example:
![image](https://user-images.githubusercontent.com/29869348/159072054-88f075a1-ad1a-4ae7-9ad3-09f56f6efd75.png)

Short form example:
![image](https://user-images.githubusercontent.com/29869348/159073354-d29aeccf-a39f-4945-aad1-c9304fc9738c.png)

This also requires `sphinx>=4.4`.