### PR TITLE
Add coding guideline that functions should accept and return `numpy.nan` values

### DIFF
--- a/changelog/1673.doc.rst
+++ b/changelog/1673.doc.rst
@@ -1,0 +1,2 @@
+Added a guideline to the coding guide specifying how |nan| values should
+be treated in functions that accept |array_like| or |Quantity| inputs.

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -119,6 +119,17 @@ Coding guidelines
   >>> print(f"{package_name!r}")  # shortcut for f"{repr(package_name)}"
   'PlasmaPy'
 
+* Functions that accept |array_like| or |Quantity| inputs should accept
+  and return |nan| values. This guideline applies when |nan| is the
+  input as well as when |nan| is included in an array.
+
+  .. tip::
+
+     Normally, ``numpy.nan == numpy.nan`` evaluates to `False`, which
+     complicates testing |nan| behavior. Functions such as
+     `numpy.allclose` often have an ``equal_nan`` keyword such that
+     ``allclose(nan, nan, equal_nan=True)`` will return `True` instead.
+
 * Do not use :term:`mutable` objects as default values in the function
   or method declaration. This can lead to unexpected behavior.
 

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -127,9 +127,9 @@ Coding guidelines
   .. tip::
 
      Normally, ``numpy.nan == numpy.nan`` evaluates to `False`, which
-     complicates testing |nan| behavior. Functions such as
-     `numpy.allclose` often have an ``equal_nan`` keyword such that
-     ``allclose(nan, nan, equal_nan=True)`` will return `True` instead.
+     complicates testing |nan| behavior. The ``equal_nan`` keyword of
+     functions like `numpy.allclose` and `numpy.testing.assert_allclose`
+     makes it so that |nan| is considered equal to itself.
 
 * Do not use :term:`mutable` objects as default values in the function
   or method declaration. This can lead to unexpected behavior.

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -120,8 +120,9 @@ Coding guidelines
   'PlasmaPy'
 
 * Functions that accept |array_like| or |Quantity| inputs should accept
-  and return |nan| values. This guideline applies when |nan| is the
-  input as well as when |nan| is included in an array.
+  and return |nan| (not a number) values. This guideline applies when
+  |nan| is the input as well as when |nan| values are included in an
+  array.
 
   .. tip::
 

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -120,7 +120,7 @@ Coding guidelines
   'PlasmaPy'
 
 * Functions that accept |array_like| or |Quantity| inputs should accept
-  and return |nan| (not a number) values. This guideline applies when
+  and return |nan| (`not a number`_) values. This guideline applies when
   |nan| is the input as well as when |nan| values are included in an
   array.
 
@@ -799,6 +799,7 @@ the README file of `benchmarks-repo`_.
 .. _example notebook on particles: ../notebooks/getting_started/particles.ipynb
 .. _example notebook on units: ../notebooks/getting_started/units.ipynb
 .. _extract function refactoring pattern: https://refactoring.guru/extract-method
+.. _not a number: https://en.wikipedia.org/wiki/NaN
 .. _NumPy Enhancement Proposal 29: https://numpy.org/neps/nep-0029-deprecation_policy.html
 .. _pyupgrade: https://github.com/asottile/pyupgrade
 .. _rename refactoring in PyCharm: https://www.jetbrains.com/help/pycharm/rename-refactorings.html


### PR DESCRIPTION
Following up on #1672, this PR adds a guideline that says that functions should accept and return `nan` (not a number) values.  The reason is that sometimes we will work with arrays that have bad data that are flagged as `nan`, and still need to perform calculations on them.