### PR TITLE
Move `quantum_theta` to `quantum.py`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -927,7 +927,7 @@ Improved Documentation
 - Put the docstring for `plasmapy.particles.Particle.is_category` into
   `numpydoc` format. (`#1039 <https://github.com/plasmapy/plasmapy/pull/1039>`__)
 - Adds formulas (which were missing) to the docstrings of
-  ``~plasmapy.formulary.dimensionless.quantum_theta`` and
+  ``plasmapy.formulary.dimensionless.quantum_theta`` and
   `~plasmapy.formulary.dimensionless.beta`. (`#1041 <https://github.com/plasmapy/plasmapy/pull/1041>`__)
 - Add live rendering of changelog entries on documentation builds, based on
   `sphinx-changelog <https://github.com/OpenAstronomy/sphinx-changelog>`_. (`#1052 <https://github.com/plasmapy/plasmapy/pull/1052>`__)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -927,7 +927,7 @@ Improved Documentation
 - Put the docstring for `plasmapy.particles.Particle.is_category` into
   `numpydoc` format. (`#1039 <https://github.com/plasmapy/plasmapy/pull/1039>`__)
 - Adds formulas (which were missing) to the docstrings of
-  `~plasmapy.formulary.dimensionless.quantum_theta` and
+  ``~plasmapy.formulary.dimensionless.quantum_theta`` and
   `~plasmapy.formulary.dimensionless.beta`. (`#1041 <https://github.com/plasmapy/plasmapy/pull/1041>`__)
 - Add live rendering of changelog entries on documentation builds, based on
   `sphinx-changelog <https://github.com/OpenAstronomy/sphinx-changelog>`_. (`#1052 <https://github.com/plasmapy/plasmapy/pull/1052>`__)

--- a/changelog/1671.trivial.rst
+++ b/changelog/1671.trivial.rst
@@ -1,1 +1,1 @@
-Move the `~plasmapy.formulary.dimensionless.quantum_theta` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.
+Move the ``~plasmapy.formulary.dimensionless.quantum_theta`` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.

--- a/changelog/1671.trivial.rst
+++ b/changelog/1671.trivial.rst
@@ -1,0 +1,1 @@
+Move the `~plasmapy.formulary.dimensionless.quantum_theta` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.

--- a/changelog/1671.trivial.rst
+++ b/changelog/1671.trivial.rst
@@ -1,1 +1,1 @@
-Move the ``~plasmapy.formulary.dimensionless.quantum_theta`` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.
+Move the ``plasmapy.formulary.dimensionless.quantum_theta`` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.

--- a/docs/whatsnew/0.6.0.rst
+++ b/docs/whatsnew/0.6.0.rst
@@ -184,7 +184,7 @@ Improved Documentation
 - Put the docstring for `plasmapy.particles.particle_class.Particle.is_category` into
   ``numpydoc`` format. (`#1039 <https://github.com/plasmapy/plasmapy/pull/1039>`__)
 - Adds formulas (which were missing) to the docstrings of
-  `~plasmapy.formulary.dimensionless.quantum_theta` and
+  ``~plasmapy.formulary.dimensionless.quantum_theta`` and
   `~plasmapy.formulary.dimensionless.beta`. (`#1041 <https://github.com/plasmapy/plasmapy/pull/1041>`__)
 - Add live rendering of changelog entries on documentation builds, based on
   `sphinx-changelog <https://github.com/OpenAstronomy/sphinx-changelog>`_. (`#1052 <https://github.com/plasmapy/plasmapy/pull/1052>`__)

--- a/docs/whatsnew/0.6.0.rst
+++ b/docs/whatsnew/0.6.0.rst
@@ -184,7 +184,7 @@ Improved Documentation
 - Put the docstring for `plasmapy.particles.particle_class.Particle.is_category` into
   ``numpydoc`` format. (`#1039 <https://github.com/plasmapy/plasmapy/pull/1039>`__)
 - Adds formulas (which were missing) to the docstrings of
-  ``~plasmapy.formulary.dimensionless.quantum_theta`` and
+  ``plasmapy.formulary.dimensionless.quantum_theta`` and
   `~plasmapy.formulary.dimensionless.beta`. (`#1041 <https://github.com/plasmapy/plasmapy/pull/1041>`__)
 - Add live rendering of changelog entries on documentation builds, based on
   `sphinx-changelog <https://github.com/OpenAstronomy/sphinx-changelog>`_. (`#1052 <https://github.com/plasmapy/plasmapy/pull/1052>`__)

--- a/plasmapy/formulary/dimensionless.py
+++ b/plasmapy/formulary/dimensionless.py
@@ -23,7 +23,8 @@ import numpy as np
 
 from astropy.constants.si import k_B, mu0
 
-from plasmapy.formulary import frequencies, lengths, misc, quantum
+from plasmapy.formulary import frequencies, lengths, misc
+from plasmapy.formulary.quantum import quantum_theta
 from plasmapy.particles import Particle
 from plasmapy.utils.decorators import validate_quantities
 
@@ -223,66 +224,6 @@ def Hall_parameter(
 
 betaH_ = Hall_parameter
 """Alias to `~plasmapy.formulary.dimensionless.Hall_parameter`."""
-
-
-@validate_quantities(
-    T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
-    n_e={"can_be_negative": False},
-)
-def quantum_theta(T: u.K, n_e: u.m**-3) -> u.dimensionless_unscaled:
-    r"""
-    Compare Fermi energy to thermal kinetic energy to check if quantum
-    effects are important.
-
-    The quantum theta (:math:`θ`) of a plasma is defined by
-
-    .. math::
-        θ = \frac{E_T}{E_F}
-
-    where :math:`E_T` is the thermal energy of the plasma
-    and :math:`E_F` is the Fermi energy of the plasma.
-
-    Parameters
-    ----------
-    T : `~astropy.units.Quantity`
-        The temperature of the plasma.
-
-    n_e : `~astropy.units.Quantity`
-          The electron number density of the plasma.
-
-    Examples
-    --------
-    >>> import astropy.units as u
-    >>> quantum_theta(1*u.eV, 1e20*u.m**-3)
-    <Quantity 127290.619...>
-    >>> quantum_theta(1*u.eV, 1e16*u.m**-3)
-    <Quantity 59083071...>
-    >>> quantum_theta(1*u.eV, 1e26*u.m**-3)
-    <Quantity 12.72906...>
-    >>> quantum_theta(1*u.K, 1e26*u.m**-3)
-    <Quantity 0.00109...>
-
-    Returns
-    -------
-    theta : `~astropy.units.Quantity`
-
-    Notes
-    -----
-    The thermal energy of the plasma (:math:`E_T`) is defined by
-
-    .. math::
-        E_T = k_B T
-
-    where :math:`k_B` is the Boltzmann constant
-    and :math:`T` is the temperature of the plasma.
-
-    See Also
-    --------
-    ~plasmapy.formulary.quantum.Fermi_energy
-    """
-    fermi_energy = quantum.Fermi_energy(n_e)
-    thermal_energy = k_B * T
-    return thermal_energy / fermi_energy
 
 
 @validate_quantities(

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -10,6 +10,7 @@ __all__ = [
     "Thomas_Fermi_length",
     "thermal_deBroglie_wavelength",
     "Wigner_Seitz_radius",
+    "quantum_theta",
 ]
 __aliases__ = ["Ef_", "lambdaDB_", "lambdaDB_th_"]
 
@@ -595,3 +596,63 @@ def _chemical_potential_interp(n_e, T):
     term3 = term3num / term3den
     beta_mu = term1 + term2 + term3
     return beta_mu.to(u.dimensionless_unscaled)
+
+
+@validate_quantities(
+    T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
+    n_e={"can_be_negative": False},
+)
+def quantum_theta(T: u.K, n_e: u.m**-3) -> u.dimensionless_unscaled:
+    r"""
+    Compare Fermi energy to thermal kinetic energy to check if quantum
+    effects are important.
+
+    The quantum theta (:math:`θ`) of a plasma is defined by
+
+    .. math::
+        θ = \frac{E_T}{E_F}
+
+    where :math:`E_T` is the thermal energy of the plasma
+    and :math:`E_F` is the Fermi energy of the plasma.
+
+    Parameters
+    ----------
+    T : `~astropy.units.Quantity`
+        The temperature of the plasma.
+
+    n_e : `~astropy.units.Quantity`
+          The electron number density of the plasma.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> quantum_theta(1*u.eV, 1e20*u.m**-3)
+    <Quantity 127290.619...>
+    >>> quantum_theta(1*u.eV, 1e16*u.m**-3)
+    <Quantity 59083071...>
+    >>> quantum_theta(1*u.eV, 1e26*u.m**-3)
+    <Quantity 12.72906...>
+    >>> quantum_theta(1*u.K, 1e26*u.m**-3)
+    <Quantity 0.00109...>
+
+    Returns
+    -------
+    theta : `~astropy.units.Quantity`
+
+    Notes
+    -----
+    The thermal energy of the plasma (:math:`E_T`) is defined by
+
+    .. math::
+        E_T = k_B T
+
+    where :math:`k_B` is the Boltzmann constant
+    and :math:`T` is the temperature of the plasma.
+
+    See Also
+    --------
+    ~plasmapy.formulary.quantum.Fermi_energy
+    """
+    fermi_energy = Fermi_energy(n_e)
+    thermal_energy = k_B * T
+    return thermal_energy / fermi_energy

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -7,10 +7,10 @@ __all__ = [
     "chemical_potential",
     "deBroglie_wavelength",
     "Fermi_energy",
+    "quantum_theta",
     "Thomas_Fermi_length",
     "thermal_deBroglie_wavelength",
     "Wigner_Seitz_radius",
-    "quantum_theta",
 ]
 __aliases__ = ["Ef_", "lambdaDB_", "lambdaDB_th_"]
 

--- a/plasmapy/formulary/tests/test_dimensionless.py
+++ b/plasmapy/formulary/tests/test_dimensionless.py
@@ -11,7 +11,6 @@ from plasmapy.formulary.dimensionless import (
     Hall_parameter,
     Mag_Reynolds,
     nD_,
-    quantum_theta,
     Re_,
     Reynolds_number,
     Rm_,
@@ -46,11 +45,6 @@ def test_aliases(alias, parent):
 def test_beta_dimensionless():
     # Check that beta is dimensionless
     float(beta(T, n, B))
-
-
-def test_quantum_theta_dimensionless():
-    # Check that quantum theta is dimensionless
-    float(quantum_theta(T, n))
 
 
 def test_beta_nan():

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -12,6 +12,7 @@ from plasmapy.formulary.quantum import (
     Fermi_energy,
     lambdaDB_,
     lambdaDB_th_,
+    quantum_theta,
     thermal_deBroglie_wavelength,
     Thomas_Fermi_length,
     Wigner_Seitz_radius,
@@ -231,3 +232,26 @@ def test_quantum_aliases():
     assert Ef_ is Fermi_energy
     assert lambdaDB_ is deBroglie_wavelength
     assert lambdaDB_th_ is thermal_deBroglie_wavelength
+
+
+class TestQuantumTheta:
+    """Test the quantum_theta function in quantum.py."""
+
+    T = 1 * u.eV
+    n_e = 1e26 * u.m**-3
+
+    @pytest.fixture()
+    def theta(self):
+        """Calculate theta for the given example parameters"""
+
+        return quantum_theta(self.T, self.n_e)
+
+    def test_units(self, theta):
+        """Test the return units"""
+
+        assert theta.unit.is_equivalent(u.dimensionless_unscaled)
+
+    def test_value(self, theta):
+        """Compare the calculated theta with the expected value."""
+
+        assert np.isclose(theta.value, 12.72906)

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -237,21 +237,25 @@ def test_quantum_aliases():
 class TestQuantumTheta:
     """Test the quantum_theta function in quantum.py."""
 
-    T = 1 * u.eV
-    n_e = 1e26 * u.m**-3
-
-    @pytest.fixture()
-    def theta(self):
-        """Calculate theta for the given example parameters"""
-
-        return quantum_theta(self.T, self.n_e)
-
-    def test_units(self, theta):
+    def test_units(self):
         """Test the return units"""
+
+        theta = quantum_theta(1 * u.eV, 1e26 * u.m**-3)
 
         assert theta.unit.is_equivalent(u.dimensionless_unscaled)
 
-    def test_value(self, theta):
+    @pytest.mark.parametrize(
+        "T, n_e, expected_theta",
+        [
+            (1 * u.eV, 1e26 * u.m**-3, 12.72906),  # Both regimes are present
+            (2 / 3 * u.eV, 1e40 * u.m**-3, 3.93887e-9),  # Fermi regime
+            (8.61e2 * u.eV, 1e12 * u.m**-3, 2.36120e13),  # Thermal regime
+            (1 * u.K, 1e26 * u.m**-3, 1.09690e-3),  # Specify temperature in Kelvin
+        ],
+    )
+    def test_value(self, T, n_e, expected_theta):
         """Compare the calculated theta with the expected value."""
 
-        assert np.isclose(theta.value, 12.72906)
+        theta = quantum_theta(T, n_e)
+
+        assert np.isclose(theta.value, expected_theta)


### PR DESCRIPTION
Resolves #1443 

This pull request moves the `quantum_theta` function definition into `quantum.py`, while still exposing the `dimensionless` namespace to the function to ensure no compatibility issues. Additionally, this pull request rewrites the test functions for `quantum_theta` to include a more thorough test suite

- [x] I have added a changelog entry for this pull request.

- [x] If adding new functionality, I have added tests and
      docstrings.

- [x] I have fixed any newly failing tests.
