### PR TITLE
Add GitHub Action for codespell

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -119,6 +119,24 @@ jobs:
       run: sudo apt-get install graphviz pandoc
     - name: Run tests
       run: tox  -e build_docs -- -q
+  codespell:
+    name: codespell
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+    - name: Install Python dependencies
+      run: python -m pip install --progress-bar off --upgrade tox
+    - name: Run tests
+      run: tox -e codespell -q
   build-n-publish:
     name: Packaging
     runs-on: ubuntu-18.04

--- a/changelog/1530.doc.rst
+++ b/changelog/1530.doc.rst
@@ -1,0 +1,3 @@
+Described the `GitHub Action`_ for
+`codespell <https://github.com/codespell-project/codespell>`__
+in the |testing guide|.

--- a/changelog/1530.doc.rst
+++ b/changelog/1530.doc.rst
@@ -1,3 +1,2 @@
-Described the `GitHub Action`_ for
-`codespell <https://github.com/codespell-project/codespell>`__
+Described the GitHub Action for `codespell <https://github.com/codespell-project/codespell>`__
 in the |testing guide|.

--- a/changelog/1530.trivial.rst
+++ b/changelog/1530.trivial.rst
@@ -1,3 +1,3 @@
-Added a `GitHub Action`_ for `codespell
+Added a GitHub Action for `codespell
 <https://github.com/codespell-project/codespell>`__, and updated the
 corresponding tox_ environment to print out contextual information.

--- a/changelog/1530.trivial.rst
+++ b/changelog/1530.trivial.rst
@@ -1,0 +1,3 @@
+Added a `GitHub Action`_ for `codespell
+<https://github.com/codespell-project/codespell>`__, and updated the
+corresponding tox_ environment to print out contextual information.

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -731,6 +731,7 @@ should be balanced with each other rather than absolute principles.
 .. _Atom: https://atom.io
 .. _Codecov: https://about.codecov.io
 .. _`code coverage`: https://en.wikipedia.org/wiki/Code_coverage
+.. _codespell: https://github.com/codespell-project/codespell
 .. _`coverage.py`: https://coverage.readthedocs.io
 .. _`create a pull request`: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests
 .. _fixtures: https://docs.pytest.org/en/latest/explanation/fixtures.html

--- a/docs/development/testing_guide.rst
+++ b/docs/development/testing_guide.rst
@@ -158,6 +158,19 @@ The following checks are performed with each pull request.
 * The **Pull Request Labeler / triage (pull_request_target)** check
   applies appropriate GitHub_ labels to pull requests.
 
+* The **CI / codespell (pull request)** check runs codespell_ to catch
+  by looking for common misspellings.
+
+  * If codespell_ has been installed (e.g., by ``pip install codespell``),
+    then it may be run by going into the appropriate directory and
+    running ``codespell -i 2 -w``. This command will identify common
+    misspellings, interactively suggest replacements, and then write the
+    replacements into the file.
+
+  * Occasionally codespell_ will report false positives. Please add
+    false positives to ``ignore-words-list`` under ``codespell`` in
+    :file:`setup.cfg`.
+
 .. note::
 
    For first-time contributors, existing maintainers `may need to

--- a/tox.ini
+++ b/tox.ini
@@ -139,5 +139,8 @@ commands =
   codespell .
 commands_post =
   echo
-  echo "Add false postives detected by codespell to ignore-words-list under [codespell] in setup.cfg."
+  echo "Please add false postives detected by codespell to ignore-words-list"
+  echo "under [codespell] in setup.cfg. Codespell can be installed locally"
+  echo "by running `pip install codespell`, and then run locally with"
+  echo "`codespell -i 2 -w`."
   echo

--- a/tox.ini
+++ b/tox.ini
@@ -137,7 +137,7 @@ commands_pre =
   echo
   echo "Codespell finds typos in source code. Rather than checking if each word"
   echo "matches a dictionary entry, it looks for a set of common misspellings"
-  echo "in order to reduce the number of false postives."
+  echo "in order to reduce the number of false positives."
   echo
 commands =
   codespell .
@@ -146,4 +146,4 @@ commands_post =
   echo "After codespell has been installed locally (`pip install codespell`),"
   echo "running the command `codespell -i 2 -w` will interactively go through"
   echo "misspellings and suggest one or more replacements. Add any false"
-  echo "positives under ignore-words-list under `[codespell]` in setup.cfg."
+  echo "positives under ignore-words-list under [codespell] in setup.cfg."

--- a/tox.ini
+++ b/tox.ini
@@ -134,18 +134,14 @@ commands = python -c 'import plasmapy'
 deps =
   codespell
 commands_pre =
-  echo
   echo "Codespell finds typos in source code. Rather than checking if each word"
   echo "matches a dictionary entry, it looks for a set of common misspellings"
-  echo "which reduce the number of false positives."
+  echo "in order to reduce the number of false postives."
   echo
 commands =
   codespell .
 commands_post =
   echo
-  echo "Please add false postives detected by codespell to ignore-words-list"
-  echo "under [codespell] in setup.cfg. Codespell can be installed locally by"
-  echo "running `pip install codespell`, and then run locally with:"
-  echo
-  echo "    codespell -i 2 -w"
-  echo
+  echo "After codespell has been installed locally (`pip install codespell`),"
+  echo "running the command `codespell -i 2 -w` will interactively go through"
+  echo "misspellings and suggest one or more replacements."

--- a/tox.ini
+++ b/tox.ini
@@ -134,6 +134,7 @@ commands = python -c 'import plasmapy'
 deps =
   codespell
 commands_pre =
+  echo
   echo "Codespell finds typos in source code. Rather than checking if each word"
   echo "matches a dictionary entry, it looks for a set of common misspellings"
   echo "in order to reduce the number of false postives."
@@ -144,4 +145,5 @@ commands_post =
   echo
   echo "After codespell has been installed locally (`pip install codespell`),"
   echo "running the command `codespell -i 2 -w` will interactively go through"
-  echo "misspellings and suggest one or more replacements."
+  echo "misspellings and suggest one or more replacements. Add any false"
+  echo "positives under ignore-words-list under `[codespell]` in setup.cfg."

--- a/tox.ini
+++ b/tox.ini
@@ -135,12 +135,17 @@ deps =
   codespell
 commands_pre =
   echo
+  echo "Codespell finds typos in source code. Rather than checking if each word"
+  echo "matches a dictionary entry, it looks for a set of common misspellings"
+  echo "which reduce the number of false positives."
+  echo
 commands =
   codespell .
 commands_post =
   echo
   echo "Please add false postives detected by codespell to ignore-words-list"
-  echo "under [codespell] in setup.cfg. Codespell can be installed locally"
-  echo "by running `pip install codespell`, and then run locally with"
-  echo "`codespell -i 2 -w`."
+  echo "under [codespell] in setup.cfg. Codespell can be installed locally by"
+  echo "running `pip install codespell`, and then run locally with:"
+  echo
+  echo "    codespell -i 2 -w"
   echo

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,10 @@ indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
-whitelist_externals=
+allowlist_externals=
     /bin/bash
     /usr/bin/bash
+    echo
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180

--- a/tox.ini
+++ b/tox.ini
@@ -132,5 +132,11 @@ commands = python -c 'import plasmapy'
 [testenv:codespell]
 deps =
   codespell
+commands_pre =
+  echo
 commands =
   codespell .
+commands_post =
+  echo
+  echo "Add false postives detected by codespell to ignore-words-list under [codespell] in setup.cfg."
+  echo


### PR DESCRIPTION
This PR follows up on #1493 by adding a GitHub Action for [codespell](https://github.com/codespell-project/codespell).  This is very similar to the GA added in https://github.com/HinodeXRT/xrtpy/pull/37.  

Codespell works by looking for common misspellings rather than by looking for words that aren't in a dictionary, so it has a low (but nonzero) number of false positives.  I was hesitant about including codespell in our pre-commit configuration because of the occasional false positives and the need for human intervention, but I think a GA would be appropriate so long as any failure messages describe what to do to fix any false positives.  

 - [x] Make tox environment print out how to fix false positives and how to run codespell locally to write changes
 - [x] Update testing guide to reflect these changes