### PR TITLE
Use `pathlib` to get path to `plasma-calculator` notebook

### DIFF
--- a/plasmapy/utils/calculator/__init__.py
+++ b/plasmapy/utils/calculator/__init__.py
@@ -43,12 +43,13 @@ def main():
 
     command = [
         "voila",
-        no_browser,
-        f"--port={args.port}" f"--{theme=}",
         notebook_path,
-        "--VoilaConfiguration.file_whitelist",
-        favicon_path,
+        f"--port={args.port}",
+        f"--theme={theme}",
+        f"--VoilaConfiguration.file_whitelist={favicon_path}",
     ]
+    if no_browser:
+        command.append(no_browser)
 
     try:
         subprocess.call(command)

--- a/plasmapy/utils/calculator/__init__.py
+++ b/plasmapy/utils/calculator/__init__.py
@@ -33,15 +33,24 @@ def main():
         "--no-browser", action="store_true", help="Do not open the browser"
     )
 
-    notebook_path = pathlib.Path(__file__).parent.absolute() / "plasma_calculator.ipynb"
+    module_path = pathlib.Path(__file__).parent.absolute()
+    notebook_path = module_path / "plasma_calculator.ipynb"
+    favicon_path = module_path / "favicon.ico"
 
     args = parser.parse_args()
     theme = "dark" if args.dark else "light"
     no_browser = "--no-browser" if args.no_browser else ""
 
-    command = f"voila {no_browser} --port={args.port} --theme={theme} {notebook_path} \
-        --VoilaConfiguration.file_whitelist favicon.ico"
+    command = [
+        "voila",
+        no_browser,
+        f"--port={args.port}" f"--{theme=}",
+        notebook_path,
+        "--VoilaConfiguration.file_whitelist",
+        favicon_path,
+    ]
+
     try:
-        subprocess.call(shlex.split(command))
+        subprocess.call(command)
     except KeyboardInterrupt:
         print("Stopping calculator! Bye")

--- a/plasmapy/utils/calculator/__init__.py
+++ b/plasmapy/utils/calculator/__init__.py
@@ -4,7 +4,7 @@ Script and utilities to launch the plasma calculator
 __all__ = ["main"]
 
 import argparse
-import os
+import pathlib
 import shlex
 import subprocess
 
@@ -33,15 +33,13 @@ def main():
         "--no-browser", action="store_true", help="Do not open the browser"
     )
 
-    # module_path = plasmapy.__path__[0]
-    module_path = os.path.dirname(os.path.abspath(__file__))
-    computed_calculator_path = os.path.join(module_path, "plasma_calculator.ipynb")
+    notebook_path = pathlib.Path(__file__).parent.absolute() / "plasma_calculator.ipynb"
 
     args = parser.parse_args()
     theme = "dark" if args.dark else "light"
     no_browser = "--no-browser" if args.no_browser else ""
 
-    command = f"voila {no_browser} --port={args.port} --theme={theme} {computed_calculator_path} \
+    command = f"voila {no_browser} --port={args.port} --theme={theme} {notebook_path} \
         --VoilaConfiguration.file_whitelist favicon.ico"
     try:
         subprocess.call(shlex.split(command))


### PR DESCRIPTION
This PR uses `pathlib` instead of `os` to create the path to the plasma calculator notebook.  Closes #1612.  I hope.