### PR TITLE
[TEST] Remove `graphviz` from GitHub Actions & doc builds

### DIFF
--- a/.github/workflows/fortnightly.yml
+++ b/.github/workflows/fortnightly.yml
@@ -69,7 +69,7 @@ jobs:
       run: python -m pip install --upgrade tox codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
-      run: sudo apt-get install graphviz pandoc
+      run: sudo apt-get install pandoc
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -91,7 +91,7 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade tox codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
-      run: sudo apt-get install graphviz pandoc
+      run: sudo apt-get install pandoc
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov
@@ -116,7 +116,7 @@ jobs:
     - name: Install Python dependencies
       run: python -m pip install --progress-bar off --upgrade tox
     - name: Install language-pack-fr and tzdata
-      run: sudo apt-get install graphviz pandoc
+      run: sudo apt-get install pandoc
     - name: Run tests
       run: tox -e build_docs -- -q
   codespell:

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -111,7 +111,6 @@
 .. _GitHub Flavored Markdown: https://github.github.com/gfm
 .. _GitHub: https://github.com
 .. _Gitter bridge: https://gitter.im/PlasmaPy/Lobby
-.. _Graphviz: https://graphviz.org
 .. _hypothesis: https://hypothesis.readthedocs.io
 .. _intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 .. _isort: https://pycqa.github.io/isort

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,6 @@ needs_sphinx = "4.4"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.extlinks",
-    "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",

--- a/docs/development/doc_guide.rst
+++ b/docs/development/doc_guide.rst
@@ -355,7 +355,6 @@ extensions:
 * `sphinx.ext.autodoc` for including documentation from docstrings.
 * `sphinx.ext.extlinks` for shortening links to external sites (e.g.,
   ``:orcid:`` and ``:wikipedia:``).
-* `sphinx.ext.graphviz` to allow Graphviz_ graphs to be included.
 * `sphinx.ext.intersphinx` for linking to other projects' documentation.
 * `sphinx.ext.mathjax` for math rendering with MathJax_.
 * `sphinx.ext.napoleon` for allowing NumPy style docstrings.


### PR DESCRIPTION
Currently we install `graphviz` in GitHub Actions, and have `sphinx.ext.graphviz` as a Sphinx extension for our doc builds.  However, I haven't been able to figure out where we use `graphviz` in our package.  This PR is an experiment to remove `graphviz` and see what happens.  If it turns out that we do need it, I'm planning to reimagine this PR as an update to the doc guide to mention what we use `graphviz` for.  