### PR TITLE
Note that dev versions should not be used in published work

### DIFF
--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -35,4 +35,4 @@ depends on, including but not limited to
 `NumPy <https://numpy.org/citing-numpy>`__, and
 `SciPy <https://scipy.org/citing-scipy>`__.
 
-Note that a dev version of plasmapy should NOT be cited or used in published work.
+Note that a development version of PlasmaPy should NOT be cited or used in published work.

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -34,3 +34,5 @@ depends on, including but not limited to
 `Astropy <https://www.astropy.org/acknowledging.html>`__,
 `NumPy <https://numpy.org/citing-numpy>`__, and
 `SciPy <https://scipy.org/citing-scipy>`__.
+
+Note that a dev version of plasmapy should NOT be cited or used in published work.

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -134,7 +134,7 @@ class PlasmaBlob(GenericPlasma):
         kinetic energy.
         """
         couple = coupling_parameter(
-            self.T_e, self.n_e, (self.particle, self.particle), self.Z
+            self.T_e, self.n_e, (self.particle, self.particle), self.Z*u.dimensionless_unscaled
         )
         if couple < 0.01:
             warnings.warn(

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -134,7 +134,7 @@ class PlasmaBlob(GenericPlasma):
         kinetic energy.
         """
         couple = coupling_parameter(
-            self.T_e, self.n_e, (self.particle, self.particle), self.Z*u.dimensionless_unscaled
+            self.T_e, self.n_e, (self.particle, self.particle), self.Z
         )
         if couple < 0.01:
             warnings.warn(


### PR DESCRIPTION

added  a final line in PlasmaPymodificado/docs/about/citation: "Note that a dev version of plasmapy should NOT be cited or used in published work."  as requested in issue #1536 
