### PR TITLE
Set `sphinx` requirement to `>= 4.4, < 5.0`

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,7 +11,7 @@ nbsphinx
 numpydoc
 pillow
 pygments >= 2.11.0
-sphinx >= 4.4
+sphinx >= 4.4, < 5.0
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ docs =
   numpydoc
   pillow
   pygments >= 2.11.0
-  sphinx >= 4.4
+  sphinx >= 4.4, < 5.0
   sphinx-changelog
   sphinx-copybutton
   sphinx-gallery


### PR DESCRIPTION
Recent release of `sphinx == 5.0` is incompatible with `plasmapy_sphinx`, so, for now, restricting the `sphinx` requirement to `< 5.0`

![image](https://user-images.githubusercontent.com/29869348/171266576-531b8e71-0e70-4516-a8a4-ccd9d361c868.png)
