### PR TITLE
Add `robots.txt` to tell web crawlers for search engines to ignore all but `stable` & `latest` doc builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,6 +209,8 @@ exclude_patterns = [
     "**Untitled*",
 ]
 
+html_extra_path = ["robots.txt"]
+
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /*/latest/
+Allow: /en/latest/   # Fallback for bots that don't understand wildcards
+Allow: /*/stable/
+Allow: /en/stable/   # Fallback for bots that don't understand wildcards
+Disallow: /


### PR DESCRIPTION
In a discussion about *Stars in My Pocket Like Grains of Sand* by Samuel R. Delaney, it came up that in the mid-1990s there emerged a [standard for robot exclusion](http://www.robotstxt.org/orig.html) via a `robots.txt` file.  This file is used to tell web crawlers (spiders!) to ignore or exclude certain files from being indexed.  I occasionally get search results for version 0.1.0, and was hoping to try this out for us.  This PR copies the `robots.txt` file from Astropy, and modifies `docs/conf.py` so that it appears in the online documentation.