### PR TITLE
Fix to Z dependence in `fundamental_collision_freq`. 

### DIFF
--- a/changelog/1546.bugfix.rst
+++ b/changelog/1546.bugfix.rst
@@ -1,4 +1,4 @@
 Fixed the ``Z`` dependence in
-`~plasmapy.formulary.collisions.fundamental_collision_freq`, by replacing
-``n_e`` with ``n_i`` while calling
+`~plasmapy.formulary.collisions.fundamental_electron_collision_freq`,
+by replacing ``n_e`` with ``n_i`` while calling
 `~plasmapy.formulary.collisions.collision_frequency`.

--- a/changelog/1546.bugfix.rst
+++ b/changelog/1546.bugfix.rst
@@ -1,1 +1,4 @@
-Fixed the Z dependence in formulary.collisions.fundamental_collision_freq, by replacing n_e with n_i while calling collision_frequency. Closes Issue #1545.
+Fixed the ``Z`` dependence in
+`~plasmapy.formulary.collisions.fundamental_collision_freq`, by replacing
+``n_e`` with ``n_i`` while calling
+`~plasmapy.formulary.collisions.collision_frequency`.

--- a/changelog/1546.bugfix.rst
+++ b/changelog/1546.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the Z dependence in formulary.collisions.fundamental_collision_freq, by replacing n_e with n_i while calling collision_frequency. Closes Issue #1545.

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -1191,8 +1191,9 @@ def fundamental_electron_collision_freq(
 
     species = [ion, "e-"]
     Z_i = particles.charge_number(ion) * u.dimensionless_unscaled
+    n_i = n_e / Z_i
     nu = collision_frequency(
-        T_e, n_e, species, z_mean=Z_i, V=V, method=coulomb_log_method
+        T_e, n_i, species, z_mean=Z_i, V=V, method=coulomb_log_method
     )
     coeff = 4 / np.sqrt(np.pi) / 3
 


### PR DESCRIPTION
Changed from calling collision_frequency using n_e to calling with n_i, to reflect calculating for electron-ion collisions. This should fix the Z dependence to match e.g. Spitzer thermal conductivity.

Closes #1545