### PR TITLE
Appease codespell, which now peeks into our notebooks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -304,10 +304,10 @@ exclude_lines =
 [codespell]
 skip = *.png,*cache*,*egg*,.git,.hypothesis,.idea,.tox,_build,*charged_particle*.ipynb,venv
 ignore-words-list =
-    Bu,
     aci,
     afe,
     ba,
+    bu,
     circularly,
     ded,
     dne,

--- a/setup.cfg
+++ b/setup.cfg
@@ -304,6 +304,7 @@ exclude_lines =
 [codespell]
 skip = *.png,*cache*,*egg*,.git,.hypothesis,.idea,.tox,_build,*charged_particle*.ipynb,venv
 ignore-words-list =
+    Bu,
     aci,
     afe,
     ba,
@@ -314,9 +315,10 @@ ignore-words-list =
     explin,
     fo,
     fof,
+    gud,
+    hax,
     hist,
     hve,
-    gud,
     nd,
     noo,
     nwo,


### PR DESCRIPTION
[Codespell v2.2.0](https://github.com/codespell-project/codespell/releases/tag/v2.2.0) is out! And it checks notebooks now, so this PR fixes [the new codespell failure on `main`](https://github.com/PlasmaPy/PlasmaPy/runs/7897035567?check_suite_focus=true).