### PR TITLE
Test that ``plasmapy`` can be imported

### DIFF
--- a/.github/workflows/fortnightly.yml
+++ b/.github/workflows/fortnightly.yml
@@ -41,6 +41,21 @@ jobs:
           python: 3.8
           toxenv: py38-xarraydev
 
+        - name: Import PlasmaPy (Windows)
+          os: windows-latest
+          python: 3.8
+          toxenv: py38-minimal-pypi-import
+
+        - name: Import PlasmaPy (macOS X)
+          os: macos-latest
+          python: 3.8
+          toxenv: py38-minimal-pypi-import
+
+        - name: Import PlasmaPy (Ubuntu)
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-minimal-pypi-import
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,6 @@ jobs:
           python: 3.9
           toxenv: py39
 
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -156,3 +155,21 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.pypi_access_token }}
+  import-plasmapy:
+    name: Importing PlasmaPy
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+    - name: Install Python dependencies
+      run: python -m pip install --progress-bar off --upgrade tox
+    - name: Import PlasmaPy
+      run: tox -e py38-minimal-pypi-import

--- a/changelog/1501.trivial.rst
+++ b/changelog/1501.trivial.rst
@@ -1,0 +1,1 @@
+Added a test that ``import plasmapy`` does not raise an exception.

--- a/plasmapy/tests/test_import.py
+++ b/plasmapy/tests/test_import.py
@@ -1,6 +1,0 @@
-"""Tests for importing ``plasmapy``."""
-
-
-def test_that_plasmapy_can_be_imported():
-    """Test that it is possible to import ``plasmapy``."""
-    import plasmapy

--- a/plasmapy/tests/test_import.py
+++ b/plasmapy/tests/test_import.py
@@ -1,0 +1,6 @@
+"""Tests for importing ``plasmapy``."""
+
+
+def test_that_plasmapy_can_be_imported():
+    """Test that it is possible to import ``plasmapy``."""
+    import plasmapy


### PR DESCRIPTION
This PR adds a simple test in our test suite that runs ``import plasmapy`` to make sure that it can be imported.

I decided to include this as a test rather than as a GitHub Action so that:
 - We are able to test this on platforms besides GitHub, including locally
 - We are able to straightforwardly test this on multiple operating systems and versions of Python.

We also currently have a [tox environment](https://github.com/PlasmaPy/PlasmaPy/blob/9e4cc617e56ce01fea1a5e356d25c659627b208c/tox.ini#L122) that can be used to perform this test.