### PR TITLE
Add `RelxationRates`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -927,7 +927,7 @@ Improved Documentation
 - Put the docstring for `plasmapy.particles.Particle.is_category` into
   `numpydoc` format. (`#1039 <https://github.com/plasmapy/plasmapy/pull/1039>`__)
 - Adds formulas (which were missing) to the docstrings of
-  ``~plasmapy.formulary.dimensionless.quantum_theta`` and
+  ``plasmapy.formulary.dimensionless.quantum_theta`` and
   `~plasmapy.formulary.dimensionless.beta`. (`#1041 <https://github.com/plasmapy/plasmapy/pull/1041>`__)
 - Add live rendering of changelog entries on documentation builds, based on
   `sphinx-changelog <https://github.com/OpenAstronomy/sphinx-changelog>`_. (`#1052 <https://github.com/plasmapy/plasmapy/pull/1052>`__)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -927,7 +927,7 @@ Improved Documentation
 - Put the docstring for `plasmapy.particles.Particle.is_category` into
   `numpydoc` format. (`#1039 <https://github.com/plasmapy/plasmapy/pull/1039>`__)
 - Adds formulas (which were missing) to the docstrings of
-  `~plasmapy.formulary.dimensionless.quantum_theta` and
+  ``~plasmapy.formulary.dimensionless.quantum_theta`` and
   `~plasmapy.formulary.dimensionless.beta`. (`#1041 <https://github.com/plasmapy/plasmapy/pull/1041>`__)
 - Add live rendering of changelog entries on documentation builds, based on
   `sphinx-changelog <https://github.com/OpenAstronomy/sphinx-changelog>`_. (`#1052 <https://github.com/plasmapy/plasmapy/pull/1052>`__)

--- a/changelog/1671.trivial.rst
+++ b/changelog/1671.trivial.rst
@@ -1,1 +1,1 @@
-Move the `~plasmapy.formulary.dimensionless.quantum_theta` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.
+Move the ``~plasmapy.formulary.dimensionless.quantum_theta`` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.

--- a/changelog/1671.trivial.rst
+++ b/changelog/1671.trivial.rst
@@ -1,0 +1,1 @@
+Move the `~plasmapy.formulary.dimensionless.quantum_theta` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.

--- a/changelog/1671.trivial.rst
+++ b/changelog/1671.trivial.rst
@@ -1,1 +1,1 @@
-Move the ``~plasmapy.formulary.dimensionless.quantum_theta`` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.
+Move the ``plasmapy.formulary.dimensionless.quantum_theta`` function to the `~plasmapy.formulary.quantum` module. Note, this function can still be called from the `plasmapy.formulary.dimensionless` module without issue.

--- a/docs/whatsnew/0.6.0.rst
+++ b/docs/whatsnew/0.6.0.rst
@@ -184,7 +184,7 @@ Improved Documentation
 - Put the docstring for `plasmapy.particles.particle_class.Particle.is_category` into
   ``numpydoc`` format. (`#1039 <https://github.com/plasmapy/plasmapy/pull/1039>`__)
 - Adds formulas (which were missing) to the docstrings of
-  `~plasmapy.formulary.dimensionless.quantum_theta` and
+  ``~plasmapy.formulary.dimensionless.quantum_theta`` and
   `~plasmapy.formulary.dimensionless.beta`. (`#1041 <https://github.com/plasmapy/plasmapy/pull/1041>`__)
 - Add live rendering of changelog entries on documentation builds, based on
   `sphinx-changelog <https://github.com/OpenAstronomy/sphinx-changelog>`_. (`#1052 <https://github.com/plasmapy/plasmapy/pull/1052>`__)

--- a/docs/whatsnew/0.6.0.rst
+++ b/docs/whatsnew/0.6.0.rst
@@ -184,7 +184,7 @@ Improved Documentation
 - Put the docstring for `plasmapy.particles.particle_class.Particle.is_category` into
   ``numpydoc`` format. (`#1039 <https://github.com/plasmapy/plasmapy/pull/1039>`__)
 - Adds formulas (which were missing) to the docstrings of
-  ``~plasmapy.formulary.dimensionless.quantum_theta`` and
+  ``plasmapy.formulary.dimensionless.quantum_theta`` and
   `~plasmapy.formulary.dimensionless.beta`. (`#1041 <https://github.com/plasmapy/plasmapy/pull/1041>`__)
 - Add live rendering of changelog entries on documentation builds, based on
   `sphinx-changelog <https://github.com/OpenAstronomy/sphinx-changelog>`_. (`#1052 <https://github.com/plasmapy/plasmapy/pull/1052>`__)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -58,6 +58,7 @@ import astropy.units as u
 import math
 import numpy as np
 import scipy.integrate
+import scipy.misc
 import warnings
 
 from astropy.constants.si import e, eps0, hbar, k_B, m_e
@@ -2037,37 +2038,53 @@ def coupling_parameter(
     return coulomb_energy / kinetic_energy
 
 
+@validate_quantities(
+    n_b={"can_be_negative": False},
+    T_b={"can_be_negative": False, "equivalencies": u.temperature_energy()},
+)
 class RelaxationRates:
     def __init__(
         self,
         species: (particles.Particle, particles.Particle),
-        /,
         v_a: u.m / u.s,
         n_b: u.m**-3,
-        T_b: u.eV,
+        T_b: u.K,
+        coulomb_log: u.dimensionless_unscaled,
     ):
         self.species = species
         self.v_a = v_a
         self.n_b = n_b
         self.T_b = T_b
+        self.coulomb_log = coulomb_log
+
+        v_0 = self._v_0()
+        x = self._x()
+        phi = self._phi(x)
+        phi_prime = self._phi_prime(x)
+
+        mu = species[0].mass / species[1].mass
+
+        self.slowing_down = (1 + mu) * phi * v_0
+        self.transverse_diffusion = (
+            2 * ((1 - 1 / (2 * x)) * phi + phi_prime) * v_0
+        )
+        self.parallel_diffusion = (phi / x) * v_0
+        self.energy_loss = 2 * (mu * phi - phi_prime) * v_0
 
     def _v_0(self):
-        coulomb_log = Coulomb_logarithm(self.T_b, self.n_b, self.species, V=self.v_a)
-
         return (
             4
             * math.pi
             * self.species[0].charge ** 2
             * self.species[1].charge ** 2
-            * coulomb_log
+            * self.coulomb_log
             * self.n_b
             / (self.species[0].mass ** 2 * self.v_a**3)
         )
 
-    def x(self):
-        return (self.species[1].mass * self.v_a**2 / (2 * k_B * self.T_b)).to(
-            u.dimensionless_unscaled, equivalencies=u.temperature_energy()
-        )
+    def _x(self) -> u.dimensionless_unscaled:
+        x = self.species[1].mass * self.v_a**2 / (2 * k_B * self.T_b)
+        return x.to(u.dimensionless_unscaled)
 
     @staticmethod
     def _phi_integrand(t: u.dimensionless_unscaled):
@@ -2076,3 +2093,6 @@ class RelaxationRates:
     def _phi(self, x: u.dimensionless_unscaled):
         integral, _ = scipy.integrate.quad(self._phi_integrand, 0, x)
         return 2 / math.pi**0.5 * integral
+
+    def _phi_prime(self, x: u.dimensionless_unscaled):
+        return scipy.misc.derivative(self._phi, x)

--- a/plasmapy/formulary/dimensionless.py
+++ b/plasmapy/formulary/dimensionless.py
@@ -23,7 +23,8 @@ import numpy as np
 
 from astropy.constants.si import k_B, mu0
 
-from plasmapy.formulary import frequencies, lengths, misc, quantum
+from plasmapy.formulary import frequencies, lengths, misc
+from plasmapy.formulary.quantum import quantum_theta
 from plasmapy.particles import Particle
 from plasmapy.utils.decorators import validate_quantities
 
@@ -223,66 +224,6 @@ def Hall_parameter(
 
 betaH_ = Hall_parameter
 """Alias to `~plasmapy.formulary.dimensionless.Hall_parameter`."""
-
-
-@validate_quantities(
-    T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
-    n_e={"can_be_negative": False},
-)
-def quantum_theta(T: u.K, n_e: u.m**-3) -> u.dimensionless_unscaled:
-    r"""
-    Compare Fermi energy to thermal kinetic energy to check if quantum
-    effects are important.
-
-    The quantum theta (:math:`θ`) of a plasma is defined by
-
-    .. math::
-        θ = \frac{E_T}{E_F}
-
-    where :math:`E_T` is the thermal energy of the plasma
-    and :math:`E_F` is the Fermi energy of the plasma.
-
-    Parameters
-    ----------
-    T : `~astropy.units.Quantity`
-        The temperature of the plasma.
-
-    n_e : `~astropy.units.Quantity`
-          The electron number density of the plasma.
-
-    Examples
-    --------
-    >>> import astropy.units as u
-    >>> quantum_theta(1*u.eV, 1e20*u.m**-3)
-    <Quantity 127290.619...>
-    >>> quantum_theta(1*u.eV, 1e16*u.m**-3)
-    <Quantity 59083071...>
-    >>> quantum_theta(1*u.eV, 1e26*u.m**-3)
-    <Quantity 12.72906...>
-    >>> quantum_theta(1*u.K, 1e26*u.m**-3)
-    <Quantity 0.00109...>
-
-    Returns
-    -------
-    theta : `~astropy.units.Quantity`
-
-    Notes
-    -----
-    The thermal energy of the plasma (:math:`E_T`) is defined by
-
-    .. math::
-        E_T = k_B T
-
-    where :math:`k_B` is the Boltzmann constant
-    and :math:`T` is the temperature of the plasma.
-
-    See Also
-    --------
-    ~plasmapy.formulary.quantum.Fermi_energy
-    """
-    fermi_energy = quantum.Fermi_energy(n_e)
-    thermal_energy = k_B * T
-    return thermal_energy / fermi_energy
 
 
 @validate_quantities(

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -10,6 +10,7 @@ __all__ = [
     "Thomas_Fermi_length",
     "thermal_deBroglie_wavelength",
     "Wigner_Seitz_radius",
+    "quantum_theta",
 ]
 __aliases__ = ["Ef_", "lambdaDB_", "lambdaDB_th_"]
 
@@ -595,3 +596,63 @@ def _chemical_potential_interp(n_e, T):
     term3 = term3num / term3den
     beta_mu = term1 + term2 + term3
     return beta_mu.to(u.dimensionless_unscaled)
+
+
+@validate_quantities(
+    T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
+    n_e={"can_be_negative": False},
+)
+def quantum_theta(T: u.K, n_e: u.m**-3) -> u.dimensionless_unscaled:
+    r"""
+    Compare Fermi energy to thermal kinetic energy to check if quantum
+    effects are important.
+
+    The quantum theta (:math:`θ`) of a plasma is defined by
+
+    .. math::
+        θ = \frac{E_T}{E_F}
+
+    where :math:`E_T` is the thermal energy of the plasma
+    and :math:`E_F` is the Fermi energy of the plasma.
+
+    Parameters
+    ----------
+    T : `~astropy.units.Quantity`
+        The temperature of the plasma.
+
+    n_e : `~astropy.units.Quantity`
+          The electron number density of the plasma.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> quantum_theta(1*u.eV, 1e20*u.m**-3)
+    <Quantity 127290.619...>
+    >>> quantum_theta(1*u.eV, 1e16*u.m**-3)
+    <Quantity 59083071...>
+    >>> quantum_theta(1*u.eV, 1e26*u.m**-3)
+    <Quantity 12.72906...>
+    >>> quantum_theta(1*u.K, 1e26*u.m**-3)
+    <Quantity 0.00109...>
+
+    Returns
+    -------
+    theta : `~astropy.units.Quantity`
+
+    Notes
+    -----
+    The thermal energy of the plasma (:math:`E_T`) is defined by
+
+    .. math::
+        E_T = k_B T
+
+    where :math:`k_B` is the Boltzmann constant
+    and :math:`T` is the temperature of the plasma.
+
+    See Also
+    --------
+    ~plasmapy.formulary.quantum.Fermi_energy
+    """
+    fermi_energy = Fermi_energy(n_e)
+    thermal_energy = k_B * T
+    return thermal_energy / fermi_energy

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -7,10 +7,10 @@ __all__ = [
     "chemical_potential",
     "deBroglie_wavelength",
     "Fermi_energy",
+    "quantum_theta",
     "Thomas_Fermi_length",
     "thermal_deBroglie_wavelength",
     "Wigner_Seitz_radius",
-    "quantum_theta",
 ]
 __aliases__ = ["Ef_", "lambdaDB_", "lambdaDB_th_"]
 

--- a/plasmapy/formulary/tests/test_dimensionless.py
+++ b/plasmapy/formulary/tests/test_dimensionless.py
@@ -11,7 +11,6 @@ from plasmapy.formulary.dimensionless import (
     Hall_parameter,
     Mag_Reynolds,
     nD_,
-    quantum_theta,
     Re_,
     Reynolds_number,
     Rm_,
@@ -46,11 +45,6 @@ def test_aliases(alias, parent):
 def test_beta_dimensionless():
     # Check that beta is dimensionless
     float(beta(T, n, B))
-
-
-def test_quantum_theta_dimensionless():
-    # Check that quantum theta is dimensionless
-    float(quantum_theta(T, n))
 
 
 def test_beta_nan():

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -12,6 +12,7 @@ from plasmapy.formulary.quantum import (
     Fermi_energy,
     lambdaDB_,
     lambdaDB_th_,
+    quantum_theta,
     thermal_deBroglie_wavelength,
     Thomas_Fermi_length,
     Wigner_Seitz_radius,
@@ -231,3 +232,26 @@ def test_quantum_aliases():
     assert Ef_ is Fermi_energy
     assert lambdaDB_ is deBroglie_wavelength
     assert lambdaDB_th_ is thermal_deBroglie_wavelength
+
+
+class TestQuantumTheta:
+    """Test the quantum_theta function in quantum.py."""
+
+    T = 1 * u.eV
+    n_e = 1e26 * u.m**-3
+
+    @pytest.fixture()
+    def theta(self):
+        """Calculate theta for the given example parameters"""
+
+        return quantum_theta(self.T, self.n_e)
+
+    def test_units(self, theta):
+        """Test the return units"""
+
+        assert theta.unit.is_equivalent(u.dimensionless_unscaled)
+
+    def test_value(self, theta):
+        """Compare the calculated theta with the expected value."""
+
+        assert np.isclose(theta.value, 12.72906)

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -237,21 +237,25 @@ def test_quantum_aliases():
 class TestQuantumTheta:
     """Test the quantum_theta function in quantum.py."""
 
-    T = 1 * u.eV
-    n_e = 1e26 * u.m**-3
-
-    @pytest.fixture()
-    def theta(self):
-        """Calculate theta for the given example parameters"""
-
-        return quantum_theta(self.T, self.n_e)
-
-    def test_units(self, theta):
+    def test_units(self):
         """Test the return units"""
+
+        theta = quantum_theta(1 * u.eV, 1e26 * u.m**-3)
 
         assert theta.unit.is_equivalent(u.dimensionless_unscaled)
 
-    def test_value(self, theta):
+    @pytest.mark.parametrize(
+        "T, n_e, expected_theta",
+        [
+            (1 * u.eV, 1e26 * u.m**-3, 12.72906),  # Both regimes are present
+            (2 / 3 * u.eV, 1e40 * u.m**-3, 3.93887e-9),  # Fermi regime
+            (8.61e2 * u.eV, 1e12 * u.m**-3, 2.36120e13),  # Thermal regime
+            (1 * u.K, 1e26 * u.m**-3, 1.09690e-3),  # Specify temperature in Kelvin
+        ],
+    )
+    def test_value(self, T, n_e, expected_theta):
         """Compare the calculated theta with the expected value."""
 
-        assert np.isclose(theta.value, 12.72906)
+        theta = quantum_theta(T, n_e)
+
+        assert np.isclose(theta.value, expected_theta)


### PR DESCRIPTION
Resolves PlasmaPy/hack-week#23

This pull request implements the four types of relaxation described on page 31 of the NRL formulary (see issue for screenshot)

For now, the class relies on a parameter called `coulomb_log`, which is the value of the Coulomb logarithm evaluated for the two interacting plasmas. This is because the current implementation of the Coulomb logarithm is limited to electron interactions... In a future pull request I will be revisiting the Coulomb logarithm to include for a broader array of interactions

- [ ] I have added a changelog entry for this pull request.
- [ ] If adding new functionality, I have added tests and
      docstrings.
- [ ] I have fixed any newly failing tests.
