### PR TITLE
Delete redundant changelog entry

### DIFF
--- a/changelog/1540.trivial.rst
+++ b/changelog/1540.trivial.rst
@@ -1,1 +1,0 @@
-Updated the minimum required version of NumPy to 1.20.0.


### PR DESCRIPTION
I was originally going to bump the minimum version of numpy in #1540, but I ended up splitting that off into its own pull request in #1694.  However, I forgot to delete the corresponding changelog entry in #1540.  This PR fixes that.  