### PR TITLE
Specify allowed reST/Sphinx roles & directives for flake8-rst-docstrings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -186,9 +186,11 @@ exclude =
     setup.py,
     .jupyter
 # Use rst-roles and rst-directives to list roles and directives from
-# Sphinx extensions so that they don't get flagged when using
+# Sphinx and its extensions so that they don't get flagged when using
 # flake8-rst-docstrings.
 rst-roles =
+    abbr
+    any
     attr
     cite
     cite:ct
@@ -198,24 +200,54 @@ rst-roles =
     cite:t
     cite:ts
     class
+    command
     confval
     data
+    dfn
+    doc
+    download
+    envvar
+    eq
     event
     exc
     file
     func
+    guilabel
+    kbd
+    keyword
+    makevar
+    manpage
+    menuselection
     meth
     mod
+    numref
+    option
+    pep
+    program
     ref
+    regexp
     rst:dir
+    samp
     term
+    token
 rst-directives =
+    codeauthor
     confval
     deprecated
     event
+    highlight
+    hlist
+    index
+    literalinclude
     nbgallery
+    only
     rst:directive
+    sectionauthor
+    seealso
+    tabularcolumns
     todo
+    versionadded
+    versionchanged
 enable-extensions =
     # Look for strings that have {} in them but aren't f-strings.
     # If there is a false positive from this in a file, put that in


### PR DESCRIPTION
The [flake8-rst-docstrings](https://github.com/peterjc/flake8-rst-docstrings) extension to flake8 checks a bunch of things regarding reStructuredText (reST) formatting in our docstrings, including about whether or not there are any undefined [roles](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html) or [directives](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html).

Unfortunately, it appears to only know the roles/directives from basic reST, and not the roles/directives defined by Sphinx which are a superset of those from basic reST.  This means that we have to specify which reST role/directives are allowed in docstrings via the appropriate variables in `setup.cfg` (`rst-roles` and `rst-directives`).  This PR adds most of the remaining Sphinx roles/directives to these two variables so that they can be used in docstrings. 

This extension does not check our narrative docs.  Some of the added roles/directives might never end up being needed in docstrings, but I put them in since they're valid.  Roles/directives from Sphinx extensions may still need to be added here in the future.