### PR TITLE
Restrict `sphinx_gallery < 0.11`

### DIFF
--- a/changelog/1654.trivial.rst
+++ b/changelog/1654.trivial.rst
@@ -1,0 +1,4 @@
+Restricted dependency of `sphinx_gallery` to ``< 0.11.0``, since
+`sphinx_gallery` changed their thumbnail containers to flex containers,
+see :pr:`sphinx-gallery/sphinx-gallery#906` and
+:issue:`sphinx-gallery/sphinx-gallery#905`.

--- a/changelog/1654.trivial.rst
+++ b/changelog/1654.trivial.rst
@@ -1,4 +1,8 @@
-Restricted dependency of `sphinx_gallery` to ``< 0.11.0``, since
-`sphinx_gallery` changed their thumbnail containers to flex containers,
-see :pr:`sphinx-gallery/sphinx-gallery#906` and
-:issue:`sphinx-gallery/sphinx-gallery#905`.
+Restricted dependency of
+`sphinx-gallery <https://sphinx-gallery.github.io/stable/index.html>`__
+to ``< 0.11.0``, since
+``sphinx-gallery`` changed their thumbnail containers to flex containers,
+see PR
+`sphinx-gallery/#906 <https://github.com/sphinx-gallery/sphinx-gallery/pull/906>`__
+and issue
+`sphinx-gallery/#905 <https://github.com/sphinx-gallery/sphinx-gallery/issues/905>`__\ .

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -14,7 +14,7 @@ pygments >= 2.11.0
 sphinx >= 4.4, != 5.1
 sphinx-changelog
 sphinx-copybutton
-sphinx-gallery
+sphinx-gallery < 0.11.0
 sphinx-hoverxref >= 1.1.1
 sphinx-issues >= 3.0.1
 sphinx-notfound-page >= 0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ docs =
     sphinx >= 4.4, != 5.1
     sphinx-changelog
     sphinx-copybutton
-    sphinx-gallery
+    sphinx-gallery < 0.11.0
     sphinx-hoverxref >= 1.1.1
     sphinx-issues >= 3.0.1
     sphinx-notfound-page >= 0.8


### PR DESCRIPTION
Today (2022-07-29) `sphinx_gallery` released [version `0.11.0`](https://pypi.org/project/sphinx-gallery/0.11.0/).  The changes introduced in this version are negatively affecting the display of thumbnail galleries generated by `nbsphinx`, as such I'm restricting `sphinx_gallery` to `< 0.11.0`.

There are likely multiple changes that are sources to this issue, all of which are probably related to https://github.com/sphinx-gallery/sphinx-gallery/issues/905.  I do think the issue can be traced back to the change of the `.spx-glr-thubcontainer` style to a flex container.  **Instead of spending days trying to fix this my(our)selves.  I'm just restricting the `sphinx_gallery` version and hoping `nbsphinx` comes up with their own solution that we can adopt later.** :)

 on the change to flex containersThe root cause of the display issues comes from changes made to the `.spx-glr-thubcontainer` style...

## OLD

```css
.sphx-glr-thumbcontainer {
  background: #fff;
  border: solid #fff 1px;
  -moz-border-radius: 5px;
  -webkit-border-radius: 5px;
  border-radius: 5px;
  box-shadow: none;
  float: left;
  margin: 5px;
  min-height: 230px;
  padding-top: 5px;
  position: relative;
}
```

![image](https://user-images.githubusercontent.com/29869348/181863603-26aed77a-5acf-4072-bee2-b1cc9a9a4082.png)


## NEW

```css
.sphx-glr-thumbcontainer {
  background: transparent;
  -moz-border-radius: 5px;
  -webkit-border-radius: 5px;
  border-radius: 5px;
  box-shadow: 0 0 10px var(--sg-thumb-box-shadow-color);

  /* useful to absolutely position link in div */
  position: relative;

  /* thumbnail width should include padding and borders
  and take all available space */
  box-sizing: border-box;
  width: 100%;
  padding: 10px;
  border: 1px solid transparent;

  /* align content in thumbnail */
  display: flex;
  flex-direction: column;
  align-items: center;
  gap: 7px;
}
```

![image](https://user-images.githubusercontent.com/29869348/181863591-f8b198e8-278f-4187-b620-6592b19e3bff.png)

---

`nbsphinx` has already taken not of this... https://github.com/spatialaudio/nbsphinx/issues/655
