### PR TITLE
Install PlasmaPy from repo when launching notebooks with binder for `latest` docs 

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements/build.txt
 -r ../requirements/install.txt
 -r ../requirements/extras.txt
+.
 jupytext
-plasmapy == 0.8


### PR DESCRIPTION
During the 0.8.1 release, I mistakenly included a change to `binder/requirements.txt` in #1621 that should not have gone back into `main`.  This PR will revert that change for `main`, so that binder will install PlasmaPy from the `main` branch of the repository and not `pip`.

This will fix part of #1635, but not all.

 - [ ] Test that binder links from the doc build for this PR are able successfully spin up an environment