### PR TITLE
Update requirements for `towncrier` and `sphinx-changelog`

### DIFF
--- a/changelog/1710.trivial.rst
+++ b/changelog/1710.trivial.rst
@@ -1,1 +1,2 @@
-Change towncrier version to 21.9.0
+Changed the towncrier_ version to ``>= 19.2.0, < 22.8.0``. Superseded by
+:pr:`1717`\ .

--- a/changelog/1717.trivial.rst
+++ b/changelog/1717.trivial.rst
@@ -1,2 +1,2 @@
 Changed the minimum version of towncrier_ to 22.8.0 and the minimum
-version of |sphinx-changelog|_ to 1.2.0.
+version of |sphinx_changelog|_ to 1.2.0.

--- a/changelog/1717.trivial.rst
+++ b/changelog/1717.trivial.rst
@@ -1,0 +1,2 @@
+Changed the minimum version of towncrier_ to 22.8.0 and the minimum
+version of |sphinx-changelog|_ to 1.2.0.

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -100,6 +100,7 @@
 .. |glossary| replace:: :ref:`glossary`\
 .. |keyword-only| replace:: :term:`keyword-only`\
 .. |minpython| replace:: 3.8
+.. |particle-like| replace:: :term:`particle-like`\
 .. |plasma-calculator| replace:: :ref:`plasmapy-calculator`\
 .. |release guide| replace:: :ref:`release guide`\
 .. |testing guide| replace:: :ref:`testing guide`\

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,7 +12,7 @@ numpydoc
 pillow
 pygments >= 2.11.0
 sphinx >= 4.4, != 5.1
-sphinx-changelog
+sphinx-changelog >= 1.2.0
 sphinx-copybutton
 sphinx-gallery < 0.11.0
 sphinx-hoverxref >= 1.1.1
@@ -21,4 +21,4 @@ sphinx-notfound-page >= 0.8
 sphinx-reredirects
 sphinx_rtd_theme >= 1.0.0
 sphinxcontrib-bibtex
-towncrier >= 19.2.0, < 22.8.0
+towncrier >= 22.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ docs =
     pillow
     pygments >= 2.11.0
     sphinx >= 4.4, != 5.1
-    sphinx-changelog
+    sphinx-changelog >= 1.2.0
     sphinx-copybutton
     sphinx-gallery < 0.11.0
     sphinx-hoverxref >= 1.1.1
@@ -106,7 +106,7 @@ docs =
     sphinx-reredirects
     sphinx_rtd_theme >= 1.0.0
     sphinxcontrib-bibtex
-    towncrier >= 19.2.0, < 22.8.0
+    towncrier >= 22.8.0
 developer =
     # install everything for developers
     # ought to functionally mirror requirements.txt


### PR DESCRIPTION
Following the release of `sphinx-changelog` 1.2.0 a few minutes ago, the issues we were getting with our documentation build from the new release of towncrier should be resolved now.  This PR bumps the minimum versions of `sphinx-changelog` and `towncrier` to the most recent releases.

Closes #1711. Follows up on #1710. See also https://github.com/OpenAstronomy/sphinx-changelog/pull/14.