### PR TITLE
Bump minimum NumPy version to 1.20.0

### DIFF
--- a/changelog/1694.trivial.rst
+++ b/changelog/1694.trivial.rst
@@ -1,0 +1,1 @@
+Increased the minimum version of NumPy_ to 1.20.0.

--- a/codemeta.json
+++ b/codemeta.json
@@ -61,7 +61,7 @@
         "matplotlib >= 3.3.0",
         "mpmath >= 1.2.1",
         "numba",
-        "numpy >= 1.19.0",
+        "numpy >= 1.20.0",
         "packaging",
         "pandas >= 1.0.0",
         "scipy >= 1.5.0",

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -9,7 +9,7 @@ lmfit >= 1.0.0
 matplotlib >= 3.3.0
 mpmath >= 1.2.1
 numba
-numpy >= 1.19.0
+numpy >= 1.20.0
 packaging
 pandas >= 1.0.0
 scipy >= 1.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     matplotlib >= 3.3.0
     mpmath >= 1.2.1
     numba
-    numpy >= 1.19.0
+    numpy >= 1.20.0
     packaging
     pandas >= 1.0.0
     scipy >= 1.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ conda_deps =
     h5py >= 3.0.0
     matplotlib
     mpmath
-    numpy >= 1.19.0
+    numpy >= 1.20.0
     numpydoc
     pillow
     pytest >= 5.4.0


### PR DESCRIPTION
This PR bumps the minimum version of NumPy to 1.20, primarily so that we can use type hint annotations from `numpy.typing`. This is in line with the schedule in [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule):  

```
On Jun 21, 2022 drop support for NumPy 1.19 (initially released on Jun 20, 2020)
```

This is a spinoff of #1540.