### PR TITLE
Update guidelines for "Parameters", "Raises", and "Warns" sections of docstrings

### DIFF
--- a/changelog/1667.doc.rst
+++ b/changelog/1667.doc.rst
@@ -1,0 +1,3 @@
+Updated the |documentation guide| to state that the "Raises" section of
+docstrings should include exceptions raised by the function itself and
+not exceptions raised by decorators that are applied to that function.

--- a/changelog/1667.doc.rst
+++ b/changelog/1667.doc.rst
@@ -1,3 +1,2 @@
-Updated the |documentation guide| to state that the "Raises" section of
-docstrings should include exceptions raised by the function itself and
-not exceptions raised by decorators that are applied to that function.
+Updated the section of the |documentation guide| with more detail on the
+"Parameters", "Raises", and "Warns" sections of docstrings.

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -58,6 +58,12 @@
 
 .. |ParticleTracker| replace:: :class:`~plasmapy.simulation.particletracker.ParticleTracker`
 
+.. --------------
+.. plasmapy.utils
+.. --------------
+
+.. |validate_quantities| replace:: :func:`~plasmapy.utils.decorators.validators.validate_quantities`
+
 .. ------------------
 .. NumPy replacements
 .. ------------------

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -946,12 +946,16 @@ Docstring guidelines
   derivations and extensive discussions of mathematics in the "Notes"
   section.
 
-* Docstrings may include a Raises_ section that describes which
+* Docstrings may include a "Raises_" section that describes which
   exceptions get raised and under what conditions. This section should
   be used only for errors that are non-obvious or have a large chance of
   getting raised. Documenting exceptions makes it easier for future
-  developers to plan exception handling. However, in practice this
-  section often becomes outdated.
+  developers to plan exception handling.
+
+  * The "Raises_" section of a docstring should include exceptions that
+    are raised by the function itself, but not exceptions that are
+    raised by decorators such as |validate_quantities| and
+    |particle_input|.
 
 * Private code objects (e.g., code objects that begin with a single
   underscore, like ``_private_object``) should have docstrings. A

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -970,8 +970,8 @@ Docstring guidelines
 
   * If the shapes and sizes of the parameters are interrelated, then
     include that information in parentheses immediately before the type
-    information. A trailing comma should be included inside the
-    parentheses when the parameter is 1D::
+    information. Include a trailing comma inside the parentheses when
+    the parameter is 1D.
 
     .. code-block:: rst
 
@@ -985,6 +985,10 @@ Docstring guidelines
 
        out : (M, N) ndarray, optional
            A location where the result is stored.
+
+    Use an asterisk (``*``) for a dimension that can be of arbitrary
+    size, and an ellipsis (``...``) to represent an arbitrary number of
+    dimensions that can each be of arbitrary size.
 
 * Docstrings may include a "Raises_" section that describes which
   exceptions get raised and under what conditions. This section should

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -992,21 +992,27 @@ Docstring guidelines
 
 * Docstrings may include a "Raises_" section that describes which
   exceptions get raised and under what conditions, and a "Warns_"
-  section that describes which warnings will be issued and for which
+  section that describes which warnings will be issued and for what
   reasons.
 
   * The "Raises_" and "Warns_" sections should only include exceptions
-    and warnings that are non-obvious or have a high probability of
-    occurring. For example, the "Raises_" section should not include a
-    `TypeError` for when an :term:`argument` is not of the type that is
-    listed in the "Parameters_" section of the docstring.
+    and warnings that are not obvious or have a high probability of
+    occurring. For example, the "Raises_" section should usually not
+    include a `TypeError` for when an :term:`argument` is not of the
+    type that is listed in the "Parameters_" section of the docstring.
+
+  * The "Raises_" section should include all exceptions that could
+    reasonably be expected to require exception handling.
+
+  * The "Raises_" section should be more complete for functionality that
+    is frequently used (e.g., |Particle|).
 
   * The "Raises_" and "Warns_" sections should typically only include
     exceptions and warnings that are raised or issued by the function
     itself. Exceptions and warnings from commonly used decorators like
     |validate_quantities| and |particle_input| should usually not be
     included in these sections, but may be included if there is
-    sufficient justification to do so.
+    strong justification to do so.
 
 * Private code objects (e.g., code objects that begin with a single
   underscore, like ``_private_object``) should have docstrings. A

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -1114,3 +1114,4 @@ Narrative documentation guidelines
 .. _Sphinx's glossary: https://www.sphinx-doc.org/en/master/glossary.html
 .. _Sphinx's templating page: https://www.sphinx-doc.org/en/master/templating.html
 .. _style overrides: https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html
+.. _warns: https://numpydoc.readthedocs.io/en/latest/format.html#warns

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -562,7 +562,7 @@ Here is an example docstring in the numpydoc_ format:
 
       Returns
       -------
-      difference : float
+      float
           The difference between ``a`` and ``b``.
 
       Raises
@@ -946,6 +946,46 @@ Docstring guidelines
   derivations and extensive discussions of mathematics in the "Notes"
   section.
 
+* Describe each :term:`parameter` in the "Parameters_" section of the
+  docstring.
+
+  .. code-block:: rst
+
+     Parameters
+     ----------
+     x : float
+        Description of ``x``.
+
+     y : bool, optional, default: True
+        Description of ``y``.
+
+  * Place type information to the right of the parameter name, along
+    with ``optional`` and/or ``keyword-only`` if necessary.
+
+  * Describe any requirements for the parameter, including preconditions
+    specified using |validate_quantities| or |particle_input|.
+
+  * Use the substitution ``|array_like|`` to indicate that an argument
+    should be able to be converted into an |ndarray|.
+
+  * If the shapes and sizes of the parameters are interrelated, then
+    include that information in parentheses immediately before the type
+    information. A trailing comma should be included inside the
+    parentheses when the parameter is 1D::
+
+    .. code-block:: rst
+
+       Parameters
+       ----------
+       a : (M,) array_like
+           First input vector.
+
+       b : (N,) array_like
+           Second input vector.
+
+       out : (M, N) ndarray, optional
+           A location where the result is stored.
+
 * Docstrings may include a "Raises_" section that describes which
   exceptions get raised and under what conditions. This section should
   be used only for errors that are non-obvious or have a large chance of
@@ -1055,6 +1095,7 @@ Narrative documentation guidelines
 .. _doctests: https://docs.pytest.org/en/6.2.x/doctest.html
 .. _nested inline markup: https://docutils.sphinx-users.jp/docutils/docs/dev/rst/alternatives.html#nested-inline-markup
 .. _options to sphinx-build: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#options
+.. _parameters: https://numpydoc.readthedocs.io/en/latest/format.html#parameters
 .. _raise an issue: https://github.com/PlasmaPy/PlasmaPy/issues/new?title=Improve+documentation+for...&labels=Documentation
 .. _raises: https://numpydoc.readthedocs.io/en/latest/format.html#raises
 .. _raw string: https://docs.python.org/3/reference/lexical_analysis.html#literals

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -991,15 +991,22 @@ Docstring guidelines
     dimensions that can each be of arbitrary size.
 
 * Docstrings may include a "Raises_" section that describes which
-  exceptions get raised and under what conditions. This section should
-  be used only for errors that are non-obvious or have a large chance of
-  getting raised. Documenting exceptions makes it easier for future
-  developers to plan exception handling.
+  exceptions get raised and under what conditions, and a "Warns_"
+  section that describes which warnings will be issued and for which
+  reasons.
 
-  * The "Raises_" section of a docstring should include exceptions that
-    are raised by the function itself, but not exceptions that are
-    raised by decorators such as |validate_quantities| and
-    |particle_input|.
+  * The "Raises_" and "Warns_" sections should only include exceptions
+    and warnings that are non-obvious or have a high probability of
+    occurring. For example, the "Raises_" section should not include a
+    `TypeError` for when an :term:`argument` is not of the type that is
+    listed in the "Parameters_" section of the docstring.
+
+  * The "Raises_" and "Warns_" sections should typically only include
+    exceptions and warnings that are raised or issued by the function
+    itself. Exceptions and warnings from commonly used decorators like
+    |validate_quantities| and |particle_input| should usually not be
+    included in these sections, but may be included if there is
+    sufficient justification to do so.
 
 * Private code objects (e.g., code objects that begin with a single
   underscore, like ``_private_object``) should have docstrings. A


### PR DESCRIPTION
This PR updates the documentation guide by saying that the "Raises" section of a docstring should only include the exceptions raised by the function itself, and not exceptions that are raised by decorators.  The motivations are:

 - Including the exceptions raised by decorators leads to a lot of repeated text, which should instead be uniquely defined in the docstring of the decorator.  
 - The "Raises" section is one of the least useful sections of a docstring, so it should be correspondingly short.
 - The "Raises" section of docstrings is one of the most likely to become outdated, at least in my experience.
 - The numpydoc guidelines themselves say that this section should be used judiciously. 