### PR TITLE
Return `False` when comparing an ionization object to an object of a different type

### DIFF
--- a/changelog/1721.breaking.rst
+++ b/changelog/1721.breaking.rst
@@ -1,0 +1,4 @@
+Changed the behavior of |IonicLevel|, |IonizationState|, and
+|IonizationStateCollection| so that an equality comparison with an
+`object` of a different type returns `False` instead of raising a
+`TypeError`.

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -62,27 +62,27 @@ class IonicLevel:
 
     def __eq__(self, other):
 
+        if not isinstance(other, IonicLevel):
+            return False
+
         if self.ionic_symbol != getattr(other, "ionic_symbol", None):
             return False
 
-        try:
+        ionic_fraction_within_rtol = u.isclose(
+            self.ionic_fraction,
+            other.ionic_fraction,
+            rtol=1e-15,
+            equal_nan=True,
+        )
 
-            ionic_fraction_within_rtol = u.isclose(
-                self.ionic_fraction,
-                getattr(other, "ionic_fraction"),
-                rtol=1e-15,
-            )
+        number_density_within_rtol = u.isclose(
+            self.number_density,
+            other_number_density,
+            rtol=1e-15,
+            equal_nan=True,
+        )
 
-            number_density_within_rtol = u.isclose(
-                self.number_density,
-                other_number_density,
-                rtol=1e-15,
-            )
-
-            return ionic_fraction_within_rtol and number_density_within_rtol
-
-        except TypeError:
-            return False
+        return ionic_fraction_within_rtol and number_density_within_rtol
 
     @particle_input
     def __init__(

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -69,13 +69,13 @@ class IonicLevel:
 
             ionic_fraction_within_rtol = u.isclose(
                 self.ionic_fraction,
-                getattr(other, "ionic_fraction", None),
+                getattr(other, "ionic_fraction"),
                 rtol=1e-15,
             )
 
             number_density_within_rtol = u.isclose(
                 self.number_density,
-                getattr(other, "number_density", None),
+                other_number_density,
                 rtol=1e-15,
             )
 
@@ -402,7 +402,10 @@ class IonizationState:
 
         """
         if not isinstance(other, IonizationState):
-            return False
+            raise TypeError(
+                "An instance of the IonizationState class may only be "
+                "compared with another IonizationState instance."
+            )
 
         same_element = self.element == other.element
         same_isotope = self.isotope == other.isotope

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -77,7 +77,7 @@ class IonicLevel:
 
         number_density_within_rtol = u.isclose(
             self.number_density,
-            other_number_density,
+            other.number_density,
             rtol=1e-15,
             equal_nan=True,
         )

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -402,10 +402,7 @@ class IonizationState:
 
         """
         if not isinstance(other, IonizationState):
-            raise TypeError(
-                "An instance of the IonizationState class may only be "
-                "compared with another IonizationState instance."
-            )
+            return False
 
         same_element = self.element == other.element
         same_isotope = self.isotope == other.isotope

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -62,32 +62,27 @@ class IonicLevel:
 
     def __eq__(self, other):
 
+        if self.ionic_symbol != getattr(other, "ionic_symbol", None):
+            return False
+
         try:
-            if self.ionic_symbol != other.ionic_symbol:
-                return False
 
-            ionic_fraction_within_tolerance = np.isclose(
+            ionic_fraction_within_rtol = u.isclose(
                 self.ionic_fraction,
-                other.ionic_fraction,
+                getattr(other, "ionic_fraction", None),
                 rtol=1e-15,
             )
 
-            number_density_within_tolerance = u.isclose(
+            number_density_within_rtol = u.isclose(
                 self.number_density,
-                other.number_density,
+                getattr(other, "number_density", None),
                 rtol=1e-15,
             )
 
-            return all(
-                [ionic_fraction_within_tolerance, number_density_within_tolerance]
-            )
+            return ionic_fraction_within_rtol and number_density_within_rtol
 
-        except TypeError as exc:
-            raise TypeError(
-                "Unable to ascertain equality between the following objects:\n"
-                f"  {self}\n"
-                f"  {other}"
-            ) from exc
+        except TypeError:
+            return False
 
     @particle_input
     def __init__(

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -65,7 +65,7 @@ class IonicLevel:
         if not isinstance(other, IonicLevel):
             return False
 
-        if self.ionic_symbol != getattr(other, "ionic_symbol", None):
+        if self.ionic_symbol != other.ionic_symbol:
             return False
 
         ionic_fraction_within_rtol = u.isclose(

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -343,16 +343,10 @@ class IonizationStateCollection:
     def __eq__(self, other):
 
         if not isinstance(other, IonizationStateCollection):
-            raise TypeError(
-                "IonizationStateCollection instance can only be compared with "
-                "other IonizationStateCollection instances."
-            )
+            return False
 
         if self.base_particles != other.base_particles:
-            raise ParticleError(
-                "Two IonizationStateCollection instances can be compared only "
-                "if the base particles are the same."
-            )
+            return False
 
         min_tol = np.min([self.tol, other.tol])
 
@@ -362,10 +356,6 @@ class IonizationStateCollection:
         for attribute in ["T_e", "n_e", "kappa"]:
             this = getattr(self, attribute)
             that = getattr(other, attribute)
-
-            # TODO: Maybe create a function in utils called same_enough
-            # TODO: that would take care of all of these disparate
-            # TODO: equality measures.
 
             this_equals_that = np.any(
                 [

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -959,3 +959,8 @@ def test_average_particle_exception():
 def test_inequality_with_different_type():
     ionization_states = IonizationStateCollection({"H": [1, 0], "He": [1, 0, 0]})
     assert ionization_states != "different type"
+
+
+def test_inequality_with_different_base_particles():
+    ionization_states = IonizationStateCollection({"H": [1, 0], "He": [1, 0, 0]})
+    IonizationStateCollection({"H": [1, 0], "Li": [1, 0, 0, 0]})

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -849,8 +849,8 @@ def test_iteration_with_nested_iterator():
 
 
 @pytest.mark.xfail()
-def test_hydrogen_deuterium():
-    instance = IonizationStateCollection(["H", "D"])
+def test_two_isotopes_of_same_element():
+    instance = IonizationStateCollection(["H-1", "D"])
 
 
 example_ionic_fractions = [

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -954,3 +954,8 @@ def test_average_particle_exception():
 
     with pytest.raises(ParticleError):
         ionization_states.average_ion()
+
+
+def test_inequality_with_different_type():
+    ionization_states = IonizationStateCollection({"H": [1, 0], "He": [1, 0, 0]})
+    assert ionization_states != "different type"

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -962,5 +962,6 @@ def test_inequality_with_different_type():
 
 
 def test_inequality_with_different_base_particles():
-    ionization_states = IonizationStateCollection({"H": [1, 0], "He": [1, 0, 0]})
-    IonizationStateCollection({"H": [1, 0], "Li": [1, 0, 0, 0]})
+    instance1 = IonizationStateCollection({"H": [1, 0], "He": [1, 0, 0]})
+    instance2 = IonizationStateCollection({"H": [1, 0], "Li": [1, 0, 0, 0]})
+    assert instance1 != instance2

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -84,7 +84,7 @@ def test_ionic_level_comparison_with_different_ions(ion1, ion2):
 
 
 def test_ionic_level_inequality_with_different_type():
-    instance = IonicLevel("H", 0.3)
+    instance = IonicLevel("H 1+", 0.3)
     assert instance != "different type"
 
 
@@ -213,7 +213,7 @@ class Test_IonizationState:
         ), "Different IonizationState instances are equal."
 
     def test_inequality_with_different_type(self):
-        assert self.instance["Li ground state"] != "different type"
+        assert self.instances["Li ground state"] != "different type"
 
     def test_equality_no_more_exception(self):
         """

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -60,7 +60,7 @@ def test_ionic_level_invalid_inputs(invalid_fraction, expected_exception):
 
 
 @pytest.mark.parametrize("invalid_particle", ["H", "e-", "Fe-56"])
-def test_ionic_fraction_invalid_particles(invalid_particle):
+def test_ionic_level_invalid_particles(invalid_particle):
     """
     Test that `~plasmapy.particles.IonicLevel` raises the appropriate
     exception when passed a particle that isn't a neutral or ion.
@@ -70,7 +70,7 @@ def test_ionic_fraction_invalid_particles(invalid_particle):
 
 
 @pytest.mark.parametrize("ion1, ion2", [("Fe-56 6+", "Fe-56 5+"), ("H 1+", "D 1+")])
-def test_ionic_fraction_comparison_with_different_ions(ion1, ion2):
+def test_ionic_level_comparison_with_different_ions(ion1, ion2):
     """
     Test that a `TypeError` is raised when an `IonicLevel` object
     is compared to an `IonicLevel` object of a different ion.
@@ -81,6 +81,11 @@ def test_ionic_fraction_comparison_with_different_ions(ion1, ion2):
     ionic_fraction_2 = IonicLevel(ion=ion2, ionic_fraction=fraction)
 
     assert ionic_fraction_1 != ionic_fraction_2
+
+
+def test_ionic_level_inequality_with_different_type():
+    instance = IonicLevel("H", 0.3)
+    assert instance != "different type"
 
 
 def test_ionization_state_ion_input_error():

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -212,6 +212,9 @@ class Test_IonizationState:
             self.instances["Li ground state"] != self.instances["Li"]
         ), "Different IonizationState instances are equal."
 
+    def test_inequality_with_different_type(self):
+        assert self.instance["Li ground state"] != "different type"
+
     def test_equality_no_more_exception(self):
         """
         Test that comparisons of `IonizationState` instances for


### PR DESCRIPTION
This PR changes `IonicLevel.__eq__`, `IonizationState.__eq__`, and `IonizationStateCollection.__eq__` so that an equality comparison with another type of object doesn't raise an exception but rather returns `False`.  This change is to better match the typical/expected behavior of Python objects.