### PR TITLE
Add a section to the coding guide on naming best practices

### DIFF
--- a/changelog/1650.doc.rst
+++ b/changelog/1650.doc.rst
@@ -1,0 +1,2 @@
+Added a section to the |coding guide| on best practices for variable
+names.

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -128,6 +128,7 @@
 .. _MathJax: https://www.mathjax.org
 .. _matplotlib: https://matplotlib.org
 .. _Matrix chat room: https://app.element.io/#/room/#plasmapy:openastronomy.org
+.. _nbqa: https://nbqa.readthedocs.io
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
 .. _NumPy: https://numpy.org
 .. _OpenPMD: https://www.openpmd.org/

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -96,6 +96,7 @@
 .. Websites
 .. --------
 
+.. _API: https://en.wikipedia.org/wiki/API
 .. _Astropy docs: https://docs.astropy.org
 .. _Astropy: https://www.astropy.org
 .. _BibTeX format: https://www.bibtex.com/g/bibtex-format
@@ -115,6 +116,7 @@
 .. _Gitter bridge: https://gitter.im/PlasmaPy/Lobby
 .. _Graphviz: https://graphviz.org
 .. _hypothesis: https://hypothesis.readthedocs.io
+.. _ide: https://en.wikipedia.org/wiki/Integrated_development_environment
 .. _intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 .. _isort: https://pycqa.github.io/isort
 .. _Jinja: https://jinja.palletsprojects.com

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -442,7 +442,6 @@ Equations and Physical Formulae
   the beginning of a sentence, even if their symbol is capitalized. For
   example, kelvin is a unit while Kelvin was a scientist.
 
-
 Angular Frequencies
 ===================
 
@@ -497,7 +496,6 @@ the notebook* but store it in the repository with a ``preexecuted_`` prefix, e.g
 Benchmarks
 ==========
 
-
 .. _benchmarks: https://www.plasmapy.org/plasmapy-benchmarks
 .. _benchmarks-repo: https://github.com/PlasmaPy/plasmapy-benchmarks
 .. _asv: https://github.com/airspeed-velocity/asv
@@ -511,7 +509,8 @@ instructions on writing such benchmarks can be found at `asv-docs`_.
 Up-to-date instructions on running the benchmark suite will be located in
 the README file of `benchmarks-repo`_.
 
- .. _ASCII: https://en.wikipedia.org/wiki/ASCII
+.. _ASCII: https://en.wikipedia.org/wiki/ASCII
+.. _nbqa: https://nbqa.readthedocs.io
 
 .. _cggglm: http://www.netlib.org/lapack/explore-html/d9/d98/group__complex_o_t_h_e_reigen_ga4be128ffc05552459683f0aade5a7937.html
 .. |cggglm| replace:: ``cggglm``

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -155,8 +155,8 @@ Coding Style
 PlasmaPy Code Style Guide, codified
 -----------------------------------
 
-* PlasmaPy generally follows the :pep:`8` style guide for Python code.
-  This style choice helps ensure that the code will be consistent and
+* PlasmaPy generally follows the :pep:`8` style guide for Python code and the black_ code style.
+  This helps ensure that the code will be consistent and
   readable.
 
   * Docstrings and comments should generally be limited to

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -77,7 +77,7 @@ the code is supposed to be doing.
 
 * Python allows alphanumeric Unicode characters to be used in object
   names (e.g., ``πλάσμα`` or ``φυσική``). These characters may be used
-  for *internal* code when doing so improves readability (i.e. to match
+  for *internal* code when doing so improves readability (i.e., to match
   a commonly used symbol).
 
 * Only ASCII_ characters should be used in code that is part of the
@@ -306,16 +306,6 @@ Suggestions on `how to write a git commit message
 
 * Use the body to explain what and why vs. how
 
-Documentation
-=============
-
-* All public classes, methods, and functions should have docstrings
-  using the numpydoc format.
-
-* Docstrings may be checked locally using pydocstyle_.
-
-* These docstrings should include usage examples.
-
 Warnings and Exceptions
 =======================
 
@@ -459,7 +449,7 @@ Please note that it is necessary to store notebooks with their outputs stripped
 If you have an example notebook that includes packages unavailable in the
 documentation building environment (e.g., ``bokeh``) or runs some heavy
 computation that should not be executed on every commit, *keep the outputs in
-the notebook* but store it in the repository with a ``preexecuted_`` prefix, e.g.
+the notebook* but store it in the repository with a ``preexecuted_`` prefix, e.g.,
 :file:`preexecuted_full_3d_mhd_chaotic_turbulence_simulation.ipynb`.
 
 Benchmarks

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -180,8 +180,7 @@ It includes
 * black_ to automatically format code and ensure a consistent code style
   throughout the package
 * isort_ to automatically sort imports.
-* `nbqa <https://github.com/nbQA-dev/nbQA>`_ to automatically apply the above
-  to example notebooks as well.
+* nbqa_ to automatically apply the above to example notebooks as well.
 * a few tools for :file:`requirements.txt`, :file:`.yml` files and the like.
 
 PlasmaPy Code Style Guide, codified

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -10,6 +10,134 @@ followed during the development of PlasmaPy and affiliated packages.
 Code written for PlasmaPy must be compatible with Python 3.8 and
 later.
 
+Names
+=====
+
+Names are the most fundamental means of communicating the intent and
+purpose of code. Judicious choices of names can greatly improve the
+understandability of code, while inadequate naming can obfuscate what
+the code is supposed to be doing.
+
+* Use :pep:`8` conventions for naming variables, functions, classes, and
+  constants (except as described later in this list).
+
+  - Use lowercase words separated by underscores for function and
+    variable names (e.g., ``function_name`` and ``variable_name``).
+
+  - Use capitalized words without separators when naming a :term:`class`
+    or an exception (e.g., ``ClassName`` or ``ExceptionName``). However,
+    keep acronyms capitalized (e.g., ``MHDEquations``).
+
+  - Use capital letters words separated by underscores for constants
+    (e.g., ``CONSTANT`` or ``CONSTANT_NAME``).
+
+* Choose names that are pronounceable so that they are easier to
+  remember and more compatible with text-to-speech technology.
+
+* Choose names that can be used in searches on the World Wide Web™.
+
+* Avoid unnecessary abbreviations, as these can make code more difficult
+  to read. Clarity is more important than brevity, except for code that
+  is used frequently and interactively (e.g., :command:`ls` or
+  :command:`cd` in the Unix shell).
+
+  .. tip::
+
+     Measure the length of a variable not by the number of characters,
+     but rather by the time needed to understand its meaning.
+
+     By this measure, ``cggglm`` is significantly longer than
+     ``solve_gauss_markov_linear_model``.
+
+* Use a capital letter for a :term:`parameter` when it matches the
+  standard usage in plasma science. For example, use ``B`` for magnetic
+  field strength and ``T`` for temperature.
+
+* Avoid potentially ambiguous names. Does ``temp`` mean "temperature",
+  "temporary", or "template"?
+
+* Functions based on plasma parameters that are named after people may
+  be capitalized (e.g., ``Alfven_speed``).
+
+* Append ``_e`` to the name of a :term:`parameter` to indicate that it
+  refers to electrons, ``_i`` to indicate that it refers to ions, and
+  ``_p`` to indicate that it refers to protons (e.g., ``T_e``, ``T_i``,
+  and ``T_p``).
+
+* Only use ASCII_ characters in code that is part of the public API_.
+
+* Python allows alphanumeric Unicode characters to be used in object
+  names (e.g., ``πλάσμα`` or ``φυσική``). These characters may be used
+  for internal code when doing so improves readability (i.e. to match a
+  commonly used symbol).
+
+* If a plasma parameter has multiple names, then use the name that
+  provides the most physical insight. For example, ``gyrofrequency``
+  indicates gyration but ``Larmor_frequency`` does not.
+
+* It is *usually* preferable to name a variable after its name rather
+  than its symbol.  An object named ``Debye_length`` is more broadly
+  understandable than ``lambda_D``. However, there are some exceptions
+  to this guideline.
+
+  * Symbols used widely across plasma science can be used with low risk
+    of confusion, such as when using :math:`T` for temperature or
+    :math:`β` for plasma `~plasmapy.formulary.dimensionless.beta`.
+    However, different symbols may be used for different subfields of
+    plasma science.
+
+  * Symbols defined in docstrings can be used with decreased likelihood
+    of confusion.
+
+  * If the implementation of a function is based on a journal article,
+    then the function might be more readable and maintainable if the
+    variable names are based on the symbols used in that article. The
+    article should be cited in the docstring of that function so that it
+    appears in the |bibliography|.
+
+  * Sometimes code that represents an equation will be most readable if
+    the Unicode characters for the symbols are used. For example,
+    ``λ = c / ν`` will be
+    ``lambda = c / nu`` or ``wavelength = speed_of_light / frequency``.
+    Using Unicode characters for variable names is most beneficial for
+    complex equations.
+
+* To mark that an object is not part of PlasmaPy's public API_, begin
+  its name with a leading underscore (e.g., ``_private_variable``).
+  Private variables should not be included in ``__all__``.
+
+* In most situations, avoid single character variable names. Single
+  character variable names may be used for standard plasma physics
+  symbols (i.e., ``B``) or as indices in ``for`` loops (though more
+  descriptive names are preferred).
+
+* In general, avoid encoding type information in a variable name.
+
+* Intermediate variable names can provide additional context and
+  meaning. For example, suppose we have a conditional operating on a
+  complicated expression:
+
+  .. code-block:: python
+
+     if u[0] < x < u[1] and v[0] < y < v[1] and w[0] < z < w[1]: ...
+
+  Defining an intermediate variable allows us to communicate the meaning
+  and intent of the expression.
+
+  .. code-block:: python
+
+     point_is_in_grid_cell = u[0] < x < u[1] and v[0] < y < v[1] and w[0] < z < w[1]
+
+     if point_is_in_grid_cell:
+         ...
+
+.. hint::
+
+   Most IDEs_ have a built-in tool for simultaneously renaming a
+   variable throughout a project. For example, a `rename refactoring in
+   PyCharm`_ can be done with :kbd:`Shift+F6` on Windows or Linux, and
+   :kbd:`⇧F6` or :kbd:`⌥⌘R` on macOS.
+
 Coding Style
 ============
 
@@ -369,3 +497,6 @@ generated from results located in `benchmarks-repo`_. Detailed
 instructions on writing such benchmarks can be found at `asv-docs`_.
 Up-to-date instructions on running the benchmark suite will be located in
 the README file of `benchmarks-repo`_.
+
+.. _cggglm: http://www.netlib.org/lapack/explore-html/d9/d98/group__complex_o_t_h_e_reigen_ga4be128ffc05552459683f0aade5a7937.html
+.. |cggglm| replace:: ``cggglm``

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -155,13 +155,9 @@ Coding Style
 PlasmaPy Code Style Guide, codified
 -----------------------------------
 
-* PlasmaPy follows the `PEP8 Style Guide for Python Code
+* PlasmaPy generally follows the `PEP8 Style Guide for Python Code
   <https://peps.python.org/pep-0008>`__.  This style choice
   helps ensure that the code will be consistent and readable.
-
-  * Line lengths should be chosen to maximize the readability and
-    elegance of the code.  The maximum line length for Python code in
-    PlasmaPy is 88 characters.
 
   * Docstrings and comments should generally be limited to
     about 72 characters.

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -145,9 +145,10 @@ the code is supposed to be doing.
 
    Most `integrated development environments <IDE>`_ (IDEs) have a
    built-in tool for simultaneously renaming a variable throughout a
-   project. For example, a `rename refactoring in PyCharm`_ can be done
-   with :kbd:`Shift+F6` on Windows or Linux, and :kbd:`⇧F6` or
-   :kbd:`⌥⌘R` on macOS.
+   project. For example, a `rename refactoring in PyCharm
+   <https://www.jetbrains.com/help/pycharm/rename-refactorings.html>`__
+   can be done with :kbd:`Shift+F6` on Windows or Linux, and :kbd:`⇧F6`
+   or :kbd:`⌥⌘R` on macOS.
 
 Coding Style
 ============
@@ -510,7 +511,7 @@ Up-to-date instructions on running the benchmark suite will be located in
 the README file of `benchmarks-repo`_.
 
 .. _ASCII: https://en.wikipedia.org/wiki/ASCII
-.. _nbqa: https://nbqa.readthedocs.io
+.. _rename refactoring in PyCharm: https://www.jetbrains.com/help/pycharm/rename-refactorings.html
 
 .. _cggglm: http://www.netlib.org/lapack/explore-html/d9/d98/group__complex_o_t_h_e_reigen_ga4be128ffc05552459683f0aade5a7937.html
 .. |cggglm| replace:: ``cggglm``

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -143,10 +143,11 @@ the code is supposed to be doing.
 
 .. hint::
 
-   Most IDEs_ have a built-in tool for simultaneously renaming a
-   variable throughout a project. For example, a `rename refactoring in
-   PyCharm`_ can be done with :kbd:`Shift+F6` on Windows or Linux, and
-   :kbd:`⇧F6` or :kbd:`⌥⌘R` on macOS.
+   Most `integrated development environments <IDE>`_ (IDEs) have a
+   built-in tool for simultaneously renaming a variable throughout a
+   project. For example, a `rename refactoring in PyCharm`_ can be done
+   with :kbd:`Shift+F6` on Windows or Linux, and :kbd:`⇧F6` or
+   :kbd:`⌥⌘R` on macOS.
 
 Coding Style
 ============
@@ -509,6 +510,8 @@ generated from results located in `benchmarks-repo`_. Detailed
 instructions on writing such benchmarks can be found at `asv-docs`_.
 Up-to-date instructions on running the benchmark suite will be located in
 the README file of `benchmarks-repo`_.
+
+ .. _ASCII: https://en.wikipedia.org/wiki/ASCII
 
 .. _cggglm: http://www.netlib.org/lapack/explore-html/d9/d98/group__complex_o_t_h_e_reigen_ga4be128ffc05552459683f0aade5a7937.html
 .. |cggglm| replace:: ``cggglm``

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -24,32 +24,40 @@ Names
 =====
 
 Names are the most fundamental means of communicating the intent and
-purpose of code. Judicious choices of names can greatly improve the
+purpose of code. Wise choices of names can greatly improve the
 understandability of code, while inadequate naming can obfuscate what
 the code is supposed to be doing.
 
-* Use :pep:`8` conventions for naming variables, functions, classes, and
-  constants (except as described later in this list).
+* PlasmaPy generally uses the :pep:`8` conventions for variable names.
 
   - Use lowercase words separated by underscores for function and
     variable names (e.g., ``function_name`` and ``variable_name``).
 
   - Use capitalized words without separators when naming a :term:`class`
-    or an exception (e.g., ``ClassName`` or ``ExceptionName``). However,
-    keep acronyms capitalized (e.g., ``MHDEquations``).
+    (e.g., ``ClassName``), but keep acronyms capitalized (e.g.,
+    ``MHDEquations``).
 
   - Use capital letters words separated by underscores for constants
     (e.g., ``CONSTANT`` or ``CONSTANT_NAME``).
 
-* Choose names that are pronounceable so that they are easier to
-  remember and more compatible with text-to-speech technology.
+  There are some situations in PlasmaPy which justify a departure from
+  the :pep:`8` conventions.
 
-* Choose names that can be used in searches on the World Wide Web™.
+  - Functions based on plasma parameters that are named after people may
+    be capitalized (e.g., ``Alfven_speed``).
 
-* Avoid unnecessary abbreviations, as these can make code more difficult
-  to read. Clarity is more important than brevity, except for code that
-  is used frequently and interactively (e.g., :command:`ls` or
-  :command:`cd` in the Unix shell).
+  - Capital letters may be used for a variable when it matches the
+    standard usage in plasma science (e.g., ``B`` for magnetic field and
+    ``T`` for temperature).
+
+* Pronounceable names are more memorable and compatible with
+  text-to-speech technology.
+
+* Choose names will produce more relevant results in internet searches.
+
+* Avoid unnecessary abbreviations, as these make code harder to read.
+  Prefer clarity over brevity, except for code that is used frequently
+  and interactively (e.g., :command:`cd` or :command:`ls`).
 
   .. tip::
 
@@ -59,27 +67,21 @@ the code is supposed to be doing.
      By this measure, ``cggglm`` is significantly longer than
      ``solve_gauss_markov_linear_model``.
 
-* Use a capital letter for a :term:`parameter` when it matches the
-  standard usage in plasma science. For example, use ``B`` for magnetic
-  field strength and ``T`` for temperature.
-
-* Avoid potentially ambiguous names. Does ``temp`` mean "temperature",
-  "temporary", or "template"?
-
-* Functions based on plasma parameters that are named after people may
-  be capitalized (e.g., ``Alfven_speed``).
+* Avoid ambiguity. Does ``temp`` mean "temperature", "temporary", or
+  "template"?
 
 * Append ``_e`` to the name of a :term:`parameter` to indicate that it
   refers to electrons, ``_i`` to indicate that it refers to ions, and
   ``_p`` to indicate that it refers to protons (e.g., ``T_e``, ``T_i``,
   and ``T_p``).
 
-* Only use ASCII_ characters in code that is part of the public API_.
-
 * Python allows alphanumeric Unicode characters to be used in object
   names (e.g., ``πλάσμα`` or ``φυσική``). These characters may be used
-  for internal code when doing so improves readability (i.e. to match a
-  commonly used symbol).
+  for *internal* code when doing so improves readability (i.e. to match
+  a commonly used symbol).
+
+* Only ASCII_ characters should be used in code that is part of the
+  public API_.
 
 * If a plasma parameter has multiple names, then use the name that
   provides the most physical insight. For example, ``gyrofrequency``
@@ -87,41 +89,35 @@ the code is supposed to be doing.
 
 * It is *usually* preferable to name a variable after its name rather
   than its symbol.  An object named ``Debye_length`` is more broadly
-  understandable than ``lambda_D``. However, there are some exceptions
-  to this guideline.
+  understandable and searchable than ``lambda_D``. However, there are
+  some exceptions to this guideline:
 
   * Symbols used widely across plasma science can be used with low risk
-    of confusion, such as when using :math:`T` for temperature or
-    :math:`β` for plasma `~plasmapy.formulary.dimensionless.beta`.
-    However, different symbols may be used for different subfields of
-    plasma science.
+    of confusion, such as :math:`T` for temperature or :math:`β` for
+    plasma `~plasmapy.formulary.dimensionless.beta`.
 
-  * Symbols defined in docstrings can be used with decreased likelihood
-    of confusion.
+  * Symbols that are defined in docstrings can be used with decreased
+    likelihood of confusion.
 
-  * If the implementation of a function is based on a journal article,
-    then the function might be more readable and maintainable if the
-    variable names are based on the symbols used in that article. The
-    article should be cited in the docstring of that function so that it
-    appears in the |bibliography|.
+  * Sometimes code that represents an equation will be more readable if
+    the Unicode characters for the symbols are used, especially for
+    complex equations. For someone who is familiar with the symbols,
+    ``λ = c / ν`` will be more readable than ``lambda = c / nu`` or
+    ``wavelength = speed_of_light / frequency``.
 
-  * Sometimes code that represents an equation will be most readable if
-    the Unicode characters for the symbols are used. For example,
-    ``λ = c / ν`` will be
-    ``lambda = c / nu`` or ``wavelength = speed_of_light / frequency``.
-    Using Unicode characters for variable names is most beneficial for
-    complex equations.
+  * If an implementation is based on a journal article, then it might be
+    more readable and maintainable if the variable names are based on
+    the symbols used in that article. The article should be cited in the
+    appropriate docstring so that it appears in the |bibliography|.
 
 * To mark that an object is not part of PlasmaPy's public API_, begin
   its name with a leading underscore (e.g., ``_private_variable``).
   Private variables should not be included in ``__all__``.
 
-* In most situations, avoid single character variable names. Single
-  character variable names may be used for standard plasma physics
-  symbols (i.e., ``B``) or as indices in ``for`` loops (though more
-  descriptive names are preferred).
+* Avoid single character variable names except for standard plasma
+  physics symbols (e.g., ``B``) or as indices in ``for`` loops.
 
-* In general, avoid encoding type information in a variable name.
+* Avoid encoding type information in a variable name.
 
 * Intermediate variable names can provide additional context and
   meaning. For example, suppose we have a conditional operating on a
@@ -140,6 +136,9 @@ the code is supposed to be doing.
 
      if point_is_in_grid_cell:
          ...
+
+  In ``for`` loops, this may take the form of assignment expressions
+  with the walrus operator (``:=``).
 
 .. hint::
 
@@ -511,6 +510,3 @@ the README file of `benchmarks-repo`_.
 
 .. _ASCII: https://en.wikipedia.org/wiki/ASCII
 .. _rename refactoring in PyCharm: https://www.jetbrains.com/help/pycharm/rename-refactorings.html
-
-.. _cggglm: http://www.netlib.org/lapack/explore-html/d9/d98/group__complex_o_t_h_e_reigen_ga4be128ffc05552459683f0aade5a7937.html
-.. |cggglm| replace:: ``cggglm``

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -23,9 +23,9 @@ an idea at a community meeting.
 Names
 =====
 
-Names are the most fundamental means of communicating the intent and
-purpose of code. Wise choices of names can greatly improve the
-understandability of code, while inadequate naming can obfuscate what
+Names are our most fundamental means of communicating the intent and
+purpose of code. Wisely chosen names can greatly improve the
+understandability of code, while inadequate names can obfuscate what
 the code is supposed to be doing.
 
 * PlasmaPy generally uses the :pep:`8` conventions for variable names.
@@ -33,12 +33,12 @@ the code is supposed to be doing.
   - Use lowercase words separated by underscores for function and
     variable names (e.g., ``function_name`` and ``variable_name``).
 
-  - Use capitalized words without separators when naming a :term:`class`
-    (e.g., ``ClassName``), but keep acronyms capitalized (e.g.,
+  - Use capitalized words without separators when naming a class (e.g.,
+    ``ClassName``), but keep acronyms capitalized (e.g.,
     ``MHDEquations``).
 
-  - Use capital letters words separated by underscores for constants
-    (e.g., ``CONSTANT`` or ``CONSTANT_NAME``).
+  - Use capital letters words separated by underscores when naming
+    constants (e.g., ``CONSTANT`` or ``CONSTANT_NAME``).
 
   There are some situations in PlasmaPy which justify a departure from
   the :pep:`8` conventions.
@@ -50,10 +50,11 @@ the code is supposed to be doing.
     standard usage in plasma science (e.g., ``B`` for magnetic field and
     ``T`` for temperature).
 
-* Pronounceable names are more memorable and compatible with
-  text-to-speech technology.
+* Choose names that are pronounceable to make them more memorable and
+  compatible with text-to-speech technology.
 
-* Choose names will produce more relevant results in internet searches.
+* Choose names will produce more relevant results when searching the
+  internet.
 
 * Avoid unnecessary abbreviations, as these make code harder to read.
   Prefer clarity over brevity, except for code that is used frequently
@@ -70,18 +71,17 @@ the code is supposed to be doing.
 * Avoid ambiguity. Does ``temp`` mean "temperature", "temporary", or
   "template"?
 
-* Append ``_e`` to the name of a :term:`parameter` to indicate that it
-  refers to electrons, ``_i`` to indicate that it refers to ions, and
-  ``_p`` to indicate that it refers to protons (e.g., ``T_e``, ``T_i``,
-  and ``T_p``).
+* Append ``_e`` to a variable name to indicate that it refers to
+  electrons, ``_i`` for ions, and ``_p`` for protons (e.g., ``T_e``,
+  ``T_i``, and ``T_p``).
+
+* Only ASCII_ characters should be used in code that is part of the
+  public API_.
 
 * Python allows alphanumeric Unicode characters to be used in object
   names (e.g., ``πλάσμα`` or ``φυσική``). These characters may be used
   for *internal* code when doing so improves readability (i.e., to match
-  a commonly used symbol).
-
-* Only ASCII_ characters should be used in code that is part of the
-  public API_.
+  a commonly used symbol) and in Jupyter_ notebooks.
 
 * If a plasma parameter has multiple names, then use the name that
   provides the most physical insight. For example, ``gyrofrequency``
@@ -90,7 +90,7 @@ the code is supposed to be doing.
 * It is *usually* preferable to name a variable after its name rather
   than its symbol.  An object named ``Debye_length`` is more broadly
   understandable and searchable than ``lambda_D``. However, there are
-  some exceptions to this guideline:
+  some exceptions to this guideline.
 
   * Symbols used widely across plasma science can be used with low risk
     of confusion, such as :math:`T` for temperature or :math:`β` for
@@ -105,10 +105,10 @@ the code is supposed to be doing.
     ``λ = c / ν`` will be more readable than ``lambda = c / nu`` or
     ``wavelength = speed_of_light / frequency``.
 
-  * If an implementation is based on a journal article, then it might be
-    more readable and maintainable if the variable names are based on
-    the symbols used in that article. The article should be cited in the
-    appropriate docstring so that it appears in the |bibliography|.
+  * If an implementation is based on a journal article, then variable
+    names may be based on the symbols used in that article. The article
+    should be :ref:`cited <citation-instructions>` in the appropriate
+    docstring so that it appears in the |bibliography|.
 
 * To mark that an object is not part of PlasmaPy's public API_, begin
   its name with a leading underscore (e.g., ``_private_variable``).
@@ -140,7 +140,7 @@ the code is supposed to be doing.
   In ``for`` loops, this may take the form of assignment expressions
   with the walrus operator (``:=``).
 
-.. hint::
+.. tip::
 
    Most `integrated development environments <IDE>`_ (IDEs) have a
    built-in tool for simultaneously renaming a variable throughout a
@@ -155,9 +155,9 @@ Coding Style
 PlasmaPy Code Style Guide, codified
 -----------------------------------
 
-* PlasmaPy generally follows the `PEP8 Style Guide for Python Code
-  <https://peps.python.org/pep-0008>`__.  This style choice
-  helps ensure that the code will be consistent and readable.
+* PlasmaPy generally follows the :pep:`8` style guide for Python code.
+  This style choice helps ensure that the code will be consistent and
+  readable.
 
   * Docstrings and comments should generally be limited to
     about 72 characters.

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -450,6 +450,8 @@ substitutions should not be used in docstrings when it is important that
 users have quick access to the full path of the `object` (such as in the
 ``See Also`` section).
 
+.. _citation-instructions:
+
 Bibliography
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR is another spin-off from #1305 that focuses on best practices on naming variables and functions.  

This depends on a few things in #1649, and will need to be merged afterwards.