### PR TITLE
Restrict `sphinx != 5.1`

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,7 +11,7 @@ nbsphinx
 numpydoc
 pillow
 pygments >= 2.11.0
-sphinx >= 4.4, < 5.1
+sphinx >= 4.4, != 5.1
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,7 +11,7 @@ nbsphinx
 numpydoc
 pillow
 pygments >= 2.11.0
-sphinx >= 4.4
+sphinx >= 4.4, < 5.1
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ docs =
     numpydoc
     pillow
     pygments >= 2.11.0
-    sphinx >= 4.4, < 5.1
+    sphinx >= 4.4, != 5.1
     sphinx-changelog
     sphinx-copybutton
     sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ docs =
     numpydoc
     pillow
     pygments >= 2.11.0
-    sphinx >= 4.4
+    sphinx >= 4.4, < 5.1
     sphinx-changelog
     sphinx-copybutton
     sphinx-gallery


### PR DESCRIPTION
The July 24th release of `sphinx` `v5.1` still has a few bugs, which are causing our documentation builds to fail.

Related issues and PRs are...

* PR https://github.com/sphinx-doc/sphinx/pull/10709
* Issue https://github.com/sphinx-doc/sphinx/issues/10705
* Comment https://github.com/sphinx-doc/sphinx/pull/9856#issuecomment-1193401531

This PR just nots `sphinx` `v5.1`, so hopefully we don't have to come back to update any dependencies.  Assuming everything is fixed in `v5.1.1`.