### PR TITLE
Move `ionic_levels` to `plasmapy.particles.atomic`

### DIFF
--- a/changelog/1697.breaking.rst
+++ b/changelog/1697.breaking.rst
@@ -1,0 +1,2 @@
+Moved ``plasmapy.particles.particle_collections.ionic_levels`` to
+`plasmapy.particle.atomic.ionic_levels`.

--- a/changelog/1697.breaking.rst
+++ b/changelog/1697.breaking.rst
@@ -1,2 +1,2 @@
 Moved ``plasmapy.particles.particle_collections.ionic_levels`` to
-`plasmapy.particle.atomic.ionic_levels`.
+`plasmapy.particles.atomic.ionic_levels`.

--- a/docs/whatsnew/0.7.0.rst
+++ b/docs/whatsnew/0.7.0.rst
@@ -139,7 +139,7 @@ Features
   related to analytical dispersion solutions. (`#1208 <https://github.com/plasmapy/plasmapy/pull/1208>`__)
 - Implemented ``__eq__``, ``__ne__`` and ``__hash__`` to allow
   |CustomParticle| instances to be used as `dict` keys. (`#1216 <https://github.com/plasmapy/plasmapy/pull/1216>`__)
-- Added the `~plasmapy.particles.particle_collections.ionic_levels` function to create a
+- Added the ``plasmapy.particles.particle_collections.ionic_levels`` function to create a
   |ParticleList| initialized with different ionic levels of an element or isotope. (`#1223 <https://github.com/plasmapy/plasmapy/pull/1223>`__)
 
 

--- a/plasmapy/particles/__init__.py
+++ b/plasmapy/particles/__init__.py
@@ -13,6 +13,7 @@ from plasmapy.particles.atomic import (
     common_isotopes,
     electric_charge,
     half_life,
+    ionic_levels,
     is_stable,
     isotopic_abundance,
     known_isotopes,
@@ -35,11 +36,7 @@ from plasmapy.particles.particle_class import (
     Particle,
     ParticleLike,
 )
-from plasmapy.particles.particle_collections import (
-    ionic_levels,
-    ParticleList,
-    ParticleListLike,
-)
+from plasmapy.particles.particle_collections import ParticleList, ParticleListLike
 from plasmapy.particles.serialization import (
     json_load_particle,
     json_loads_particle,

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -6,6 +6,7 @@ __all__ = [
     "common_isotopes",
     "electric_charge",
     "half_life",
+    "ionic_levels",
     "isotopic_abundance",
     "is_stable",
     "known_isotopes",
@@ -1107,6 +1108,54 @@ def periodic_table_category(argument: Union[str, Integral]) -> str:
         )
     symbol = atomic_symbol(argument)
     return _elements.data_about_elements[symbol]["category"]
+
+
+@particle_input(any_of={"element", "isotope", "ion"})
+def ionic_levels(
+    particle: Particle,
+    min_charge: Integral = 0,
+    max_charge: Optional[Integral] = None,
+) -> ParticleList:
+    """
+    Return a |ParticleList| that includes different ionic levels of a
+    base atom.
+    Parameters
+    ----------
+    particle : `~plasmapy.particles.particle_class.ParticleLike`
+        Representation of an element, ion, or isotope.
+    min_charge : integer, optional
+        The starting charge number. Defaults to ``0``.
+    max_charge : integer, optional
+        The ending charge number, which will be included in the
+        |ParticleList|.  Defaults to the atomic number.
+    Returns
+    -------
+    `~plasmapy.particles.particle_collections.ParticleList`
+        The ionic levels of the atom provided from ``min_charge`` to
+        ``max_charge``.
+    Examples
+    --------
+    >>> from plasmapy.particles import ionic_levels
+    >>> ionic_levels("He")
+    ParticleList(['He 0+', 'He 1+', 'He 2+'])
+    >>> ionic_levels("Fe-56", min_charge=13, max_charge=15)
+    ParticleList(['Fe-56 13+', 'Fe-56 14+', 'Fe-56 15+'])
+    """
+    base_particle = Particle(particle.isotope or particle.element)
+
+    if max_charge is None:
+        max_charge = particle.atomic_number
+
+    if not min_charge <= max_charge <= particle.atomic_number:
+        raise ChargeError(
+            f"Need min_charge ({min_charge}) "
+            f"≤ max_charge ({max_charge}) "
+            f"≤ atomic number ({base_particle.atomic_number})."
+        )
+
+    return ParticleList(
+        [Particle(base_particle, Z=Z) for Z in range(min_charge, max_charge + 1)]
+    )
 
 
 def _is_electron(arg: Any) -> bool:

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -36,9 +36,8 @@ from plasmapy.particles.exceptions import (
     MissingParticleDataError,
 )
 from plasmapy.particles.particle_class import Particle
+from plasmapy.particles.particle_collections import ParticleList
 from plasmapy.particles.symbols import atomic_symbol
-from plasmapy.utils.decorators.deprecation import deprecated
-from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
 __all__.sort()
 

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -1119,20 +1119,25 @@ def ionic_levels(
     """
     Return a |ParticleList| that includes different ionic levels of a
     base atom.
+
     Parameters
     ----------
     particle : `~plasmapy.particles.particle_class.ParticleLike`
         Representation of an element, ion, or isotope.
+
     min_charge : integer, optional
         The starting charge number. Defaults to ``0``.
+
     max_charge : integer, optional
         The ending charge number, which will be included in the
         |ParticleList|.  Defaults to the atomic number.
+
     Returns
     -------
     `~plasmapy.particles.particle_collections.ParticleList`
         The ionic levels of the atom provided from ``min_charge`` to
         ``max_charge``.
+
     Examples
     --------
     >>> from plasmapy.particles import ionic_levels

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -30,6 +30,7 @@ from typing import Any, List, Optional, Union
 from plasmapy.particles import _elements, _isotopes
 from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.exceptions import (
+    ChargeError,
     InvalidElementError,
     InvalidIsotopeError,
     InvalidParticleError,

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -12,6 +12,7 @@ from astropy import units as u
 from numbers import Integral, Real
 from typing import List, Optional, Union
 
+from plasmapy.particles.atomic import ionic_levels
 from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.exceptions import (
     ChargeError,
@@ -19,10 +20,8 @@ from plasmapy.particles.exceptions import (
     ParticleError,
 )
 from plasmapy.particles.particle_class import CustomParticle, Particle
-from plasmapy.particles.particle_collections import ionic_levels, ParticleList
+from plasmapy.particles.particle_collections import ParticleList
 from plasmapy.utils.decorators import validate_quantities
-from plasmapy.utils.decorators.deprecation import deprecated
-from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
 _number_density_errmsg = (
     "Number densities must be Quantity objects with units of inverse volume."

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -1,6 +1,6 @@
 """Collections of `~plasmapy.particles.particle_class.Particle` objects."""
 
-__all__ = ["ionic_levels", "ParticleList", "ParticleListLike"]
+__all__ = ["ParticleList", "ParticleListLike"]
 
 import astropy.units as u
 import collections

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -436,60 +436,6 @@ Remove the first occurrence of a
 
 ParticleList.reverse.__doc__ = """Reverse the |ParticleList| in place."""
 
-
-@particle_input(any_of={"element", "isotope", "ion"})
-def ionic_levels(
-    particle: Particle,
-    min_charge: Integral = 0,
-    max_charge: Optional[Integral] = None,
-) -> ParticleList:
-    """
-    Return a |ParticleList| that includes different ionic levels of a
-    base atom.
-
-    Parameters
-    ----------
-    particle : `~plasmapy.particles.particle_class.ParticleLike`
-        Representation of an element, ion, or isotope.
-
-    min_charge : integer, optional
-        The starting charge number. Defaults to ``0``.
-
-    max_charge : integer, optional
-        The ending charge number, which will be included in the
-        |ParticleList|.  Defaults to the atomic number.
-
-    Returns
-    -------
-    `~plasmapy.particles.particle_collections.ParticleList`
-        The ionic levels of the atom provided from ``min_charge`` to
-        ``max_charge``.
-
-    Examples
-    --------
-    >>> from plasmapy.particles import ionic_levels
-    >>> ionic_levels("He")
-    ParticleList(['He 0+', 'He 1+', 'He 2+'])
-    >>> ionic_levels("Fe-56", min_charge=13, max_charge=15)
-    ParticleList(['Fe-56 13+', 'Fe-56 14+', 'Fe-56 15+'])
-    """
-    base_particle = Particle(particle.isotope or particle.element)
-
-    if max_charge is None:
-        max_charge = particle.atomic_number
-
-    if not min_charge <= max_charge <= particle.atomic_number:
-        raise ChargeError(
-            f"Need min_charge ({min_charge}) "
-            f"≤ max_charge ({max_charge}) "
-            f"≤ atomic number ({base_particle.atomic_number})."
-        )
-
-    return ParticleList(
-        [Particle(base_particle, Z=Z) for Z in range(min_charge, max_charge + 1)]
-    )
-
-
 ParticleListLike = Union[ParticleList, Sequence[ParticleLike]]
 
 ParticleListLike.__doc__ = r"""

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -12,6 +12,7 @@ from plasmapy.particles.atomic import (
     common_isotopes,
     electric_charge,
     half_life,
+    ionic_levels,
     is_stable,
     isotopic_abundance,
     known_isotopes,
@@ -26,6 +27,7 @@ from plasmapy.particles.atomic import (
     standard_atomic_weight,
 )
 from plasmapy.particles.exceptions import (
+    ChargeError,
     InvalidElementError,
     InvalidIsotopeError,
     InvalidParticleError,
@@ -515,6 +517,39 @@ class TestReducedMassInput:
     def test_missing_atomic_data(self):
         with pytest.raises(MissingParticleDataError):
             reduced_mass("Og", "H")
+
+
+def test_ion_list_example():
+    ions = ionic_levels("He-4")
+    np.testing.assert_equal(ions.charge_number, [0, 1, 2])
+    assert ions.symbols == ["He-4 0+", "He-4 1+", "He-4 2+"]
+
+
+@pytest.mark.parametrize(
+    "particle, min_charge, max_charge, expected_charge_numbers",
+    [
+        ("H-1", 0, 1, [0, 1]),
+        ("p+", 1, 1, [1]),
+        (Particle("p+"), 0, 0, [0]),
+        ("C", 3, 5, [3, 4, 5]),
+    ],
+)
+def test_ion_list(particle, min_charge, max_charge, expected_charge_numbers):
+    """Test that inputs to ionic_levels are interpreted correctly."""
+    particle = Particle(particle)
+    ions = ionic_levels(particle, min_charge, max_charge)
+    np.testing.assert_equal(ions.charge_number, expected_charge_numbers)
+    assert ions[0].element == particle.element
+    if particle.is_category("isotope"):
+        assert ions[0].isotope == particle.isotope
+
+
+@pytest.mark.parametrize(
+    "element, min_charge, max_charge", [("Li", 0, 4), ("Li", 3, 2)]
+)
+def test_invalid_inputs_to_ion_list(element, min_charge, max_charge):
+    with pytest.raises(ChargeError):
+        ionic_levels(element, min_charge, max_charge)
 
 
 str_electron_table = [

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -34,6 +34,7 @@ from plasmapy.particles.exceptions import (
     MissingParticleDataError,
     ParticleWarning,
 )
+from plasmapy.particles.particle_class import Particle
 from plasmapy.particles.symbols import atomic_symbol, element_name, isotope_symbol
 from plasmapy.utils.pytest_helpers import run_test
 

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -10,14 +10,14 @@ from plasmapy.particles import (
     atomic_number,
     atomic_symbol,
     charge_number,
+    ionic_levels,
     isotope_symbol,
     particle_symbol,
 )
 from plasmapy.particles.exceptions import InvalidIsotopeError, ParticleError
 from plasmapy.particles.ionization_state import IonicLevel, IonizationState
 from plasmapy.particles.particle_class import Particle
-from plasmapy.particles.particle_collections import ionic_levels, ParticleList
-from plasmapy.utils.exceptions import PlasmaPyFutureWarning
+from plasmapy.particles.particle_collections import ParticleList
 
 ionic_fraction_table = [
     ("Fe 6+", 0.52, 5.2e-6 * u.m**-3),

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from plasmapy.particles import alpha, electron, neutron, proton
 from plasmapy.particles.atomic import atomic_number
-from plasmapy.particles.exceptions import ChargeError, InvalidParticleError
+from plasmapy.particles.exceptions import InvalidParticleError
 from plasmapy.particles.nuclear import nuclear_reaction_energy
 from plasmapy.particles.particle_class import (
     CustomParticle,
@@ -15,7 +15,7 @@ from plasmapy.particles.particle_class import (
     Particle,
     ParticleLike,
 )
-from plasmapy.particles.particle_collections import ionic_levels, ParticleList
+from plasmapy.particles.particle_collections import ParticleList
 
 custom_particle = CustomParticle(mass=1e-25 * u.kg, charge=1e-18 * u.C)
 dimensionless_particle = DimensionlessParticle(mass=1.25, charge=1.58)
@@ -493,36 +493,3 @@ def test_particle_list_with_no_arguments():
     empty_particle_list = ParticleList()
     assert isinstance(empty_particle_list, ParticleList)
     assert len(empty_particle_list) == 0
-
-
-def test_ion_list_example():
-    ions = ionic_levels("He-4")
-    np.testing.assert_equal(ions.charge_number, [0, 1, 2])
-    assert ions.symbols == ["He-4 0+", "He-4 1+", "He-4 2+"]
-
-
-@pytest.mark.parametrize(
-    "particle, min_charge, max_charge, expected_charge_numbers",
-    [
-        ("H-1", 0, 1, [0, 1]),
-        ("p+", 1, 1, [1]),
-        (Particle("p+"), 0, 0, [0]),
-        ("C", 3, 5, [3, 4, 5]),
-    ],
-)
-def test_ion_list(particle, min_charge, max_charge, expected_charge_numbers):
-    """Test that inputs to ionic_levels are interpreted correctly."""
-    particle = Particle(particle)
-    ions = ionic_levels(particle, min_charge, max_charge)
-    np.testing.assert_equal(ions.charge_number, expected_charge_numbers)
-    assert ions[0].element == particle.element
-    if particle.is_category("isotope"):
-        assert ions[0].isotope == particle.isotope
-
-
-@pytest.mark.parametrize(
-    "element, min_charge, max_charge", [("Li", 0, 4), ("Li", 3, 2)]
-)
-def test_invalid_inputs_to_ion_list(element, min_charge, max_charge):
-    with pytest.raises(ChargeError):
-        ionic_levels(element, min_charge, max_charge)


### PR DESCRIPTION
This PR moves `ionic_levels` from `plasmapy.particles.particle_collections` to `plasmapy.particles.atomic`. 

This PR is a spinoff of #1057.  As noted in [this commit](https://github.com/PlasmaPy/PlasmaPy/pull/1057/commits/59e146763c378f9865ca46b68a5c7cfd99ed594b), this was moved to avoid a circular import during the refactoring of `particle_input`.  