### PR TITLE
Fix hyperlinks prior to 0.8.0 release

### DIFF
--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -138,10 +138,10 @@ Attribution
 
 This Code of Conduct is adapted from the `Contributor Covenant`_,
 version 2.1, available at
-https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+https://www.contributor-covenant.org/version/2/1/code_of_conduct\ .
 
 Community Impact Guidelines were inspired by `Mozilla’s code of conduct
-enforcement ladder <https://github.com/mozilla/diversity>`__.
+enforcement ladder <https://github.com/mozilla/inclusion>`__.
 
 For answers to common questions about this code of conduct, see the FAQ
 at https://www.contributor-covenant.org/faq. Translations are available

--- a/docs/about/vision_statement.rst
+++ b/docs/about/vision_statement.rst
@@ -129,8 +129,7 @@ New code should conform to the `PEP 8 style guide for Python
 code <https://www.python.org/dev/peps/pep-0008>`_ and the established
 coding style within PlasmaPy. New code should be submitted with
 documentation and tests. Documentation should be written primarily in
-docstrings and follow the `numpydoc documentation style
-guide <https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt>`_.
+docstrings and follow the numpydoc_ documentation style guide.
 Every new module, class and function should have an appropriate
 docstring. The documentation should describe the interface and the
 purpose for the method, but generally not the implementation. The code

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -212,7 +212,7 @@ will be installed.
    fork a repository and create branches so that you may make
    contributions via pull requests.
 
-.. _Anaconda Navigator: https://www.anaconda.com/products/individual
+.. _Anaconda Navigator: https://www.anaconda.com/products/distribution
 .. _clone a repository using SSH: https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-ssh-urls
 .. _conda-forge: https://conda-forge.org
 .. _download Python: https://www.python.org/downloads/


### PR DESCRIPTION
I did a `make linkcheck` for the docs, and found a few errors & redirects.  This PR updates the corresponding hyperlinks.

