### PR TITLE
Add pygrep-hooks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,3 +79,9 @@ repos:
   - id: pyupgrade
     args: [--keep-runtime-typing, --py38-plus]
     files: ^plasmapy/
+
+- repo: https://github.com/pre-commit/pygrep-hooks
+  rev: v1.9.0
+  hooks:
+  - id: rst-directive-colons
+  - id: rst-inline-touching-normal


### PR DESCRIPTION
This PR adds two pre-commit pygrep-hooks for reStructuredText files.  The two checks are:
 - Making sure that reST directives end with two colons
 - Checking for when inline code is next to normal text

I think errors like these would normally lead to doc build failures, but this will catch the issues sooner without having to wait for the doc build to complete.