### PR TITLE
Make docs build off sphinxdev actually build docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,17 @@ setenv =
     HOME = {envtmpdir}
 commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
 
+[testenv:build_docs-sphinxdev]
+changedir = {toxinidir}
+extras = docs
+setenv =
+    HOME = {envtmpdir}
+commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
+deps =
+    git+https://github.com/sphinx-doc/sphinx
+description =
+    sphinxdev: with the development version of sphinx
+
 [testenv:build_docs_no_examples]
 changedir = {toxinidir}
 extras = docs


### PR DESCRIPTION
07ee524db54416a8afc2c44123562238f79641d7 fixes #1646, but I'd still like to play around with this a little to see whether the three `build_docs` tox envs we have now couldn't be compressed into one.

The issue here is that `sphinxdev` is defined in `testenv` rather than in `testenv:build_docs`, and I think there's logic in `tox` that pulls the `commands` field from `all: {env:PYTEST_COMMAND} {posargs}` defined in  `testenv`.