### PR TITLE
Add `CollisionFrequencies`

### DIFF
--- a/changelog/1676.feature.rst
+++ b/changelog/1676.feature.rst
@@ -1,3 +1,3 @@
 Added the `~plasmapy.formulary.collisions.CollisionFrequencies` class. This class can be used to calculate collision frequencies for two interacting plasmas.
 
-Deprecated the `~plasmapy.formulary.collisions.collision_frequency` in favor of the ``Lorentz_collision_frequency`` method in the `~plasmapy.formulary.collisions.CollisionFrequencies` class.
+Deprecated the `~plasmapy.formulary.collisions.collision_frequency` in favor of the ``Lorentz_collision_frequency`` attribute in the `~plasmapy.formulary.collisions.CollisionFrequencies` class.

--- a/changelog/1676.feature.rst
+++ b/changelog/1676.feature.rst
@@ -1,0 +1,1 @@
+Added the `~plasmapy.formulary.collisions.RelaxationRates` class. This class can be used to calculate the four relaxation parameters for two interacting plasmas.

--- a/changelog/1676.feature.rst
+++ b/changelog/1676.feature.rst
@@ -1,3 +1,3 @@
 Added the `~plasmapy.formulary.collisions.CollisionFrequencies` class. This class can be used to calculate collision frequencies for two interacting plasmas.
 
-Deprecated the `~plasmapy.formulary.collisions.collision_frequency` in favor of the `Lorentz_collision_frequency` method in the `~plasmapy.formulary.collisions.CollisionFrequencies` class.
+Deprecated the `~plasmapy.formulary.collisions.collision_frequency` in favor of the ``Lorentz_collision_frequency`` method in the `~plasmapy.formulary.collisions.CollisionFrequencies` class.

--- a/changelog/1676.feature.rst
+++ b/changelog/1676.feature.rst
@@ -1,1 +1,3 @@
 Added the `~plasmapy.formulary.collisions.CollisionFrequencies` class. This class can be used to calculate collision frequencies for two interacting plasmas.
+
+Deprecated the `~plasmapy.formulary.collisions.collision_frequency` in favor of the `Lorentz_collision_frequency` method in the `~plasmapy.formulary.collisions.CollisionFrequencies` class.

--- a/changelog/1676.feature.rst
+++ b/changelog/1676.feature.rst
@@ -1,1 +1,1 @@
-Added the `~plasmapy.formulary.collisions.CollisionFrequencies` class. This class can be used to calculate the four relaxation parameters for two interacting plasmas.
+Added the `~plasmapy.formulary.collisions.CollisionFrequencies` class. This class can be used to calculate collision frequencies for two interacting plasmas.

--- a/changelog/1676.feature.rst
+++ b/changelog/1676.feature.rst
@@ -1,1 +1,1 @@
-Added the `~plasmapy.formulary.collisions.RelaxationRates` class. This class can be used to calculate the four relaxation parameters for two interacting plasmas.
+Added the `~plasmapy.formulary.collisions.CollisionFrequencies` class. This class can be used to calculate the four relaxation parameters for two interacting plasmas.

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2145,6 +2145,11 @@ class CollisionFrequencies:
         self.test_particle = test_particle
         self.field_particle = field_particle
         self.v_a = v_a
+        self.T_a = (
+            T_a
+            if T_a is not None
+            else (0.5 * test_particle.mass.to(u.g) * v_a**2 / k_B).to(u.K)
+        )
         self.n_b = n_b
         self.T_b = T_b
         self.Coulomb_log = Coulomb_log
@@ -2155,13 +2160,29 @@ class CollisionFrequencies:
 
         mass_ratio = test_particle.mass / field_particle.mass
 
-        self.v_0 = self.v_0()
+        self.v_0 = self.Lorentz_collision_frequency()
         self.slowing_down = (1 + mass_ratio) * phi * self.v_0
         self.transverse_diffusion = 2 * ((1 - 1 / (2 * x)) * phi + phi_prime) * self.v_0
         self.parallel_diffusion = (phi / x) * self.v_0
         self.energy_loss = 2 * (mass_ratio * phi - phi_prime) * self.v_0
 
-    def v_0(self):
+    def Lorentz_collision_frequency(self):
+        r"""
+        The Lorentz collision frequency (see Ch. 5 of :cite:t:`chen:2016`) is given
+        by
+
+        .. math::
+
+            ν = n σ v \ln{Λ}
+
+        where :math:`n` is the particle density, :math:`σ` is the
+        collisional cross-section, :math:`v` is the inter-particle velocity
+        (typically taken as the thermal velocity), and :math:`\ln{Λ}` is the
+        Coulomb logarithm accounting for small angle collisions.
+
+        See Equation (2.14) in :cite:t:`callen:unpublished`.
+        """
+
         return (
             4
             * np.pi

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2173,21 +2173,22 @@ class CollisionFrequencies:
         self.T_b = T_b
         self.Coulomb_log = Coulomb_log
 
-        # These attributes are used in testing
-        self._x = self.x
-        self._v_0 = self.Lorentz_collision_frequency
-
-        phi = self._phi(self.x)
-        phi_prime = self._phi_prime(self.x)
-
         mass_ratio = test_particle.mass / field_particle.mass
 
-        self.momentum_loss = (1 + mass_ratio) * phi * self._v_0
-        self.transverse_diffusion = (
-            2 * ((1 - 1 / (2 * self.x)) * phi + phi_prime) * self._v_0
+        self.momentum_loss = (
+            (1 + mass_ratio) * self.phi * self.Lorentz_collision_frequency
         )
-        self.parallel_diffusion = (phi / self.x) * self._v_0
-        self.energy_loss = 2 * (mass_ratio * phi - phi_prime) * self._v_0
+        self.transverse_diffusion = (
+            2
+            * ((1 - 1 / (2 * self.x)) * self.phi + self._phi_prime)
+            * self.Lorentz_collision_frequency
+        )
+        self.parallel_diffusion = (self.phi / self.x) * self.Lorentz_collision_frequency
+        self.energy_loss = (
+            2
+            * (mass_ratio * self.phi - self._phi_prime)
+            * self.Lorentz_collision_frequency
+        )
 
     @property
     def Lorentz_collision_frequency(self):
@@ -2247,18 +2248,22 @@ class CollisionFrequencies:
 
         return integral
 
-    def _phi(self, x: u.dimensionless_unscaled):
+    @property
+    def phi(self):
         """
         The parameter phi used in calculating collision frequencies
-        For more information refer to page 19 of the NRL Formulary
+        calculated using the default error tolerances of`~scipy.integrate.quad`
+
+        For more information refer to page 31 of the NRL Formulary.
         """
         vectorized_integral = np.vectorize(self._phi_explicit)
 
-        return 2 / np.pi**0.5 * vectorized_integral(x.value)
+        return 2 / np.pi**0.5 * vectorized_integral(self.x.value)
 
-    def _phi_prime(self, x: u.dimensionless_unscaled):
+    @property
+    def _phi_prime(self):
         """
         The derivative of phi evaluated at x
         """
 
-        return 2 / np.pi**0.5 * self._phi_integrand(x)
+        return 2 / np.pi**0.5 * self._phi_integrand(self.x)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2039,10 +2039,10 @@ def coupling_parameter(
 
 
 class RelaxationRates:
-	@validate_quantities(
-	    n_b={"can_be_negative": False},
-	    T_b={"can_be_negative": False, "equivalencies": u.temperature_energy()},
-	)
+    @validate_quantities(
+        n_b={"can_be_negative": False},
+        T_b={"can_be_negative": False, "equivalencies": u.temperature_energy()},
+    )
     def __init__(
         self,
         species: (particles.Particle, particles.Particle),
@@ -2050,12 +2050,14 @@ class RelaxationRates:
         n_b: u.m**-3,
         T_b: u.K,
         coulomb_log: u.dimensionless_unscaled,
+        dx: float = 1e-20,
     ):
         self.species = species
         self.v_a = v_a
         self.n_b = n_b
         self.T_b = T_b
         self.coulomb_log = coulomb_log
+        self.dx = dx
 
         v_0 = self._v_0()
         x = self._x()
@@ -2093,4 +2095,4 @@ class RelaxationRates:
         return 2 / math.pi**0.5 * integral
 
     def _phi_prime(self, x: u.dimensionless_unscaled):
-        return scipy.misc.derivative(self._phi, x)
+        return scipy.misc.derivative(self._phi, x, dx=self.dx)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -59,6 +59,7 @@ import numpy as np
 import warnings
 
 from astropy.constants.si import e, eps0, hbar, k_B, m_e
+import math
 from numbers import Real
 from numpy import pi
 
@@ -2034,6 +2035,7 @@ def coupling_parameter(
 
     return coulomb_energy / kinetic_energy
 
+
 @validate_quantities(
     n_b={"can_be_negative": False},
     T_b={"can_be_negative": False, "equivalencies": u.temperature_energy()},
@@ -2061,9 +2063,7 @@ class RelaxationRates:
         mu = species[0].mass / species[1].mass
 
         self.slowing_down = (1 + mu) * phi * v_0
-        self.transverse_diffusion = (
-            2 * ((1 - 1 / (2 * x)) * phi + phi_prime) * v_0
-        )
+        self.transverse_diffusion = 2 * ((1 - 1 / (2 * x)) * phi + phi_prime) * v_0
         self.parallel_diffusion = (phi / x) * v_0
         self.energy_loss = 2 * (mu * phi - phi_prime) * v_0
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2222,14 +2222,14 @@ class CollisionFrequencies:
     @cached_property
     def momentum_loss(self):
         """
-        The momentum loss for the specified particles.
+        The momentum loss rate due to collisions.
         """
         return (1 + self._mass_ratio) * self.phi * self.Lorentz_collision_frequency
 
     @cached_property
     def transverse_diffusion(self):
         """
-        The transverse diffusion for the specified particles.
+        The rate of transverse diffusion due to collisions.
         """
         return (
             2
@@ -2240,14 +2240,14 @@ class CollisionFrequencies:
     @cached_property
     def parallel_diffusion(self):
         """
-        The parallel diffusion for the specified particles.
+        The rate of parallel diffusion due to collisions.
         """
         return (self.phi / self.x) * self.Lorentz_collision_frequency
 
     @cached_property
     def energy_loss(self):
         """
-        The energy loss for the specified particles.
+        The energy loss rate due to collisions.
         """
         return (
             2

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2111,6 +2111,8 @@ class CollisionFrequencies:
 
         For general solutions and limiting cases we encourage the curious reader to refer to p. 31 of :cite:t:`nrlformulary:2019`
 
+        This function uses CGS units under the hood to coincide with our references, but passing MKS units is acceptable.
+
         Examples
         --------
         >>> import astropy.units as u
@@ -2123,11 +2125,18 @@ class CollisionFrequencies:
         ... )
         >>> frequencies.slowing_down
         <Quantity 1.83701432e+11 Hz>
+
+        See Also
+        --------
+        ~plasmapy.formulary.collisions.Coulomb_log : Evaluates the Coulomb
+            logarithm for two interacting electron species.
+
+        ~plasmapy.formulary.collisions.collision_frequency : The Lorentz collision frequency.
         """
 
         if v_a is None:
             if T_a is not None:
-                v_a = thermal_speed(T_a, test_particle).to(u.cm / u.s)
+                v_a = thermal_speed(T_a, test_particle)  # .to(u.cm / u.s)
             else:
                 raise ValueError("Please specify either v_a or T_a.")
         elif T_a is not None:

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2064,7 +2064,7 @@ class CollisionFrequencies:
         Coulomb_log: u.dimensionless_unscaled,
     ):
         r"""
-        Compute collision frequencies
+        Compute collision frequencies between test particles (labeled 'a') and field particles (labeled 'b')
 
         Parameters
         ----------
@@ -2075,7 +2075,7 @@ class CollisionFrequencies:
             The background particle being interacted with.
 
         v_a : `~astropy.units.Quantity`, optional
-            The relative velocity between particles. If not provided,
+            The relative velocity between particles. If not provided, T_a must be specified and
             thermal velocity is assumed: :math:`μ v_a^2 \sim 2 k_B T_a` where
             :math:`μ` is the reduced mass.
 
@@ -2128,7 +2128,7 @@ class CollisionFrequencies:
 
         See Also
         --------
-        ~plasmapy.formulary.collisions.Coulomb_log : Evaluates the Coulomb
+        ~plasmapy.formulary.collisions.Coulomb_logarithm : Evaluates the Coulomb
             logarithm for two interacting electron species.
 
         ~plasmapy.formulary.collisions.collision_frequency : The Lorentz collision frequency.
@@ -2136,7 +2136,7 @@ class CollisionFrequencies:
 
         if v_a is None:
             if T_a is not None:
-                v_a = thermal_speed(T_a, test_particle)  # .to(u.cm / u.s)
+                v_a = thermal_speed(T_a, test_particle).to(u.cm / u.s)
             else:
                 raise ValueError("Please specify either v_a or T_a.")
         elif T_a is not None:
@@ -2155,13 +2155,13 @@ class CollisionFrequencies:
 
         mass_ratio = test_particle.mass / field_particle.mass
 
-        self.v_0 = self._v_0()
+        self.v_0 = self.v_0()
         self.slowing_down = (1 + mass_ratio) * phi * self.v_0
         self.transverse_diffusion = 2 * ((1 - 1 / (2 * x)) * phi + phi_prime) * self.v_0
         self.parallel_diffusion = (phi / x) * self.v_0
         self.energy_loss = 2 * (mass_ratio * phi - phi_prime) * self.v_0
 
-    def _v_0(self):
+    def v_0(self):
         return (
             4
             * np.pi

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2317,7 +2317,7 @@ class CollisionFrequencies:
     def phi(self):
         """
         The parameter phi used in calculating collision frequencies
-        calculated using the default error tolerances of `~scipy.integrate.quad`
+        calculated using the default error tolerances of `~scipy.integrate.quad`.
 
         For more information refer to page 31 of the NRL Formulary.
         """

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2045,14 +2045,16 @@ class RelaxationRates:
     )
     def __init__(
         self,
-        species: (particles.Particle, particles.Particle),
+        test_particle: particles.Particle,
+        field_particle: particles.Particle,
         v_a: u.cm / u.s,
         n_b: u.cm**-3,
         T_b: u.K,
         coulomb_log: u.dimensionless_unscaled,
         dx: float = 1e-20,
     ):
-        self.species = species
+        self.test_particle = test_particle
+        self.field_particle = field_particle
         self.v_a = v_a
         self.n_b = n_b
         self.T_b = T_b
@@ -2064,26 +2066,26 @@ class RelaxationRates:
         phi = self._phi(x)
         phi_prime = self._phi_prime(x)
 
-        mu = species[0].mass / species[1].mass
+        particle_mass_ratio = test_particle.mass / field_particle.mass
 
-        self.slowing_down = (1 + mu) * phi * v_0
+        self.slowing_down = (1 + particle_mass_ratio) * phi * v_0
         self.transverse_diffusion = 2 * ((1 - 1 / (2 * x)) * phi + phi_prime) * v_0
         self.parallel_diffusion = (phi / x) * v_0
-        self.energy_loss = 2 * (mu * phi - phi_prime) * v_0
+        self.energy_loss = 2 * (particle_mass_ratio * phi - phi_prime) * v_0
 
     def _v_0(self):
         return (
             4
             * math.pi
-            * (self.species[0].charge_number * e.esu) ** 2
-            * (self.species[1].charge_number * e.esu) ** 2
+            * (self.test_particle.charge_number * e.esu) ** 2
+            * (self.field_particle.charge_number * e.esu) ** 2
             * self.coulomb_log
             * self.n_b
-            / (self.species[0].mass.to(u.g) ** 2 * self.v_a**3)
+            / (self.test_particle.mass.to(u.g) ** 2 * self.v_a**3)
         ).to(u.Hz)
 
     def _x(self) -> u.dimensionless_unscaled:
-        x = self.species[1].mass.to(u.g) * self.v_a**2 / (2 * k_B.cgs * self.T_b)
+        x = self.field_particle.mass.to(u.g) * self.v_a**2 / (2 * k_B.cgs * self.T_b)
         return x.to(u.dimensionless_unscaled)
 
     @staticmethod

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2055,7 +2055,7 @@ def coupling_parameter(
 
 class CollisionFrequencies:
     @validate_quantities(
-        v_a={"none_shall_pass": True},
+        v_a={"none_shall_pass": True, "can_be_negative": False},
         T_a={
             "none_shall_pass": True,
             "can_be_negative": False,
@@ -2070,9 +2070,9 @@ class CollisionFrequencies:
         test_particle: particles.Particle,
         field_particle: particles.Particle,
         *,
-        v_a: u.cm / u.s = None,
+        v_a: u.m / u.s = None,
         T_a: u.K = None,
-        n_b: u.cm**-3,
+        n_b: u.m**-3,
         T_b: u.K,
         Coulomb_log: u.dimensionless_unscaled,
     ):

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -40,6 +40,7 @@ These include:
 * `~plasmapy.formulary.collisions.coupling_parameter`
 """
 __all__ = [
+    "CollisionFrequencies",
     "Coulomb_logarithm",
     "impact_parameter_perp",
     "impact_parameter",
@@ -52,7 +53,6 @@ __all__ = [
     "mobility",
     "Knudsen_number",
     "coupling_parameter",
-    "CollisionFrequencies",
 ]
 
 import astropy.units as u

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2258,6 +2258,8 @@ class CollisionFrequencies:
     @cached_property
     def Lorentz_collision_frequency(self):
         r"""
+        The Lorentz collision frequency.
+        
         The Lorentz collision frequency (see Ch. 5 of :cite:t:`chen:2016`) is given
         by
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2057,23 +2057,20 @@ class CollisionFrequencies:
         test_particle: particles.Particle,
         field_particle: particles.Particle,
         *,
-        v_a: u.cm / u.s = np.nan * u.cm / u.s,
-        T_a: u.K = np.nan * u.K,
+        v_a: u.cm / u.s = None,
+        T_a: u.K = None,
         n_b: u.cm**-3,
         T_b: u.K,
         coulomb_log: u.dimensionless_unscaled,
-        dx: float = 1e-15,
     ):
 
-        if np.any(np.logical_and(np.isnan(v_a), np.isnan(T_a))):
-            raise ValueError("Please specify either v_a or T_a.")
-
-        if np.any(np.logical_and(np.isfinite(v_a), np.isfinite(T_a))):
+        if v_a is None:
+            if T_a is not None:
+                v_a = thermal_speed(T_a, test_particle).to(u.cm / u.s)
+            else:
+                raise ValueError("Please specify either v_a or T_a.")
+        elif T_a is not None:
             raise ValueError("Please specify either v_a or T_a, not both.")
-
-        v_a = _replace_nan_velocity_with_thermal_velocity(
-            v_a, T_a, test_particle.mass, test_particle
-        ).to(u.cm / u.s)
 
         self.test_particle = test_particle
         self.field_particle = field_particle
@@ -2081,7 +2078,6 @@ class CollisionFrequencies:
         self.n_b = n_b
         self.T_b = T_b
         self.coulomb_log = coulomb_log
-        self.dx = dx
 
         x = self._x()
         phi = self._phi(x)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -1005,7 +1005,7 @@ def collision_frequency(
 
     See Also
     --------
-    ~plasmapy.formulary.collisions.CollisionFrequencies.Lorentz_collision_frequency
+    ~plasmapy.formulary.collisions.CollisionFrequencies
 
     """
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2080,7 +2080,7 @@ class CollisionFrequencies:
             :math:`μ` is the reduced mass.
 
         T_a : `~astropy.units.Quantity`, optional
-            The temperature of the test species. Only necessary if `v_a` is not provided.
+            The temperature of the test species. Only necessary if :math:`v_a` is not provided.
 
         n_b : `~astropy.units.Quantity`
             The number density of the background field particles.
@@ -2094,8 +2094,8 @@ class CollisionFrequencies:
         Raises
         ------
         `ValueError`
-            If both `v_a` and `T_a` are specified, or neither
-            `v_a` nor `T_a` are specified.
+            If both :math:`v_a` and :math:`T_a` are specified, or neither
+            :math:`v_a` nor :math:`T_a` are specified.
 
         Notes
         -----

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2184,7 +2184,7 @@ class CollisionFrequencies:
         ...     "e-", "e-", v_a=v_a, n_b=n_b, T_b=T_b, Coulomb_log=Coulomb_log
         ... )
         >>> frequencies_using_velocity.energy_loss
-        <Quantity 193756965.39266655 Hz>
+        <Quantity -9.69828719e+15 Hz>
 
         See Also
         --------

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -56,7 +56,6 @@ __all__ = [
 ]
 
 import astropy.units as u
-import math
 import numpy as np
 import scipy.integrate
 import scipy.misc
@@ -2099,7 +2098,7 @@ class CollisionFrequencies:
     def _v_0(self):
         return (
             4
-            * math.pi
+            * np.pi
             * (self.test_particle.charge_number * e.esu) ** 2
             * (self.field_particle.charge_number * e.esu) ** 2
             * self.coulomb_log
@@ -2113,7 +2112,7 @@ class CollisionFrequencies:
 
     @staticmethod
     def _phi_integrand(t: u.dimensionless_unscaled):
-        return t**0.5 * math.exp(-t)
+        return t**0.5 * np.exp(-t)
 
     def _phi_explicit(self, x: float) -> float:
         integral, _ = scipy.integrate.quad(self._phi_integrand, 0, x)
@@ -2123,7 +2122,7 @@ class CollisionFrequencies:
     def _phi(self, x: u.dimensionless_unscaled):
         vectorized_integral = np.vectorize(self._phi_explicit)
 
-        return 2 / math.pi**0.5 * vectorized_integral(x.value)
+        return 2 / np.pi**0.5 * vectorized_integral(x.value)
 
     def _phi_prime(self, x: u.dimensionless_unscaled):
-        return scipy.misc.derivative(self._phi, x, dx=self.dx)
+        return 2 / np.pi**0.5 * self._phi_integrand(x)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2145,7 +2145,7 @@ class CollisionFrequencies:
 
             parallel diffusion: :math:`ν_{||}^{α\backslashβ}=\left[\frac{ψ\left(x^{α\backslashβ}\right)}{x^{α\backslashβ}}\right]ν_{0}^{α\backslashβ}`
 
-            energy loss: :math:`ν_{ε}^{α\backslashβ}=2\left[\left(\frac{m_{α}}{m_{β}}\right)ψ\left(x^{α\backslashβ}\right)-ψ'\left(x^{α\backslashβ}\right)\right]ν_{0}^{α\backslashβ}`
+            energy loss: :math:`ν_{ϵ}^{α\backslashβ}=2\left[\left(\frac{m_{α}}{m_{β}}\right)ψ\left(x^{α\backslashβ}\right)-ψ'\left(x^{α\backslashβ}\right)\right]ν_{0}^{α\backslashβ}`
 
         where,
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2114,17 +2114,15 @@ class CollisionFrequencies:
         Examples
         --------
         >>> import astropy.units as u
-        >>> test_particle = Particle("e-")
-        >>> field_particle = Particle("e-")
         >>> T_a = 1 * u.eV
         >>> n_b = 1e20 * u.cm**-3
         >>> T_b = 1e3 * u.eV
         >>> Coulomb_log = 10 * u.dimensionless_unscaled
         >>> frequencies = CollisionFrequencies(
-        >>>     test_particle, field_particle, T_a=T_a, n_b=n_b, T_b=T_b, Coulomb_log=Coulomb_log
-        >>> )
+        ...     "e-", "e-", T_a=T_a, n_b=n_b, T_b=T_b, Coulomb_log=Coulomb_log
+        ... )
         >>> frequencies.slowing_down
-        <Quantity 183701431620.49692>
+        <Quantity 1.83701432e+11 Hz>
         """
 
         if v_a is None:

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2126,15 +2126,35 @@ class CollisionFrequencies:
         -----
         The collision frequencies between two interacting particles are given by four differential equations:
 
-            momentum loss - :math:`\frac{d\textbf{v}_{α}}{dt}=-ν_{s}^{α\backslashβ}\textbf{v}_{α}`
+            :math:`\frac{d\textbf{v}_{α}}{dt}=-ν_{s}^{α\backslashβ}\textbf{v}_{α}`
 
-            transverse diffusion - :math:`\frac{d}{dt}\left(\overline{\textbf{v}}_{α}-\overline{\textbf{v}}_{α}\right)_{⊥}^{2}=ν_{⊥}^{α\backslashβ}v_{α}^{2}`
+            :math:`\frac{d}{dt}\left(\overline{\textbf{v}}_{α}-\overline{\textbf{v}}_{α}\right)_{⊥}^{2}=ν_{⊥}^{α\backslashβ}v_{α}^{2}`
 
-            parallel diffusion - :math:`\frac{d}{dt}\left(\overline{\textbf{v}}_{α}-\overline{\textbf{v}}_{α}\right)_{∥}^{2}=ν_{∥}^{α\backslashβ}v_{α}^{2}`
+            :math:`\frac{d}{dt}\left(\overline{\textbf{v}}_{α}-\overline{\textbf{v}}_{α}\right)_{∥}^{2}=ν_{∥}^{α\backslashβ}v_{α}^{2}`
 
-            energy loss - :math:`\frac{d}{dt}v_{α}^{2}=-ν_{ϵ}^{α\backslashβ}v_{α}^{2}`
+            :math:`\frac{d}{dt}v_{α}^{2}=-ν_{ϵ}^{α\backslashβ}v_{α}^{2}`
 
-        For general solutions and limiting cases we encourage the curious reader to refer to p. 31 of :cite:t:`nrlformulary:2019`
+        These equations yield the exact formulas:
+
+            momentum loss - :math:`ν_{s}^{α\backslashβ}=\left(1+\frac{m_{α}}{m_{β}}\right)ψ\left(x^{α\backslashβ}\right)ν_{0}^{α\backslashβ}`
+
+            transverse diffusion - :math:`ν_{⊥}^{α\backslashβ}=2\left[\left(1-\frac{1}{2x^{α\backslashβ}}\right)ψ\left(x^{α\backslashβ}\right)\ +ψ'\left(x^{α\backslashβ}\right)\right]ν_{0}^{α\backslashβ}`
+
+            parallel diffusion - :math:`ν_{||}^{α\backslashβ}=\left[\frac{ψ\left(x^{α\backslashβ}\right)}{x^{α\backslashβ}}\right]ν_{0}^{α\backslashβ}`
+
+            energy loss - :math:`ν_{ε}^{α\backslashβ}=2\left[\left(\frac{m_{α}}{m_{β}}\right)ψ\left(x^{α\backslashβ}\right)-ψ'\left(x^{α\backslashβ}\right)\right]ν_{0}^{α\backslashβ}`
+
+        where,
+
+            :math:`ν_{0}^{α\backslashβ}=\frac{4\pi e_{α}^{2}e_{β}^{2}λ_{αβ}n_{β}}{m_{α}^{2}v_{α}^{3}}`,
+
+            :math:`x^{α\backslashβ}=\frac{m_{β}v_{α}^{2}}{2kT_{β}}`,
+
+            :math:`ψ\left(x\right)=\frac{2}{\sqrt{\pi}}\int_{0}^{x}t^{\frac{1}{2}}e^{-t}dt`, and
+
+            :math:`ψ'\left(x\right)=\frac{dψ}{dx}`
+
+        For limiting cases we encourage the curious reader to refer to p. 31 of :cite:t:`nrlformulary:2019`
 
         This function uses CGS units under the hood to coincide with our references, but passing MKS units is acceptable.
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2046,8 +2046,8 @@ class RelaxationRates:
     def __init__(
         self,
         species: (particles.Particle, particles.Particle),
-        v_a: u.m / u.s,
-        n_b: u.m**-3,
+        v_a: u.cm / u.s,
+        n_b: u.cm**-3,
         T_b: u.K,
         coulomb_log: u.dimensionless_unscaled,
         dx: float = 1e-20,
@@ -2075,15 +2075,15 @@ class RelaxationRates:
         return (
             4
             * math.pi
-            * self.species[0].charge ** 2
-            * self.species[1].charge ** 2
+            * (self.species[0].charge_number * e.esu) ** 2
+            * (self.species[1].charge_number * e.esu) ** 2
             * self.coulomb_log
             * self.n_b
-            / (self.species[0].mass ** 2 * self.v_a**3)
-        )
+            / (self.species[0].mass.to(u.g) ** 2 * self.v_a**3)
+        ).to(u.Hz)
 
     def _x(self) -> u.dimensionless_unscaled:
-        x = self.species[1].mass * self.v_a**2 / (2 * k_B * self.T_b)
+        x = self.species[1].mass.to(u.g) * self.v_a**2 / (2 * k_B.cgs * self.T_b)
         return x.to(u.dimensionless_unscaled)
 
     @staticmethod

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2061,8 +2061,71 @@ class CollisionFrequencies:
         T_a: u.K = None,
         n_b: u.cm**-3,
         T_b: u.K,
-        coulomb_log: u.dimensionless_unscaled,
+        Coulomb_log: u.dimensionless_unscaled,
     ):
+        r"""
+        Compute collision frequencies
+
+        Parameters
+        ----------
+        test_particle : |Particle|
+            The test particle streaming through a background of field particles.
+
+        field_particle : |Particle|
+            The background particle being interacted with.
+
+        v_a : `~astropy.units.Quantity`, optional
+            The relative velocity between particles. If not provided,
+            thermal velocity is assumed: :math:`μ v_a^2 \sim 2 k_B T_a` where
+            :math:`μ` is the reduced mass.
+
+        T_a : `~astropy.units.Quantity`, optional
+            The temperature of the test species. Only necessary if `v_a` is not provided.
+
+        n_b : `~astropy.units.Quantity`
+            The number density of the background field particles.
+
+        T_b : `~astropy.units.Quantity`
+            The temperature of the background field particles.
+
+        Coulomb_log : `~astropy.units.Quantity`
+            The value of the Coulomb logarithm evaluated for the two interacting particles.
+
+        Raises
+        ------
+        `ValueError`
+            If both `v_a` and `T_a` are specified, or neither
+            `v_a` nor `T_a` are specified.
+
+        Notes
+        -----
+        The collision frequencies between two interacting particles is given by four differential equations:
+
+            slowing down - :math:`\frac{d\textbf{v}_{α}}{dt}=-ν_{s}^{α\backslashβ}\textbf{v}_{α}`
+
+            transverse diffusion - :math:`\frac{d}{dt}\left(\overline{\textbf{v}}_{α}-\overline{\textbf{v}}_{α}\right)_{⊥}^{2}=ν_{⊥}^{α\backslashβ}v_{α}^{2}`
+
+            parallel diffusion - :math:`\frac{d}{dt}\left(\overline{\textbf{v}}_{α}-\overline{\textbf{v}}_{α}\right)_{∥}^{2}=ν_{∥}^{α\backslashβ}v_{α}^{2}`
+
+            energy loss - :math:`\frac{d}{dt}v_{α}^{2}=-ν_{ϵ}^{α\backslashβ}v_{α}^{2}`
+
+        For general solutions and limiting cases we encourage the curious reader to refer to p. 31 of :cite:t:`nrlformulary:2019`
+
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> test_particle = Particle("e-")
+        >>> field_particle = Particle("e-")
+        >>> T_a = 1 * u.eV
+        >>> n_b = 1e20 * u.cm**-3
+        >>> T_b = 1e3 * u.eV
+        >>> Coulomb_log = 10 * u.dimensionless_unscaled
+        >>> frequencies = CollisionFrequencies(
+        >>>     test_particle, field_particle, T_a=T_a, n_b=n_b, T_b=T_b, Coulomb_log=Coulomb_log
+        >>> )
+        >>> frequencies.slowing_down
+        <Quantity 183701431620.49692>
+        """
 
         if v_a is None:
             if T_a is not None:
@@ -2077,7 +2140,7 @@ class CollisionFrequencies:
         self.v_a = v_a
         self.n_b = n_b
         self.T_b = T_b
-        self.coulomb_log = coulomb_log
+        self.Coulomb_log = Coulomb_log
 
         x = self._x()
         phi = self._phi(x)
@@ -2097,7 +2160,7 @@ class CollisionFrequencies:
             * np.pi
             * (self.test_particle.charge_number * e.esu) ** 2
             * (self.field_particle.charge_number * e.esu) ** 2
-            * self.coulomb_log
+            * self.Coulomb_log
             * self.n_b
             / (self.test_particle.mass.to(u.g) ** 2 * self.v_a**3)
         ).to(u.Hz)

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2101,10 +2101,10 @@ class CollisionFrequencies:
             The temperature of the test species. Only necessary if :math:`v_a` is not provided.
 
         n_b : `~astropy.units.Quantity`
-            The number density of the background field particles in units convertable to :math:`\frac{1}{m^{3}}`
+            The number density of the background field particles in units convertible to :math:`\frac{1}{m^{3}}`
 
         T_b : `~astropy.units.Quantity`
-            The temperature of the background field particles in units convertable to degrees Kelvin.
+            The temperature of the background field particles in units convertible to degrees Kelvin.
 
         Coulomb_log : `~astropy.units.Quantity`
             The value of the Coulomb logarithm evaluated for the two interacting particles.

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2063,7 +2063,7 @@ class CollisionFrequencies:
         n_b: u.cm**-3,
         T_b: u.K,
         coulomb_log: u.dimensionless_unscaled,
-        dx: float = 1e-20,
+        dx: float = 1e-15,
     ):
 
         if np.any(np.logical_and(np.isnan(v_a), np.isnan(T_a))):

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2170,7 +2170,7 @@ class CollisionFrequencies:
         --------
         >>> import astropy.units as u
         >>> T_a = 1 * u.eV
-        >>> n_b = 1e20 * u.cm**-3
+        >>> n_b = 1e26 * u.m**-3
         >>> T_b = 1e3 * u.eV
         >>> Coulomb_log = 10 * u.dimensionless_unscaled
         >>> frequencies_using_temperature = CollisionFrequencies(
@@ -2179,7 +2179,7 @@ class CollisionFrequencies:
         >>> frequencies_using_temperature.momentum_loss
         <Quantity 1.83701432e+11 Hz>
 
-        >>> v_a = 1e7 * u.cm / u.s
+        >>> v_a = 1e5 * u.m / u.s
         >>> frequencies_using_velocity = CollisionFrequencies(
         ...     "e-", "e-", v_a=v_a, n_b=n_b, T_b=T_b, Coulomb_log=Coulomb_log
         ... )
@@ -2197,7 +2197,7 @@ class CollisionFrequencies:
 
         if v_a is None:
             if T_a is not None:
-                v_a = thermal_speed(T_a, test_particle).to(u.cm / u.s)
+                v_a = thermal_speed(T_a, test_particle)
             else:
                 raise ValueError("Please specify either v_a or T_a.")
         elif T_a is not None:

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2099,7 +2099,7 @@ class CollisionFrequencies:
 
         Notes
         -----
-        The collision frequencies between two interacting particles is given by four differential equations:
+        The collision frequencies between two interacting particles are given by four differential equations:
 
             slowing down - :math:`\frac{d\textbf{v}_{α}}{dt}=-ν_{s}^{α\backslashβ}\textbf{v}_{α}`
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -905,6 +905,12 @@ def collision_frequency(
     method="classical",
 ) -> u.Hz:
     r"""
+    .. note::
+        The `~plasmapy.formulary.collisions.collision_frequency` function has been
+        replaced by the more general `~plasmapy.formulary.collisions.CollisionFrequencies` class.
+        To replicate the functionality of collision_frequency, create a
+        `~plasmapy.formulary.collisions.CollisionFrequencies` class and access the `Lorentz_collision_frequency` attribute.
+
     Collision frequency of particles in a plasma.
 
     Parameters
@@ -1014,8 +1020,8 @@ def collision_frequency(
         warning_type=PlasmaPyFutureWarning,
         message=(
             "The collision_frequency function has been replaced by the more general "
-            "CollisionFrequency class. To replicate the functionality of collision_frequency, "
-            "create a CollisionFrequency class and access the `Lorentz_collision_frequency` "
+            "CollisionFrequencies class. To replicate the functionality of collision_frequency, "
+            "create a CollisionFrequencies class and access the `Lorentz_collision_frequency` "
             "attribute."
         ),
     )
@@ -2252,7 +2258,7 @@ class CollisionFrequencies:
     def phi(self):
         """
         The parameter phi used in calculating collision frequencies
-        calculated using the default error tolerances of`~scipy.integrate.quad`
+        calculated using the default error tolerances of `~scipy.integrate.quad`
 
         For more information refer to page 31 of the NRL Formulary.
         """

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -910,7 +910,7 @@ def collision_frequency(
         The `~plasmapy.formulary.collisions.collision_frequency` function has been
         replaced by the more general `~plasmapy.formulary.collisions.CollisionFrequencies` class.
         To replicate the functionality of collision_frequency, create a
-        `~plasmapy.formulary.collisions.CollisionFrequencies` class and access the `Lorentz_collision_frequency` attribute.
+        `~plasmapy.formulary.collisions.CollisionFrequencies` class and access the ``Lorentz_collision_frequency`` attribute.
 
     Collision frequency of particles in a plasma.
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2052,9 +2052,9 @@ class CollisionFrequencies:
     )
     def __init__(
         self,
-        *,
         test_particle: particles.Particle,
         field_particle: particles.Particle,
+        *,
         v_a: u.cm / u.s = None,
         T_a: u.K = None,
         n_b: u.cm**-3,

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -27,7 +27,7 @@ Collision rates
 
 The module gathers a few functions helpful for calculating collision
 rates between particles. The most general of these is
-`~plasmapy.formulary.collisions.collision_frequency`.
+`~plasmapy.formulary.collisions.CollisionFrequencies`.
 
 Macroscopic properties
 ======================
@@ -74,8 +74,9 @@ from plasmapy.formulary.quantum import (
     Wigner_Seitz_radius,
 )
 from plasmapy.formulary.speeds import thermal_speed
-from plasmapy.utils.decorators import validate_quantities
+from plasmapy.utils.decorators import deprecated, validate_quantities
 from plasmapy.utils.decorators.checks import _check_relativistic
+from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
 
 @validate_quantities(
@@ -1002,6 +1003,18 @@ def collision_frequency(
     >>> collision_frequency(T, n, species)
     <Quantity 70249... Hz>
     """
+
+    deprecated(
+        since="0.8.0",
+        warning_type=PlasmaPyFutureWarning,
+        message=(
+            "The collision_frequency function has been replaced by the more general "
+            "CollisionFrequency class. To replicate the functionality of collision_frequency, "
+            "create a CollisionFrequency class and access the `Lorentz_collision_frequency` "
+            "attribute."
+        ),
+    )
+
     T, masses, charges, reduced_mass, V_r = _process_inputs(T=T, species=species, V=V)
     # using a more descriptive name for the thermal velocity using
     # reduced mass

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -55,11 +55,13 @@ __all__ = [
 ]
 
 import astropy.units as u
+import math
 import numpy as np
+import scipy.integrate
+import scipy.misc
 import warnings
 
 from astropy.constants.si import e, eps0, hbar, k_B, m_e
-import math
 from numbers import Real
 from numpy import pi
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2042,7 +2042,11 @@ def coupling_parameter(
 class CollisionFrequencies:
     @validate_quantities(
         v_a={"none_shall_pass": True},
-        T_a={"none_shall_pass": True},
+        T_a={
+            "none_shall_pass": True,
+            "can_be_negative": False,
+            "equivalencies": u.temperature_energy(),
+        },
         n_b={"can_be_negative": False},
         T_b={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     )

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -52,6 +52,7 @@ __all__ = [
     "mobility",
     "Knudsen_number",
     "coupling_parameter",
+    "CollisionFrequencies",
 ]
 
 import astropy.units as u
@@ -2038,7 +2039,7 @@ def coupling_parameter(
     return coulomb_energy / kinetic_energy
 
 
-class RelaxationRates:
+class CollisionFrequencies:
     @validate_quantities(
         n_b={"can_be_negative": False},
         T_b={"can_be_negative": False, "equivalencies": u.temperature_energy()},

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2259,7 +2259,7 @@ class CollisionFrequencies:
     def Lorentz_collision_frequency(self):
         r"""
         The Lorentz collision frequency.
-        
+
         The Lorentz collision frequency (see Ch. 5 of :cite:t:`chen:2016`) is given
         by
 

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2153,14 +2153,14 @@ class CollisionFrequencies:
 
             :math:`x^{α\backslashβ}=\frac{m_{β}v_{α}^{2}}{2k_B T_{β}}`,
 
-            :math:`ψ\left(x\right)=\frac{2}{\sqrt{\pi}}\int_{0}^{x}t^{\frac{1}{2}}e^{-t}dt`, and
+            :math:`ψ\left(x\right)=\frac{2}{\sqrt{\pi}}\int_{0}^{x}t^{\frac{1}{2}}e^{-t}dt`,
 
-            :math:`ψ'\left(x\right)=\frac{dψ}{dx}`
+            :math:`ψ'\left(x\right)=\frac{dψ}{dx}`,
 
-        where :math:`\lambda_{\alpha \beta}` is the Coulomb logarithm for the collisions,
+        and :math:`\lambda_{\alpha \beta}` is the Coulomb logarithm for the collisions,
         :math:`n_\beta` is the number density of the field particles, :math:`v_\alpha` is
         the speed of the test particles relative to the field particles, :math:`k_B` is Boltzmann's
-        constant and :math:`T_\beta` is the temperature of the field particles.
+        constant, and :math:`T_\beta` is the temperature of the field particles.
 
         For values of x<<1 (the 'slow' or 'thermal' limit) or x>>1 (the 'fast' or 'beam' limit),
         :math:`\psi` asymptotes to zero or one respectively. For simplified expressions in these limits

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -559,6 +559,7 @@ def _process_inputs(T: u.K, species: (particles.Particle, particles.Particle), V
     return T, masses, charges, reduced_mass, V
 
 
+# TODO: Remove redundant mass parameter
 def _replace_nan_velocity_with_thermal_velocity(
     V, T, m, species=particles.Particle("e-")
 ):

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2038,11 +2038,11 @@ def coupling_parameter(
     return coulomb_energy / kinetic_energy
 
 
-@validate_quantities(
-    n_b={"can_be_negative": False},
-    T_b={"can_be_negative": False, "equivalencies": u.temperature_energy()},
-)
 class RelaxationRates:
+	@validate_quantities(
+	    n_b={"can_be_negative": False},
+	    T_b={"can_be_negative": False, "equivalencies": u.temperature_energy()},
+	)
     def __init__(
         self,
         species: (particles.Particle, particles.Particle),

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1702,8 +1702,8 @@ class Test_coupling_parameter:
             coupling_parameter(self.T, self.n_e, self.particles, method="not a method")
 
 
-class TestRelaxationRates:
-    """Test the RelaxationRates class in collisions.py."""
+class TestCollisionFrequencies:
+    """Test the CollisionFrequencies class in collisions.py."""
 
     attribute_test_case = CollisionFrequencies(
         Particle("e-"),
@@ -1721,6 +1721,8 @@ class TestRelaxationRates:
         "energy_loss",
         "v_0",
     ]
+
+    ones_array = np.ones(5)
 
     @pytest.mark.parametrize("attribute_to_test", attributes_to_test)
     def test_units(self, attribute_to_test):
@@ -1743,7 +1745,7 @@ class TestRelaxationRates:
                     "T_a": 1e2 * u.eV,
                     "T_b": 1e2 * u.eV,
                     "n_b": 1e20 * u.cm**-3,
-                    "coulomb_log": 6.2889877978064606,
+                    "coulomb_log": 6.2889877978064606 * u.dimensionless_unscaled,
                 },
             ),
         ],
@@ -1776,7 +1778,7 @@ class TestRelaxationRates:
                     "T_a": 1 * u.eV,
                     "T_b": 1 * u.eV,
                     "n_b": 1 * u.cm**-3,
-                    "coulomb_log": 1,
+                    "coulomb_log": 1 * u.dimensionless_unscaled,
                 },
             ),
             (
@@ -1785,7 +1787,7 @@ class TestRelaxationRates:
                 {
                     "T_b": 1 * u.eV,
                     "n_b": 1 * u.cm**-3,
-                    "coulomb_log": 1,
+                    "coulomb_log": 1 * u.dimensionless_unscaled,
                 },
             ),
         ],
@@ -1799,3 +1801,21 @@ class TestRelaxationRates:
             CollisionFrequencies(
                 *constructor_arguments, **constructor_keyword_arguments
             )
+
+    @pytest.mark.parametrize(
+        "constructor_keyword_arguments",
+        [
+            {
+                "test_particle": Particle("e-"),
+                "field_particle": Particle("e-"),
+                "T_a": ones_array * u.eV,
+                "T_b": ones_array * u.eV,
+                "n_b": ones_array * u.cm**-3,
+                "coulomb_log": ones_array * u.dimensionless_unscaled,
+            },
+        ],
+    )
+    def test_handle_nparrays(self, constructor_keyword_arguments):
+        """Test for ability to handle numpy array quantities"""
+
+        case = CollisionFrequencies(**constructor_keyword_arguments)

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1715,7 +1715,7 @@ class TestCollisionFrequencies:
     )
 
     attributes_to_test = [
-        "slowing_down",
+        "momentum_loss",
         "transverse_diffusion",
         "parallel_diffusion",
         "energy_loss",
@@ -1829,7 +1829,7 @@ class TestCollisionFrequencies:
                 )
         # The expected energy loss collision frequency should always equal this
         limit_values.append(
-            2 * cases.slowing_down.value
+            2 * cases.momentum_loss.value
             - cases.transverse_diffusion.value
             - cases.parallel_diffusion.value
         )

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1764,3 +1764,38 @@ class TestRelaxationRates:
             calculated_value = getattr(value_test_case, name)
 
             assert np.isclose(calculated_value.value, expected_value)
+
+    @pytest.mark.parametrize(
+        "expected_error, constructor_arguments, constructor_keyword_arguments",
+        [
+            (
+                ValueError,
+                (Particle("e-"), Particle("e-")),
+                {
+                    "v_a": 1 * u.cm / u.s,
+                    "T_a": 1 * u.eV,
+                    "T_b": 1 * u.eV,
+                    "n_b": 1 * u.cm**-3,
+                    "coulomb_log": 1,
+                },
+            ),
+            (
+                ValueError,
+                (Particle("e-"), Particle("e-")),
+                {
+                    "T_b": 1 * u.eV,
+                    "n_b": 1 * u.cm**-3,
+                    "coulomb_log": 1,
+                },
+            ),
+        ],
+    )
+    def test_errors(
+        self, expected_error, constructor_arguments, constructor_keyword_arguments
+    ):
+        """Test errors raised in the function body"""
+
+        with pytest.raises(expected_error):
+            CollisionFrequencies(
+                *constructor_arguments, **constructor_keyword_arguments
+            )

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1711,7 +1711,7 @@ class TestCollisionFrequencies:
         v_a=1 * u.m / u.s,
         T_b=1 * u.K,
         n_b=1 * u.m**-3,
-        coulomb_log=1 * u.dimensionless_unscaled,
+        Coulomb_log=1 * u.dimensionless_unscaled,
     )
 
     attributes_to_test = [
@@ -1749,7 +1749,7 @@ class TestCollisionFrequencies:
                     "T_a": 1 * u.eV,
                     "T_b": 1e4 * u.eV,
                     "n_b": 1e15 * u.cm**-3,
-                    "coulomb_log": 10 * u.dimensionless_unscaled,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
                 },
             ),
             (
@@ -1765,7 +1765,7 @@ class TestCollisionFrequencies:
                     "T_a": 1e-4 * u.eV,
                     "T_b": 1e4 * u.eV,
                     "n_b": 1e20 * u.cm**-3,
-                    "coulomb_log": 10 * u.dimensionless_unscaled,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
                 },
             ),
             (
@@ -1781,7 +1781,7 @@ class TestCollisionFrequencies:
                     "T_a": 1 * u.eV,
                     "T_b": 1e2 * u.eV,
                     "n_b": 1e10 * u.cm**-3,
-                    "coulomb_log": 10 * u.dimensionless_unscaled,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
                 },
             ),
             (
@@ -1797,7 +1797,7 @@ class TestCollisionFrequencies:
                     "T_a": 1e2 * u.eV,
                     "T_b": 1e4 * u.eV,
                     "n_b": 1e20 * u.cm**-3,
-                    "coulomb_log": 10 * u.dimensionless_unscaled,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
                 },
             ),
         ],
@@ -1816,7 +1816,7 @@ class TestCollisionFrequencies:
         )
 
         coulomb_density_constant = (
-            constructor_keyword_arguments["coulomb_log"].value
+            constructor_keyword_arguments["Coulomb_log"].value
             * constructor_keyword_arguments["n_b"].value
         )
 
@@ -1841,7 +1841,7 @@ class TestCollisionFrequencies:
                     "T_a": 1 * u.eV,
                     "T_b": 1 * u.eV,
                     "n_b": 1 * u.cm**-3,
-                    "coulomb_log": 1 * u.dimensionless_unscaled,
+                    "Coulomb_log": 1 * u.dimensionless_unscaled,
                 },
             ),
             (
@@ -1850,7 +1850,7 @@ class TestCollisionFrequencies:
                 {
                     "T_b": 1 * u.eV,
                     "n_b": 1 * u.cm**-3,
-                    "coulomb_log": 1 * u.dimensionless_unscaled,
+                    "Coulomb_log": 1 * u.dimensionless_unscaled,
                 },
             ),
         ],
@@ -1874,7 +1874,7 @@ class TestCollisionFrequencies:
                 "T_a": ones_array * u.eV,
                 "T_b": ones_array * u.eV,
                 "n_b": ones_array * u.cm**-3,
-                "coulomb_log": ones_array * u.dimensionless_unscaled,
+                "Coulomb_log": ones_array * u.dimensionless_unscaled,
             },
         ],
     )

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1738,8 +1738,6 @@ class TestCollisionFrequencies:
 
         value = getattr(self.attribute_test_case, attribute_to_test)
 
-        print(f"\n {value.unit} =? {expected_attribute_units}")
-
         assert getattr(self.attribute_test_case, attribute_to_test).unit.is_equivalent(
             expected_attribute_units
         )
@@ -2028,9 +2026,6 @@ class TestCollisionFrequencies:
         expected_limit_values = self.get_limit_value(
             interaction_type, limit_type, value_test_case
         )
-
-        print(f"\nX: {value_test_case.x}")
-        print(self.return_values_to_test)
 
         if interaction_type == "e|e":
             charge_constant = 1

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1720,7 +1720,9 @@ class TestCollisionFrequencies:
         "parallel_diffusion",
         "energy_loss",
     ]
-    return_values_to_test = attributes_to_test + ["v_0",]
+    return_values_to_test = attributes_to_test + [
+        "v_0",
+    ]
 
     ones_array = np.ones(5)
 
@@ -1825,7 +1827,7 @@ class TestCollisionFrequencies:
                         9e-8 * mu**0.5 * mu_prime**-1 * T_b * T_a**-2.5,
                     ]
                 )
-# The expected energy loss collision frequency should always equal this
+        # The expected energy loss collision frequency should always equal this
         limit_values.append(
             2 * cases.slowing_down.value
             - cases.transverse_diffusion.value
@@ -2033,7 +2035,7 @@ class TestCollisionFrequencies:
             zip(self.return_values_to_test, expected_limit_values)
         ):
             calculated_limit_value = getattr(value_test_case, attribute_name).value
-# Energy loss limit value is already in units of frequencies because of the way it is calculated
+            # Energy loss limit value is already in units of frequencies because of the way it is calculated
             if attribute_name != "energy_loss":
                 calculated_limit_value = calculated_limit_value / (
                     coulomb_density_constant * charge_constant

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -2033,7 +2033,7 @@ class TestCollisionFrequencies:
             zip(self.return_values_to_test, expected_limit_values)
         ):
             calculated_limit_value = getattr(value_test_case, attribute_name).value
-
+# Energy loss limit value is already in units of frequencies because of the way it is calculated
             if attribute_name != "energy_loss":
                 calculated_limit_value = calculated_limit_value / (
                     coulomb_density_constant * charge_constant

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1734,8 +1734,6 @@ class TestCollisionFrequencies:
             argument_to_convert
         ] = CGS_unit_conversion_test_constructor_arguments[argument_to_convert].cgs
 
-    print(CGS_unit_conversion_test_constructor_arguments)
-
     MKS_test_case = CollisionFrequencies(
         **MKS_unit_conversion_test_constructor_arguments
     )

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1732,15 +1732,15 @@ class TestCollisionFrequencies:
             u.Hz
         )
 
-    # TODO: Add tests for interactions where x >> 0
     @pytest.mark.parametrize(
         "interaction_type, expected_attribute_values, constructor_arguments, constructor_keyword_arguments",
         [
+            # Slow limit (x << 1)
             (
                 "e|e",
                 {
-                    "slowing_down": 5.8e-12,
-                    "transverse_diffusion": 5.8e-8,
+                    "slowing_down": 5.812e-12,
+                    "transverse_diffusion": 5.812e-8,
                     "parallel_diffusion": 2.9e-8,
                     "energy_loss": -8.72e8,
                 },
@@ -1757,7 +1757,7 @@ class TestCollisionFrequencies:
                 {
                     "slowing_down": 2.5e-5,
                     "transverse_diffusion": 1.2e-1,
-                    "parallel_diffusion": 5.7e-2,
+                    "parallel_diffusion": 5.9e-2,
                     "energy_loss": -1.8e20,
                 },
                 (Particle("e-"), Particle("Na+")),
@@ -1771,10 +1771,10 @@ class TestCollisionFrequencies:
             (
                 "i|e",
                 {
-                    "slowing_down": 6.9e-14,
+                    "slowing_down": 6.935e-14,
                     "transverse_diffusion": 1.39e-11,
                     "parallel_diffusion": 6.94e-12,
-                    "energy_loss": -2.1,
+                    "energy_loss": -2.07,
                 },
                 (Particle("Na+"), Particle("e-")),
                 {
@@ -1787,7 +1787,7 @@ class TestCollisionFrequencies:
             (
                 "i|i",
                 {
-                    "slowing_down": 4.4e-14,
+                    "slowing_down": 4.440e-14,
                     "transverse_diffusion": 3.5e-12,
                     "parallel_diffusion": 1.75e-12,
                     "energy_loss": -5.17e9,
@@ -1796,6 +1796,71 @@ class TestCollisionFrequencies:
                 {
                     "T_a": 1e2 * u.eV,
                     "T_b": 1e4 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            # Fast limit (x >> 1)
+            (
+                "e|e",
+                {
+                    "slowing_down": 7.727e-9,
+                    "transverse_diffusion": 7.727e-9,
+                    "parallel_diffusion": 3.9e-12,
+                    "energy_loss": 7.727e12,
+                },
+                (Particle("e-"), Particle("e-")),
+                {
+                    "T_a": 1e2 * u.eV,
+                    "T_b": 1e-1 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
+                "e|i",
+                {
+                    "slowing_down": 3.900,
+                    "transverse_diffusion": 7.700,
+                    "parallel_diffusion": 9.201e-4,
+                    "energy_loss": 1.844e17,
+                },
+                (Particle("e-"), Particle("Na+")),
+                {
+                    "T_a": 1e-4 * u.eV,
+                    "T_b": 1e-3 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
+                "i|e",
+                {
+                    "slowing_down": 7.909e-10,
+                    "transverse_diffusion": 3.767e-14,
+                    "parallel_diffusion": 7.909e-17,
+                    "energy_loss": 1.582e12,
+                },
+                (Particle("Na+"), Particle("e-")),
+                {
+                    "T_a": 1e4 * u.eV,
+                    "T_b": 1e-3 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
+                "i|i",
+                {
+                    "slowing_down": 3.101e-14,
+                    "transverse_diffusion": 3.768e-14,
+                    "parallel_diffusion": 1.222e-16,
+                    "energy_loss": 2.448e7,
+                },
+                (Particle("Na+"), Particle("Cl-")),
+                {
+                    "T_a": 1e4 * u.eV,
+                    "T_b": 1e2 * u.eV,
                     "n_b": 1e20 * u.cm**-3,
                     "Coulomb_log": 10 * u.dimensionless_unscaled,
                 },
@@ -1828,7 +1893,7 @@ class TestCollisionFrequencies:
                 if name != "energy_loss":
                     calculated_value = calculated_value / coulomb_density_constant
 
-            assert np.allclose(calculated_value, expected_value, rtol=5e-2, atol=0)
+            assert np.allclose(calculated_value, expected_value, rtol=1e-2, atol=0)
 
     @pytest.mark.parametrize(
         "expected_error, constructor_arguments, constructor_keyword_arguments",

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1730,13 +1730,11 @@ class TestCollisionFrequencies:
             ("transverse_diffusion", u.Hz),
             ("parallel_diffusion", u.Hz),
             ("energy_loss", u.Hz),
-            ("_x", u.dimensionless_unscaled),
+            ("x", u.dimensionless_unscaled),
         ],
     )
     def test_units(self, attribute_to_test, expected_attribute_units):
         """Test the return units"""
-
-        value = getattr(self.attribute_test_case, attribute_to_test)
 
         assert getattr(self.attribute_test_case, attribute_to_test).unit.is_equivalent(
             expected_attribute_units

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1825,7 +1825,7 @@ class TestCollisionFrequencies:
                         9e-8 * mu**0.5 * mu_prime**-1 * T_b * T_a**-2.5,
                     ]
                 )
-
+# The expected energy loss collision frequency should always equal this
         limit_values.append(
             2 * cases.slowing_down.value
             - cases.transverse_diffusion.value

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1819,7 +1819,7 @@ class TestCollisionFrequencies:
                         * 10**-8
                         * mu_prime ** (1 / 2)
                         * mu ** (-1)
-                        * (1 + mu_prime / mu) ** (-1 / 2)
+                        * (1 + mu_prime / mu) 
                         * T_b ** (-3 / 2),
                         1.4
                         * 10**-7

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1719,15 +1719,8 @@ class TestCollisionFrequencies:
         "transverse_diffusion",
         "parallel_diffusion",
         "energy_loss",
-        "v_0",
     ]
-
-    return_values_to_test = [
-        "slowing_down",
-        "transverse_diffusion",
-        "parallel_diffusion",
-        "energy_loss",
-    ]
+    return_values_to_test = attributes_to_test + ["v_0",]
 
     ones_array = np.ones(5)
 

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1765,7 +1765,7 @@ class TestCollisionFrequencies:
         for _, (name, expected_value) in enumerate(expected_attribute_values.items()):
             calculated_value = getattr(value_test_case, name)
 
-            assert np.isclose(calculated_value.value, expected_value)
+            assert np.allclose(calculated_value.value, expected_value)
 
     @pytest.mark.parametrize(
         "expected_error, constructor_arguments, constructor_keyword_arguments",
@@ -1818,4 +1818,4 @@ class TestCollisionFrequencies:
     def test_handle_nparrays(self, constructor_keyword_arguments):
         """Test for ability to handle numpy array quantities"""
 
-        case = CollisionFrequencies(**constructor_keyword_arguments)
+        CollisionFrequencies(**constructor_keyword_arguments)

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1722,6 +1722,7 @@ class TestCollisionFrequencies:
     ]
 
     ones_array = np.ones(5)
+    ones_array2d = np.ones([5, 5])
 
     @pytest.mark.parametrize(
         "attribute_to_test, expected_attribute_units",
@@ -1731,6 +1732,7 @@ class TestCollisionFrequencies:
             ("parallel_diffusion", u.Hz),
             ("energy_loss", u.Hz),
             ("x", u.dimensionless_unscaled),
+            ("Lorentz_collision_frequency", u.Hz),
         ],
     )
     def test_units(self, attribute_to_test, expected_attribute_units):
@@ -2098,6 +2100,14 @@ class TestCollisionFrequencies:
                 "T_b": ones_array * u.eV,
                 "n_b": ones_array * u.cm**-3,
                 "Coulomb_log": ones_array * u.dimensionless_unscaled,
+            },
+            {
+                "test_particle": Particle("e-"),
+                "field_particle": Particle("e-"),
+                "T_a": ones_array2d * u.eV,
+                "T_b": ones_array2d * u.eV,
+                "n_b": ones_array2d * u.cm**-3,
+                "Coulomb_log": ones_array2d * u.dimensionless_unscaled,
             },
         ],
     )

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1714,24 +1714,34 @@ class TestCollisionFrequencies:
         Coulomb_log=1 * u.dimensionless_unscaled,
     )
 
-    attributes_to_test = [
+    return_values_to_test = [
         "momentum_loss",
         "transverse_diffusion",
         "parallel_diffusion",
         "energy_loss",
     ]
-    return_values_to_test = attributes_to_test + [
-        "v_0",
-    ]
 
     ones_array = np.ones(5)
 
-    @pytest.mark.parametrize("attribute_to_test", attributes_to_test)
-    def test_units(self, attribute_to_test):
+    @pytest.mark.parametrize(
+        "attribute_to_test, expected_attribute_units",
+        [
+            ("momentum_loss", u.Hz),
+            ("transverse_diffusion", u.Hz),
+            ("parallel_diffusion", u.Hz),
+            ("energy_loss", u.Hz),
+            ("_x", u.dimensionless_unscaled),
+        ],
+    )
+    def test_units(self, attribute_to_test, expected_attribute_units):
         """Test the return units"""
 
+        value = getattr(self.attribute_test_case, attribute_to_test)
+
+        print(f"\n {value.unit} =? {expected_attribute_units}")
+
         assert getattr(self.attribute_test_case, attribute_to_test).unit.is_equivalent(
-            u.Hz
+            expected_attribute_units
         )
 
     @staticmethod
@@ -1742,7 +1752,7 @@ class TestCollisionFrequencies:
         These formulae are taken from page 31 of the NRL Formulary.
         """
 
-        T_a = (cases.T_a * k_B).to(u.eV).value
+        v_a = (cases.T_a * k_B).to(u.eV).value
         T_b = (cases.T_b * k_B).to(u.eV).value
 
         limit_values = []
@@ -1752,16 +1762,16 @@ class TestCollisionFrequencies:
                 limit_values.extend(
                     [
                         5.8e-6 * T_b ** (-1.5),
-                        5.8e-6 * T_b ** (-0.5) * T_a ** (-1),
-                        2.9e-6 * T_b ** (-0.5) * T_a ** (-1),
+                        5.8e-6 * T_b ** (-0.5) * v_a ** (-1),
+                        2.9e-6 * T_b ** (-0.5) * v_a ** (-1),
                     ]
                 )
             elif limit_type == "fast":
                 limit_values.extend(
                     [
-                        7.7e-6 * T_a ** (-1.5),
-                        7.7e-6 * T_a ** (-1.5),
-                        3.9e-6 * T_b * T_a ** (-2.5),
+                        7.7e-6 * v_a ** (-1.5),
+                        7.7e-6 * v_a ** (-1.5),
+                        3.9e-6 * T_b * v_a ** (-2.5),
                     ]
                 )
         elif interaction_type == "e|i":
@@ -1771,16 +1781,16 @@ class TestCollisionFrequencies:
                 limit_values.extend(
                     [
                         0.23 * mu**1.5 * T_b**-1.5,
-                        2.5e-4 * mu**0.5 * T_b**-0.5 * T_a**-1,
-                        1.2e-4 * mu**0.5 * T_b**-0.5 * T_a**-1,
+                        2.5e-4 * mu**0.5 * T_b**-0.5 * v_a**-1,
+                        1.2e-4 * mu**0.5 * T_b**-0.5 * v_a**-1,
                     ]
                 )
             elif limit_type == "fast":
                 limit_values.extend(
                     [
-                        3.9e-6 * T_a**-1.5,
-                        7.7e-6 * T_a**-1.5,
-                        2.1e-9 * mu**-1 * T_b * T_a**-2.5,
+                        3.9e-6 * v_a**-1.5,
+                        7.7e-6 * v_a**-1.5,
+                        2.1e-9 * mu**-1 * T_b * v_a**-2.5,
                     ]
                 )
         elif interaction_type == "i|e":
@@ -1790,16 +1800,16 @@ class TestCollisionFrequencies:
                 limit_values.extend(
                     [
                         1.6e-9 * mu**-1 * T_b ** (-1.5),
-                        3.2e-9 * mu**-1 * T_b ** (-0.5) * T_a**-1,
-                        1.6e-9 * mu**-1 * T_b ** (-0.5) * T_a**-1,
+                        3.2e-9 * mu**-1 * T_b ** (-0.5) * v_a**-1,
+                        1.6e-9 * mu**-1 * T_b ** (-0.5) * v_a**-1,
                     ]
                 )
             elif limit_type == "fast":
                 limit_values.extend(
                     [
-                        1.7e-4 * mu**0.5 * T_a**-1.5,
-                        1.8e-7 * mu**-0.5 * T_a**-1.5,
-                        1.7e-4 * mu**0.5 * T_b * T_a**-2.5,
+                        1.7e-4 * mu**0.5 * v_a**-1.5,
+                        1.8e-7 * mu**-0.5 * v_a**-1.5,
+                        1.7e-4 * mu**0.5 * T_b * v_a**-2.5,
                     ]
                 )
 
@@ -1815,16 +1825,16 @@ class TestCollisionFrequencies:
                         * mu**-1
                         * (1 + mu_prime / mu)
                         * T_b**-1.5,
-                        1.4e-7 * mu_prime**0.5 * mu**-1 * T_b**-0.5 * T_a**-1,
-                        6.8e-8 * mu_prime**0.5 * mu**-1 * T_b**-0.5 * T_a**-1,
+                        1.4e-7 * mu_prime**0.5 * mu**-1 * T_b**-0.5 * v_a**-1,
+                        6.8e-8 * mu_prime**0.5 * mu**-1 * T_b**-0.5 * v_a**-1,
                     ]
                 )
             elif limit_type == "fast":
                 limit_values.extend(
                     [
-                        9e-8 * (1 / mu + 1 / mu_prime) * mu**0.5 * T_a**-1.5,
-                        1.8 * 10**-7 * mu**-0.5 * T_a**-1.5,
-                        9e-8 * mu**0.5 * mu_prime**-1 * T_b * T_a**-2.5,
+                        9e-8 * (1 / mu + 1 / mu_prime) * mu**0.5 * v_a**-1.5,
+                        1.8 * 10**-7 * mu**-0.5 * v_a**-1.5,
+                        9e-8 * mu**0.5 * mu_prime**-1 * T_b * v_a**-2.5,
                     ]
                 )
         # The expected energy loss collision frequency should always equal this
@@ -2019,6 +2029,9 @@ class TestCollisionFrequencies:
             interaction_type, limit_type, value_test_case
         )
 
+        print(f"\nX: {value_test_case.x}")
+        print(self.return_values_to_test)
+
         if interaction_type == "e|e":
             charge_constant = 1
         elif interaction_type == "e|i":
@@ -2042,7 +2055,7 @@ class TestCollisionFrequencies:
                 )
 
             assert np.allclose(
-                calculated_limit_value, expected_limit_value, rtol=0.1, atol=0
+                calculated_limit_value, expected_limit_value, rtol=0.05, atol=0
             )
 
     @pytest.mark.parametrize(

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1740,15 +1740,15 @@ class TestCollisionFrequencies:
         )
 
     @staticmethod
-    def get_limit_value(interaction_type, limit_type, frequencies):
+    def get_limit_value(interaction_type, limit_type, cases):
         """
         Get the limiting values for frequencies given the two particles interacting, and their frequencies class.
 
         These formulae are taken from page 31 of the NRL Formulary.
         """
 
-        T_a = (frequencies.T_a * k_B).to(u.eV).value
-        T_b = (frequencies.T_b * k_B).to(u.eV).value
+        T_a = (cases.T_a * k_B).to(u.eV).value
+        T_b = (cases.T_b * k_B).to(u.eV).value
 
         limit_values = []
 
@@ -1756,107 +1756,87 @@ class TestCollisionFrequencies:
             if limit_type == "slow":
                 limit_values.extend(
                     [
-                        5.8 * 10**-6 * T_b ** (-3 / 2),
-                        5.8 * 10**-6 * T_b ** (-1 / 2) * T_a ** (-1),
-                        2.9 * 10**-6 * T_b ** (-1 / 2) * T_a ** (-1),
+                        5.8e-6 * T_b ** (-1.5),
+                        5.8e-6 * T_b ** (-0.5) * T_a ** (-1),
+                        2.9e-6 * T_b ** (-0.5) * T_a ** (-1),
                     ]
                 )
             elif limit_type == "fast":
                 limit_values.extend(
                     [
-                        7.7 * 10**-6 * T_a ** (-3 / 2),
-                        7.7 * 10**-6 * T_a ** (-3 / 2),
-                        3.9 * 10**-6 * T_b * T_a ** (-5 / 2),
+                        7.7e-6 * T_a ** (-1.5),
+                        7.7e-6 * T_a ** (-1.5),
+                        3.9e-6 * T_b * T_a ** (-2.5),
                     ]
                 )
         elif interaction_type == "e|i":
-            mu = (frequencies.field_particle.mass / m_p).value
+            mu = (cases.field_particle.mass / m_p).value
 
             if limit_type == "slow":
                 limit_values.extend(
                     [
-                        0.23 * mu ** (3 / 2) * T_b ** (-3 / 2),
-                        2.5 * 10**-4 * mu ** (1 / 2) * T_b ** (-1 / 2) * T_a ** (-1),
-                        1.2 * 10**-4 * mu ** (1 / 2) * T_b ** (-1 / 2) * T_a ** (-1),
+                        0.23 * mu**1.5 * T_b**-1.5,
+                        2.5e-4 * mu**0.5 * T_b**-0.5 * T_a**-1,
+                        1.2e-4 * mu**0.5 * T_b**-0.5 * T_a**-1,
                     ]
                 )
             elif limit_type == "fast":
                 limit_values.extend(
                     [
-                        3.9 * 10**-6 * T_a ** (-3 / 2),
-                        7.7 * 10**-6 * T_a ** (-3 / 2),
-                        2.1 * 10**-9 * mu ** (-1) * T_b * T_a ** (-5 / 2),
+                        3.9e-6 * T_a**-1.5,
+                        7.7e-6 * T_a**-1.5,
+                        2.1e-9 * mu**-1 * T_b * T_a**-2.5,
                     ]
                 )
         elif interaction_type == "i|e":
-            mu = (frequencies.test_particle.mass / m_p).value
+            mu = (cases.test_particle.mass / m_p).value
 
             if limit_type == "slow":
                 limit_values.extend(
                     [
-                        1.6 * 10**-9 * mu ** (-1) * T_b ** (-3 / 2),
-                        3.2 * 10**-9 * mu ** (-1) * T_b ** (-1 / 2) * T_a ** (-1),
-                        1.6 * 10**-9 * mu ** (-1) * T_b ** (-1 / 2) * T_a ** (-1),
+                        1.6e-9 * mu**-1 * T_b ** (-1.5),
+                        3.2e-9 * mu**-1 * T_b ** (-0.5) * T_a**-1,
+                        1.6e-9 * mu**-1 * T_b ** (-0.5) * T_a**-1,
                     ]
                 )
             elif limit_type == "fast":
                 limit_values.extend(
                     [
-                        1.7 * 10**-4 * mu ** (1 / 2) * T_a ** (-3 / 2),
-                        1.8 * 10**-7 * mu ** (-1 / 2) * T_a ** (-3 / 2),
-                        1.7 * 10**-4 * mu ** (1 / 2) * T_b * T_a ** (-5 / 2),
+                        1.7e-4 * mu**0.5 * T_a**-1.5,
+                        1.8e-7 * mu**-0.5 * T_a**-1.5,
+                        1.7e-4 * mu**0.5 * T_b * T_a**-2.5,
                     ]
                 )
 
         elif interaction_type == "i|i":
-            mu = (frequencies.test_particle.mass / m_p).value
-            mu_prime = (frequencies.field_particle.mass / m_p).value
+            mu = (cases.test_particle.mass / m_p).value
+            mu_prime = (cases.field_particle.mass / m_p).value
 
             if limit_type == "slow":
                 limit_values.extend(
                     [
-                        6.8
-                        * 10**-8
-                        * mu_prime ** (1 / 2)
-                        * mu ** (-1)
-                        * (1 + mu_prime / mu) 
-                        * T_b ** (-3 / 2),
-                        1.4
-                        * 10**-7
-                        * mu_prime ** (1 / 2)
-                        * mu ** (-1)
-                        * T_b ** (-1 / 2)
-                        * T_a ** (-1),
-                        6.8
-                        * 10**-8
-                        * mu_prime ** (1 / 2)
-                        * mu ** (-1)
-                        * T_b ** (-1 / 2)
-                        * T_a ** (-1),
+                        6.8e-8
+                        * mu_prime**0.5
+                        * mu**-1
+                        * (1 + mu_prime / mu)
+                        * T_b**-1.5,
+                        1.4e-7 * mu_prime**0.5 * mu**-1 * T_b**-0.5 * T_a**-1,
+                        6.8e-8 * mu_prime**0.5 * mu**-1 * T_b**-0.5 * T_a**-1,
                     ]
                 )
             elif limit_type == "fast":
                 limit_values.extend(
                     [
-                        9
-                        * 10**-8
-                        * (1 / mu + 1 / mu_prime)
-                        * mu ** (1 / 2)
-                        * T_a ** (-3 / 2),
-                        1.8 * 10**-7 * mu ** (-1 / 2) * T_a ** (-3 / 2),
-                        9
-                        * 10**-8
-                        * mu ** (1 / 2)
-                        * mu_prime ** (-1)
-                        * T_b
-                        * T_a ** (-5 / 2),
+                        9e-8 * (1 / mu + 1 / mu_prime) * mu**0.5 * T_a**-1.5,
+                        1.8 * 10**-7 * mu**-0.5 * T_a**-1.5,
+                        9e-8 * mu**0.5 * mu_prime**-1 * T_b * T_a**-2.5,
                     ]
                 )
 
         limit_values.append(
-            2 * frequencies.slowing_down.value
-            - frequencies.transverse_diffusion.value
-            - frequencies.parallel_diffusion.value
+            2 * cases.slowing_down.value
+            - cases.transverse_diffusion.value
+            - cases.parallel_diffusion.value
         )
 
         return limit_values
@@ -1915,7 +1895,7 @@ class TestCollisionFrequencies:
                 "fast",
                 (Particle("e-"), Particle("e-")),
                 {
-                    "T_a": 1e2 * u.eV,
+                    "v_a": 6e8 * u.cm / u.s,
                     "T_b": 1e-1 * u.eV,
                     "n_b": 1e20 * u.cm**-3,
                     "Coulomb_log": 10 * u.dimensionless_unscaled,
@@ -1926,7 +1906,7 @@ class TestCollisionFrequencies:
                 "fast",
                 (Particle("e-"), Particle("Na+")),
                 {
-                    "T_a": 1e-4 * u.eV,
+                    "v_a": 6e5 * u.cm / u.s,
                     "T_b": 1e-3 * u.eV,
                     "n_b": 1e20 * u.cm**-3,
                     "Coulomb_log": 10 * u.dimensionless_unscaled,
@@ -1937,7 +1917,7 @@ class TestCollisionFrequencies:
                 "fast",
                 (Particle("Na+"), Particle("e-")),
                 {
-                    "T_a": 1e4 * u.eV,
+                    "v_a": 3e7 * u.cm / u.s,
                     "T_b": 1e-3 * u.eV,
                     "n_b": 1e20 * u.cm**-3,
                     "Coulomb_log": 10 * u.dimensionless_unscaled,
@@ -1948,7 +1928,7 @@ class TestCollisionFrequencies:
                 "fast",
                 (Particle("Na+"), Particle("Cl-")),
                 {
-                    "T_a": 1e4 * u.eV,
+                    "v_a": 3e7 * u.cm / u.s,
                     "T_b": 1e2 * u.eV,
                     "n_b": 1e20 * u.cm**-3,
                     "Coulomb_log": 10 * u.dimensionless_unscaled,
@@ -1971,7 +1951,7 @@ class TestCollisionFrequencies:
 
         coulomb_density_constant = (
             constructor_keyword_arguments["Coulomb_log"].value
-            * constructor_keyword_arguments["n_b"].value
+            * constructor_keyword_arguments["n_b"].to(u.cm**-3).value
         )
 
         expected_limit_values = self.get_limit_value(
@@ -1995,6 +1975,7 @@ class TestCollisionFrequencies:
     @pytest.mark.parametrize(
         "expected_error, constructor_arguments, constructor_keyword_arguments",
         [
+            # Both T_a and v_a specified error
             (
                 ValueError,
                 (Particle("e-"), Particle("e-")),
@@ -2006,6 +1987,7 @@ class TestCollisionFrequencies:
                     "Coulomb_log": 1 * u.dimensionless_unscaled,
                 },
             ),
+            # Neither T_a nor v_a specified error
             (
                 ValueError,
                 (Particle("e-"), Particle("e-")),
@@ -2040,7 +2022,7 @@ class TestCollisionFrequencies:
             },
         ],
     )
-    def test_handle_nparrays(self, constructor_keyword_arguments):
+    def test_handle_ndarrays(self, constructor_keyword_arguments):
         """Test for ability to handle numpy array quantities"""
 
         CollisionFrequencies(**constructor_keyword_arguments)

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1868,6 +1868,17 @@ class TestCollisionFrequencies:
                 },
             ),
             (
+                "e|i",
+                "slow",
+                (Particle("e-"), Particle("Ba 2+")),
+                {
+                    "T_a": 1e-4 * u.eV,
+                    "T_b": 1e4 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
                 "i|e",
                 "slow",
                 (Particle("Na+"), Particle("e-")),
@@ -1879,9 +1890,31 @@ class TestCollisionFrequencies:
                 },
             ),
             (
+                "i|e",
+                "slow",
+                (Particle("Be 2+"), Particle("e-")),
+                {
+                    "T_a": 1 * u.eV,
+                    "T_b": 1e2 * u.eV,
+                    "n_b": 1e10 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
                 "i|i",
                 "slow",
                 (Particle("Na+"), Particle("Cl-")),
+                {
+                    "T_a": 1e2 * u.eV,
+                    "T_b": 1e4 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
+                "i|i",
+                "slow",
+                (Particle("Na+"), Particle("S 2-")),
                 {
                     "T_a": 1e2 * u.eV,
                     "T_b": 1e4 * u.eV,
@@ -1913,6 +1946,17 @@ class TestCollisionFrequencies:
                 },
             ),
             (
+                "e|i",
+                "fast",
+                (Particle("e-"), Particle("Zn 2+")),
+                {
+                    "v_a": 6e5 * u.cm / u.s,
+                    "T_b": 1e-3 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
                 "i|e",
                 "fast",
                 (Particle("Na+"), Particle("e-")),
@@ -1924,9 +1968,31 @@ class TestCollisionFrequencies:
                 },
             ),
             (
+                "i|e",
+                "fast",
+                (Particle("Ca 2+"), Particle("e-")),
+                {
+                    "v_a": 3e7 * u.cm / u.s,
+                    "T_b": 1e-3 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
                 "i|i",
                 "fast",
                 (Particle("Na+"), Particle("Cl-")),
+                {
+                    "v_a": 3e7 * u.cm / u.s,
+                    "T_b": 1e2 * u.eV,
+                    "n_b": 1e20 * u.cm**-3,
+                    "Coulomb_log": 10 * u.dimensionless_unscaled,
+                },
+            ),
+            (
+                "i|i",
+                "fast",
+                (Particle("Be 2+"), Particle("Cl-")),
                 {
                     "v_a": 3e7 * u.cm / u.s,
                     "T_b": 1e2 * u.eV,
@@ -1958,14 +2024,26 @@ class TestCollisionFrequencies:
             interaction_type, limit_type, value_test_case
         )
 
+        if interaction_type == "e|e":
+            charge_constant = 1
+        elif interaction_type == "e|i":
+            charge_constant = value_test_case.field_particle.charge_number**2
+        elif interaction_type == "i|e":
+            charge_constant = value_test_case.test_particle.charge_number**2
+        elif interaction_type == "i|i":
+            charge_constant = (
+                value_test_case.test_particle.charge_number
+                * value_test_case.field_particle.charge_number
+            ) ** 2
+
         for i, (attribute_name, expected_limit_value) in enumerate(
             zip(self.return_values_to_test, expected_limit_values)
         ):
             calculated_limit_value = getattr(value_test_case, attribute_name).value
 
             if attribute_name != "energy_loss":
-                calculated_limit_value = (
-                    calculated_limit_value / coulomb_density_constant
+                calculated_limit_value = calculated_limit_value / (
+                    coulomb_density_constant * charge_constant
                 )
 
             assert np.allclose(

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1802,7 +1802,7 @@ class TestCollisionFrequencies:
             ),
         ],
     )
-    def test_electron_electron_values(
+    def test_return_values(
         self,
         interaction_type,
         expected_attribute_values,


### PR DESCRIPTION
Resolves PlasmaPy/hack-week#23

This pull request implements the four types of relaxation described on page 31 of the NRL formulary (see issue for screenshot)

For now, the class relies on a parameter called `coulomb_log`, which is the value of the Coulomb logarithm evaluated for the two interacting plasmas. This is because the current implementation of the Coulomb logarithm is limited to electron-electron interactions... In a future pull request I will be revisiting the Coulomb logarithm to include for a broader array of interactions

- [x] I have added a changelog entry for this pull request.
- [x] If adding new functionality, I have added tests and
      docstrings.
- [x] I have fixed any newly failing tests.