### PR TITLE
Add note in coding guide that we should use `pathlib` instead of `os.path`

### DIFF
--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -144,6 +144,8 @@ Coding guidelines
      >>> function()
      ['x', 'x']
 
+* Use `pathlib` when working with paths to data files.
+
 Names
 =====
 


### PR DESCRIPTION
This is a quick follow-up PR to #1684 and #1690 that says that we should use `pathlib` to deal with paths instead of `os.path`.