### PR TITLE
Attempt to fix intermittent test failure in test_optical_density_histogram

### DIFF
--- a/changelog/1685.bugfix.rst
+++ b/changelog/1685.bugfix.rst
@@ -1,0 +1,1 @@
+Modified tests in the class `TestSyntheticRadiograph` to try to fix an intermittent failure of `test_optical_density_histogram`.

--- a/changelog/1685.bugfix.rst
+++ b/changelog/1685.bugfix.rst
@@ -1,1 +1,1 @@
-Modified tests in the class `TestSyntheticRadiograph` to try to fix an intermittent failure of `test_optical_density_histogram`.
+Modified tests in the class TestSyntheticRadiograph to try to fix an intermittent failure of test_optical_density_histogram.

--- a/changelog/1685.bugfix.rst
+++ b/changelog/1685.bugfix.rst
@@ -1,1 +1,1 @@
-Modified tests in the class TestSyntheticRadiograph to try to fix an intermittent failure of test_optical_density_histogram.
+Modified tests in the class ``TestSyntheticRadiograph`` to try to fix an intermittent failure of ``test_optical_density_histogram``.

--- a/plasmapy/diagnostics/tests/test_charged_particle_radiography.py
+++ b/plasmapy/diagnostics/tests/test_charged_particle_radiography.py
@@ -4,6 +4,7 @@ Tests for proton radiography functions
 
 import astropy.constants as const
 import astropy.units as u
+import copy
 import numpy as np
 import os
 import pytest
@@ -507,7 +508,7 @@ class TestSyntheticRadiograph:
         """
         Test warning when less than half the particles reach the detector plane.
         """
-        sim_results = self.sim_results.copy()
+        sim_results = copy.deepcopy(self.sim_results)
         sim_results["nparticles"] *= 3
         with pytest.warns(RuntimeWarning):
             cpr.synthetic_radiograph(sim_results)
@@ -579,22 +580,31 @@ class TestSyntheticRadiograph:
         bins = (200, 60)
         size = np.array([[-1, 1], [-1, 1]]) * 30 * u.cm
 
-        intensity_results = cpr.synthetic_radiograph(
-            self.sim_results, size=size, bins=bins
-        )
+        sim_results = copy.deepcopy(self.sim_results)
+        intensity_results = cpr.synthetic_radiograph(sim_results, size=size, bins=bins)
+
+        sim_results = copy.deepcopy(self.sim_results)
         od_results = cpr.synthetic_radiograph(
-            self.sim_results, size=size, bins=bins, optical_density=True
+            sim_results, size=size, bins=bins, optical_density=True
         )
 
-        assert np.allclose(intensity_results[0], od_results[0])
-        assert np.allclose(intensity_results[1], od_results[1])
+        assert np.allclose(intensity_results[0], od_results[0], rtol=1e-4, atol=1e-7)
+        assert np.allclose(intensity_results[1], od_results[1], rtol=1e-4, atol=1e-7)
 
-        intensity = intensity_results[2]
-        zero_mask = intensity == 0
-        i0 = np.mean(intensity[~zero_mask])
-        od = -np.log10(intensity / i0)
+        # Manually calculate the OD and check that it agrees with the values
+        # returned from the function
 
-        assert np.allclose(od[~zero_mask], od_results[2][~zero_mask])
+        zero_mask = intensity_results[2] == 0
+        i0 = np.mean(intensity_results[2][~zero_mask])
+        with np.errstate(divide="ignore"):
+            od = -np.log10(intensity_results[2] / i0)
+
+        # Assert that the calculated od is close to that returned by the function
+        assert np.allclose(
+            od[~zero_mask], od_results[2][~zero_mask], rtol=1e-4, atol=1e-7
+        )
+
+        # Assert that all zero intensity values have gone to positive infinity
         assert np.all(np.isposinf(od_results[2][zero_mask]))
 
 


### PR DESCRIPTION
Closes #1458

This is an intermittent test failure, so I've just implemented several possible fixes.

Possible solutions implemented: 

1) Changed `np.copy()` to `copy.deepcopy()` to make sure deep copies are made of the dictionary `sim_results`
2) Updated the calculation of the array `od` to more closely match the method in `SyntheticRadiograph` (to which it is being comapred` 
3) Increased the tolerances by an order of magnitude in case numerical instability in the proton source (which is stochastic) is contributing (per @JaydenR2305 's suggestion)