### PR TITLE
Remove usage of `np.complex` in favor of `complex`

### DIFF
--- a/plasmapy/utils/decorators/tests/test_checks.py
+++ b/plasmapy/utils/decorators/tests/test_checks.py
@@ -914,7 +914,7 @@ class TestCheckValues:
                     "args": [
                         complex(5),
                         complex(2, 3),
-                        np.complex(3.0),
+                        complex(3.0),
                         complex(4.0, 2.0) * u.cm,
                         np.array([complex(4, 5), complex(1)]) * u.kg,
                     ],
@@ -928,7 +928,7 @@ class TestCheckValues:
                     "args": [
                         complex(5),
                         complex(2, 3),
-                        np.complex(3.0),
+                        complex(3.0),
                         complex(4.0, 2.0) * u.cm,
                         np.array([complex(4, 5), complex(1)]) * u.kg,
                     ],


### PR DESCRIPTION
A quick change to fix the following warning:
```
plasmapy/utils/decorators/tests/test_checks.py::TestCheckValues::test_cv_method__check_value
  /home/namurphy/Projects/PlasmaPy/plasmapy/utils/decorators/tests/test_checks.py:917: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    np.complex(3.0),
```