### PR TITLE
Resurrect `chemical_potential` and associated functions

### DIFF
--- a/changelog/1678.feature.1.rst
+++ b/changelog/1678.feature.1.rst
@@ -1,0 +1,1 @@
+Reimplemented `~plasmapy.formulary.quantum.chemical_potential`

--- a/changelog/1678.feature.2.rst
+++ b/changelog/1678.feature.2.rst
@@ -1,0 +1,1 @@
+Reimplemented `~plasmapy.formulary.quantum._chemical_potential_interp`

--- a/changelog/1678.feature.2.rst
+++ b/changelog/1678.feature.2.rst
@@ -1,1 +1,1 @@
-Reimplemented `~plasmapy.formulary.quantum._chemical_potential_interp`
+Reimplemented ``plasmapy.formulary.quantum._chemical_potential_interp``

--- a/changelog/1678.trivial.3.rst
+++ b/changelog/1678.trivial.3.rst
@@ -1,0 +1,1 @@
+Re-enabled value testing for the quantum keyword argument in `~plasmapy.formulary.collisions.coupling_parameter`

--- a/plasmapy/formulary/collisions.py
+++ b/plasmapy/formulary/collisions.py
@@ -2019,7 +2019,7 @@ def coupling_parameter(
         fermi_integral = Fermi_integral(chem_potential.si.value, 1.5)
         denominator = (n_e * lambda_deBroglie**3) * fermi_integral
         kinetic_energy = 2 * k_B * T / denominator
-        if np.all(np.imag(kinetic_energy) == 0):
+        if np.all(np.imag(kinetic_energy) < 1e-15 * u.J):
             kinetic_energy = np.real(kinetic_energy)
         else:  # coverage: ignore
             raise ValueError(

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -397,9 +397,6 @@ def Wigner_Seitz_radius(n: u.m**-3) -> u.m:
     return (3 / (4 * np.pi * n)) ** (1 / 3)
 
 
-# TODO: remove NotImplementedError and 'doctest: +SKIP' when the following issues are addressed...
-#       https://github.com/PlasmaPy/PlasmaPy/issues/726
-#       https://github.com/astropy/astropy/issues/9721
 @validate_quantities(
     n_e={"can_be_negative": False},
     T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
@@ -470,16 +467,10 @@ def chemical_potential(n_e: u.m**-3, T: u.K) -> u.dimensionless_unscaled:
     Examples
     --------
     >>> from astropy import units as u
-    >>> chemical_potential(n_e=1e21*u.cm**-3,T=11000*u.K)  # doctest: +SKIP
-    <Quantity 2.00039985e-12>
+    >>> chemical_potential(n_e=1e21*u.cm**-3,T=11000*u.K)
+    <Quantity 9.28146e-14>
     """
 
-    raise NotImplementedError(
-        "This function has been temporarily disabled due to a bug.\n"
-        "Please refer to https://github.com/PlasmaPy/PlasmaPy/issues/726 \n"
-        "and https://github.com/astropy/astropy/issues/9721 "
-        "for progress in fixing it."
-    )
     # deBroglie wavelength
     lambdaDB = thermal_deBroglie_wavelength(T)
     # degeneracy parameter
@@ -505,10 +496,6 @@ def chemical_potential(n_e: u.m**-3, T: u.K) -> u.dimensionless_unscaled:
     return beta_mu
 
 
-# TODO: decorate with validate_quantities
-# TODO: remove NotImplementedError and 'doctest: +SKIP' when the following issues are addressed...
-#       https://github.com/PlasmaPy/PlasmaPy/issues/726
-#       https://github.com/astropy/astropy/issues/9721
 def _chemical_potential_interp(n_e, T):
     r"""
     Fitting formula for interpolating chemical potential between classical
@@ -575,16 +562,10 @@ def _chemical_potential_interp(n_e, T):
     Examples
     --------
     >>> from astropy import units as u
-    >>> _chemical_potential_interp(n_e=1e23*u.cm**-3, T=11000*u.K)  # doctest: +SKIP
+    >>> _chemical_potential_interp(n_e=1e23*u.cm**-3, T=11000*u.K)
     <Quantity 8.17649>
 
     """
-    raise NotImplementedError(
-        "This function has been temporarily disabled due to a bug.\n"
-        "Please refer to https://github.com/PlasmaPy/PlasmaPy/issues/726 \n"
-        "and https://github.com/astropy/astropy/issues/9721 "
-        "for progress in fixing it."
-    )
     A = 0.25945
     B = 0.072
     b = 0.858

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -476,7 +476,7 @@ def chemical_potential(n_e: u.m**-3, T: u.K) -> u.dimensionless_unscaled:
         # note that alpha = mu / (k_B * T)
         model = mathematics.Fermi_integral(alpha, 0.5)
         complexResidue = (data - model) / eps_data
-        return complexResidue.view(np.float)
+        return complexResidue.view(np.float64)
 
     # setting parameters for fitting along with bounds
     alphaGuess = 1 * u.dimensionless_unscaled

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -458,12 +458,6 @@ def chemical_potential(n_e: u.m**-3, T: u.K) -> u.dimensionless_unscaled:
     This function returns :math:`β μ^{ideal}` the dimensionless
     ideal chemical potential.
 
-    Warnings
-    --------
-    At present this function is limited to relatively small arguments
-    due to limitations in the ``mpmath.polylog``, which PlasmaPy uses in
-    calculating the Fermi integral.
-
     Examples
     --------
     >>> from astropy import units as u

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1670,12 +1670,17 @@ class Test_coupling_parameter:
     # TODO vector z_mean
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
-    # @pytest.mark.parametrize("kwargs", [{"method": "classical"},
-    #                                     {"method": "quantum"},])   # TODO quantum issues
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"method": "classical"},
+            {"method": "quantum"},
+        ],
+    )
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs):
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
-            coupling_parameter, insert_some_nans, insert_all_nans, {}
+            coupling_parameter, insert_some_nans, insert_all_nans, kwargs
         )
 
     def test_quantum(self):

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1678,9 +1678,6 @@ class Test_coupling_parameter:
             coupling_parameter, insert_some_nans, insert_all_nans, {}
         )
 
-    @pytest.mark.xfail(
-        reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
-    )
     def test_quantum(self):
         """
         Testing quantum method for coupling parameter.

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -156,11 +156,8 @@ class Test_chemical_potential:
         self.n_e = 1e20 * u.cm**-3
         self.n_e_fail = 1e23 * u.cm**-3
         self.T = 11604 * u.K
-        self.True1 = 1.234345958778249e-11
+        self.True1 = 6.133671348607095e-11
 
-    @pytest.mark.xfail(
-        reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
-    )
     def test_known1(self):
         """
         Tests Fermi_integral for expected value.
@@ -170,9 +167,6 @@ class Test_chemical_potential:
         errStr = f"Chemical potential value should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    @pytest.mark.xfail(
-        reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
-    )
     def test_fail1(self):
         """
         Tests if test_known1() would fail if we slightly adjusted the
@@ -194,11 +188,8 @@ class Test__chemical_potential_interp:
         """initializing parameters for tests"""
         self.n_e = 1e23 * u.cm**-3
         self.T = 11604 * u.K
-        self.True1 = 7.741256653579105
+        self.True1 = 7.741254037813922
 
-    @pytest.mark.xfail(
-        reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
-    )
     def test_known1(self):
         """
         Tests Fermi_integral for expected value.
@@ -208,9 +199,6 @@ class Test__chemical_potential_interp:
         errStr = f"Chemical potential value should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    @pytest.mark.xfail(
-        reason="see issue https://github.com/PlasmaPy/PlasmaPy/issues/726"
-    )
     def test_fail1(self):
         """
         Tests if test_known1() would fail if we slightly adjusted the


### PR DESCRIPTION
Resolves #726 

Floating point errors associated with the `chemical_potential` function seem to have silently been corrected

- [x] I have added a changelog entry for this pull request.
- [x] If adding new functionality, I have added tests and
      docstrings.
- [x] I have fixed any newly failing tests.