### PR TITLE
Add `analysis` and `dispersion` to `plasmapy.__init__`

### DIFF
--- a/changelog/1512.bugfix.rst
+++ b/changelog/1512.bugfix.rst
@@ -1,0 +1,2 @@
+The `~plasmapy.analysis` and `~plasmapy.dispersion` subpackages are now
+directly imported in `plasmapy.__init__`.

--- a/changelog/1512.bugfix.rst
+++ b/changelog/1512.bugfix.rst
@@ -1,2 +1,2 @@
-Exposed the `~plasmapy.analysis` and `~plasmapy.dispersion` subpackages to the
-`plasmapy` namespace..
+Exposed the `~plasmapy.analysis` and `~plasmapy.dispersion` subpackages
+to the `plasmapy` namespace.

--- a/changelog/1512.bugfix.rst
+++ b/changelog/1512.bugfix.rst
@@ -1,2 +1,2 @@
-The `~plasmapy.analysis` and `~plasmapy.dispersion` subpackages are now
-directly imported in `plasmapy.__init__`.
+Exposed the `~plasmapy.analysis` and `~plasmapy.dispersion` subpackages to the
+`plasmapy` namespace..

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -6,7 +6,9 @@ and online at https://docs.plasmapy.org (accessible also using the
 """
 __all__ = [
     "online_help",
+    "analysis",
     "diagnostics",
+    "dispersion",
     "formulary",
     "particles",
     "plasma",

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -28,7 +28,16 @@ if sys.version_info < (3, 8):  # coverage: ignore
 # ----------------------------------------------------------------------------
 import pkg_resources
 
-from plasmapy import diagnostics, formulary, particles, plasma, simulation, utils
+from plasmapy import (
+    analysis,
+    diagnostics,
+    dispersion,
+    formulary,
+    particles,
+    plasma,
+    simulation,
+    utils,
+)
 
 # define version
 try:


### PR DESCRIPTION
This PR adds the `analysis` and `dispersion` subpackages to `plasmapy.__init__`, including in the `__all__` dunder.  