### PR TITLE
Move `valid_categories` to `particle_class.py`

### DIFF
--- a/changelog/1720.breaking.rst
+++ b/changelog/1720.breaking.rst
@@ -1,0 +1,3 @@
+Moved the ``valid_categories`` attribute of
+`~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`
+to `plasmapy.particles.particle_class.valid_categories`.

--- a/docs/notebooks/getting_started/particles.ipynb
+++ b/docs/notebooks/getting_started/particles.ipynb
@@ -748,10 +748,9 @@
    "id": "a03c8153",
    "metadata": {},
    "source": [
-    "[is_category()]: ../../api/plasmapy.particles.particle_class.Particle.rst#plasmapy.particles.particle_class.Particle.is_category\n",
-    "[Particle]: ../../api/plasmapy.particles.particle_class.Particle.rst\n",
+    "[`valid_categories`]: ../../api/plasmapy.particles.particle_class.valid_categories.rst\n",
     "\n",
-    "The `valid_categories` attribute of [is_category()] for any [Particle] gives a set containing all valid categories."
+    "All valid particle categories are included in [`valid_categories`]."
    ]
   },
   {
@@ -761,7 +760,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(electron.is_category.valid_categories)"
+    "print(valid_categories)"
    ]
   },
   {

--- a/docs/notebooks/getting_started/particles.ipynb
+++ b/docs/notebooks/getting_started/particles.ipynb
@@ -25,7 +25,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from plasmapy.particles import *"
+    "from plasmapy.particles import *\n",
+    "from plasmapy.particles.particle_class import valid_categories"
    ]
   },
   {

--- a/docs/notebooks/getting_started/particles.ipynb
+++ b/docs/notebooks/getting_started/particles.ipynb
@@ -749,9 +749,9 @@
    "id": "a03c8153",
    "metadata": {},
    "source": [
-    "[`valid_categories`]: ../../api/plasmapy.particles.particle_class.valid_categories.rst\n",
+    "[valid_categories]: ../../api/plasmapy.particles.particle_class.valid_categories.rst\n",
     "\n",
-    "All valid particle categories are included in [`valid_categories`]."
+    "All valid particle categories are included in [valid_categories]."
    ]
   },
   {

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -102,7 +102,8 @@ the particle.
 ['charged', 'electron', 'fermion', 'lepton', 'matter', 'stable']
 
 Membership of a particle within a category may be checked using the
-`~plasmapy.particles.particle_class.Particle.is_category` method.
+`~plasmapy.particles.particle_class.Particle.is_category` method, which
+also lists all valid particle categories.
 
 >>> alpha.is_category('lepton')
 False
@@ -122,15 +123,6 @@ True
 False
 >>> alpha.is_category(exclude='lepton')
 True
-
-Particle categories
--------------------
-
-Valid particle categories are available in
-`~plasmapy.particles.particle_class.valid_categories`:
-
->>> from plasmapy.particles.particle_class import valid_categories
->>> print(sorted(valid_categories))
 
 .. _particle-class-conditionals-equality:
 

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -101,9 +101,8 @@ the particle.
 >>> sorted(electron.categories)
 ['charged', 'electron', 'fermion', 'lepton', 'matter', 'stable']
 
-Membership of a particle within a category may be checked using the
-`~plasmapy.particles.particle_class.Particle.is_category` method, which
-also lists all valid particle categories.
+Membership of a particle within a category may be checked using
+|is_category|.
 
 >>> alpha.is_category('lepton')
 False
@@ -123,6 +122,8 @@ True
 False
 >>> alpha.is_category(exclude='lepton')
 True
+
+Valid particle categories are listed in the docstring for |is_category|.
 
 .. _particle-class-conditionals-equality:
 
@@ -181,3 +182,5 @@ of a |Particle| object.
 Particle("e+")
 >>> antimuon.antiparticle
 Particle("mu-")
+
+.. |is_category| replace:: `~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -123,18 +123,14 @@ False
 >>> alpha.is_category(exclude='lepton')
 True
 
-Calling the `~plasmapy.particles.particle_class.Particle.is_category`
-method with no arguments returns a set containing all of the valid
-categories for any particle.  Valid categories include:
-``"actinide"``, ``"alkali metal"``, ``"alkaline earth metal"``,
-``"antibaryon"``, ``"antilepton"``, ``"antimatter"``,
-``"antineutrino"``, ``"baryon"``, ``"boson"``, ``"charged"``,
-``"custom"``, ``"electron"``, ``"element"``, ``"fermion"``,
-``"halogen"``, ``"ion"``, ``"isotope"``, ``"lanthanide"``, ``"lepton"``,
-``"matter"``, ``"metal"``, ``"metalloid"``, ``"neutrino"``,
-``"neutron"``, ``"noble gas"``, ``"nonmetal"``, ``"positron"``,
-``"post-transition metal"``, ``"proton"``, ``"stable"``,
-``"transition metal"``, ``"uncharged"``, and ``"unstable"``.
+Particle categories
+-------------------
+
+Valid particle categories are available in
+`~plasmapy.particles.particle_class.valid_categories`:
+
+>>> from plasmapy.particles.particle_class import valid_categories
+>>> print(sorted(valid_categories))
 
 .. _particle-class-conditionals-equality:
 

--- a/plasmapy/particles/__init__.py
+++ b/plasmapy/particles/__init__.py
@@ -35,7 +35,6 @@ from plasmapy.particles.particle_class import (
     molecule,
     Particle,
     ParticleLike,
-    valid_categories,
 )
 from plasmapy.particles.particle_collections import ParticleList, ParticleListLike
 from plasmapy.particles.serialization import (

--- a/plasmapy/particles/__init__.py
+++ b/plasmapy/particles/__init__.py
@@ -35,6 +35,7 @@ from plasmapy.particles.particle_class import (
     molecule,
     Particle,
     ParticleLike,
+    valid_categories,
 )
 from plasmapy.particles.particle_collections import ParticleList, ParticleListLike
 from plasmapy.particles.serialization import (

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -81,7 +81,7 @@ valid_categories = (
     | _atomic_property_categories
     | _specific_particle_categories
 )
-"""
+r"""
 A `set` containing all valid particle categories.
 
 To add a new particle category, update

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -230,8 +230,7 @@ class AbstractPhysicalParticle(AbstractParticle):
         any_of: Union[str, Iterable[str]] = None,
         exclude: Union[str, Iterable[str]] = None,
     ) -> bool:
-        """
-        Determine if the particle meets categorization criteria.
+        """Determine if the particle meets categorization criteria.
 
         Return `True` if the particle is consistent with the provided
         categories, and `False` otherwise.
@@ -267,7 +266,19 @@ class AbstractPhysicalParticle(AbstractParticle):
         `~plasmapy.particles.particle_class.valid_categories` and
         include:
 
-
+        Calling `~plasmapy.particles.particle_class.Particle.is_category`
+        with no arguments returns a set containing all of the
+        valid categories for any particle.  Valid categories include:
+        ``"actinide"``, ``"alkali metal"``, ``"alkaline earth
+        metal"``, ``"antibaryon"``, ``"antilepton"``,
+        ``"antimatter"``, ``"antineutrino"``, ``"baryon"``,
+        ``"boson"``, ``"charged"``, ``"custom"``, ``"electron"``,
+        ``"element"``, ``"fermion"``, ``"halogen"``, ``"ion"``,
+        ``"isotope"``, ``"lanthanide"``, ``"lepton"``, ``"matter"``,
+        ``"metal"``, ``"metalloid"``, ``"neutrino"``, ``"neutron"``,
+        ``"noble gas"``, ``"nonmetal"``, ``"positron"``,
+        ``"post-transition metal"``, ``"proton"``, ``"stable"``,
+        ``"transition metal"``, ``"uncharged"``, and ``"unstable"``.
 
         Examples
         --------

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -75,7 +75,7 @@ _atomic_property_categories = {"element", "isotope", "ion"}
 
 _specific_particle_categories = {"electron", "positron", "proton", "neutron"}
 
-valid_categories = frozenset(
+valid_categories = (
     _periodic_table_categories
     | _classification_categories
     | _atomic_property_categories

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -91,6 +91,10 @@ representing the category.
 See Also
 --------
 :py:meth:`~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`
+
+Examples
+--------
+To add a new 
 """
 
 
@@ -264,21 +268,16 @@ class AbstractPhysicalParticle(AbstractParticle):
         -----
         Valid particle categories are given in
         `~plasmapy.particles.particle_class.valid_categories` and
-        include:
-
-        Calling `~plasmapy.particles.particle_class.Particle.is_category`
-        with no arguments returns a set containing all of the
-        valid categories for any particle.  Valid categories include:
-        ``"actinide"``, ``"alkali metal"``, ``"alkaline earth
-        metal"``, ``"antibaryon"``, ``"antilepton"``,
-        ``"antimatter"``, ``"antineutrino"``, ``"baryon"``,
-        ``"boson"``, ``"charged"``, ``"custom"``, ``"electron"``,
-        ``"element"``, ``"fermion"``, ``"halogen"``, ``"ion"``,
-        ``"isotope"``, ``"lanthanide"``, ``"lepton"``, ``"matter"``,
-        ``"metal"``, ``"metalloid"``, ``"neutrino"``, ``"neutron"``,
-        ``"noble gas"``, ``"nonmetal"``, ``"positron"``,
-        ``"post-transition metal"``, ``"proton"``, ``"stable"``,
-        ``"transition metal"``, ``"uncharged"``, and ``"unstable"``.
+        include: ``"actinide"``, ``"alkali metal"``, ``"alkaline earth
+        metal"``, ``"antibaryon"``, ``"antilepton"``, ``"antimatter"``,
+        ``"antineutrino"``, ``"baryon"``, ``"boson"``, ``"charged"``,
+        ``"custom"``, ``"electron"``, ``"element"``, ``"fermion"``,
+        ``"halogen"``, ``"ion"``, ``"isotope"``, ``"lanthanide"``,
+        ``"lepton"``, ``"matter"``, ``"metal"``, ``"metalloid"``,
+        ``"neutrino"``, ``"neutron"``, ``"noble gas"``, ``"nonmetal"``,
+        ``"positron"``, ``"post-transition metal"``, ``"proton"``,
+        ``"stable"``, ``"transition metal"``, ``"uncharged"``, and
+        ``"unstable"``.
 
         Examples
         --------

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -84,11 +84,6 @@ valid_categories = (
 r"""
 A `set` containing all valid particle categories.
 
-To add a new particle category, update
-`~plasmapy.particles.particle_class.valid_categories` with a new string
-representing the category (e.g., by doing
-:py:`valid_categories |= {"new_category"}`\ ).
-
 See Also
 --------
 :py:meth:`~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -10,6 +10,7 @@ __all__ = [
     "Particle",
     "ParticleLike",
     "molecule",
+    "valid_categories",
 ]
 
 import astropy.constants as const
@@ -74,12 +75,13 @@ _atomic_property_categories = {"element", "isotope", "ion"}
 
 _specific_particle_categories = {"electron", "positron", "proton", "neutron"}
 
-_valid_categories = (
+valid_categories = frozenset(
     _periodic_table_categories
     | _classification_categories
     | _atomic_property_categories
     | _specific_particle_categories
 )
+"""All valid particle categories."""
 
 
 def _category_errmsg(particle, category: str) -> str:
@@ -316,7 +318,7 @@ class AbstractPhysicalParticle(AbstractParticle):
         exclude = become_set(exclude)
         any_of = become_set(any_of)
 
-        invalid_categories = (require | exclude | any_of) - _valid_categories
+        invalid_categories = (require | exclude | any_of) - valid_categories
 
         duplicate_categories = require & exclude | exclude & any_of | require & any_of
 
@@ -354,10 +356,6 @@ class AbstractPhysicalParticle(AbstractParticle):
 
     def __gt__(self, other):
         return self._as_particle_list.__gt__(other)
-
-
-AbstractPhysicalParticle.is_category.valid_categories = _valid_categories
-"""All valid particle categories."""
 
 
 class Particle(AbstractPhysicalParticle):
@@ -413,6 +411,20 @@ class Particle(AbstractPhysicalParticle):
     CustomParticle
     DimensionlessParticle
     ~plasmapy.particles.particle_collections.ParticleList
+    ~plasmapy.particles.particle_class.valid_categories
+
+    Notes
+    -----
+    Valid particle categories include: ``"actinide"``, ``"alkali
+    metal"``, ``"alkaline earth metal"``, ``"antibaryon"``,
+    ``"antilepton"``, ``"antimatter"``, ``"antineutrino"``,
+    ``"baryon"``, ``"boson"``, ``"charged"``, ``"custom"``,
+    ``"electron"``, ``"element"``, ``"fermion"``, ``"halogen"``,
+    ``"ion"``, ``"isotope"``, ``"lanthanide"``, ``"lepton"``,
+    ``"matter"``, ``"metal"``, ``"metalloid"``, ``"neutrino"``,
+    ``"neutron"``, ``"noble gas"``, ``"nonmetal"``, ``"positron"``,
+    ``"post-transition metal"``, ``"proton"``, ``"stable"``,
+    ``"transition metal"``, ``"uncharged"``, and ``"unstable"``.
 
     Examples
     --------
@@ -534,17 +546,6 @@ class Particle(AbstractPhysicalParticle):
     The `~plasmapy.particles.particle_class.Particle.categories` attribute
     and `~plasmapy.particles.particle_class.Particle.is_category` method
     may be used to find and test particle membership in categories.
-
-    Valid particle categories include: ``'actinide'``, ``'alkali
-    metal'``, ``'alkaline earth metal'``, ``'antibaryon'``,
-    ``'antilepton'``, ``'antimatter'``, ``'antineutrino'``,
-    ``'baryon'``, ``'boson'``, ``'charged'``, ``'electron'``,
-    ``'element'``, ``'fermion'``, ``'halogen'``, ``'ion'``,
-    ``'isotope'``, ``'lanthanide'``, ``'lepton'``, ``'matter'``,
-    ``'metal'``, ``'metalloid'``, ``'neutrino'``, ``'neutron'``,
-    ``'noble gas'``, ``'nonmetal'``, ``'positron'``,
-    ``'post-transition metal'``, ``'proton'``, ``'stable'``,
-    ``'transition metal'``, ``'uncharged'``, and ``'unstable'``.
     """
 
     def __init__(

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -232,23 +232,24 @@ class AbstractPhysicalParticle(AbstractParticle):
             Required categories in the form of one or more `str` objects
             or an iterable.
 
-        require : `str` or iterable providing `str` objects, optional, keyword-only
-            One or more categories.  This method will return `False` if
-            the particle does not belong to all of these categories.
-
-        any_of : `str` or iterable providing `str` objects, optional, keyword-only
-            One or more categories. This method will return `False` if
-            the particle does not belong to at least one of these
+        require : `str` or iterable of `str`, optional, |keyword-only|
+            One or more particle categories. This method will return
+            `False` if the particle does not belong to all of these
             categories.
 
-        exclude : `str` or iterable providing `str` objects, optional, keyword-only
-            One or more categories.  This method will return `False` if
-            the particle belongs to any of these categories.
+        any_of : `str` or iterable of `str`, optional, |keyword-only|
+            One or more particle categories. This method will return
+            `False` if the particle does not belong to at least one of
+            these categories.
 
-        Notes
-        -----
-        A `set` containing all valid categories may be accessed by the
-        ``valid_categories`` attribute of ``is_category``.
+        exclude : `str` or iterable of `str`, optional, |keyword-only|
+            One or more particle categories.  This method will return
+            `False` if the particle belongs to any of these categories.
+
+        See Also
+        --------
+        ~plasmapy.particles.particle_class.valid_categories :
+            All valid particle categories.
 
         Examples
         --------

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -82,11 +82,11 @@ valid_categories = (
     | _specific_particle_categories
 )
 """
-All valid particle categories.
+A `set` containing all valid particle categories.
 
 To add a new particle category, update
 `~plasmapy.particles.particle_class.valid_categories` with a new string
-representing the category (e.g., by doing 
+representing the category (e.g., by doing
 :py:`valid_categories |= {"new_category"}`\ ).
 
 See Also

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -86,15 +86,12 @@ All valid particle categories.
 
 To add a new particle category, update
 `~plasmapy.particles.particle_class.valid_categories` with a new string
-representing the category.
+representing the category (e.g., by doing 
+:py:`valid_categories |= {"new_category"}`\ ).
 
 See Also
 --------
 :py:meth:`~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`
-
-Examples
---------
-To add a new 
 """
 
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -81,7 +81,17 @@ valid_categories = (
     | _atomic_property_categories
     | _specific_particle_categories
 )
-"""All valid particle categories."""
+"""
+All valid particle categories.
+
+To add a new particle category, update
+`~plasmapy.particles.particle_class.valid_categories` with a new string
+representing the category.
+
+See Also
+--------
+:py:meth:`~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`
+"""
 
 
 def _category_errmsg(particle, category: str) -> str:
@@ -249,7 +259,15 @@ class AbstractPhysicalParticle(AbstractParticle):
         See Also
         --------
         ~plasmapy.particles.particle_class.valid_categories :
-            All valid particle categories.
+            A `set` containing all valid particle categories.
+
+        Notes
+        -----
+        Valid particle categories are given in
+        `~plasmapy.particles.particle_class.valid_categories` and
+        include:
+
+
 
         Examples
         --------

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -28,10 +28,10 @@ from plasmapy.particles.particle_class import (
     CustomParticle,
     DimensionlessParticle,
     Particle,
+    valid_categories,
 )
 from plasmapy.utils import roman
 from plasmapy.utils.code_repr import call_string
-from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 from plasmapy.utils.pytest_helpers import run_test_equivalent_calls
 
 # (arg, kwargs, results_dict)
@@ -1451,19 +1451,19 @@ def test_particle_to_json_file(cls, kwargs, expected_repr):
 
 def test_particle_is_category_valid_categories():
     """Test the location where valid categories may be accessed."""
-    assert hasattr(Particle.is_category, "valid_categories")
     some_valid_categories = {
-        "lepton",
-        "fermion",
-        "matter",
-        "nonmetal",
+        "charged",
+        "custom",
         "electron",
+        "fermion",
         "ion",
         "isotope",
-        "charged",
+        "lepton",
+        "matter",
+        "nonmetal",
         "uncharged",
     }
-    assert some_valid_categories.issubset(Particle.is_category.valid_categories)
+    assert some_valid_categories.issubset(valid_categories)
 
 
 def test_CustomParticle_cmp():


### PR DESCRIPTION
This PR follows a suggestion from @rocco8773 to move `AbstractPhysicalParticle.is_category.valid_categories` elsewhere.  I decided to put it in `plasmapy.particles.particle_class.valid_categories` as its own thing.

We could make it a `frozenset` pretty straightforwardly, but if someone wanted to add their own particle categories, they would not be able to do so, so I kept it as a `set`.

Closes #1719.