### PR TITLE
[TEST] skipping GA checks with labels

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,16 +34,14 @@ jobs:
           echo "Label is '${{ env.SKIP_DOCUMENTATION_LABEL }}'"
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
-          if [[ $SKIP ]]; then
-            echo "1"
-            echo "dSKIP=1" >> $GITHUB_ENV 
-          else
-            echo "2"
-            echo "dSKIP=2" >> $GITHUB_ENV
-          fi
-      - name: Skip Documentation?
+          SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
+          echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV
+      - name: Skip Documentation? ${{ env.SKIP_DOCUMENTATION }}
         run: |
           echo "Documentation can be skipped: ${{ env.SKIP_DOCUMENTATION }}"
+      - name: Skip Comprehensive Tests? ${{ env.SKIP_COMPREHENSIVE }}
+        run: |
+          echo "Comprehensive tests can be skipped: ${{ env.SKIP_COMPREHENSIVE }}"
 
 #      - name: Were tests skipped?
 #        run: echo ${{ env.SKIPS_DONE }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=${{  !env.SKIPS_ALLOWED }}
+          FAIL=${{ env.SKIPS_ALLOWED }}
           if [[ FAIL ]]; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=$([! ${{ env.SKIPS_ALLOWED }} ] && ${{ env.SKIPS_DONE }})
+          FAIL=${{ env.SKIPS_ALLOWED && env.SKIPS_DONE }})
           echo $FAIL
           if $FAIL; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo "Label is '${{ env.SKIP_DOCUMENTATION_LABEL }}'"
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
-          echo "SKIP_DOCUMENTATION=$(SKIP)" >> $GITHUB_SKIP
+          echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_SKIP
           if [[ $SKIP ]]; then
             echo "1"
             echo "dSKIP=1" >> $GITHUB_ENV 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=${{ !( env.SKIPS_ALLOWED ) }}
+          FAIL=! ${{ env.SKIPS_ALLOWED }}
           echo $FAIL
           if [[ FAIL ]]; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
           fi
       - name: Skip Documentation?
         run: |
-          echo "Documentation can be skipped: ${{ env.dSKIP }}"
+          echo "Documentation can be skipped: ${{ env.SKIP_DOCUMENTATION }}"
 
 #      - name: Were tests skipped?
 #        run: echo ${{ env.SKIPS_DONE }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,7 +183,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == false }}
+    if: !needs.skips-allowed.outputs.SKIP_DOCUMENTATION
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -164,7 +164,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: always()
+    if: always() && !needs.skips-allowed.outputs.SKIP_DOCUMENTATION
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -190,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - name: RUN ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
+    - name: RUN ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == 'false' }}
       run: |
         echo "SKIP doc == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
         echo "RUN doc == ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -164,7 +164,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
+    if: ${{ always() && !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  SKIP_DOCUMENTATION_LABEL: 'GA Skip Documentation'
+  SKIP_DOCUMENTATION_LABEL: 'GA Skip: Documentation'
   SKIP_COMPREHENSIVE_LABEL: 'GA Skip: Comprehensive Tests'
   SKIPS_ALLOWED_LABEL: 'GA Skip: Merge Allowed'
 
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          if ${{ !env.SKIPS_ALLOWED && env.SKIPS_DONE}}; then
+          if ${{ !(env.SKIPS_ALLOWED) && env.SKIPS_DONE}}; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=${{ ! env.SKIPS_ALLOWED }}
+          FAIL=${{ ! env.SKIPS_ALLOWED && env.SKIPS_DONE}}
           echo $FAIL
           if $FAIL; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -165,8 +165,8 @@ jobs:
         file: ./coverage.xml
   documentation:
     if: |
-      ( ${{ needs.skips-allowed.results == "success" }} ||
-      ${{ needs.skips-allowed.results == "failur" }} ) &&
+      ( ${{ needs.skips-allowed.results == 'success' }} ||
+      ${{ needs.skips-allowed.results == 'failure' }} ) &&
       ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == false }}
     needs: skips-allowed
     name: Documentation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,12 +36,24 @@ jobs:
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
           echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV
+          SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_ALLOWED_LABEL) }}
+          echo "SKIPS_ALLOWED=${SKIP}" >> $GITHUB_ENV
       - name: Skip Documentation? ${{ env.SKIP_DOCUMENTATION }}
         run: |
           echo "Documentation can be skipped: ${{ env.SKIP_DOCUMENTATION }}"
+          if ${{ env.SKIP_DOCUMENTATION }}; then
+            echo "SKIPS_DONE=true" >> $GITHUB_ENV
+          fi
       - name: Skip Comprehensive Tests? ${{ env.SKIP_COMPREHENSIVE }}
         run: |
           echo "Comprehensive tests can be skipped: ${{ env.SKIP_COMPREHENSIVE }}"
+          if ${{ env.SKIP_COMPREHENSIVE }}; then
+            echo "SKIPS_DONE=true" >> $GITHUB_ENV
+          fi
+      - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
+        run: |
+          echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
+          
 
 #      - name: Were tests skipped?
 #        run: echo ${{ env.SKIPS_DONE }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -173,8 +173,8 @@ jobs:
     steps:
     - name: Play
       run: |
-        echo "skip doc == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
-        echo "skip comp == ${{ needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
+        echo "RUN doc == ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
+        echo "RUN comp == ${{ !needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=[! ${{ env.SKIPS_ALLOWED }} ] && ${{ env.SKIPS_DONE }}
+          FAIL=$([! ${{ env.SKIPS_ALLOWED }} ] && ${{ env.SKIPS_DONE }})
           echo $FAIL
           if $FAIL; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=! ${{ env.SKIPS_ALLOWED }}
+          FAIL=[! ${{ env.SKIPS_ALLOWED }} ] && ${{ env.SKIPS_DONE }}
           echo $FAIL
-          if [[ FAIL ]]; then
+          if $FAIL; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -165,7 +165,8 @@ jobs:
         file: ./coverage.xml
   documentation:
     if: |
-      ${{ always() }} &&
+      ( ${{ needs.skips-allowed.results == "success" }} ||
+      ${{ needs.skips-allowed.results == "failur" }} ) &&
       ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == false }}
     needs: skips-allowed
     name: Documentation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,6 +64,13 @@ jobs:
           if ${{ env.SKIP_COMPREHENSIVE }}; then
             echo "SKIPS_DONE=true" >> $GITHUB_ENV
           fi
+
+  mergeble-with-skips:
+    name: Skipping and Merge Allowed?
+    runs-on: ubuntu-latest
+    needs: skips-allowed
+
+    steps:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
@@ -164,9 +171,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: |
-      ( ${{ success() }} || ${{ failure() }} ) &&
-      ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == false }}
+    if: ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == false }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,16 +17,16 @@ on:
       - unlabeled
   workflow_dispatch:
 
-env:
-  SKIP_DOCUMENTATION_LABEL: 'GA Skip Documentation'
-  SKIP_COMPREHENSIVE_LABEL: 'GA Skip Comprehensive Tests'
-  SKIPS_ALLOWED_LABEL: 'GA Skip Merge Allowed'
-
-  SKIP_DOCUMENTATION: false
-  SKIP_COMPREHENSIVE: false
-  SKIPS_ALLOWED: false
-
-  SKIPS_DONE: false
+#env:
+#  SKIP_DOCUMENTATION_LABEL: 'GA Skip Documentation'
+#  SKIP_COMPREHENSIVE_LABEL: 'GA Skip Comprehensive Tests'
+#  SKIPS_ALLOWED_LABEL: 'GA Skip Merge Allowed'
+#
+#  SKIP_DOCUMENTATION: false
+#  SKIP_COMPREHENSIVE: false
+#  SKIPS_ALLOWED: false
+#
+#  SKIPS_DONE: false
 
 jobs:
   skips-allowed:
@@ -34,11 +34,27 @@ jobs:
     name: Determine CI Skipping
     runs-on: ubuntu-latest
 
+    env:
+      IS_PR: ${{ github.event_name == 'pull_request' }}
+      SKIP_DOCUMENTATION_LABEL: 'GA Skip Documentation'
+      SKIP_COMPREHENSIVE_LABEL: 'GA Skip Comprehensive Tests'
+      SKIPS_ALLOWED_LABEL: 'GA Skip Merge Allowed'
+
+      SKIP_DOCUMENTATION: false
+      SKIP_COMPREHENSIVE: false
+      SKIPS_ALLOWED: false
+
+      SKIPS_DONE: false
+
     outputs:
-      SKIP_DOCUMENTATION: ${{ steps.step1.outputs.SKIP_DOCUMENTATION }}
-      SKIP_COMPREHENSIVE: ${{ steps.step1.outputs.SKIP_COMPREHENSIVE }}
-      SKIPS_ALLOWED: ${{ steps.step1.outputs.SKIPS_ALLOWED }}
-      SKIPS_DONE: ${{ steps.step_skip_done.outputs.SKIPS_DONE }}
+#      SKIP_DOCUMENTATION: ${{ steps.step1.outputs.SKIP_DOCUMENTATION }}
+#      SKIP_COMPREHENSIVE: ${{ steps.step1.outputs.SKIP_COMPREHENSIVE }}
+#      SKIPS_ALLOWED: ${{ steps.step1.outputs.SKIPS_ALLOWED }}
+#      SKIPS_DONE: ${{ steps.step_skip_done.outputs.SKIPS_DONE }}
+      SKIP_DOCUMENTATION: ${{ env.SKIP_DOCUMENTATION }}
+      SKIP_COMPREHENSIVE: ${{ env.SKIP_COMPREHENSIVE }}
+      SKIPS_ALLOWED: ${{ env.SKIPS_ALLOWED }}
+      SKIPS_DONE: ${{ env.SKIPS_DONE }}
 
     steps:
       - name: Determine Skips
@@ -190,12 +206,6 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - name: RUN ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == 'false' }}
-      run: |
-        echo "SKIP doc == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
-        echo "RUN doc == ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
-        echo "SKIP comp == ${{ needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
-        echo "RUN comp == ${{ !needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          if ${{ !env.SKIPS_ALLOWED }}; then
+          if ${{ !( env.SKIPS_ALLOWED ) }}; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
           echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV
-          SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_ALLOWED_LABEL) }}
+          SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIPS_ALLOWED_LABEL) }}
           echo "SKIPS_ALLOWED=${SKIP}" >> $GITHUB_ENV
       - name: Skip Documentation? ${{ env.SKIP_DOCUMENTATION }}
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,9 +12,9 @@ on:
   workflow_dispatch:
 
 env:
-  SKIP_DOCUMENTATION_LABEL: 'GA Skip: Documentation'
-  SKIP_COMPREHENSIVE_LABEL: 'GA Skip: Comprehensive Tests'
-  SKIPS_ALLOWED_LABEL: 'GA Skip: Merge Allowed'
+  SKIP_DOCUMENTATION_LABEL: 'GA Skip Documentation'
+  SKIP_COMPREHENSIVE_LABEL: 'GA Skip Comprehensive Tests'
+  SKIPS_ALLOWED_LABEL: 'GA Skip Merge Allowed'
 
   SKIP_DOCUMENTATION: false
   SKIP_COMPREHENSIVE: false
@@ -54,7 +54,6 @@ jobs:
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
           FAIL=[! ${{ env.SKIPS_ALLOWED }} ] && ${{ env.SKIPS_DONE }}
-          echo $FAIL
           if $FAIL; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,6 +38,7 @@ jobs:
       SKIP_DOCUMENTATION: ${{ steps.step1.outputs.SKIP_DOCUMENTATION }}
       SKIP_COMPREHENSIVE: ${{ steps.step1.outputs.SKIP_COMPREHENSIVE }}
       SKIPS_ALLOWED: ${{ steps.step1.outputs.SKIPS_ALLOWED }}
+      SKIPS_DONE: ${{ steps.step_skip_done.outputs.SKIPS_DONE }}
 
     steps:
       - name: Determine Skips
@@ -54,6 +55,7 @@ jobs:
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIPS_ALLOWED_LABEL) }}
           echo "SKIPS_ALLOWED=${SKIP}" >> $GITHUB_ENV
           echo "::set-output name=SKIPS_ALLOWED::${SKIP}"
+
       - name: Skip Documentation? ${{ env.SKIP_DOCUMENTATION }}
         run: |
           echo "Documentation can be skipped: ${{ env.SKIP_DOCUMENTATION }}"
@@ -66,6 +68,10 @@ jobs:
           if ${{ env.SKIP_COMPREHENSIVE }}; then
             echo "SKIPS_DONE=true" >> $GITHUB_ENV
           fi
+      - name: Set SKIPS_DONE
+        id: step_skip_done
+        run: |
+          echo "::set-output name=SKIPS_DONE::${{ env.SKIPS_DONE }}"
 
   mergeble-with-skips:
     name: Skipping and Merge Allowed?
@@ -74,6 +80,7 @@ jobs:
 
     env:
       SKIPS_ALLOWED: ${{ needs.skips-allowed.outputs.SKIPS_ALLOWED }}
+      SKIPS_DONE: ${{ needs.skips-allowed.outputs.SKIPS_DONE }}
 
     steps:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -174,7 +174,9 @@ jobs:
     - name: Play
       run: |
         echo "SKIP doc == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
+        echo "RUN doc == ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
         echo "SKIP comp == ${{ needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
+        echo "RUN comp == ${{ !needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,12 +31,13 @@ env:
 jobs:
   skips-allowed:
     if: ${{ github.event_name == 'pull_request' }}
-    name: Skipping and Merge Allowed?
+    name: Determine CI Skipping
     runs-on: ubuntu-latest
 
     outputs:
       SKIP_DOCUMENTATION: ${{ steps.step1.outputs.SKIP_DOCUMENTATION }}
       SKIP_COMPREHENSIVE: ${{ steps.step1.outputs.SKIP_COMPREHENSIVE }}
+      SKIPS_ALLOWED: ${{ steps.step1.outputs.SKIPS_ALLOWED }}
 
     steps:
       - name: Determine Skips
@@ -52,6 +53,7 @@ jobs:
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIPS_ALLOWED_LABEL) }}
           echo "SKIPS_ALLOWED=${SKIP}" >> $GITHUB_ENV
+          echo "::set-output name=SKIPS_ALLOWED::${SKIP}"
       - name: Skip Documentation? ${{ env.SKIP_DOCUMENTATION }}
         run: |
           echo "Documentation can be skipped: ${{ env.SKIP_DOCUMENTATION }}"
@@ -69,6 +71,9 @@ jobs:
     name: Skipping and Merge Allowed?
     runs-on: ubuntu-latest
     needs: skips-allowed
+
+    env:
+      SKIPS_ALLOWED: ${{ needs.skips-allowed.outputs.SKIPS_ALLOWED }}
 
     steps:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,11 +39,11 @@ jobs:
         run: |
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
-          echo "::set-output name=SKIP_DOCUMENTATION::${{ env.SKIP_DOCUMENTATION }}"
+          echo "::set-output name=SKIP_DOCUMENTATION::${SKIP}"
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
           echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV
-          echo "::set-output name=SKIP_COMPREHENSIVE::${{ env.SKIP_COMPREHENSIVE }}"
+          echo "::set-output name=SKIP_COMPREHENSIVE::${SKIP}"
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIPS_ALLOWED_LABEL) }}
           echo "SKIPS_ALLOWED=${SKIP}" >> $GITHUB_ENV

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -165,13 +165,16 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
+    if: ${{ always() }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
+    - name: Play
+      run: |
+        echo "skip == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,11 +31,12 @@ jobs:
     steps:
       - name: Determine Skips
         run: |
-          echo "Label is '${{ env.SKIP_DOCUMENTATION_LABEL }}'"
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
+
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
           echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV
+
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIPS_ALLOWED_LABEL) }}
           echo "SKIPS_ALLOWED=${SKIP}" >> $GITHUB_ENV
       - name: Skip Documentation? ${{ env.SKIP_DOCUMENTATION }}
@@ -54,9 +55,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=${{ ! env.SKIPS_ALLOWED && env.SKIPS_DONE}}
-          echo $FAIL
-          if [ '${FAIL}' == true ]; then
+          if [[ "$SKIPS_ALLOWED" == "false" && "$SKIPS_DONE" == "true" ]]; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          if !${{ env.SKIPS_ALLOWED }}; then
+          if [[ !( ${{ env.SKIPS_ALLOWED }} ) ]]; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,7 +183,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: true
+    if: ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == 'false' }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,9 +39,11 @@ jobs:
         run: |
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
+          echo "::set-output name=SKIP_DOCUMENTATION::${{ env.SKIP_DOCUMENTATION }}"
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
           echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV
+          echo "::set-output name=SKIP_COMPREHENSIVE::${{ env.SKIP_COMPREHENSIVE }}"
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIPS_ALLOWED_LABEL) }}
           echo "SKIPS_ALLOWED=${SKIP}" >> $GITHUB_ENV
@@ -51,7 +53,6 @@ jobs:
           if ${{ env.SKIP_DOCUMENTATION }}; then
             echo "SKIPS_DONE=true" >> $GITHUB_ENV
           fi
-          echo "::set-output name=SKIP_DOCUMENTATION::$SKIP_DOCUMENTATION"
       - name: Skip Comprehensive Tests? ${{ env.SKIP_COMPREHENSIVE }}
         run: |
           echo "Comprehensive tests can be skipped: ${{ env.SKIP_COMPREHENSIVE }}"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,6 @@ on:
 
 jobs:
   skips-allowed:
-    if: ${{ github.event_name == 'pull_request' }}
     name: Determine CI Skipping
     runs-on: ubuntu-latest
 
@@ -44,6 +43,7 @@ jobs:
     steps:
       - name: Determine Skips
         id: step1
+        if: ${{ env.IS_PR }}
         run: |
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo "Label is '${{ env.SKIP_DOCUMENTATION_LABEL }}'"
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
-          echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_SKIP
+          echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
           if [[ $SKIP ]]; then
             echo "1"
             echo "dSKIP=1" >> $GITHUB_ENV 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=${{ env.SKIPS_ALLOWED }}
+          FAIL=${{ !( env.SKIPS_ALLOWED ) }}
+          echo $FAIL
           if [[ FAIL ]]; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -68,6 +68,7 @@ jobs:
           fi
 
   initial-tests:
+    if: false
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -158,7 +159,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
+    if: ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          if [[ !( ${{ env.SKIPS_ALLOWED }} ) ]]; then
+          FAIL=${{  !env.SKIPS_ALLOWED }}
+          if [[ FAIL ]]; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
   comprehensive-tests:
-    if: ${{ ! env.SKIP_COMPREHENSIVE }}
+    if: ${{ env.SKIP_COMPREHENSIVE }}
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: initial-tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,7 +183,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: !needs.skips-allowed.outputs.SKIP_DOCUMENTATION
+    if: !${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -164,7 +164,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: !needs.skips-allowed.outputs.SKIP_DOCUMENTATION
+    if: ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,14 +183,14 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: needs.skips-allowed.outputs.SKIP_DOCUMENTATION == 'false'
+    if: true
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
-    - name: Play
+    - name: Play ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
       run: |
         echo "SKIP doc == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
         echo "RUN doc == ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,6 +45,7 @@ jobs:
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
           echo "::set-output name=SKIP_DOCUMENTATION::${SKIP}"
+          echo ${{ outputs.SKIP_DOCUMENTATION }}
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
           echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           echo "Label is '${{ env.SKIP_DOCUMENTATION_LABEL }}'"
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
+          echo "SKIP_DOCUMENTATION=$(SKIP)" >> $GITHUB_SKIP
           if [[ $SKIP ]]; then
             echo "1"
             echo "dSKIP=1" >> $GITHUB_ENV 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,8 +62,6 @@ jobs:
           fi
 
   initial-tests:
-    if: ${{ always() }}
-    needs: skips-allowed
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -98,7 +96,8 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
-    needs: initial-tests
+    if: ${{ needs.initial-tests.results == 'failure' || needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}
+    needs: [initial-tests, skips-allowed]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -173,7 +173,8 @@ jobs:
     steps:
     - name: Play
       run: |
-        echo "skip == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
+        echo "skip doc == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
+        echo "skip comp == ${{ needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -166,7 +166,7 @@ jobs:
   documentation:
     if: |
       ${{ always() }} &&
-      ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
+      ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == false }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          if ${{ !(env.SKIPS_ALLOWED) && env.SKIPS_DONE}}; then
+          if ${{ !env.SKIPS_ALLOWED }}; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -190,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - name: Play ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
+    - name: RUN ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
       run: |
         echo "SKIP doc == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
         echo "RUN doc == ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -164,7 +164,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: always() && !needs.skips-allowed.outputs.SKIP_DOCUMENTATION
+    if: !needs.skips-allowed.outputs.SKIP_DOCUMENTATION
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,7 +45,6 @@ jobs:
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
           echo "::set-output name=SKIP_DOCUMENTATION::${SKIP}"
-          echo ${{ outputs.SKIP_DOCUMENTATION }}
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
           echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -94,7 +94,6 @@ jobs:
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
   comprehensive-tests:
-    if: ${{ env.SKIP_COMPREHENSIVE }}
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: initial-tests
@@ -128,7 +127,6 @@ jobs:
           os: ubuntu-latest
           python: 3.9
           toxenv: py39
-
 
     steps:
     - name: Checkout code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   skips-allowed:
     if: ${{ github.event_name == 'pull_request' }}
-    name: Merge Allowed?
+    name: Skipping and Merge Allowed?
     runs-on: ubuntu-latest
 
     steps:
@@ -55,7 +55,7 @@ jobs:
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
           FAIL=${{ ! env.SKIPS_ALLOWED && env.SKIPS_DONE}}
           echo $FAIL
-          if $FAIL; then
+          if [ '${FAIL}' == true ]; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi
@@ -96,7 +96,10 @@ jobs:
   comprehensive-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+
+    if: ${{ env.SKIP_DOCUMENTATION }}
     needs: initial-tests
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,12 @@ on:
     tags:
     - v*
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
   workflow_dispatch:
 
 env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,6 +44,7 @@ jobs:
           if ${{ env.SKIP_DOCUMENTATION }}; then
             echo "SKIPS_DONE=true" >> $GITHUB_ENV
           fi
+          echo "::set-output name=SKIP_DOCUMENTATION::$SKIP_DOCUMENTATION"
       - name: Skip Comprehensive Tests? ${{ env.SKIP_COMPREHENSIVE }}
         run: |
           echo "Comprehensive tests can be skipped: ${{ env.SKIP_COMPREHENSIVE }}"
@@ -97,7 +98,6 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
-    if: ${{ env.SKIP_DOCUMENTATION }}
     needs: initial-tests
 
     strategy:
@@ -153,7 +153,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: ${{ always() }}
+    if: ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,17 +17,6 @@ on:
       - unlabeled
   workflow_dispatch:
 
-#env:
-#  SKIP_DOCUMENTATION_LABEL: 'GA Skip Documentation'
-#  SKIP_COMPREHENSIVE_LABEL: 'GA Skip Comprehensive Tests'
-#  SKIPS_ALLOWED_LABEL: 'GA Skip Merge Allowed'
-#
-#  SKIP_DOCUMENTATION: false
-#  SKIP_COMPREHENSIVE: false
-#  SKIPS_ALLOWED: false
-#
-#  SKIPS_DONE: false
-
 jobs:
   skips-allowed:
     if: ${{ github.event_name == 'pull_request' }}
@@ -47,10 +36,6 @@ jobs:
       SKIPS_DONE: false
 
     outputs:
-#      SKIP_DOCUMENTATION: ${{ steps.step1.outputs.SKIP_DOCUMENTATION }}
-#      SKIP_COMPREHENSIVE: ${{ steps.step1.outputs.SKIP_COMPREHENSIVE }}
-#      SKIPS_ALLOWED: ${{ steps.step1.outputs.SKIPS_ALLOWED }}
-#      SKIPS_DONE: ${{ steps.step_skip_done.outputs.SKIPS_DONE }}
       SKIP_DOCUMENTATION: ${{ env.SKIP_DOCUMENTATION }}
       SKIP_COMPREHENSIVE: ${{ env.SKIP_COMPREHENSIVE }}
       SKIPS_ALLOWED: ${{ env.SKIPS_ALLOWED }}
@@ -62,15 +47,12 @@ jobs:
         run: |
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV
-          echo "::set-output name=SKIP_DOCUMENTATION::${SKIP}"
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_COMPREHENSIVE_LABEL) }}
           echo "SKIP_COMPREHENSIVE=${SKIP}" >> $GITHUB_ENV
-          echo "::set-output name=SKIP_COMPREHENSIVE::${SKIP}"
 
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIPS_ALLOWED_LABEL) }}
           echo "SKIPS_ALLOWED=${SKIP}" >> $GITHUB_ENV
-          echo "::set-output name=SKIPS_ALLOWED::${SKIP}"
 
       - name: Skip Documentation? ${{ env.SKIP_DOCUMENTATION }}
         run: |
@@ -84,10 +66,6 @@ jobs:
           if ${{ env.SKIP_COMPREHENSIVE }}; then
             echo "SKIPS_DONE=true" >> $GITHUB_ENV
           fi
-      - name: Set SKIPS_DONE
-        id: step_skip_done
-        run: |
-          echo "::set-output name=SKIPS_DONE::${{ env.SKIPS_DONE }}"
 
   mergeble-with-skips:
     name: Skipping and Merge Allowed?
@@ -108,7 +86,6 @@ jobs:
           fi
 
   initial-tests:
-    if: false
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -143,7 +120,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
-    if: ${{ needs.initial-tests.results == 'failure' || needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}
+    if: ${{ needs.skips-allowed.outputs.SKIP_COMPREHENSIVE == 'false' }}
     needs: [initial-tests, skips-allowed]
 
     strategy:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          FAIL=${{ env.SKIPS_ALLOWED && env.SKIPS_DONE }})
+          FAIL=${{ ! env.SKIPS_ALLOWED }}
           echo $FAIL
           if $FAIL; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,7 +183,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: !${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
+    if: needs.skips-allowed.outputs.SKIP_DOCUMENTATION == 'false'
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -164,7 +164,9 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: ${{ always() && !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
+    if: |
+      ${{ always() }} &&
+      ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
           FAIL=[! ${{ env.SKIPS_ALLOWED }} ] && ${{ env.SKIPS_DONE }}
+          echo $FAIL
           if $FAIL; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,8 +34,13 @@ jobs:
     name: Skipping and Merge Allowed?
     runs-on: ubuntu-latest
 
+    outputs:
+      SKIP_DOCUMENTATION: ${{ steps.step1.outputs.SKIP_DOCUMENTATION }}
+      SKIP_COMPREHENSIVE: ${{ steps.step1.outputs.SKIP_COMPREHENSIVE }}
+
     steps:
       - name: Determine Skips
+        id: step1
         run: |
           SKIP=${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DOCUMENTATION_LABEL) }}
           echo "SKIP_DOCUMENTATION=${SKIP}" >> $GITHUB_ENV

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -165,8 +165,7 @@ jobs:
         file: ./coverage.xml
   documentation:
     if: |
-      ( ${{ needs.skips-allowed.results == 'success' }} ||
-      ${{ needs.skips-allowed.results == 'failure' }} ) &&
+      ( ${{ success() }} || ${{ failure() }} ) &&
       ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION == false }}
     needs: skips-allowed
     name: Documentation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
+          if ${{ !env.SKIPS_ALLOWED && env.SKIPS_DONE}}; then
+            echo "Some tests are skipped, but skipping needs to be removed before merging!!"
+            exit 1
+          fi
           
 
 #      - name: Were tests skipped?

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -164,7 +164,7 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: ${{ always() }}
+    if: always()
     needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest
@@ -173,8 +173,8 @@ jobs:
     steps:
     - name: Play
       run: |
-        echo "RUN doc == ${{ !needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
-        echo "RUN comp == ${{ !needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
+        echo "SKIP doc == ${{ needs.skips-allowed.outputs.SKIP_DOCUMENTATION }}"
+        echo "SKIP comp == ${{ needs.skips-allowed.outputs.SKIP_COMPREHENSIVE }}"
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,19 +59,10 @@ jobs:
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi
-          
-
-#      - name: Were tests skipped?
-#        run: echo ${{ env.SKIPS_DONE }}
-#      - name: Is skipping allowed?
-#        run: |
-#          echo ${{ env.SKIPS_ALLOWED }}
-#          if ${{ env.SKIPS_DONE && !env.SKIPS_ALLOWED }}; then
-#            exit 1
-#          fi
 
   initial-tests:
-    if: false
+    if: ${{ always() }}
+    needs: skips-allowed
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -103,7 +94,7 @@ jobs:
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
   comprehensive-tests:
-    if: false
+    if: ${{ ! env.SKIP_COMPREHENSIVE }}
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: initial-tests
@@ -161,7 +152,8 @@ jobs:
       with:
         file: ./coverage.xml
   documentation:
-    if: ${{ !(contains( github.event.pull_request.labels.*.name, 'GA Skip Documentation')) }}
+    if: ${{ always() }}
+    needs: skips-allowed
     name: Documentation
     runs-on: ubuntu-latest
     strategy:
@@ -181,6 +173,7 @@ jobs:
       run: sudo apt-get install graphviz pandoc
     - name: Run tests
       run: tox  -e build_docs -- -q
+
   build-n-publish:
     name: Packaging
     runs-on: ubuntu-18.04

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Skip Tests Allowed? ${{ env.SKIPS_ALLOWED }}
         run: |
           echo "Is skipping tests allowed: ${{ env.SKIPS_ALLOWED }}"
-          if ${{ !( env.SKIPS_ALLOWED ) }}; then
+          if !${{ env.SKIPS_ALLOWED }}; then
             echo "Some tests are skipped, but skipping needs to be removed before merging!!"
             exit 1
           fi


### PR DESCRIPTION
This PR puts a framework into the CI Test workflow that allows parts of the tests to be skipped based on labels added to the PR.  

The motivation for this prototype came about when the GA Documentation Test was failing due to a recent release of `jinja2` and not related to what the contributor was doing.  In this scenario we were completely block from merging the PR until the test was resolved, luckily in that case it was an easy fix.

Another upside to this approach, we can turn off comprehensive tests until we reach the end of a PR development.  This should allows to both expand PR tests while not overloading our resources.

I did build a job into the workflow that does fail if other jobs are skipped, unless the "GA Skip Merge Allowed" label is added to the PR.  This should add some redundancy against us unintentionally merging a PR with skipped tests.

