### PR TITLE
Stop using `check-merge-conflicts` pre-commit hook for `.rst` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
   - id: check-ast
   - id: trailing-whitespace
   - id: end-of-file-fixer
-  - id: check-merge-conflict
   - id: requirements-txt-fixer
   - id: check-symlinks
   - id: check-case-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
   - id: check-ast
   - id: trailing-whitespace
   - id: end-of-file-fixer
+  - id: check-merge-conflict
+    exclude: .*\.rst
   - id: requirements-txt-fixer
   - id: check-symlinks
   - id: check-case-conflict


### PR DESCRIPTION
I've been getting occasional false positives for the `check-merge-conflict` pre-commit hook.  In particular, after I try to resolve conflicts in a `.rst` file, the `=======` that is used for headings gets treated as a separator line from a merge conflict.  

This PR stops the `check-merge-conflict` hook from being run on `.rst` files (using a Python regular expression to denote file type) to avoid these false positives.