### PR TITLE
Set maximum requirement for `click` in `pre-commit` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,8 @@ repos:
   rev: 21.12b0
   hooks:
   - id: black
+  additional_dependencies:
+  - click<8.1  # try removing when black is being updated
 
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 0.8.0
@@ -40,6 +42,7 @@ repos:
   - id: nbqa-black
     additional_dependencies:
     - black==21.12b0
+    - click<8.1  # try removing when black is being updated
     args:
     - --nbqa-mutate
   - id: nbqa-isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,8 @@ repos:
   rev: 21.12b0
   hooks:
   - id: black
-  additional_dependencies:
-  - click<8.1  # try removing when black is being updated
+    additional_dependencies:
+    - click<8.1  # remove this when black is next updated
 
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 0.8.0
@@ -42,7 +42,7 @@ repos:
   - id: nbqa-black
     additional_dependencies:
     - black==21.12b0
-    - click<8.1  # try removing when black is being updated
+    - click<8.1  # remove this when black is next updated
     args:
     - --nbqa-mutate
   - id: nbqa-isort

--- a/changelog/1504.trivial.rst
+++ b/changelog/1504.trivial.rst
@@ -1,3 +1,0 @@
-Set the maximum version of ``click`` to be less than ``8.1`` in the
-pre-commit_ configuration for compatibility with black_ version
-``21.12b0``.

--- a/changelog/1504.trivial.rst
+++ b/changelog/1504.trivial.rst
@@ -1,0 +1,3 @@
+Set the maximum version of ``click`` to be less than ``8.1`` in the
+pre-commit_ configuration for compatibility with black_ version
+``21.12b0``.


### PR DESCRIPTION
The version of `black` that we currently use in `pre-commit` has started having an issue with the newest release of `click`.  This PR temporarily sets a maximum requirement for `click`, since updating to the next version of `black` is going to be really involved (#1503).  When we update to the next version of `black` in `pre-commit`, we should be able to drop this maximum requirement. 