### PR TITLE
Add tables of contents to pages in contributor guide

### DIFF
--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -10,6 +10,14 @@ Changelog Guide
    documentation at:
    https://docs.plasmapy.org/en/latest/development/changelog_guide.html
 
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: none
+
+Introduction
+============
+
 A changelog tells users and contributors what notable changes have been
 made between each release. Pull requests to PlasmaPy need changelog
 entries before they can be merged, except when the changes are very

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -4,6 +4,10 @@
 Coding Guide
 ************
 
+.. toctree::
+   :caption: Coding Guide
+   :maxdepth: 2
+
 This guide describes common conventions, guidelines, and strategies for
 contributing code to PlasmaPy. The purpose of this guide is not to
 provide a set of rigid guidelines that must be adhered to, but rather to

--- a/docs/contributing/code_guide.rst
+++ b/docs/contributing/code_guide.rst
@@ -4,9 +4,13 @@
 Coding Guide
 ************
 
-.. toctree::
-   :caption: Coding Guide
-   :maxdepth: 2
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+   :backlinks: none
+
+Introduction
+============
 
 This guide describes common conventions, guidelines, and strategies for
 contributing code to PlasmaPy. The purpose of this guide is not to

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -5,7 +5,7 @@ Coding Guide
 ************
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
    :backlinks: none
 

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -5,7 +5,7 @@ Documentation Guide
 *******************
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
    :backlinks: none
 

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -4,6 +4,10 @@
 Documentation Guide
 *******************
 
+.. toctree::
+   :caption: Documentation Guide
+   :maxdepth: 2
+
 Documentation that is up-to-date and understandable is vital to the
 health of a software project. This page describes the documentation
 requirements and guidelines to be followed during the development of

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -4,9 +4,13 @@
 Documentation Guide
 *******************
 
-.. toctree::
-   :caption: Documentation Guide
-   :maxdepth: 2
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+   :backlinks: none
+
+Introduction
+============
 
 Documentation that is up-to-date and understandable is vital to the
 health of a software project. This page describes the documentation

--- a/docs/contributing/install_dev.rst
+++ b/docs/contributing/install_dev.rst
@@ -4,6 +4,10 @@
 Installing PlasmaPy for Development
 ***********************************
 
+.. toctree::
+   :caption: Installing PlasmaPy for Development
+   :maxdepth: 2
+
 Obtaining PlasmaPy source code
 ==============================
 

--- a/docs/contributing/install_dev.rst
+++ b/docs/contributing/install_dev.rst
@@ -4,9 +4,10 @@
 Installing PlasmaPy for Development
 ***********************************
 
-.. toctree::
-   :caption: Installing PlasmaPy for Development
-   :maxdepth: 2
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+   :backlinks: none
 
 Obtaining PlasmaPy source code
 ==============================

--- a/docs/contributing/install_dev.rst
+++ b/docs/contributing/install_dev.rst
@@ -5,7 +5,7 @@ Installing PlasmaPy for Development
 ***********************************
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
    :backlinks: none
 

--- a/docs/contributing/release_guide.rst
+++ b/docs/contributing/release_guide.rst
@@ -4,6 +4,10 @@
 Release Guide
 *************
 
+.. toctree::
+   :caption: Release Guide
+   :maxdepth: 2
+
 This document describes the procedure for making a release of PlasmaPy.
 
 The following is a partial list of tasks to be performed for each

--- a/docs/contributing/release_guide.rst
+++ b/docs/contributing/release_guide.rst
@@ -5,7 +5,7 @@ Release Guide
 *************
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
    :backlinks: none
 

--- a/docs/contributing/release_guide.rst
+++ b/docs/contributing/release_guide.rst
@@ -4,9 +4,13 @@
 Release Guide
 *************
 
-.. toctree::
-   :caption: Release Guide
-   :maxdepth: 2
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+   :backlinks: none
+
+Introduction
+------------
 
 This document describes the procedure for making a release of PlasmaPy.
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -4,6 +4,10 @@
 Testing Guide
 *************
 
+.. toctree::
+   :caption: Testing Guide
+   :maxdepth: 2
+
 Introduction
 ============
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -4,9 +4,10 @@
 Testing Guide
 *************
 
-.. toctree::
-   :caption: Testing Guide
-   :maxdepth: 2
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+   :backlinks: none
 
 Introduction
 ============

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -5,7 +5,7 @@ Testing Guide
 *************
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
    :backlinks: none
 


### PR DESCRIPTION
Following [this comment](https://github.com/PlasmaPy/PlasmaPy/pull/1660#discussion_r938008046), I'm adding tables of contents to most of the pages in the contributor guide.  

I'm still playing around with where to place the tables of contents.  I'm wondering about either right at the top, or after the preamble text.

