### PR TITLE
Add and apply substitution for `array_like`

### DIFF
--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -65,6 +65,7 @@
 .. |inf| replace:: `~numpy.inf`
 .. |nan| replace:: `~numpy.nan`
 .. |ndarray| replace:: :class:`~numpy.ndarray`
+.. |array_like| replace:: :term:`numpy:array_like`
 
 .. --------------------
 .. Astropy replacements

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -73,10 +73,10 @@ class AbstractFitFunction(ABC):
 
         Parameters
         ----------
-        x: array_like
+        x: |array_like|
             Dependent variables.
 
-        x_err: array_like, optional
+        x_err: |array_like|, optional
             Errors associated with the independent variables ``x``.  Must be of
             size one or equal to the size of ``x``.
 
@@ -119,7 +119,7 @@ class AbstractFitFunction(ABC):
 
         Parameters
         ----------
-        x: array_like
+        x: |array_like|
             Independent variables to be passed to the fit function.
 
         *args: Tuple[Union[float, int],...]
@@ -176,10 +176,10 @@ class AbstractFitFunction(ABC):
         """
         Parameters
         ----------
-        x: array_like
+        x: |array_like|
             Independent variables to be passed to the fit function.
 
-        x_err: array_like, optional
+        x_err: |array_like|, optional
             Errors associated with the independent variables ``x``.  Must be of
             size one or equal to the size of ``x``.
 
@@ -427,11 +427,11 @@ class AbstractFitFunction(ABC):
 
         Parameters
         ----------
-        xdata: array_like
+        xdata: |array_like|
             The independent variable where data is measured.  Should be 1D of
             length M.
 
-        ydata: array_like
+        ydata: |array_like|
             The dependent data associated with ``xdata``.
 
         **kwargs
@@ -502,7 +502,7 @@ class Linear(AbstractFitFunction):
 
         Parameters
         ----------
-        x: array_like
+        x: |array_like|
             Independent variable.
 
         m: float
@@ -513,7 +513,7 @@ class Linear(AbstractFitFunction):
 
         Returns
         -------
-        y: array_like
+        y: |array_like|
             dependent variables corresponding to :math:`x`
 
         """
@@ -622,11 +622,11 @@ class Linear(AbstractFitFunction):
 
         Parameters
         ----------
-        xdata: array_like
+        xdata: |array_like|
             The independent variable where data is measured.  Should be 1D of
             length M.
 
-        ydata: array_like
+        ydata: |array_like|
             The dependent data associated with ``xdata``.
 
         **kwargs
@@ -690,7 +690,7 @@ class Exponential(AbstractFitFunction):
 
         Parameters
         ----------
-        x: array_like
+        x: |array_like|
             Independent variable.
 
         a: float
@@ -701,7 +701,7 @@ class Exponential(AbstractFitFunction):
 
         Returns
         -------
-        y: array_like
+        y: |array_like|
             dependent variables corresponding to ``x``
 
         """
@@ -849,7 +849,7 @@ class ExponentialPlusLinear(AbstractFitFunction):
 
         Parameters
         ----------
-        x: array_like
+        x: |array_like|
             Independent variable.
 
         a: float
@@ -866,7 +866,7 @@ class ExponentialPlusLinear(AbstractFitFunction):
 
         Returns
         -------
-        y: array_like
+        y: |array_like|
             dependent variables corresponding to ``x``
 
         """
@@ -989,7 +989,7 @@ class ExponentialPlusOffset(AbstractFitFunction):
 
         Parameters
         ----------
-        x: array_like
+        x: |array_like|
             Independent variable.
 
         a: float
@@ -1003,7 +1003,7 @@ class ExponentialPlusOffset(AbstractFitFunction):
 
         Returns
         -------
-        y: array_like
+        y: |array_like|
             dependent variables corresponding to ``x``
 
         """

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -165,54 +165,54 @@ def _vector_space(
     Parameters
     ----------
 
-    x_arr: array_like
+    x_arr : |array_like|
         The array representing the coordinates in the x-dimension.
         If not given, then range values are used to construct a
         uniform array on that interval.
 
-    y_arr: array_like
+    y_arr : |array_like|
         The array representing the coordinates in the y-dimension.
         If not given, then range values are used to construct a
         uniform array on that interval.
 
-    z_arr: array_like
+    z_arr : |array_like|
         The array representing the coordinates in the z-dimension.
         If not given, then range values are used to construct a
         uniform array on that interval.
 
-    x_range: array_like
+    x_range : |array_like|
         A 1 by 2 array containing the range of x-values for the vector spaces.
         If not given, the default interval [0,1] is assumed.
 
-    y_range: array_like
+    y_range : |array_like|
         A 1 by 2 array containing the range of y-values for the vector spaces.
         If not given, the default interval [0,1] is assumed.
 
-    z_range: array_like
+    z_range : |array_like|
         A 1 by 2 array containing the range of z-values for the vector spaces.
         If not given, the default interval [0,1] is assumed.
 
-    u_arr: array_like
+    u_arr : |array_like|
         A 3D array containing the x-component of the vector values for the vector
         space. If not given, the vector values are generated over the vector space
         using the function func.
 
-    v_arr: array_like
+    v_arr : |array_like|
         A 3D array containing the y-component of the vector values for the vector
         space. If not given, the vector values are generated over the vector space
         using the function func.
 
-    w_arr: array_like
+    w_arr : |array_like|
         A 3D array containing the z-component of the vector values for the vector
         space. If not given, the vector values are generated over the vector space
         using the function func.
 
-    func: function
+    func : function
         A function that takes in 3 arguments, respectively representing a x, y, and z
         coordinate of a point and returns the vector value for that point in the form
         of a 1 by 3 array.
 
-    precision: array_like
+    precision : |array_like|
         A 1 by 3 array containing the approximate precision values for each dimension,
         in the case where uniform arrays are being used.
         The default value is [0.05, 0.05, 0.05].
@@ -268,13 +268,13 @@ def _trilinear_coeff_cal(vspace, cell):
     Parameters
     ----------
 
-    vspace: array_like
+    vspace: |array_like|
         The vector space as constructed by the vector_space function which is
         A 1 by 3 array with the first element containing the coordinates,
         the second element containing the vector values,
         and the third element containing the delta values for each dimension.
 
-    cell: array_like of integers
+    cell: |array_like| of integers
         A grid cell, represented by a 1 by 3 array
         of integers, which correspond to a grid cell
         in the vector space.
@@ -382,13 +382,13 @@ def trilinear_approx(vspace, cell):
     Parameters
     ----------
 
-    vspace: array_like
+    vspace: |array_like|
         The vector space as constructed by the vector_space function which is
         A 1 by 3 array with the first element containing the coordinates,
         the second element containing the vector values,
         and the third element containing the delta values for each dimension.
 
-    cell: array_like of integers
+    cell: |array_like| of integers
         A grid cell, represented by a 1 by 3 array
         of integers, which correspond to a grid cell
         in the vector space.
@@ -451,13 +451,13 @@ def _trilinear_jacobian(vspace, cell):
     Parameters
     ----------
 
-    vspace: array_like
+    vspace: |array_like|
         The vector space as constructed by the vector_space function which is
         A 1 by 3 array with the first element containing the coordinates,
         the second element containing the vector values,
         and the third element containing the delta values for each dimension.
 
-    cell: array_like of integers
+    cell: |array_like| of integers
         A grid cell, represented by a 1 by 3 array
         of integers, which correspond to a grid cell
         in the vector space.
@@ -510,13 +510,13 @@ def _reduction(vspace, cell):
     Parameters
     ----------
 
-    vspace: array_like
+    vspace: |array_like|
         The vector space as constructed by the vector_space function which is
         A 1 by 3 array with the first element containing the coordinates,
         the second element containing the vector values,
         and the third element containing the delta values for each dimension.
 
-    cell: array_like of integers
+    cell: |array_like| of integers
         A grid cell, represented by a 1 by 3 array
         of integers, which correspond to a grid cell
         in the vector space.
@@ -592,7 +592,7 @@ def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):
 
     Returns
     -------
-    roots : array_like of floats
+    roots : |array_like| of floats
         A 1 by 2 array containing the two roots
     """
     m1 = np.array([[a1, a2], [c1, c2]])
@@ -652,13 +652,13 @@ def _trilinear_analysis(vspace, cell):
     Parameters
     ----------
 
-    vspace: array_like
+    vspace: |array_like|
         The vector space as constructed by the vector_space function which is
         A 1 by 3 array with the first element containing the coordinates,
         the second element containing the vector values,
         and the third element containing the delta values for each dimension.
 
-    cell: array_like of integers
+    cell: |array_like| of integers
         A grid cell, represented by a 1 by 3 array
         of integers, which correspond to a grid cell
         in the vector space.
@@ -1122,13 +1122,13 @@ def _locate_null_point(vspace, cell, n, err):
     Parameters
     ----------
 
-    vspace: array_like
+    vspace: |array_like|
         The vector space as constructed by the vector_space function which is
         A 1 by 3 array with the first element containing the coordinates,
         the second element containing the vector values,
         and the third element containing the delta values for each dimension.
 
-    cell: array_like of integers
+    cell: |array_like| of integers
         A grid cell, represented by a 1 by 3 array
         of integers, which correspond to a grid cell
         in the vector space.
@@ -1143,7 +1143,7 @@ def _locate_null_point(vspace, cell, n, err):
 
     Returns
     -------
-    array_like of floats
+    |array_like| of floats
         A 1 by 3 array containing the converged coordinates of the
         null point.
     NoneType
@@ -1297,13 +1297,13 @@ def _classify_null_point(vspace, cell, loc):
 
     Parameters
     ----------
-    vspace: array_like
+    vspace: |array_like|
         The vector space as constructed by the vector_space function which is
         A 1 by 3 array with the first element containing the coordinates,
         the second element containing the vector values,
         and the third element containing the delta values for each dimension.
 
-    cell: array_like of integers
+    cell: |array_like| of integers
         A grid cell, represented by a 1 by 3 array
         of integers, which correspond to a grid cell
         in the vector space.
@@ -1369,7 +1369,7 @@ def _vspace_iterator(vspace, maxiter=500, err=1e-10):
 
     Parameters
     ----------
-    vspace: array_like
+    vspace: |array_like|
         The vector space as constructed by the ``_vector_space`` function which is
         A 1 by 3 array with the first element containing the coordinates,
         the second element containing the vector values,
@@ -1386,7 +1386,7 @@ def _vspace_iterator(vspace, maxiter=500, err=1e-10):
 
     Returns
     -------
-    array_like of `~plasmapy.analysis.nullpoint.NullPoint`
+    |array_like| of `~plasmapy.analysis.nullpoint.NullPoint`
         An array of `~plasmapy.analysis.nullpoint.NullPoint` objects
         representing the null points of the given vector space.
 
@@ -1427,32 +1427,32 @@ def null_point_find(
 
     Parameters
     ----------
-    x_arr: array_like
+    x_arr: |array_like|
         The array representing the coordinates in the x-dimension.
         If not given, then range values are used to construct a
         uniform array on that interval.
 
-    y_arr: array_like
+    y_arr: |array_like|
         The array representing the coordinates in the y-dimension.
         If not given, then range values are used to construct a
         uniform array on that interval.
 
-    z_arr: array_like
+    z_arr: |array_like|
         The array representing the coordinates in the z-dimension.
         If not given, then range values are used to construct a
         uniform array on that interval.
 
-    u_arr: array_like
+    u_arr: |array_like|
         A 3D array containing the x-component of the vector values for the vector
         space. If not given, the vector values are generated over the vector space
         using the function func.
 
-    v_arr: array_like
+    v_arr: |array_like|
         A 3D array containing the y-component of the vector values for the vector
         space. If not given, the vector values are generated over the vector space
         using the function func.
 
-    w_arr: array_like
+    w_arr: |array_like|
         A 3D array containing the z-component of the vector values for the vector
         space. If not given, the vector values are generated over the vector space
         using the function func.
@@ -1469,7 +1469,7 @@ def null_point_find(
 
     Returns
     -------
-    array_like of `~plasmapy.analysis.nullpoint.NullPoint`
+    |array_like| of `~plasmapy.analysis.nullpoint.NullPoint`
         An array of `~plasmapy.analysis.nullpoint.NullPoint` objects
         representing the null points of the given vector space.
 
@@ -1515,15 +1515,15 @@ def uniform_null_point_find(
 
     Parameters
     ----------
-    x_range: array_like
+    x_range: |array_like|
         A 1 by 2 array containing the range of x-values for the vector spaces.
         If not given, the default interval [0,1] is assumed.
 
-    y_range: array_like
+    y_range: |array_like|
         A 1 by 2 array containing the range of y-values for the vector spaces.
         If not given, the default interval [0,1] is assumed.
 
-    z_range: array_like
+    z_range: |array_like|
         A 1 by 2 array containing the range of z-values for the vector spaces.
         If not given, the default interval [0,1] is assumed.
 
@@ -1532,14 +1532,14 @@ def uniform_null_point_find(
         coordinate of a point and returns the vector value for that point in the form
         of a 1 by 3 array.
 
-    precision: array_like
+    precision: |array_like|
         A 1 by 3 array containing the approximate precision values for each dimension,
         in the case where uniform arrays are being used.
         The default value is [0.05, 0.05, 0.05].
 
     Returns
     -------
-    array_like of `~plasmapy.analysis.nullpoint.NullPoint`
+    |array_like| of `~plasmapy.analysis.nullpoint.NullPoint`
         An array of `~plasmapy.analysis.nullpoint.NullPoint` objects representing
         the null points of the given vector space.
 

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -302,12 +302,12 @@ def spectral_density(
         Temperature of each ion component. Shape (Ni, ) must be equal to the
         number of ion populations Ni. (in K or convertible to eV)
 
-    efract : array_like, shape (Ne, ), optional
+    efract : |array_like|, shape (Ne, ), optional
         An array-like object representing :math:`F_e` (defined above).
         Must sum to 1.0. Default is [1.0], representing a single
         electron component.
 
-    ifract : array_like, shape (Ni, ), optional
+    ifract : |array_like|, shape (Ni, ), optional
         An array-like object representing :math:`F_i` (defined above).
         Must sum to 1.0. Default is [1.0], representing a single
         ion component.

--- a/plasmapy/dispersion/dispersionfunction.py
+++ b/plasmapy/dispersion/dispersionfunction.py
@@ -34,13 +34,13 @@ def plasma_dispersion_func_lite(zeta):
 
     Parameters
     ----------
-    zeta : :term:`numpy:array_like` of real or complex values
+    zeta : |array_like| of real or complex values
         Argument of the plasma dispersion function. ``zeta`` is
         dimensionless.
 
     Returns
     -------
-    Z : :term:`numpy:array_like` of complex values
+    Z : |array_like| of complex values
         Value of plasma dispersion function.
 
     See Also
@@ -157,13 +157,13 @@ def plasma_dispersion_func_deriv_lite(zeta):
 
     Parameters
     ----------
-    zeta : :term:`numpy:array_like` of real or complex values
+    zeta : |array_like| of real or complex values
         Argument of the plasma dispersion function. ``zeta`` is
         dimensionless.
 
     Returns
     -------
-    Zprime : :term:`numpy:array_like` of complex values
+    Zprime : |array_like| of complex values
         First derivative of plasma dispersion function.
 
     See Also

--- a/plasmapy/formulary/dielectric.py
+++ b/plasmapy/formulary/dielectric.py
@@ -226,11 +226,11 @@ def permittivity_1D_Maxwellian_lite(omega, kWave, vth, wp):
 
     Parameters
     ----------
-    omega : :term:`numpy:array_like` of real positive values
+    omega : |array_like| of real positive values
         The frequency, in rad/s, of the electromagnetic wave propagating
         through the plasma.
 
-    kWave : :term:`numpy:array_like` of real values
+    kWave : |array_like| of real values
         The corresponding wavenumber, in rad/m, of the electromagnetic
         wave propagating through the plasma.
 
@@ -244,7 +244,7 @@ def permittivity_1D_Maxwellian_lite(omega, kWave, vth, wp):
 
     Returns
     -------
-    chi : :term:`numpy:array_like` of complex values
+    chi : |array_like| of complex values
         The ion or the electron dielectric permittivity of the plasma.
         This is a dimensionless quantity.
 

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -352,7 +352,7 @@ class ParticleList(collections.UserList):
 
         Parameters
         ----------
-        abundances : array_like, optional
+        abundances : |array_like|, optional
             Real numbers representing relative abundances of the particles in
             the |ParticleList|. Must have the same number of elements as the
             |ParticleList|. This parameter gets passed to `numpy.average` via


### PR DESCRIPTION
This PR adds a substitution for `array_like` from NumPy, and applies it to docstrings.  The docstrings will now link to the entry in NumPy's glossary.