### PR TITLE
added u.dimensionless_unscaled units to coupling_parameter in plasmap…

### DIFF
--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -134,7 +134,7 @@ class PlasmaBlob(GenericPlasma):
         kinetic energy.
         """
         couple = coupling_parameter(
-            self.T_e, self.n_e, (self.particle, self.particle), self.Z
+            self.T_e, self.n_e, (self.particle, self.particle), self.Z*u.dimensionless_unscaled
         )
         if couple < 0.01:
             warnings.warn(


### PR DESCRIPTION
…y/plasma/sources/plasmablob.py so warning is fix in pytest plasmapy/plasma/sources/plasmablob.py

-added u.dimensionless_unscaled units to coupling_parameter in plasmapy/plasma/sources/plasmablob.py in order to fix the warning mention in  Fix the many warnings emitted during tests #844 

