### PR TITLE
Bump requiremnt to `sphinx-hoverxref>=1.1.1`

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -15,7 +15,7 @@ sphinx >= 4.4
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery
-sphinx-hoverxref >= 1.0.0
+sphinx-hoverxref >= 1.1.1
 sphinx-issues >= 3.0.1
 sphinx-notfound-page >= 0.8
 sphinx_rtd_theme >= 1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,7 +98,7 @@ docs =
   sphinx-changelog
   sphinx-copybutton
   sphinx-gallery
-  sphinx-hoverxref >= 1.0.0
+  sphinx-hoverxref >= 1.1.1
   sphinx-issues >= 3.0.1
   sphinx-notfound-page >= 0.8
   sphinx_rtd_theme >= 1.0.0


### PR DESCRIPTION
Bump the minimum `sphinx-hoverxref` to `v1.1.1`.  This includes the more robust intersphinx mapping from https://github.com/readthedocs/sphinx-hoverxref/pull/171.