### PR TITLE
Correct version in citation instructions

### DIFF
--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -3,7 +3,7 @@
 Acknowledging and Citing
 ========================
 
-.. |version_to_cite| replace:: 0.8.0
+.. |version_to_cite| replace:: 0.8.1
 .. |doi_hyperlink| replace:: https://doi.org/10.5281/zenodo.6774350
 .. |citation_year| replace:: 2022
 


### PR DESCRIPTION
This PR fixes the version number of PlasmaPy that corresponds to the DOI from `v0.8.0` to `v0.8.1`, since I ran into some issues and released `v0.8.1` instead of `v0.8.0` (#1595, #1615, #1616).