### PR TITLE
Create a notebook on relevant plasma length scales & frequencies for a spacecraft constellation

### DIFF
--- a/docs/notebooks/formulary/satellite_constellation_length_scales.ipynb
+++ b/docs/notebooks/formulary/satellite_constellation_length_scales.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dee08605",
+   "metadata": {},
+   "source": [
+    "# Planning a spacecraft constellation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9587734f",
+   "metadata": {},
+   "source": [
+    "[magnetic reconnection]: https://en.wikipedia.org/wiki/Magnetic_reconnection\n",
+    "\n",
+    "The *Magnetospheric Multiscale Mission* (*MMS*) is a constellation of four identical spacecraft. The goal of *MMS* is to investigate the small-scale physics of [magnetic reconnection] in Earth's magnetosphere. In order to do this, the spacecraft need to orbit in a tight configuration.  But how tight does the constellation have to be?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e018b988",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from plasmapy.formulary import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27be84f6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f317f40",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "984c566c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a717c75f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b200d5a9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e5a4dd9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c65420f8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96fee1ef",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3748c587",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb13246c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds an example notebook that will calculate various plasma length scales (i.e. ion & electron inertial lengths & gyroradii) and frequencies (electron plasma frequency, etc.) in Earth's magnetosphere, and then compares them to the intraspacecraft distancing and time resolution of instruments on the *Magnetospheric Multiscale Mission*.  The goal is to introduce `plasmapy.formulary` in the context of magnetic reconnection, and show how formulary functions could help out in the design of a spacecraft constellation.

Like #1552, I'm planning on using this for the Python in Heliophysics Community summer school.  Ideally we could get this merged by May 24 or so, but that might be a bit optimistic.