### PR TITLE
Create `ParticleListLike` typing construct and "particle-list-like" term

### DIFF
--- a/changelog/1528.feature.rst
+++ b/changelog/1528.feature.rst
@@ -1,0 +1,2 @@
+Created the |ParticleListLike| typing construct and added
+:term:`particle-list-like` to the |glossary|.

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -20,6 +20,7 @@
 .. |particle_input| replace:: :func:`~plasmapy.particles.decorators.particle_input`
 .. |ParticleLike| replace:: :obj:`~plasmapy.particles.particle_class.ParticleLike`
 .. |ParticleList| replace:: :class:`~plasmapy.particles.particle_collections.ParticleList`
+.. |ParticleListLike| replace:: :obj:`~plasmapy.particles.particle_collections.ParticleListLike`
 
 .. |ChargeError| replace:: :class:`~plasmapy.particles.exceptions.ChargeError`
 .. |InvalidElementError| replace:: :class:`~plasmapy.particles.exceptions.InvalidElementError`

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -107,6 +107,12 @@ Glossary
 
       For more complete details, refer to |ParticleLike|.
 
+   particle-list-like
+      An `object` is *particle-list-like* if it is a |ParticleList|, or
+      can be cast into one.
+
+      For more complete details, refer to |ParticleListLike|.
+
    real number
       Any numeric type that represents a real number. This could include
       a `float`, `int`, a dimensionless |Quantity|, or any of the

--- a/plasmapy/particles/__init__.py
+++ b/plasmapy/particles/__init__.py
@@ -36,7 +36,11 @@ from plasmapy.particles.particle_class import (
     Particle,
     ParticleLike,
 )
-from plasmapy.particles.particle_collections import ionic_levels, ParticleList
+from plasmapy.particles.particle_collections import (
+    ionic_levels,
+    ParticleList,
+    ParticleListLike,
+)
 from plasmapy.particles.serialization import (
     json_load_particle,
     json_loads_particle,

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -8,7 +8,7 @@ import contextlib
 import numpy as np
 
 from numbers import Integral
-from typing import Callable, Iterable, List, Optional, Union
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple, Union
 
 from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.exceptions import ChargeError, InvalidParticleError
@@ -488,3 +488,42 @@ def ionic_levels(
     return ParticleList(
         [Particle(base_particle, Z=Z) for Z in range(min_charge, max_charge + 1)]
     )
+
+
+ParticleListLike = Union[ParticleList, Sequence[ParticleLike]]
+
+ParticleListLike.__doc__ = r"""
+An `object` is :term:`particle-list-like` if it can be identified as a
+`~plasmapy.particles.particle_collections.ParticleList` or cast into
+one.
+
+When used as a type hint annotation, `ParticleListLike` indicates that
+the corresponding argument should represent a sequence of physical
+particles. Each item in a `ParticleListLike` must be
+`~plasmapy.particles.particle_class.ParticleLike`.
+
+Notes
+-----
+`~plasmapy.particles.particle_class.DimensionlessParticle` instances do
+not uniquely represent a physical particle, and are thus not
+|ParticleLike| and cannot be contained in a `ParticleListLike` object.
+
+See Also
+--------
+~plasmapy.particles.particle_collections.ParticleList
+~plasmapy.particles.particle_class.ParticleLike
+~plasmapy.particles.decorators.particle_input
+
+Examples
+--------
+Using `ParticleListLike` as a type hint annotation indicates that an
+argument or variable should represent a sequence of |ParticleLike|
+objects.
+
+>>> from plasmapy.particles import ParticleList, ParticleListLike
+>>> def contains_only_leptons(particles: ParticleListLike):
+...     particle_list = ParticleList(particles)
+...     return all(particle_list.is_category("lepton"))
+>>> contains_only_leptons(["electron", "muon"])
+True
+"""


### PR DESCRIPTION
This pull request is to create `plasmapy.particles.particle_collections.ParticleListLike` as a typing construct that could be used in `particle_input`.  This PR follows up on #985.

Eventually I'm wondering if it would make sense to create `plasmapy.particles.typing` to contain things like this, but not in this PR.

