### PR TITLE
Fix assertions in tests that were always `True`

### DIFF
--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -172,8 +172,7 @@ class Test_permittivity_1D_Maxwellian:
         kwargs["kWave"] = kwargs["omega"] / vth
 
         val = permittivity_1D_Maxwellian(**kwargs)
-        assert (
-            np.isclose(val, expected, rtol=1e-6, atol=0.0),
+        assert np.isclose(val, expected, rtol=1e-6, atol=0.0), (
             f"Permittivity value should be {expected} and not {val}.",
         )
 
@@ -189,8 +188,7 @@ class Test_permittivity_1D_Maxwellian:
         val = permittivity_1D_Maxwellian(**kwargs)
 
         expected += 1e-15
-        assert (
-            not np.isclose(val, expected, rtol=1e-16, atol=0.0),
+        assert not np.isclose(val, expected, rtol=1e-16, atol=0.0), (
             f"Permittivity value test gives {val} and should not be "
             f"equal to {expected}.",
         )
@@ -218,8 +216,7 @@ class Test_permittivity_1D_Maxwellian_lite:
             wp.value,
         )
 
-        assert (
-            np.isclose(val, val_lite, rtol=1e-6, atol=0.0),
+        assert np.isclose(val, val_lite, rtol=1e-6, atol=0.0), (
             "'permittivity_1D_Maxwellian' and 'permittivity_1D_Maxwellian_lite' "
             "do not agree.",
         )


### PR DESCRIPTION
There were a few tests in `test_dielectric.py` which were of the form
```Python
assert (
    np.isclose(...), "message"
)
```
This was doing an `assert` on a non-empty `tuple`, which consequently always evaluated to `True`.  This PR adjusts the parentheses on the tests.