### PR TITLE
Move & revise section on installing and using pre-commit

### DIFF
--- a/changelog/1651.doc.rst
+++ b/changelog/1651.doc.rst
@@ -1,0 +1,2 @@
+Updated the section of the contributor guide on |pre-commit|_, and
+moved it to :file:`docs/contributing/install_dev.rst`.

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -136,7 +136,6 @@
 .. _PlasmaPy's documentation: https://docs.plasmapy.org/en/stable
 .. _PlasmaPy's GitHub repository: https://github.com/PlasmaPy/plasmapy
 .. _PlasmaPy's Matrix chat room: https://app.element.io/#/room/#plasmapy:openastronomy.org
-.. _pre-commit: https://pre-commit.com
 .. _`pre-commit.ci`: https://pre-commit.ci
 .. _pydocstyle: https://www.pydocstyle.org/en/stable
 .. _pygments: https://pygments.org
@@ -210,6 +209,12 @@
 
 .. _numba: https://numba.readthedocs.io
 .. |numba| replace:: `numba`
+
+.. _pre-commit: https://pre-commit.com
+.. |pre-commit| replace:: ``pre-commit``
+
+.. _`.pre-commit-config.yaml`: https://github.com/PlasmaPy/PlasmaPy/blob/main/.pre-commit-config.yaml
+.. |.pre-commit-config.yaml| replace:: :file:`.pre-commit-config.yaml`
 
 .. _`setup.cfg`: https://github.com/PlasmaPy/PlasmaPy/blob/main/setup.cfg
 .. |setup.cfg| replace:: :file:`setup.cfg`

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -13,37 +13,6 @@ later.
 Coding Style
 ============
 
-TL;DR: use pre-commit
----------------------
-
-PlasmaPy has a configuration for the `pre-commit framework
-<https://pre-commit.com/>`_ that takes care of style mostly automatically.
-Install it with ``pip install pre-commit``, then use ``pre-commit install`` within
-the repository.
-
-This will cause pre-commit to download the right versions of linters we use,
-then run an automated style checking suite on every commit.  Do note that this
-works better with a ``git add``, then ``git commit`` workflow than a ``git commit
--a`` workflow — that way, you can check via ``git diff`` what the automated
-changes actually did.
-
-Note that the "Style linters / pre-commit (pull_request)" part of our
-Continuous Integration system can and will (metaphorically) shout at you if it
-finds you didn't apply the linters. Also note that the linters' output may vary
-with version, so, rather than apply black_ and isort_ manually, let
-pre-commit do the version management for you instead!
-
-Our pre-commit suite can be found in `.pre-commit-config.yaml
-<https://github.com/PlasmaPy/PlasmaPy/blob/main/.pre-commit-config.yaml>`_.
-It includes
-
-* black_ to automatically format code and ensure a consistent code style
-  throughout the package
-* isort_ to automatically sort imports.
-* `nbqa <https://github.com/nbQA-dev/nbQA>`_ to automatically apply the above
-  to example notebooks as well.
-* a few tools for :file:`requirements.txt`, :file:`.yml` files and the like.
-
 PlasmaPy Code Style Guide, codified
 -----------------------------------
 

--- a/docs/contributing/install_dev.rst
+++ b/docs/contributing/install_dev.rst
@@ -275,3 +275,6 @@ apply the changes to all files.
 .. code-block:: bash
 
    pre-commit run --all-files
+
+.. _nbqa: https://nbqa.readthedocs.io
+.. _pull the changes: https://docs.github.com/en/get-started/using-git/getting-changes-from-a-remote-repository#pulling-changes-from-a-remote-repository

--- a/docs/contributing/install_dev.rst
+++ b/docs/contributing/install_dev.rst
@@ -216,3 +216,62 @@ repository root and use one of
 Either one of these commands will create a soft link to your cloned
 repository.  Any changes in Python code you make there will be there
 when you ``import plasmapy`` from an interactive session.
+
+Installing pre-commit
+=====================
+
+PlasmaPy uses the |pre-commit|_ framework to perform validations and
+automatically apply a consistent style to code contributions. Using
+|pre-commit|_ helps us find errors and shortens code reviews. PlasmaPy's
+pre-commit suite includes hooks such as:
+
+* ``check-ast`` to verify that the Python code is valid.
+* ``trailing-whitespace`` to remove trailing whitespace.
+* black_ to format code.
+* isort_ to sort imports.
+* nbqa_ to format notebooks.
+
+Most of the changes required by |pre-commit|_ can be applied
+automatically. To apply these changes in a pull request, add a comment
+that says ``pre-commit.ci autofix``. After doing this, be sure to `pull
+the changes`_ from GitHub to your computer with ``git pull``.
+
+To enable |pre-commit|_ locally, open a terminal, enter the directory of
+the PlasmaPy repository, and run:
+
+.. code-block:: bash
+
+   pip install pre-commit
+   pre-commit install
+
+Now suppose we added some trailing whitespace to :file:`some_file.py`
+and attempted to commit it. If |pre-commit|_ has been installed, then
+the ``trailing-whitespace`` hook will cause |pre-commit|_ to fail while
+modifying :file:`some_file.py` to remove the trailing whitespace.
+
+.. code-block:: console
+
+   $ git add some_file.py
+   $ git commit -m "Add trailing whitespace"
+   Trim Trailing Whitespace.................................................Failed
+   - hook id: trailing-whitespace
+   - exit code: 1
+   - files were modified by this hook
+
+At this point it will be necessary to run these two commands again to
+commit the changes. The changes made by |pre-commit|_ will be unstaged and
+thus could be seen by running ``git diff``. Sometimes |pre-commit|_ will
+not be able to automatically fix the files, such as when there are
+syntax errors in Python code. In these cases, the files will need to be
+changed manually before running the ``git add`` and ``git commit``
+commands again. Alternatively, the |pre-commit|_ hooks can be skipped
+using ``git commit --no-verify`` instead.
+
+The |pre-commit|_ configuration is given in |.pre-commit-config.yaml|_.
+
+After adding or updating |pre-commit|_ hooks, run the following command to
+apply the changes to all files.
+
+.. code-block:: bash
+
+   pre-commit run --all-files


### PR DESCRIPTION
In #1305, I updated the section that describes how to use pre-commit in the coding guide.  This PR takes that section and moves it to `install_dev.rst`, which I'm intending to update later.

I still have to...

 - [x] Remove section on pre-commit from coding guide