### PR TITLE
Update docs and the use of `kwargs` in `fit_functions.Linear.curve_fit`

### DIFF
--- a/changelog/1518.bugfix.rst
+++ b/changelog/1518.bugfix.rst
@@ -1,5 +1,6 @@
-Changed the :meth:`~plasmapy.fit_functions.Linear.curve_fit` method on
-`plasmapy.fit_functions.Linear` so that the arbitrary keyword arguments
-get passed to `scipy.stats.linregress`. Previously,
-:meth:`~plasmapy.fit_functions.Linear.curve_fit` had accepted arbitrary
-keyword arguments but not passed them along to `~scipy.stats.linregress`.
+Changed the :meth:`~plasmapy.analysis.fit_functions.Linear.curve_fit`
+method on `plasmapy.analysis.fit_functions.Linear` so that the
+arbitrary keyword arguments get passed to `scipy.stats.linregress`.
+Previously, :meth:`~plasmapy.analysis.fit_functions.Linear.curve_fit`
+had accepted arbitrary keyword arguments but did not pass them along to
+`~scipy.stats.linregress`.

--- a/changelog/1518.bugfix.rst
+++ b/changelog/1518.bugfix.rst
@@ -1,0 +1,5 @@
+Changed the :meth:`~plasmapy.fit_functions.Linear.curve_fit` method on
+`plasmapy.fit_functions.Linear` so that the arbitrary keyword arguments
+get passed to `scipy.stats.linregress`. Previously,
+:meth:`~plasmapy.fit_functions.Linear.curve_fit` had accepted arbitrary
+keyword arguments but not passed them along to `~scipy.stats.linregress`.

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -633,10 +633,10 @@ class Linear(AbstractFitFunction):
             The dependent data associated with ``xdata``.
 
         **kwargs
-            Any keywords accepted by `scipy.stats.linregress.curve_fit`.
+            Any keywords accepted by `scipy.stats.linregress`.
 
         """
-        results = linregress(xdata, ydata)
+        results = linregress(xdata, ydata, **kwargs)
         self._curve_fit_results = results
 
         m = results[0]


### PR DESCRIPTION
While going through #1509, I noticed that `kwargs` was accepted for `fit_functions.Linear.curve_fit`, but it wasn't used in the method when calling `linregress`.  This PR makes it so that the `kwargs` are passed to `linregress`. I also updated the reST link to be `scipy.stats.linregress`.

@rocco8773 — could you take a look at this to make sure the change is consistent with the intended behavior?  Thank you!  

