### PR TITLE
Fix documentation build errors

### DIFF
--- a/changelog/1710.trivial.rst
+++ b/changelog/1710.trivial.rst
@@ -1,0 +1,1 @@
+Change towncrier version to 21.9.0

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -11,7 +11,6 @@ including bug fixes and changes to the application programming interface
 .. toctree::
    :maxdepth: 1
 
-   dev
    0.8.1
    0.7.0
    0.6.0

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -11,6 +11,7 @@ including bug fixes and changes to the application programming interface
 .. toctree::
    :maxdepth: 1
 
+   dev
    0.8.1
    0.7.0
    0.6.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -21,4 +21,4 @@ sphinx-notfound-page >= 0.8
 sphinx-reredirects
 sphinx_rtd_theme >= 1.0.0
 sphinxcontrib-bibtex
-towncrier == 21.9.0
+towncrier >= 19.2.0, < 22.8.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -21,4 +21,4 @@ sphinx-notfound-page >= 0.8
 sphinx-reredirects
 sphinx_rtd_theme >= 1.0.0
 sphinxcontrib-bibtex
-towncrier >= 19.2.0
+towncrier == 21.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,7 +106,7 @@ docs =
     sphinx-reredirects
     sphinx_rtd_theme >= 1.0.0
     sphinxcontrib-bibtex
-    towncrier == 21.9.0
+    towncrier >= 19.2.0, < 22.8.0
 developer =
     # install everything for developers
     # ought to functionally mirror requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,7 +106,7 @@ docs =
     sphinx-reredirects
     sphinx_rtd_theme >= 1.0.0
     sphinxcontrib-bibtex
-    towncrier >= 19.2.0
+    towncrier == 21.9.0
 developer =
     # install everything for developers
     # ought to functionally mirror requirements.txt


### PR DESCRIPTION
This pull request resolves an error in building documentation that seems to have arisen due to towncrier release 22.8.0.


- [x] I have added a changelog entry for this pull request.
- [x] If adding new functionality, I have added tests and
      docstrings.
- [x] I have fixed any newly failing tests.