### PR TITLE
Apply `|keyword-only|` substitution in docstrings and reST files

### DIFF
--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -62,8 +62,8 @@ Coding guidelines
      f(T_i = 1e6 * u.K, T_e = 2e6 * u.K)
 
   Similarly, when a function has parameters named ``T_e`` and ``T_i``,
-  these parameters should be made :term:`keyword-only` to avoid
-  ambiguity and reduce the chance of errors.
+  these parameters should be made |keyword-only| to avoid ambiguity and
+  reduce the chance of errors.
 
   .. code-block:: python
 

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -562,7 +562,7 @@ Here is an example docstring in the numpydoc_ format:
       b : `float`
           The right multiplicand.
 
-      switch_order : `bool`, optional, keyword-only
+      switch_order : `bool`, optional, |keyword-only|
           If `True`, return :math:`a - b`. If `False`, then return
           :math:`b - a`. Defaults to `True`.
 

--- a/docs/whatsnew/0.8.1.rst
+++ b/docs/whatsnew/0.8.1.rst
@@ -52,7 +52,7 @@ Backwards Incompatible Changes
 
 - In `~plasmapy.diagnostics.thomson.spectral_density`, the arguments
   ``Te`` and ``Ti`` have been renamed ``T_e`` and ``T_i`` and are now
-  required :term:`keyword-only` arguments. (`#974
+  required |keyword-only| arguments. (`#974
   <https://github.com/plasmapy/plasmapy/pull/974>`__)
 - Moved the ``grid_resolution`` attribute from
   `~plasmapy.plasma.grids.AbstractGrid` to
@@ -81,7 +81,7 @@ Backwards Incompatible Changes
   and removed from the public API. (`#1440
   <https://github.com/plasmapy/plasmapy/pull/1440>`__)
 - The parameters ``Z`` and ``mass_numb`` to |Particle| are now
-  :term:`keyword-only`. (`#1456
+  |keyword-only|. (`#1456
   <https://github.com/plasmapy/plasmapy/pull/1456>`__)
 
 

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -294,11 +294,11 @@ def spectral_density(
         Total combined number density of all electron populations.
         (convertible to cm\ :sup:`-3`)
 
-    T_e : `~astropy.units.Quantity`, keyword-only, shape (Ne, )
+    T_e : `~astropy.units.Quantity`, |keyword-only|, shape (Ne, )
         Temperature of each electron component. Shape (Ne, ) must be equal to the
         number of electron populations Ne. (in K or convertible to eV)
 
-    T_i : `~astropy.units.Quantity`, keyword-only, shape (Ni, )
+    T_i : `~astropy.units.Quantity`, |keyword-only|, shape (Ni, )
         Temperature of each ion component. Shape (Ni, ) must be equal to the
         number of ion populations Ni. (in K or convertible to eV)
 

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -127,14 +127,14 @@ def gyroradius(
         charge state information is provided, then the particles are assumed
         to be singly charged.
 
-    Vperp : `~astropy.units.Quantity`, optional, keyword-only
+    Vperp : `~astropy.units.Quantity`, optional, |keyword-only|
         The component of particle velocity that is perpendicular to the
         magnetic field in units convertible to meters per second.
 
-    T : `~astropy.units.Quantity`, optional, keyword-only
+    T : `~astropy.units.Quantity`, optional, |keyword-only|
         The particle temperature in units convertible to kelvin.
 
-    T_i : `~astropy.units.Quantity`, optional, keyword-only
+    T_i : `~astropy.units.Quantity`, optional, |keyword-only|
         The particle temperature in units convertible to kelvin.
         Note: Deprecated. Use ``T`` instead.
 

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -209,10 +209,10 @@ def particle_mass(
         particle; an integer representing an atomic number; or an
         instance of the Particle class.
 
-    Z: `int`, optional, keyword-only
+    Z: `int`, optional, |keyword-only|
         The ionization state of the ion.
 
-    mass_numb: `int`, optional, keyword-only
+    mass_numb: `int`, optional, |keyword-only|
         The mass number of an isotope.
 
     Returns

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -193,14 +193,14 @@ class IonizationState:
         the number densities of each neutral/ion.  This argument cannot
         be specified when ``particle`` is an ion.
 
-    T_e: `~astropy.units.Quantity`, keyword-only, optional
+    T_e: `~astropy.units.Quantity`, |keyword-only|, optional
         The electron temperature or thermal energy per electron.
 
-    n_elem: `~astropy.units.Quantity`, keyword-only, optional
+    n_elem: `~astropy.units.Quantity`, |keyword-only|, optional
         The number density of the element, including neutrals and all
         ions.
 
-    tol: `float` or integer, keyword-only, optional
+    tol: `float` or integer, |keyword-only|, optional
         The absolute tolerance used by `~numpy.isclose` and similar
         functions when testing normalizations and making comparisons.
         Defaults to ``1e-15``.
@@ -828,16 +828,16 @@ class IonizationState:
 
         Parameters
         ----------
-        include_neutrals : `bool`, optional, keyword-only
+        include_neutrals : `bool`, optional, |keyword-only|
             If `True`, include neutrals when calculating the mean values
             of the different particles.  If `False`, exclude neutrals.
             Defaults to `True`.
 
-        use_rms_charge : `bool`, optional, keyword-only
+        use_rms_charge : `bool`, optional, |keyword-only|
             If `True`, use the root mean square charge instead of the
             mean charge. Defaults to `False`.
 
-        use_rms_mass : `bool`, optional, keyword-only
+        use_rms_mass : `bool`, optional, |keyword-only|
             If `True`, use the root mean square mass instead of the mean
             mass. Defaults to `False`.
 

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -42,29 +42,29 @@ class IonizationStateCollection:
         with elements or isotopes as keys and `~astropy.units.Quantity`
         instances with units of number density.
 
-    abundances: `dict`, optional, keyword-only
+    abundances: `dict`, optional, |keyword-only|
         A `dict` with `~plasmapy.particles.particle_class.ParticleLike`
         objects used as the keys and the corresponding relative abundance as the
         values.  The values must be positive real numbers.
 
-    log_abundances: `dict`, optional, keyword-only
+    log_abundances: `dict`, optional, |keyword-only|
         A `dict` with `~plasmapy.particles.particle_class.ParticleLike`
         objects used as the keys and the corresponding base 10 logarithms of their
         relative abundances as the values.  The values must be real numbers.
 
-    n0: `~astropy.units.Quantity`, optional, keyword-only
+    n0: `~astropy.units.Quantity`, optional, |keyword-only|
         The number density normalization factor corresponding to the
         abundances.  The number density of each element is the product
         of its abundance and ``n0``.
 
-    T_e: `~astropy.units.Quantity`, optional, keyword-only
+    T_e: `~astropy.units.Quantity`, optional, |keyword-only|
         The electron temperature in units of temperature or thermal
         energy per particle.
 
-    kappa: `float`, optional, keyword-only
+    kappa: `float`, optional, |keyword-only|
         The value of kappa for a kappa distribution function.
 
-    tol: `float` or `integer`, optional, keyword-only
+    tol: `float` or `integer`, optional, |keyword-only|
         The absolute tolerance used by `~numpy.isclose` when testing
         normalizations and making comparisons.  Defaults to ``1e-15``.
 
@@ -874,16 +874,16 @@ class IonizationStateCollection:
 
         Parameters
         ----------
-        include_neutrals : `bool`, optional, keyword-only
+        include_neutrals : `bool`, optional, |keyword-only|
             If `True`, include neutrals when calculating the mean values
             of the different particles.  If `False`, exclude neutrals.
             Defaults to `True`.
 
-        use_rms_charge : `bool`, optional, keyword-only
+        use_rms_charge : `bool`, optional, |keyword-only|
             If `True`, use the root mean square charge instead of the
             mean charge. Defaults to `False`.
 
-        use_rms_mass : `bool`, optional, keyword-only
+        use_rms_mass : `bool`, optional, |keyword-only|
             If `True`, use the root mean square mass instead of the mean
             mass. Defaults to `False`.
 

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -123,12 +123,12 @@ def nuclear_reaction_energy(*args, **kwargs):
         A string representing the reaction, like
         ``"D + T --> alpha + n"`` or ``"Be-8 --> 2 * He-4"``.
 
-    reactants: `list`, `tuple`, or `str`, optional, keyword-only
+    reactants: `list`, `tuple`, or `str`, optional, |keyword-only|
         A `list` or `tuple` containing the reactants of a nuclear
         reaction (e.g., ``['D', 'T']``), or a string representing the
         sole reactant.
 
-    products: `list`, `tuple`, or `str`, optional, keyword-only
+    products: `list`, `tuple`, or `str`, optional, |keyword-only|
         A list or tuple containing the products of a nuclear reaction
         (e.g., ``['alpha', 'n']``), or a string representing the sole
         product.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -233,10 +233,10 @@ class Particle(AbstractPhysicalParticle):
         integer representing the atomic number of an element; or a
         |Particle| instance.
 
-    mass_numb : `int`, optional, keyword-only
+    mass_numb : `int`, optional, |keyword-only|
         The mass number of an isotope or nuclide.
 
-    Z : `int`, optional, keyword-only
+    Z : `int`, optional, |keyword-only|
         The charge number of the particle.
 
     Raises
@@ -1512,16 +1512,16 @@ class Particle(AbstractPhysicalParticle):
             Required categories in the form of one or more `str` objects
             or an iterable.
 
-        require : `str` or iterable providing `str` objects, optional, keyword-only
+        require : `str` or iterable providing `str` objects, optional, |keyword-only|
             One or more categories.  This method will return `False` if
             the |Particle| does not belong to all of these categories.
 
-        any_of : `str` or iterable providing `str` objects, optional, keyword-only
+        any_of : `str` or iterable providing `str` objects, optional, |keyword-only|
             One or more categories. This method will return `False` if
             the |Particle| does not belong to at least one of these
             categories.
 
-        exclude : `str` or iterable providing `str` objects, optional, keyword-only
+        exclude : `str` or iterable providing `str` objects, optional, |keyword-only|
             One or more categories.  This method will return `False` if
             the |Particle| belongs to any of these categories.
 
@@ -1824,10 +1824,10 @@ class DimensionlessParticle(AbstractParticle):
 
     Parameters
     ----------
-    mass : positive real number, keyword-only, optional
+    mass : positive real number, |keyword-only|, optional
         The mass of the dimensionless particle.  Defaults to `numpy.nan`.
 
-    charge : real number, keyword-only, optional
+    charge : real number, |keyword-only|, optional
         The electric charge of the dimensionless particle.  Defaults to
         `numpy.nan`.
 

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -360,11 +360,11 @@ class ParticleList(collections.UserList):
             particles contained in the |ParticleList| are assumed to be
             equally abundant.
 
-        use_rms_charge : `bool`, optional, keyword-only
+        use_rms_charge : `bool`, optional, |keyword-only|
             If `True`, use the root mean square charge instead of the mean
             charge. Defaults to `False`.
 
-        use_rms_mass : `bool`, optional, keyword-only
+        use_rms_mass : `bool`, optional, |keyword-only|
             If `True`, use the root mean square mass instead of the mean mass.
             Defaults to `False`.
 

--- a/plasmapy/utils/_units_helpers.py
+++ b/plasmapy/utils/_units_helpers.py
@@ -29,14 +29,14 @@ def _get_physical_type_dict(
         A iterable that is expected to contain objects with physical
         types.
 
-    only_quantities : `bool`, keyword-only, optional
+    only_quantities : `bool`, |keyword-only|, optional
         If `True`, only `~astropy.units.Quantity` instances in
         ``iterable`` will be passed into the resulting `dict`. If
         `False`, then any unit, |PhysicalType|, or object that can be
         converted to a |Quantity| or that has a physical type will be
         included in the `dict`. Defaults to `False`.
 
-    numbers_become_quantities : `bool`, keyword-only, optional
+    numbers_become_quantities : `bool`, |keyword-only|, optional
         If `True`, `~numbers.Number` objects will be converted into
         dimensionless |Quantity| instances. If `False`,
         `~numbers.Number` objects will be skipped. Defaults to `False`.

--- a/plasmapy/utils/code_repr.py
+++ b/plasmapy/utils/code_repr.py
@@ -345,7 +345,7 @@ def method_call_string(
         other type of `object` if there is only one positional argument,
         to be used during instantiation of ``cls``.
 
-    kwargs_to_cls: `dict`, keyword-only optional
+    kwargs_to_cls: `dict`, |keyword-only| optional
         A `dict` containing the keyword arguments to be used during
         instantiation of ``cls``.
 
@@ -354,11 +354,11 @@ def method_call_string(
         used in the method call, or any other `object` if there is only
         one positional argument.
 
-    kwargs_to_method: `dict`, keyword-only, optional
+    kwargs_to_method: `dict`, |keyword-only|, optional
         A `dict` containing the keyword arguments to be used during
         the method call.
 
-    max_items : int, keyword-only, optional
+    max_items : int, |keyword-only|, optional
         The maximum number of items to include in a `~numpy.ndarray` or
         `~astropy.units.Quantity`; additional items will be truncated
         with an ellipsis.  Defaults to 12.


### PR DESCRIPTION
This PR does a quick search and replace in `.py` files for `, keyword-only` → `, |keyword-only|`, where `|keyword-only|` is a substitution defined in `docs/common_links.rst` for ``` :term:`keyword-only` ```.  This PR also applies this substitution in a few `.rst` files. Linking this to the glossary entry will probably be mildly helpful for new users.