### PR TITLE
Update labeling of pull requests done by GitHub Actions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,12 @@
+Analysis: plasmapy/analysis/**/*
+
 Continuous integration: .github/**/*
 
 Contributor Guide: docs/contributing/*
 
 Diagnostics: plasmapy/diagnostics/**/*
+
+Dispersion: plasmapy/dispersion/**/*
 
 Formulary: plasmapy/formulary/**/*
 
@@ -15,13 +19,13 @@ Particles: plasmapy/particles/**/*
 # Add Documentation label to any change in docs but notebooks
 Documentation:
 - any: [docs/**/*]
-  all: ['!docs/notebooks/**/*']
+  all: ['!docs/notebooks/**/*', '!docs/contributing/*']
 
 Notebooks: docs/notebooks/**/*
 
 Plasma class: plasmapy/plasma/**/*
 
-simulations: plasmapy/simulations/**/*
+simulations: plasmapy/simulation/**/*
 
 Utilities: plasmapy/utils/**/*
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,7 @@
 Continuous integration: .github/**/*
 
+Contributor Guide: docs/contributing/*
+
 Diagnostics: plasmapy/diagnostics/**/*
 
 Formulary: plasmapy/formulary/**/*


### PR DESCRIPTION
This PR makes some pretty straightforward updates to the GitHub Action that does labeling of pull requests.
 - Added "Analysis" & Dispersion
 - Added "Contributor Guide"
 - Fixed typo for `plasmapy.simulation`
