### PR TITLE
Add pre-commit configuration for pyupgrade and update other pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,4 +77,5 @@ repos:
   rev: v2.34.0
   hooks:
   - id: pyupgrade
-    args: [--keep-runtime-typing, --py38-plus, plasmapy]
+    args: [--keep-runtime-typing, --py38-plus]
+    files: ^plasmapy/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,13 @@ ci:
   autofix_prs: false
   autoupdate_schedule: quarterly
 
-# using default_language_version
 default_language_version:
   node: 16.15.0
 
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: check-ast
   - id: trailing-whitespace
@@ -35,7 +34,7 @@ repos:
     - python
 
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 22.6.0
   hooks:
   - id: black
 
@@ -44,7 +43,7 @@ repos:
   hooks:
   - id: nbqa-black
     additional_dependencies:
-    - black==22.3.0
+    - black==22.6.0
     args:
     - --nbqa-mutate
   - id: nbqa-isort
@@ -73,3 +72,9 @@ repos:
   hooks:
   - id: absolufy-imports
     exclude: docs/plasmapy_sphinx
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.34.0
+  hooks:
+  - id: pyupgrade
+    args: [--keep-runtime-typing, --py38-plus, plasmapy]

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -111,7 +111,7 @@ def online_help(query: str):
 
     url = (
         "http://docs.plasmapy.org/en/stable/search.html?"
-        "{0}&check_keywords=yes&area=default"
+        "{}&check_keywords=yes&area=default"
     ).format(urlencode({"q": query}))
 
     if query.lower() in ("unit", "units", "quantity", "quantities"):

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -471,7 +471,7 @@ def spectral_density(
         raise ValueError("At least one ion species needs to be defined.")
 
     try:
-        if sum([ion.charge_number <= 0 for ion in ions]):
+        if sum(ion.charge_number <= 0 for ion in ions):
             raise ValueError("All ions must be positively charged.")
     # Catch error if charge information is missing
     except ChargeError:
@@ -682,7 +682,7 @@ def _spectral_density_model(wavelengths, settings=None, **params):
 
 
 def spectral_density_model(wavelengths, settings, params):
-    """
+    r"""
     Returns a `lmfit.model.Model` function for Thomson spectral density function.
 
     Parameters


### PR DESCRIPTION
This PR adds [pyupgrade](https://github.com/asottile/pyupgrade) as a pre-commit hook, which will automatically upgrade Python code to the specified minimum version. When we upgrade to a newer version of Python, pyupgrade make most of the changes with the next syntax automatically, and it's helpful for general code cleanup too. I'm tentatively excluding `plasmapy_sphinx` from this hook since that might make it harder to pull in changes that were originally elsewhere.

I also bumped the version for a few other pre-commit hooks like black, but there were no code changes as a result.

Closes #1438.