### PR TITLE
Update `plasmapy.particles._parsing.extract_charge()` to better handle white spaces

### DIFF
--- a/changelog/1555.bugfix.rst
+++ b/changelog/1555.bugfix.rst
@@ -1,0 +1,5 @@
+Updated the regular expression matching used by
+`~plasmapy.particles.particle_class.Paricle` to parse and identify a
+:term:`particle-like` string.  This fixes the bug where a string with
+a trailing space (e.g. ``"Ar "``) was convert into a negatively charged
+ion (e.g. ``"Ar -1"``).

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -210,7 +210,7 @@ def extract_charge(arg: str):
 
     elif isotope_info.endswith(("-", "+")):  # Cases like 'H-' and 'Pb-209+++'
         match = re.fullmatch(
-            r"\s*(?P<isotope>\w+(-[0-9]+)*)(?P<charge>([-]+|[+]+)+)+\s*",
+            r"\s*(?P<isotope>\w+(-[0-9]+)*)(?P<charge>[-+]+)\s*",
             isotope_info,
         )
         isotope_info = match.groupdict()["isotope"]

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -167,7 +167,8 @@ def extract_charge(arg: str):
     )
 
     match = re.fullmatch(
-        r"\s*(?P<isotope>\w+(-[0-9]+)*([+-]*)*)(\s*(?P<charge>[+-]?[IVXLCDM0-9]+[+-]?)*)*\s*",
+        r"\s*(?P<isotope>\w+(-[0-9]+)*([+-]*)*)"
+        r"(\s*(?P<charge>[+-]?[IVXLCDM0-9]+[+-]?)*)*\s*",
         arg,
     )
 

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -210,7 +210,7 @@ def extract_charge(arg: str):
 
     elif isotope_info.endswith(("-", "+")):  # Cases like 'H-' and 'Pb-209+++'
         match = re.fullmatch(
-            r"\s*(?P<isotope>\w+(-[0-9]+)*)(?P<charge>[-+]+)\s*",
+            r"\s*(?P<isotope>\w+(-[0-9]+)?)(?P<charge>[-+]+)\s*",
             isotope_info,
         )
         isotope_info = match.groupdict()["isotope"]

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -166,8 +166,22 @@ def extract_charge(arg: str):
         f"Invalid charge information in the particle string '{arg}'."
     )
 
-    if arg.count(" ") == 1:  # Cases like 'H 1-' and 'Fe-56 1+'
-        isotope_info, charge_info = arg.split(" ")
+    match = re.fullmatch(
+        r"\s*(?P<isotope>\w+(-[0-9]+)*([+-]*)*)(\s*(?P<charge>[+-]*[0-9]+[+-]*)*)*\s*",
+        arg,
+    )
+
+    if match is None:
+        raise InvalidParticleError(invalid_charge_errmsg) from None
+
+    isotope_info = match.groupdict()["isotope"]
+    charge_info = match.groupdict()["charge"]
+    Z_from_arg = None
+
+    if charge_info is not None and isotope_info.endswith(("-", "+")):
+        # charge info is defined on both the charge_info and isotope_into strings
+        raise InvalidParticleError(invalid_charge_errmsg) from None
+    elif charge_info is not None:  # Cases like 'H 1-' and 'Fe-56 1+'
 
         sign_indicator_only_on_one_end = charge_info.endswith(
             ("-", "+")
@@ -194,19 +208,20 @@ def extract_charge(arg: str):
         except ValueError:
             raise InvalidParticleError(invalid_charge_errmsg) from None
 
-    elif arg.endswith(("-", "+")):  # Cases like 'H-' and 'Pb-209+++'
-        char = arg[-1]
-        match = re.match(f"[{char}]*", arg[::-1])
-        Z_from_arg = match.span()[1]
-        isotope_info = arg[: len(arg) - match.span()[1]]
+    elif isotope_info.endswith(("-", "+")):  # Cases like 'H-' and 'Pb-209+++'
+        match = re.fullmatch(
+            r"\s*(?P<isotope>\w+(-[0-9]+)*)(?P<charge>([-]+|[+]+)+)+\s*",
+            isotope_info,
+        )
+        isotope_info = match.groupdict()["isotope"]
+        charge_info = match.groupdict()["charge"]
 
-        if char == "-":
-            Z_from_arg = -Z_from_arg
-        if isotope_info.endswith(("-", "+")):
+        if len(set(charge_info)) != 1:
             raise InvalidParticleError(invalid_charge_errmsg) from None
-    else:
-        isotope_info = arg
-        Z_from_arg = None
+
+        Z_from_arg = len(charge_info)
+        if charge_info[0] == "-":
+            Z_from_arg = -Z_from_arg
 
     return isotope_info, Z_from_arg
 

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -167,7 +167,7 @@ def extract_charge(arg: str):
     )
 
     match = re.fullmatch(
-        r"\s*(?P<isotope>\w+(-[0-9]+)*([+-]*)*)(\s*(?P<charge>[+-]*[0-9]+[+-]*)*)*\s*",
+        r"\s*(?P<isotope>\w+(-[0-9]+)*([+-]*)*)(\s*(?P<charge>[+-]?[IVXLCDM0-9]+[+-]?)*)*\s*",
         arg,
     )
 


### PR DESCRIPTION
The PR incorporates regex matching into the `_parsing.extract_charge` to better handle white spaces.  The PR was prompted by issue #1553, where a string like `"Ar "` (with a trailing space) would result in a negatively charged ion `"Ar -1"`.  Additionally, the previous functionality couldn't handle scenarios when the isotope and charge info are separated by multiple spaces.

Closes #1553 