### PR TITLE
Modify impact_parameter() to work with N-D arrays

### DIFF
--- a/changelog/1604.feature.rst
+++ b/changelog/1604.feature.rst
@@ -1,1 +1,1 @@
-Added support for arbitrarily shaped input arrays to the function `formulary.collisions.impact_parameter`.
+Added support for arbitrarily shaped input arrays to the function `plasmapy.formulary.collisions.impact_parameter`.

--- a/changelog/1604.feature.rst
+++ b/changelog/1604.feature.rst
@@ -1,0 +1,1 @@
+Added support for arbitrarily shaped input arrays to the function `formulary.collisions.impact_parameter`.

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -880,7 +880,7 @@ def impact_parameter(
     # T and V will be scalar from _process_inputs, so bmin will scalar. However
     # if n_e is an array, then bmax will be an array. if this is the case,
     # we want to extend the scalar bmin to match the dimensions of bmax.
-    if np.isscalar(bmin.value) and not np.isscalar(bmax.value):
+    if bmin.size == 1 and bmax.size != 1:
         bmin = bmin * np.ones(bmax.shape)
 
     return bmin.to(u.m), bmax.to(u.m)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -879,9 +879,9 @@ def impact_parameter(
     # it could be that bmin and bmax have different sizes. If Te is a scalar,
     # T and V will be scalar from _process_inputs, so bmin will scalar. However
     # if n_e is an array, then bmax will be an array. if this is the case,
-    # do we want to extend the scalar bmin to equal the length of bmax? Sure.
+    # we want to extend the scalar bmin to match the dimensions of bmax.
     if np.isscalar(bmin.value) and not np.isscalar(bmax.value):
-        bmin = np.repeat(bmin, len(bmax))
+        bmin = bmin * np.ones(bmax.shape)
 
     return bmin.to(u.m), bmax.to(u.m)
 

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1016,6 +1016,36 @@ class Test_impact_parameter:
         self.V = 1e4 * u.km / u.s
         self.True1 = np.array([7.200146594293746e-10, 2.3507660003984624e-08])
 
+    @pytest.mark.parametrize(
+        "n_e_shape,T_shape",
+        # Scalar T
+        [
+            ((2, 3, 5), (1,)),
+            # Scalar n
+            ((1,), (2, 3, 5)),
+            # Both arrays of equal size
+            ((2, 3, 5), (2, 3, 5)),
+            # Higher dimensional test
+            ((2, 3, 5, 4, 2), (2, 3, 5, 4, 2)),
+        ],
+    )
+    def test_handles_ND_arrays(self, n_e_shape, T_shape):
+
+        if len(T_shape) >= len(n_e_shape):
+            output_shape = T_shape
+        else:
+            output_shape = n_e_shape
+
+        n_e = self.n_e * np.ones(n_e_shape)
+        T = self.T * np.ones(T_shape)
+
+        bmin, bmax = impact_parameter(T, n_e, self.particles)
+
+        msg = f"wrong shape for n_e shape {n_e.shape} and " f"T shape {T.shape}"
+
+        assert bmin.shape == output_shape, "Bmin " + msg
+        assert bmax.shape == output_shape, "Bmax " + msg
+
     def test_symmetry(self):
         result = impact_parameter(self.T, self.n_e, self.particles)
         resultRev = impact_parameter(self.T, self.n_e, self.particles[::-1])

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1117,17 +1117,14 @@ class Test_impact_parameter:
 
         """
 
-        if len(T_shape) >= len(n_e_shape):
-            output_shape = T_shape
-        else:
-            output_shape = n_e_shape
+        output_shape = max(map(len, [T_shape, n_e_shape]))
 
         n_e = self.n_e * np.ones(n_e_shape)
         T = self.T * np.ones(T_shape)
 
         bmin, bmax = impact_parameter(T, n_e, self.particles)
 
-        msg = f"wrong shape for n_e shape {n_e.shape} and " f"T shape {T.shape}"
+        msg = f"wrong shape for {n_e.shape = } and {T.shape = }"
 
         assert bmin.shape == output_shape, "Bmin " + msg
         assert bmax.shape == output_shape, "Bmax " + msg

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1016,36 +1016,6 @@ class Test_impact_parameter:
         self.V = 1e4 * u.km / u.s
         self.True1 = np.array([7.200146594293746e-10, 2.3507660003984624e-08])
 
-    @pytest.mark.parametrize(
-        "n_e_shape,T_shape",
-        # Scalar T
-        [
-            ((2, 3, 5), (1,)),
-            # Scalar n
-            ((1,), (2, 3, 5)),
-            # Both arrays of equal size
-            ((2, 3, 5), (2, 3, 5)),
-            # Higher dimensional test
-            ((2, 3, 5, 4, 2), (2, 3, 5, 4, 2)),
-        ],
-    )
-    def test_handles_ND_arrays(self, n_e_shape, T_shape):
-
-        if len(T_shape) >= len(n_e_shape):
-            output_shape = T_shape
-        else:
-            output_shape = n_e_shape
-
-        n_e = self.n_e * np.ones(n_e_shape)
-        T = self.T * np.ones(T_shape)
-
-        bmin, bmax = impact_parameter(T, n_e, self.particles)
-
-        msg = f"wrong shape for n_e shape {n_e.shape} and " f"T shape {T.shape}"
-
-        assert bmin.shape == output_shape, "Bmin " + msg
-        assert bmax.shape == output_shape, "Bmax " + msg
-
     def test_symmetry(self):
         result = impact_parameter(self.T, self.n_e, self.particles)
         resultRev = impact_parameter(self.T, self.n_e, self.particles[::-1])
@@ -1124,13 +1094,43 @@ class Test_impact_parameter:
             impact_parameter, insert_some_nans, insert_all_nans, kwargs
         )
 
-    def test_extend_scalar_bmin(self):
+    @pytest.mark.parametrize(
+        "n_e_shape,T_shape",
+        # Scalar T
+        [
+            ((2, 3, 5), (1,)),
+            # Scalar n
+            ((1,), (2, 3, 5)),
+            # Both arrays of equal size
+            ((2, 3, 5), (2, 3, 5)),
+            # Higher dimensional test
+            ((2, 3, 5, 4, 2), (2, 3, 5, 4, 2)),
+        ],
+    )
+    def test_extend_output_for_array_input(self, n_e_shape, T_shape):
         """
-        Test to verify that if T is scalar and n is vector, bmin will be extended
-        to the same length as bmax
+        Test to verify that if either/or T and n_e are arrays, the resulting
+        bmin and bmax have the correct shapes.
+
+        This is necessary in addition to test_handle_nparrays to ensure that
+        the output arrays are extended correctly.
+
         """
-        (bmin, bmax) = impact_parameter(1 * u.eV, self.n_e_arr, self.particles)
-        assert len(bmin) == len(bmax)
+
+        if len(T_shape) >= len(n_e_shape):
+            output_shape = T_shape
+        else:
+            output_shape = n_e_shape
+
+        n_e = self.n_e * np.ones(n_e_shape)
+        T = self.T * np.ones(T_shape)
+
+        bmin, bmax = impact_parameter(T, n_e, self.particles)
+
+        msg = f"wrong shape for n_e shape {n_e.shape} and " f"T shape {T.shape}"
+
+        assert bmin.shape == output_shape, "Bmin " + msg
+        assert bmax.shape == output_shape, "Bmax " + msg
 
 
 class Test_collision_frequency:

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1117,7 +1117,7 @@ class Test_impact_parameter:
 
         """
 
-        output_shape = max(map(len, [T_shape, n_e_shape]))
+        output_shape = T_shape if len(T_shape) >= len(n_e_shape) else n_e_shape
 
         n_e = self.n_e * np.ones(n_e_shape)
         T = self.T * np.ones(T_shape)


### PR DESCRIPTION
The `impact_parameter` function in `collisions.py` can currently handle a 1D array of densities or temperatures, but not arrays of higher dimension. This PR changes line that handles 1D arrays to work for any shape array. 

`impact_parameter` is called by many of the other functions in the collisions module (for example, `collision_frequency'), so this change will also enable support for higher dimension arrays in some of those functions. 