### PR TITLE
Add `flake8-implicit-str-concat` and `flake8-mutable` extensions to linters

### DIFF
--- a/changelog/1557.trivial.rst
+++ b/changelog/1557.trivial.rst
@@ -1,3 +1,4 @@
 Added `flake8-implicit-str-concat
 <https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat>`__
-as a flake8_ extension.
+and `flake8-mutable <https://github.com/ebeweber/flake8-mutable>`__
+as extensions for flake8_.

--- a/changelog/1557.trivial.rst
+++ b/changelog/1557.trivial.rst
@@ -1,0 +1,3 @@
+Added `flake8-implicit-str-concat
+<https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat>`__
+as a flake8_ extension.

--- a/plasmapy/diagnostics/charged_particle_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography.py
@@ -1094,7 +1094,7 @@ class Tracker:
 
         self._log("Run completed")
 
-        self._log(f"Fraction of particles tracked: {self.fract_tracked*100:.1f}%")
+        self._log(f"Fraction of particles tracked: {self.fract_tracked:.1%}")
 
         self._log(
             "Fraction of tracked particles that entered the grid: "

--- a/plasmapy/diagnostics/charged_particle_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography.py
@@ -1094,7 +1094,7 @@ class Tracker:
 
         self._log("Run completed")
 
-        self._log("Fraction of particles tracked: " f"{self.fract_tracked*100:.1f}%")
+        self._log(f"Fraction of particles tracked: {self.fract_tracked*100:.1f}%")
 
         self._log(
             "Fraction of tracked particles that entered the grid: "

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -520,7 +520,7 @@ def Coulomb_logarithm(
         ]:
             warnings.warn(
                 f"The Coulomb logarithm is {ln_Lambda}, and the specified "
-                + f'method, "{method}", depends on weak coupling.',
+                f'method, "{method}", depends on weak coupling.',
                 utils.CouplingWarning,
             )
         elif np.any(ln_Lambda < 4):

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -374,7 +374,7 @@ class AbstractGrid(ABC):
             return self.units[0]
         else:
             raise ValueError(
-                "Array dimensions do not all have the same " f"units: {self.units}"
+                f"Array dimensions do not all have the same units: {self.units}"
             )
 
     # *************************************************************************
@@ -783,9 +783,7 @@ class AbstractGrid(ABC):
                 stop[i] = stop[i].to(unit)
 
             except u.UnitConversionError:
-                raise ValueError(
-                    f"Units of {stop[i]} and " f" {unit} are not compatible"
-                )
+                raise ValueError(f"Units of {stop[i]} and {unit} are not compatible")
 
             # strip units
             stop[i] = stop[i].value

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,6 +8,7 @@ dlint
 flake8
 flake8-absolute-import
 flake8-implicit-str-concat
+flake8-mutable
 flake8-rst-docstrings
 flake8-use-fstring
 hypothesis

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,6 +7,7 @@
 dlint
 flake8
 flake8-absolute-import
+flake8-implicit-str-concat
 flake8-rst-docstrings
 flake8-use-fstring
 hypothesis

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ tests =
   dlint
   flake8
   flake8-absolute-import
+  flake8-implicit-str-concat
   flake8-rst-docstrings
   flake8-use-fstring
   hypothesis

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ tests =
   flake8
   flake8-absolute-import
   flake8-implicit-str-concat
+  flake8-mutable
   flake8-rst-docstrings
   flake8-use-fstring
   hypothesis

--- a/tox.ini
+++ b/tox.ini
@@ -117,6 +117,7 @@ deps =
   flake8
   flake8-absolute-import
   flake8-implicit-str-concat
+  flake8-mutable
   flake8-rst-docstrings
   flake8-use-fstring
   pydocstyle

--- a/tox.ini
+++ b/tox.ini
@@ -116,6 +116,7 @@ deps =
   dlint
   flake8
   flake8-absolute-import
+  flake8-implicit-str-concat
   flake8-rst-docstrings
   flake8-use-fstring
   pydocstyle


### PR DESCRIPTION
First, this PR adds [flake8-implicit-str-concat](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat), which checks for situations like the following (which are sometimes created when black reformats a file):
```Python
    raise ValueError(
        "original first line" "previously was the second line"
    )
```

Second, this PR adds [flake8-mutable](https://github.com/ebeweber/flake8-mutable), which checks that functions do not have mutable default arguments, since that can lead to unexpected behavior.
