### PR TITLE
Patch for to allow `sphinx == 5.0+`

### DIFF
--- a/docs/plasmapy_sphinx/automodsumm/generate.py
+++ b/docs/plasmapy_sphinx/automodsumm/generate.py
@@ -66,21 +66,10 @@ class AutomodsummRenderer(AutosummaryRenderer):
 
     app : `sphinx.application.Sphinx`
         Instance of the `sphinx` application.
-
-    template_dir : str
-        Path to a specified template directory.
     """
 
-    def __init__(
-        self,
-        app: Union["Builder", "Sphinx"],
-        template_dir: str = None,
-    ) -> None:
-
-        asumm_path = templates_dir
-        relpath = os.path.relpath(asumm_path, start=app.srcdir)
-        app.config.templates_path.append(relpath)
-        super().__init__(app, template_dir)
+    def __init__(self, app: "Sphinx") -> None:
+        super().__init__(app)
 
     def render(self, template_name: str, context: Dict) -> str:
         """

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,7 +11,7 @@ nbsphinx
 numpydoc
 pillow
 pygments >= 2.11.0
-sphinx >= 4.4, < 5.0
+sphinx >= 4.4
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ docs =
   numpydoc
   pillow
   pygments >= 2.11.0
-  sphinx >= 4.4, < 5.0
+  sphinx >= 4.4
   sphinx-changelog
   sphinx-copybutton
   sphinx-gallery


### PR DESCRIPTION
This will resolve #1580 (hopefully) and allow for the use of `sphinx >= 5.0`.