### PR TITLE
Use different action to generate PR size labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,21 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         sync-labels: true
     - name: Add Size Label to PR
-      uses: WizardOhio24/label-pr-size-action@master
+      uses: codelytv/pr-size-labeler@v1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        size-label-color: 10, very small, ffaf65 | 50, small, ff9e58 | 200, medium, ff9654 | 400, large, ff905d | 100000, massive, ff905d
+        xs_label: 'size/very-small'
+        xs_max_size: '10'
+        s_label: 'size/small'
+        s_max_size: '50'
+        m_label: 'size/medium'
+        m_max_size: '200'
+        l_label: 'size/large'
+        l_max_size: '400'
+        xl_label: 'size/extra-large'
+        fail_if_xl: 'false'
+        message_if_xl: >
+          'This PR exceeds the recommended size of less than 400 lines.
+          Please make sure you are NOT addressing multiple issues with one PR.
+          Note this PR might be rejected due to its size.'
+        github_api_url: 'api.github.com'


### PR DESCRIPTION
Overwrites the work of PR #1489 , looks like the previous used action was faulty hence replacing it. Tested the changes on my fork it works fine. Since this is a trivial change not adding a changelog entry. 

<!--
Thank you for contributing to PlasmaPy! Here's a bunch of pointers to
make things easier for all of us:

* If this PR will solve an issue tracked by GitHub, then please add
  "Closes #42" so the issue automatically closes once this pull request
  is merged.  In this example, issue #42 would have been closed.
  If your PR will not completely solve the issue, then please still reference
  still reference the issue like "issue #42".  (For more info see [GitHub's primer
  on linking issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)

* Remember to add some description of your changes in this text box.

* If your pull request is not yet ready for review - either because
  you're just looking for feedback on a change or because you're not
  perfectly satisfied with your change - submit it as a draft pull request.
  Remember to change its' status once it's ready.

* If this is your first contribution, please add your name to the author
  list in `docs/about/credits.rst`.

* Feel free to chat with other developers on our Matrix channel at:
   https://app.element.io/#/room/#plasmapy:openastronomy.org

* We have a developer's guide to help answer some of your questions.
  http://docs.plasmapy.org/en/latest/development/index.html

Many thanks in advance for following these pointers and for being willing to contribute!

When submitting a pull request, please ensure that you can (eventually,
sometime before it is merged) check the following basic requirements:

-->

- [ ] I have added a changelog entry for this pull request.

<!--

In short: A changelog entry is a short description of your PR's changes.
Each entry is written in a `<PULL REQUEST>.<TYPE>.rst` file and stored in
the `changelog` directory,  where `<PULL REQUEST>` is a pull request
number and `<TYPE>` is one of:

* `breaking`: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
* `feature`: New user facing features and any new behavior.
* `bugfix`: Fixes a reported bug.
* `doc`: Documentation addition or improvement, like rewording an entire session or adding missing docs.
* `removal`: Feature deprecation and/or feature removal.
* `trivial`: A change which has no user facing effect or is tiny change.

A PR number is generated after you successfully submit a new PR, so the changelog
file can only be added after you open the PR.```

For more information, see:
https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst

--->

