### PR TITLE
Add tip to changelog guide on updating broken reST links

### DIFF
--- a/changelog/1674.doc.rst
+++ b/changelog/1674.doc.rst
@@ -1,0 +1,3 @@
+Added an admonition to the |changelog guide| that describes how to
+change reST_ links for removed code objects into inline literals in old
+changelog entries.

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -125,6 +125,24 @@ Changelog guidelines
   superseded or reverted and include a link to the appropriate pull
   request.
 
+.. _fixing-obsolete-rest-links:
+
+.. tip::
+
+   When removing or moving an object, reST_ links that follow the
+   original namespace will break, causing the documentation build to
+   fail.
+
+   To remedy this problem in old changelog entries, change the broken
+   reST_ link into an inline literal by surrounding the old link with
+   double back ticks (instead of single back ticks) and remove the
+   preceding tilde (if present). For example,
+   ``` `~plasmapy.subpackage.module.old_function` ``` should be changed
+   to ``` ``plasmapy.subpackage.module.old_function`` ```.
+
+   In the rest of the documentation, the namespace should be corrected
+   but not changed into an inline literal.
+
 Building the changelog
 ======================
 

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -133,15 +133,16 @@ Changelog guidelines
    original namespace will break, causing the documentation build to
    fail.
 
-   To remedy this problem in old changelog entries, change the broken
-   reST_ link into an inline literal by surrounding the old link with
-   double back ticks (instead of single back ticks) and remove the
-   preceding tilde (if present). For example,
-   ``` `~plasmapy.subpackage.module.old_function` ``` should be changed
-   to ``` ``plasmapy.subpackage.module.old_function`` ```.
+   Text in single back ticks is used to link to code objects, while text
+   in double back ticks is treated as an `inline literal`_. To remedy
+   this problem in old changelog entries, change the broken link into an
+   inline literal by surrounding it with double back ticks instead.
+   Remove the tilde if present. For example,
+   ``` `~plasmapy.subpackage.module.function` ``` should be changed
+   to ``` ``plasmapy.subpackage.module.function`` ```.
 
-   In the rest of the documentation, the namespace should be corrected
-   but not changed into an inline literal.
+   Outside of the changelog, the namespace should be corrected rather
+   than changed into an inline literal.
 
 Building the changelog
 ======================
@@ -186,3 +187,5 @@ steps to update the changelog are described in the :ref:`Release Guide`.
    Here, ``⟨number⟩`` is replaced with the pull request number and
    ``⟨type⟩`` is replaced with the one of the changelog types as
    described above.
+
+.. _inline literal: https://docutils.sourceforge.io/docs/user/rst/quickref.html#inline-markup

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -139,7 +139,11 @@ Changelog guidelines
    inline literal by surrounding it with double back ticks instead.
    Remove the tilde if present. For example,
    ```~plasmapy.subpackage.module.function``` should be changed
-   to ```plasmapy.subpackage.module.function```.
+   to:
+
+   .. code-block:: rst
+
+      ``plasmapy.subpackage.module.function``
 
    Outside of the changelog, the namespace should be corrected rather
    than changed into an inline literal.

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -138,8 +138,8 @@ Changelog guidelines
    this problem in old changelog entries, change the broken link into an
    inline literal by surrounding it with double back ticks instead.
    Remove the tilde if present. For example,
-   ``` `~plasmapy.subpackage.module.function` ``` should be changed
-   to ``` ``plasmapy.subpackage.module.function`` ```.
+   ```~plasmapy.subpackage.module.function``` should be changed
+   to ```plasmapy.subpackage.module.function```.
 
    Outside of the changelog, the namespace should be corrected rather
    than changed into an inline literal.

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -90,6 +90,7 @@
    used just before a period.
 
 .. |bibliography| replace:: :ref:`bibliography`\
+.. |changelog guide| replace:: :ref:`changelog guide`\
 .. |coding guide| replace:: :ref:`coding guide`\
 .. |contributor guide| replace:: :ref:`contributor guide`\
 .. |documentation guide| replace:: :ref:`documentation guide`\


### PR DESCRIPTION
When a code object is deleted, any reST links to the old namespace will break.  While reST links in most of the documentation should be updated, the namespace in old changelog entries should be preserved.  This PR states how to change a reST link into an inline literal in old changelog entries.

An alternative would be to change all reST links in changelog entries into inline literals, which is what some other packages do (like Astropy, I think).  This would be less maintenance, but would make it more difficult for someone reading the changelog entry to access newly created features.