### PR TITLE
Expose `radation` to `formulary` namespace

### DIFF
--- a/changelog/1572.bugfix.rst
+++ b/changelog/1572.bugfix.rst
@@ -1,0 +1,2 @@
+Exposed `plasmapy.formulary.radiation` and functions therein to the
+`plasmapy.formulary` namespace.

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -49,6 +49,7 @@ for modname in (
     "misc",
     "parameters",
     "quantum",
+    "radiation",
     "relativity",
     "speeds",
 ):

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -19,6 +19,7 @@ from plasmapy.formulary.magnetostatics import *
 from plasmapy.formulary.mathematics import *
 from plasmapy.formulary.misc import *
 from plasmapy.formulary.quantum import *
+from plasmapy.formulary.radiation import *
 from plasmapy.formulary.relativity import *
 from plasmapy.formulary.speeds import *
 

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -261,7 +261,7 @@ class ParticleList(collections.UserList):
         meet categorization criteria.
 
         Return a `list` in which each element will be `True` if the
-        corresponding particle is consistent with the categoziation
+        corresponding particle is consistent with the categorization
         criteria, and `False` otherwise.
 
         Please refer to the documentation of


### PR DESCRIPTION
This PR exposes `plasmapy.formulary.radiation` and functions therein to the `plasmapy.formulary` namespace.  These were formerly missing.

Disclaimer: This PR may increase risk of exposure to `radiation`.