### PR TITLE
Base bibliography html anchors on citation key

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,7 @@ extensions = [
 bibtex_bibfiles = ["bibliography.bib"]
 bibtex_default_style = "plain"
 bibtex_reference_style = "author_year"
+bibtex_cite_id = "{key}"
 
 # Intersphinx generates automatic links to the documentation of objects
 # in other packages. When mappings are removed or added, please update

--- a/docs/development/install_dev.rst
+++ b/docs/development/install_dev.rst
@@ -59,7 +59,7 @@ Conda
 -----
 
 To set up a development environment for PlasmaPy, we strongly recommend
-the `Anaconda distribution <https://www.anaconda.com/products/individual>`_.
+the `Anaconda distribution <https://www.anaconda.com/products/distribution>`_.
 
 Activate Anaconda
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Prior to this PR, the html anchors used for each reference in our bibliography was of a form like `id20`, where the number corresponds to the number in the bibliography.  While links created using roles like `:cite:p:` and `:cite:t:` will be updated automatically, external links that point to one bibliography entry at one point in time are not guaranteed to point to that same entry at a later time (for example, if more bibliography entries got added).  This is also true for hard links to bibliography entries that were included in Markdown cells in our example notebooks.

This PR sets the html anchors to the citation key, with colons replaced by dashes.  This provides an extra level of stability, as the anchors won't change as long as the citation key doesn't change.  If a citation key does end up changing, then we would be more likely to catch a broken anchor from using `make linkcheck`.