### PR TITLE
Use `contextlib.suppress` to suppress exceptions instead of `try` & `except`

### DIFF
--- a/changelog/1494.trivial.rst
+++ b/changelog/1494.trivial.rst
@@ -1,0 +1,2 @@
+Used `contextlib.suppress` to suppress exceptions, instead of `try` &
+`except` blocks.

--- a/changelog/1494.trivial.rst
+++ b/changelog/1494.trivial.rst
@@ -1,2 +1,2 @@
-Used `contextlib.suppress` to suppress exceptions, instead of `try` &
-`except` blocks.
+Used `contextlib.suppress` to suppress exceptions, instead of ``try`` &
+``except`` blocks.

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -6,6 +6,8 @@ __all__ = []
 __aliases__ = []
 __lite_funcs__ = []
 
+import contextlib
+
 from plasmapy.formulary.braginskii import *
 from plasmapy.formulary.collisions import *
 from plasmapy.formulary.dielectric import *
@@ -52,15 +54,11 @@ for modname in (
     except KeyError:  # coverage: ignore
         continue
 
-    try:
+    with contextlib.suppress(AttributeError):
         __aliases__.extend(obj.__aliases__)
-    except AttributeError:
-        pass
 
-    try:
+    with contextlib.suppress(AttributeError):
         __lite_funcs__.extend(obj.__lite_funcs__)
-    except AttributeError:
-        pass
 
 __aliases__ = list(sorted(set(__aliases__)))
 __lite_funcs__ = list(sorted(set(__lite_funcs__)))

--- a/plasmapy/particles/_factory.py
+++ b/plasmapy/particles/_factory.py
@@ -6,6 +6,8 @@ appropriate instance of one of those three classes.
 
 __all__ = []
 
+import contextlib
+
 from typing import Union
 
 from plasmapy.particles.exceptions import InvalidParticleError
@@ -69,10 +71,8 @@ def _physical_particle_factory(
         raise TypeError("Particle information has not been provided.")
 
     for particle_type in (Particle, CustomParticle, ParticleList):
-        try:
+        with contextlib.suppress(TypeError, InvalidParticleError):
             return particle_type(*args, **kwargs)
-        except (TypeError, InvalidParticleError):
-            pass
 
     raise InvalidParticleError(
         f"Unable to create an appropriate particle object with "

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -4,6 +4,7 @@ __all__ = ["ionic_levels", "ParticleList"]
 
 import astropy.units as u
 import collections
+import contextlib
 import numpy as np
 
 from numbers import Integral
@@ -148,10 +149,8 @@ class ParticleList(collections.UserList):
         if isinstance(other, ParticleList):
             return other
 
-        try:
+        with contextlib.suppress(TypeError, InvalidParticleError):
             return ParticleList(other)
-        except (InvalidParticleError, TypeError):
-            pass
 
         try:
             return ParticleList([other])

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -9,6 +9,7 @@ __all__ = [
 ]
 
 import astropy.units as u
+import contextlib
 import numpy as np
 import pandas as pd
 import scipy.interpolate as interp
@@ -1016,14 +1017,10 @@ class AbstractGrid(ABC):
         # If not persistent, clear the cached properties so they are re-created
         # when called below
         if not persistent:
-            try:
+            with contextlib.suppress(AttributeError):
                 del self._interp_quantities
-            except AttributeError:
-                pass
-            try:
+            with contextlib.suppress(AttributeError):
                 del self._interp_units
-            except AttributeError:
-                pass
 
         return pos, args, persistent
 
@@ -1422,10 +1419,8 @@ class NonUniformCartesianGrid(AbstractGrid):
         # _persistant_interpolator_setup function because it is unique
         # to this non_uniform grid.
         if not persistent:
-            try:
+            with contextlib.suppress(AttributeError):
                 del self._nearest_neighbor_interpolator
-            except AttributeError:
-                pass
 
         pts0 = self.pts0.to(u.m).value
         pts1 = self.pts1.to(u.m).value

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -18,6 +18,7 @@ import warnings
 
 from astropy import units as u
 from astropy.constants import c
+from astropy.units.equivalencies import Equivalency
 from functools import reduce
 from operator import add
 from typing import Any, Dict, List, Tuple, Union
@@ -28,14 +29,6 @@ from plasmapy.utils.exceptions import (
     RelativityError,
     RelativityWarning,
 )
-
-try:
-    from astropy.units.equivalencies import Equivalency
-except ImportError:
-    # TODO: remove once we have dependency Astropy >= 3.2.1
-    # astropy defined the Equivalency class in v3.2.1
-    class Equivalency:
-        pass
 
 
 class CheckBase:


### PR DESCRIPTION
This PR implements a recommended refactoring that I learned recently.  Instead of:

```Python
try:
    ...
except ValueError:
    pass
```

we can do:

```Python
    with contextlib.suppress(ValueError):
        ...
```

However, the main purpose of this is to test the pull request labeler in #1492.