### PR TITLE
Enable categorization of `CustomParticle` objects

### DIFF
--- a/changelog/1700.feature.1.rst
+++ b/changelog/1700.feature.1.rst
@@ -1,0 +1,3 @@
+Moved the ``is_category`` method of |Particle| to
+`~plasmapy.particles.particle_class.AbstractPhysicalParticle`. This
+method is now inherited by both |Particle| and |CustomParticle|.

--- a/changelog/1700.feature.2.rst
+++ b/changelog/1700.feature.2.rst
@@ -1,0 +1,2 @@
+Added the `~plasmapy.particles.particle_class.CustomParticle.categories`
+attribute to |CustomParticle|.

--- a/changelog/1700.feature.2.rst
+++ b/changelog/1700.feature.2.rst
@@ -1,2 +1,3 @@
 Added the `~plasmapy.particles.particle_class.CustomParticle.categories`
-attribute to |CustomParticle|.
+attribute to |CustomParticle|, and added the ``"custom"`` particle
+category.

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -126,15 +126,15 @@ True
 Calling the `~plasmapy.particles.particle_class.Particle.is_category`
 method with no arguments returns a set containing all of the valid
 categories for any particle.  Valid categories include:
-``'actinide'``, ``'alkali metal'``, ``'alkaline earth metal'``,
-``'antibaryon'``, ``'antilepton'``, ``'antimatter'``,
-``'antineutrino'``, ``'baryon'``, ``'boson'``, ``'charged'``,
-``'electron'``, ``'element'``, ``'fermion'``, ``'halogen'``,
-``'ion'``, ``'isotope'``, ``'lanthanide'``, ``'lepton'``,
-``'matter'``, ``'metal'``, ``'metalloid'``, ``'neutrino'``,
-``'neutron'``, ``'noble gas'``, ``'nonmetal'``, ``'positron'``,
-``'post-transition metal'``, ``'proton'``, ``'stable'``,
-``'transition metal'``, ``'uncharged'``, and ``'unstable'``.
+``"actinide"``, ``"alkali metal"``, ``"alkaline earth metal"``,
+``"antibaryon"``, ``"antilepton"``, ``"antimatter"``,
+``"antineutrino"``, ``"baryon"``, ``"boson"``, ``"charged"``,
+``"custom"``, ``"electron"``, ``"element"``, ``"fermion"``,
+``"halogen"``, ``"ion"``, ``"isotope"``, ``"lanthanide"``, ``"lepton"``,
+``"matter"``, ``"metal"``, ``"metalloid"``, ``"neutrino"``,
+``"neutron"``, ``"noble gas"``, ``"nonmetal"``, ``"positron"``,
+``"post-transition metal"``, ``"proton"``, ``"stable"``,
+``"transition metal"``, ``"uncharged"``, and ``"unstable"``.
 
 .. _particle-class-conditionals-equality:
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2232,7 +2232,7 @@ class CustomParticle(AbstractPhysicalParticle):
         """Categories for the |CustomParticle|."""
         if np.isnan(self.charge):
             return set()
-        return {"charged"} if self.charge == 0 * u.C else {"uncharged"}
+        return {"uncharged"} if self.charge == 0 * u.C else {"charged"}
 
     def __eq__(self, other) -> bool:
         """

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -328,7 +328,7 @@ class AbstractPhysicalParticle(AbstractParticle):
                 raise ParticleError(
                     f"The following categories in {self.__repr__()}"
                     f".is_category are {adjective}: {problem_categories}"
-                )  # NEEDS A TEST
+                )
 
         if exclude and exclude & self.categories:
             return False

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1,4 +1,4 @@
-"""The Particle class."""
+"""Classes to represent particles."""
 
 from __future__ import annotations
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2227,6 +2227,13 @@ class CustomParticle(AbstractPhysicalParticle):
         else:
             raise TypeError("symbol needs to be a string.")
 
+    @property
+    def categories(self) -> Set[str]:
+        """Categories for the |CustomParticle|."""
+        if np.isnan(self.charge):
+            return set()
+        return {"charged"} if self.charge == 0 * u.C else {"uncharged"}
+
     def __eq__(self, other) -> bool:
         """
         Determine if two objects correspond to the same particle.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from numbers import Integral, Real
-from typing import Iterable, List, Optional, Set, Tuple, Union
+from typing import Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 from plasmapy.particles import _elements, _isotopes, _parsing, _special_particles
 from plasmapy.particles.exceptions import (
@@ -296,15 +296,13 @@ class AbstractPhysicalParticle(AbstractParticle):
         False
         """
 
-        def become_set(arg: Union[str, Set, Tuple, List]) -> Set[str]:
+        def become_set(arg: Union[str, Set, Sequence]) -> Set[str]:
             """Change the argument into a `set`."""
             if arg is None:
                 return set()
             if isinstance(arg, set):
                 return arg
-            if isinstance(arg, str):
-                return {arg}
-            return set(arg[0]) if isinstance(arg[0], (tuple, list, set)) else set(arg)
+            return {arg} if isinstance(arg, str) else set(arg)
 
         if category_tuple and require:  # coverage: ignore
             raise ParticleError(
@@ -330,7 +328,7 @@ class AbstractPhysicalParticle(AbstractParticle):
                 raise ParticleError(
                     f"The following categories in {self.__repr__()}"
                     f".is_category are {adjective}: {problem_categories}"
-                )
+                )  # NEEDS A TEST
 
         if exclude and exclude & self.categories:
             return False

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -37,8 +37,6 @@ from plasmapy.particles.exceptions import (
     ParticleWarning,
 )
 from plasmapy.utils import roman
-from plasmapy.utils.decorators import deprecated
-from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
 _classification_categories = {
     "lepton",
@@ -206,6 +204,141 @@ class AbstractPhysicalParticle(AbstractParticle):
 
         return ParticleList([self])
 
+    @property
+    @abstractmethod
+    def categories(self) -> Set[str]:
+        """Provide the particle's categories."""
+        raise NotImplementedError
+
+    def is_category(
+        self,
+        *category_tuple,
+        require: Union[str, Iterable[str]] = None,
+        any_of: Union[str, Iterable[str]] = None,
+        exclude: Union[str, Iterable[str]] = None,
+    ) -> bool:
+        """
+        Determine if the particle meets categorization criteria.
+
+        Return `True` if the particle is consistent with the provided
+        categories, and `False` otherwise.
+
+        Parameters
+        ----------
+        *category_tuple
+            Required categories in the form of one or more `str` objects
+            or an iterable.
+
+        require : `str` or iterable providing `str` objects, optional, keyword-only
+            One or more categories.  This method will return `False` if
+            the particle does not belong to all of these categories.
+
+        any_of : `str` or iterable providing `str` objects, optional, keyword-only
+            One or more categories. This method will return `False` if
+            the particle does not belong to at least one of these
+            categories.
+
+        exclude : `str` or iterable providing `str` objects, optional, keyword-only
+            One or more categories.  This method will return `False` if
+            the particle belongs to any of these categories.
+
+        Notes
+        -----
+        A `set` containing all valid categories may be accessed by the
+        ``valid_categories`` attribute of ``is_category``.
+
+        Examples
+        --------
+        Required categories may be entered as positional arguments,
+        including as a `list`, `set`, or `tuple` of required categories.
+
+        >>> electron = Particle("e-")
+        >>> electron.is_category("lepton")
+        True
+        >>> electron.is_category("lepton", "baryon")
+        False
+        >>> electron.is_category(["fermion", "matter"])
+        True
+
+        Required arguments may also be provided using the ``require``
+        keyword argument.
+
+        >>> electron.is_category(require="lepton")
+        True
+        >>> electron.is_category(require=["lepton", "baryon"])
+        False
+
+        This method will return `False` if the particle does not belong
+        to at least one of the categories provided with the ``any_of``
+        keyword argument.
+
+        >>> electron.is_category(any_of=["lepton", "baryon"])
+        True
+        >>> electron.is_category(any_of=("noble gas", "lanthanide", "halogen"))
+        False
+
+        This method will return `False` if the particle belongs to any
+        of the categories provided in the ``exclude`` keyword argument.
+
+        >>> electron.is_category(exclude="baryon")
+        True
+        >>> electron.is_category(exclude={"lepton", "baryon"})
+        False
+
+        The ``require``, ``any_of``, and ``exclude`` keywords may be
+        combined.  If the particle matches all of the provided criteria,
+        then this method will return `True`.
+
+        >>> electron.is_category(
+        ...     require="fermion", any_of={'lepton', 'baryon'}, exclude='charged',
+        ... )
+        False
+        """
+
+        def become_set(arg: Union[str, Set, Tuple, List]) -> Set[str]:
+            """Change the argument into a `set`."""
+            if arg is None:
+                return set()
+            if isinstance(arg, set):
+                return arg
+            if isinstance(arg, str):
+                return {arg}
+            return set(arg[0]) if isinstance(arg[0], (tuple, list, set)) else set(arg)
+
+        if category_tuple and require:  # coverage: ignore
+            raise ParticleError(
+                "No positional arguments are allowed if the `require` keyword "
+                "is set in is_category."
+            )
+
+        require = become_set(category_tuple) if category_tuple else become_set(require)
+        exclude = become_set(exclude)
+        any_of = become_set(any_of)
+
+        invalid_categories = (require | exclude | any_of) - _valid_categories
+
+        duplicate_categories = require & exclude | exclude & any_of | require & any_of
+
+        categories_and_adjectives = [
+            (invalid_categories, "invalid"),
+            (duplicate_categories, "duplicated"),
+        ]
+
+        for problem_categories, adjective in categories_and_adjectives:
+            if problem_categories:
+                raise ParticleError(
+                    f"The following categories in {self.__repr__()}"
+                    f".is_category are {adjective}: {problem_categories}"
+                )
+
+        if exclude and exclude & self.categories:
+            return False
+
+        if any_of and not any_of & self.categories:
+            return False
+
+        return require <= self.categories
+
     def __add__(self, other):
         return self._as_particle_list + other
 
@@ -220,6 +353,10 @@ class AbstractPhysicalParticle(AbstractParticle):
 
     def __gt__(self, other):
         return self._as_particle_list.__gt__(other)
+
+
+AbstractPhysicalParticle.is_category.valid_categories = _valid_categories
+"""All valid particle categories."""
 
 
 class Particle(AbstractPhysicalParticle):
@@ -1493,137 +1630,6 @@ class Particle(AbstractPhysicalParticle):
         """
         return self._categories
 
-    def is_category(
-        self,
-        *category_tuple,
-        require: Union[str, Iterable[str]] = None,
-        any_of: Union[str, Iterable[str]] = None,
-        exclude: Union[str, Iterable[str]] = None,
-    ) -> bool:
-        """
-        Determine if the particle meets categorization criteria.
-
-        Return `True` if the particle is consistent with the provided
-        categories, and `False` otherwise.
-
-        Parameters
-        ----------
-        *category_tuple
-            Required categories in the form of one or more `str` objects
-            or an iterable.
-
-        require : `str` or iterable providing `str` objects, optional, keyword-only
-            One or more categories.  This method will return `False` if
-            the |Particle| does not belong to all of these categories.
-
-        any_of : `str` or iterable providing `str` objects, optional, keyword-only
-            One or more categories. This method will return `False` if
-            the |Particle| does not belong to at least one of these
-            categories.
-
-        exclude : `str` or iterable providing `str` objects, optional, keyword-only
-            One or more categories.  This method will return `False` if
-            the |Particle| belongs to any of these categories.
-
-        Notes
-        -----
-        A `set` containing all valid categories may be accessed by the
-        ``valid_categories`` attribute of
-        `~plasmapy.particles.particle_class.Particle.is_category`.
-
-        Examples
-        --------
-        Required categories may be entered as positional arguments,
-        including as a `list`, `set`, or `tuple` of required categories.
-
-        >>> electron = Particle("e-")
-        >>> electron.is_category("lepton")
-        True
-        >>> electron.is_category("lepton", "baryon")
-        False
-        >>> electron.is_category(["fermion", "matter"])
-        True
-
-        Required arguments may also be provided using the ``require``
-        keyword argument.
-
-        >>> electron.is_category(require="lepton")
-        True
-        >>> electron.is_category(require=["lepton", "baryon"])
-        False
-
-        This method will return `False` if the particle does not belong
-        to at least one of the categories provided with the ``any_of``
-        keyword argument.
-
-        >>> electron.is_category(any_of=["lepton", "baryon"])
-        True
-        >>> electron.is_category(any_of=("noble gas", "lanthanide", "halogen"))
-        False
-
-        This method will return `False` if the particle belongs to any
-        of the categories provided in the ``exclude`` keyword argument.
-
-        >>> electron.is_category(exclude="baryon")
-        True
-        >>> electron.is_category(exclude={"lepton", "baryon"})
-        False
-
-        The ``require``, ``any_of``, and ``exclude`` keywords may be
-        combined.  If the particle matches all of the provided criteria,
-        then `~plasmapy.particles.particle_class.Particle.is_category`
-        will return `True`.
-
-        >>> electron.is_category(
-        ...     require="fermion", any_of={'lepton', 'baryon'}, exclude='charged',
-        ... )
-        False
-        """
-
-        def become_set(arg: Union[str, Set, Tuple, List]) -> Set[str]:
-            """Change the argument into a `set`."""
-            if arg is None:
-                return set()
-            if isinstance(arg, set):
-                return arg
-            if isinstance(arg, str):
-                return {arg}
-            return set(arg[0]) if isinstance(arg[0], (tuple, list, set)) else set(arg)
-
-        if category_tuple and require:  # coverage: ignore
-            raise ParticleError(
-                "No positional arguments are allowed if the `require` keyword "
-                "is set in is_category."
-            )
-
-        require = become_set(category_tuple) if category_tuple else become_set(require)
-        exclude = become_set(exclude)
-        any_of = become_set(any_of)
-
-        invalid_categories = (require | exclude | any_of) - _valid_categories
-
-        duplicate_categories = require & exclude | exclude & any_of | require & any_of
-
-        categories_and_adjectives = [
-            (invalid_categories, "invalid"),
-            (duplicate_categories, "duplicated"),
-        ]
-
-        for problem_categories, adjective in categories_and_adjectives:
-            if problem_categories:
-                raise ParticleError(
-                    f"The following categories in {self.__repr__()}"
-                    f".is_category are {adjective}: {problem_categories}"
-                )
-
-        if exclude and exclude & self._categories:
-            return False
-
-        if any_of and not any_of & self._categories:
-            return False
-
-        return require <= self._categories
-
     @property
     def is_electron(self) -> bool:
         """
@@ -1809,10 +1815,6 @@ class Particle(AbstractPhysicalParticle):
             self.__init__(base_particle, Z=new_charge_number)
         else:
             return Particle(base_particle, Z=new_charge_number)
-
-
-Particle.is_category.valid_categories = _valid_categories
-"""All valid particle categories."""
 
 
 class DimensionlessParticle(AbstractParticle):

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -209,7 +209,7 @@ class AbstractPhysicalParticle(AbstractParticle):
     @abstractmethod
     def categories(self) -> Set[str]:
         """Provide the particle's categories."""
-        raise NotImplementedError
+        ...
 
     def is_category(
         self,

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1949,6 +1949,10 @@ class Particle(AbstractPhysicalParticle):
             return Particle(base_particle, Z=new_charge_number)
 
 
+Particle.is_category.valid_categories = _valid_categories
+"""All valid particle categories."""
+
+
 class DimensionlessParticle(AbstractParticle):
     """
     A class to represent dimensionless custom particles.
@@ -2365,9 +2369,9 @@ class CustomParticle(AbstractPhysicalParticle):
         categories_ = {"custom"}
 
         if self.charge == 0 * u.C:
-            categories_ &= {"uncharged"}
+            categories_ |= {"uncharged"}
         elif not np.isnan(self.charge):
-            categories_ &= {"charged"}
+            categories_ |= {"charged"}
 
         return categories_
 
@@ -2396,6 +2400,10 @@ class CustomParticle(AbstractPhysicalParticle):
         as a key in a `dict`.
         """
         return hash(self.__repr__())
+
+
+CustomParticle.is_category.valid_categories = _valid_categories
+"""All valid particle categories."""
 
 
 def molecule(

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -302,7 +302,9 @@ class AbstractPhysicalParticle(AbstractParticle):
                 return set()
             if isinstance(arg, set):
                 return arg
-            return {arg} if isinstance(arg, str) else set(arg)
+            if isinstance(arg, str):
+                return {arg}
+            return set(arg[0]) if isinstance(arg[0], (tuple, list, set)) else set(arg)
 
         if category_tuple and require:  # coverage: ignore
             raise ParticleError(
@@ -1628,137 +1630,6 @@ class Particle(AbstractPhysicalParticle):
 
         """
         return self._categories
-
-    def is_category(
-        self,
-        *category_tuple,
-        require: Union[str, Iterable[str]] = None,
-        any_of: Union[str, Iterable[str]] = None,
-        exclude: Union[str, Iterable[str]] = None,
-    ) -> bool:
-        """
-        Determine if the particle meets categorization criteria.
-
-        Return `True` if the particle is consistent with the provided
-        categories, and `False` otherwise.
-
-        Parameters
-        ----------
-        *category_tuple
-            Required categories in the form of one or more `str` objects
-            or an iterable.
-
-        require : `str` or iterable providing `str` objects, optional, |keyword-only|
-            One or more categories.  This method will return `False` if
-            the |Particle| does not belong to all of these categories.
-
-        any_of : `str` or iterable providing `str` objects, optional, |keyword-only|
-            One or more categories. This method will return `False` if
-            the |Particle| does not belong to at least one of these
-            categories.
-
-        exclude : `str` or iterable providing `str` objects, optional, |keyword-only|
-            One or more categories.  This method will return `False` if
-            the |Particle| belongs to any of these categories.
-
-        Notes
-        -----
-        A `set` containing all valid categories may be accessed by the
-        ``valid_categories`` attribute of
-        `~plasmapy.particles.particle_class.Particle.is_category`.
-
-        Examples
-        --------
-        Required categories may be entered as positional arguments,
-        including as a `list`, `set`, or `tuple` of required categories.
-
-        >>> electron = Particle("e-")
-        >>> electron.is_category("lepton")
-        True
-        >>> electron.is_category("lepton", "baryon")
-        False
-        >>> electron.is_category(["fermion", "matter"])
-        True
-
-        Required arguments may also be provided using the ``require``
-        keyword argument.
-
-        >>> electron.is_category(require="lepton")
-        True
-        >>> electron.is_category(require=["lepton", "baryon"])
-        False
-
-        This method will return `False` if the particle does not belong
-        to at least one of the categories provided with the ``any_of``
-        keyword argument.
-
-        >>> electron.is_category(any_of=["lepton", "baryon"])
-        True
-        >>> electron.is_category(any_of=("noble gas", "lanthanide", "halogen"))
-        False
-
-        This method will return `False` if the particle belongs to any
-        of the categories provided in the ``exclude`` keyword argument.
-
-        >>> electron.is_category(exclude="baryon")
-        True
-        >>> electron.is_category(exclude={"lepton", "baryon"})
-        False
-
-        The ``require``, ``any_of``, and ``exclude`` keywords may be
-        combined.  If the particle matches all of the provided criteria,
-        then `~plasmapy.particles.particle_class.Particle.is_category`
-        will return `True`.
-
-        >>> electron.is_category(
-        ...     require="fermion", any_of={'lepton', 'baryon'}, exclude='charged',
-        ... )
-        False
-        """
-
-        def become_set(arg: Union[str, Set, Tuple, List]) -> Set[str]:
-            """Change the argument into a `set`."""
-            if arg is None:
-                return set()
-            if isinstance(arg, set):
-                return arg
-            if isinstance(arg, str):
-                return {arg}
-            return set(arg[0]) if isinstance(arg[0], (tuple, list, set)) else set(arg)
-
-        if category_tuple and require:  # coverage: ignore
-            raise ParticleError(
-                "No positional arguments are allowed if the `require` keyword "
-                "is set in is_category."
-            )
-
-        require = become_set(category_tuple) if category_tuple else become_set(require)
-        exclude = become_set(exclude)
-        any_of = become_set(any_of)
-
-        invalid_categories = (require | exclude | any_of) - _valid_categories
-
-        duplicate_categories = require & exclude | exclude & any_of | require & any_of
-
-        categories_and_adjectives = [
-            (invalid_categories, "invalid"),
-            (duplicate_categories, "duplicated"),
-        ]
-
-        for problem_categories, adjective in categories_and_adjectives:
-            if problem_categories:
-                raise ParticleError(
-                    f"The following categories in {self.__repr__()}"
-                    f".is_category are {adjective}: {problem_categories}"
-                )
-
-        if exclude and exclude & self._categories:
-            return False
-
-        if any_of and not any_of & self._categories:
-            return False
-
-        return require <= self._categories
 
     @property
     def is_electron(self) -> bool:

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1818,10 +1818,6 @@ class Particle(AbstractPhysicalParticle):
             return Particle(base_particle, Z=new_charge_number)
 
 
-Particle.is_category.valid_categories = _valid_categories
-"""All valid particle categories."""
-
-
 class DimensionlessParticle(AbstractParticle):
     """
     A class to represent dimensionless custom particles.
@@ -2269,10 +2265,6 @@ class CustomParticle(AbstractPhysicalParticle):
         as a key in a `dict`.
         """
         return hash(self.__repr__())
-
-
-CustomParticle.is_category.valid_categories = _valid_categories
-"""All valid particle categories."""
 
 
 def molecule(

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from numbers import Integral, Real
-from typing import Iterable, List, Optional, Sequence, Set, Tuple, Union
+from typing import Iterable, Optional, Sequence, Set, Union
 
 from plasmapy.particles import _elements, _isotopes, _parsing, _special_particles
 from plasmapy.particles.exceptions import (

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -53,6 +53,7 @@ _classification_categories = {
     "unstable",
     "charged",
     "uncharged",
+    "custom",
 }
 
 _periodic_table_categories = {
@@ -2361,9 +2362,14 @@ class CustomParticle(AbstractPhysicalParticle):
     @property
     def categories(self) -> Set[str]:
         """Categories for the |CustomParticle|."""
-        if np.isnan(self.charge):
-            return set()
-        return {"uncharged"} if self.charge == 0 * u.C else {"charged"}
+        categories_ = {"custom"}
+
+        if self.charge == 0 * u.C:
+            categories_ &= {"uncharged"}
+        elif not np.isnan(self.charge):
+            categories_ &= {"charged"}
+
+        return categories_
 
     def __eq__(self, other) -> bool:
         """

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -214,6 +214,7 @@ test_Particle_table = [
             'is_category(any_of={"positron"})': True,
             'is_category(exclude="positron")': False,
             'is_category("ion")': False,
+            'is_category("invalid_category")': ParticleError,
             "__str__()": "e+",
             "__repr__()": 'Particle("e+")',
             "periodic_table.group": InvalidElementError,

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -621,7 +621,7 @@ test_Particle_error_table = [
     (["e-"], {}, ".ionize()", InvalidElementError),
     (["e+"], {}, ".recombine()", InvalidElementError),
     (["e+"], {}, ".is_category('invalid_category')", ParticleError),
-    (["e+"], {}, ".is_category(require='element', exclude='element'])", ParticleError),
+    (["e+"], {}, ".is_category(require='element', exclude='element')", ParticleError),
     (["H", 1], {}, "", TypeError),
     (["H", 1, 1], {}, "", TypeError),
 ]

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -620,6 +620,7 @@ test_Particle_error_table = [
     (["Fe 25+"], {}, ".recombine(8.2)", TypeError),
     (["e-"], {}, ".ionize()", InvalidElementError),
     (["e+"], {}, ".recombine()", InvalidElementError),
+    (["e+"], {}, ".is_category('invalid_category')", ParticleError),
     (["H", 1], {}, "", TypeError),
     (["H", 1, 1], {}, "", TypeError),
 ]

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -969,6 +969,9 @@ customized_particle_tests = [
     (CustomParticle, {"mass": "100.0 g"}, "mass", 100.0 * u.g),
     (CustomParticle, {"charge": -np.inf * u.kC}, "charge", -np.inf * u.C),
     (CustomParticle, {"charge": "5.0 C"}, "charge", 5.0 * u.C),
+    (CustomParticle, {"charge": 0.0 * u.C}, "categories", {"uncharged"}),
+    (CustomParticle, {"charge": 1.0 * u.C}, "categories", {"charged"}),
+    (CustomParticle, {}, "categories", set()),
 ]
 
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -621,6 +621,7 @@ test_Particle_error_table = [
     (["e-"], {}, ".ionize()", InvalidElementError),
     (["e+"], {}, ".recombine()", InvalidElementError),
     (["e+"], {}, ".is_category('invalid_category')", ParticleError),
+    (["e+"], {}, ".is_category(require='element', exclude='element'])", ParticleError),
     (["H", 1], {}, "", TypeError),
     (["H", 1, 1], {}, "", TypeError),
 ]

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -969,9 +969,6 @@ customized_particle_tests = [
     (CustomParticle, {"mass": "100.0 g"}, "mass", 100.0 * u.g),
     (CustomParticle, {"charge": -np.inf * u.kC}, "charge", -np.inf * u.C),
     (CustomParticle, {"charge": "5.0 C"}, "charge", 5.0 * u.C),
-    (CustomParticle, {"charge": 0.0 * u.C}, "categories", {"uncharged"}),
-    (CustomParticle, {"charge": 1.0 * u.C}, "categories", {"charged"}),
-    (CustomParticle, {}, "categories", set()),
 ]
 
 
@@ -1001,6 +998,20 @@ def test_custom_particle_symbol(cls, symbol, expected):
     assert instance.symbol == expected
 
 
+custom_particle_categories_table = [
+    ({"charge": 0.0 * u.C}, {"uncharged"}),
+    ({"charge": 1.0 * u.C}, {"charged"}),
+    ({}, set()),
+]
+
+
+@pytest.mark.parametrize("kwargs, expected", custom_particle_categories_table)
+def test_custom_particle_categories(kwargs, expected):
+    """Test that CustomParticle.categories behaves as expected."""
+    custom_particle = CustomParticle(**kwargs)
+    assert custom_particle.categories == expected
+
+
 custom_particle_is_category_table = [
     ({"charge": 0 * u.C}, {"require": "charged"}, False),
     ({"charge": 0 * u.C}, {"exclude": "charged"}, True),
@@ -1023,6 +1034,7 @@ def test_custom_particle_is_category(
     kwargs_to_is_category,
     expected,
 ):
+    """Test that CustomParticle.is_category works as expected."""
     custom_particle = CustomParticle(**kwargs_to_custom_particle)
     actual = custom_particle.is_category(**kwargs_to_is_category)
     assert actual == expected

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1001,7 +1001,7 @@ def test_custom_particle_symbol(cls, symbol, expected):
     assert instance.symbol == expected
 
 
-customized_particle_errors = [
+custom_particle_errors = [
     (DimensionlessParticle, {"mass": -1e-36}, InvalidParticleError),
     (DimensionlessParticle, {"mass": [1, 1]}, InvalidParticleError),
     (DimensionlessParticle, {"charge": [-1, 1]}, InvalidParticleError),
@@ -1039,7 +1039,7 @@ customized_particle_errors = [
 ]
 
 
-@pytest.mark.parametrize("cls, kwargs, exception", customized_particle_errors)
+@pytest.mark.parametrize("cls, kwargs, exception", custom_particle_errors)
 def test_customized_particles_errors(cls, kwargs, exception):
     """
     Test that attempting to create invalid dimensionless or custom particles

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -999,9 +999,9 @@ def test_custom_particle_symbol(cls, symbol, expected):
 
 
 custom_particle_categories_table = [
-    ({"charge": 0.0 * u.C}, {"uncharged"}),
-    ({"charge": 1.0 * u.C}, {"charged"}),
-    ({}, set()),
+    ({"charge": 0.0 * u.C}, {"custom", "uncharged"}),
+    ({"charge": 1.0 * u.C}, {"custom", "charged"}),
+    ({}, {"custom"}),
 ]
 
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1001,6 +1001,33 @@ def test_custom_particle_symbol(cls, symbol, expected):
     assert instance.symbol == expected
 
 
+custom_particle_is_category_table = [
+    ({"charge": 0 * u.C}, {"require": "charged"}, False),
+    ({"charge": 0 * u.C}, {"exclude": "charged"}, True),
+    ({"charge": 0 * u.C}, {"require": "uncharged"}, True),
+    ({"charge": 0 * u.C}, {"exclude": "uncharged"}, False),
+    ({"charge": 1 * u.C}, {"require": "charged"}, True),
+    ({"charge": 1 * u.C}, {"exclude": "charged"}, False),
+    ({"charge": 1 * u.C}, {"require": "uncharged"}, False),
+    ({"charge": 1 * u.C}, {"exclude": "uncharged"}, True),
+    ({}, {"any_of": {"charged", "uncharged"}}, False),
+]
+
+
+@pytest.mark.parametrize(
+    "kwargs_to_custom_particle, kwargs_to_is_category, expected",
+    custom_particle_is_category_table,
+)
+def test_custom_particle_is_category(
+    kwargs_to_custom_particle,
+    kwargs_to_is_category,
+    expected,
+):
+    custom_particle = CustomParticle(**kwargs_to_custom_particle)
+    actual = custom_particle.is_category(**kwargs_to_is_category)
+    assert actual == expected
+
+
 custom_particle_errors = [
     (DimensionlessParticle, {"mass": -1e-36}, InvalidParticleError),
     (DimensionlessParticle, {"mass": [1, 1]}, InvalidParticleError),

--- a/setup.cfg
+++ b/setup.cfg
@@ -300,6 +300,7 @@ exclude_lines =
     @jit
     @numba.njit
     @njit
+    @abstractmethod
 
 [codespell]
 skip = *.png,*cache*,*egg*,.git,.hypothesis,.idea,.tox,_build,*charged_particle*.ipynb,venv


### PR DESCRIPTION
This PR moves `Particle.is_category` to `AbstractPhysicalParticle` so that it can be inherited by `CustomParticle` too.  It also adds an abstract property for `AbstractPhysicalParticle.categories` and then a concrete property for `CustomParticle.categories`, which will return an empty set if the `CustomParticle` charge is NaN...or `{"charged"}` or `{"uncharged"}` depending on if the charge is zero or not.  

I still need to add tests of `CustomParticle.is_category` and `CustomParticle.categories`, maybe update the documentation, and add a changelog entry.

This PR will be helpful for #1057.