### PR TITLE
Update versions of `black`, `nbqa`, and `pyupgrade` used by `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     - python
 
 - repo: https://github.com/psf/black
-  rev: 22.6.0
+  rev: 22.8.0
   hooks:
   - id: black
 
@@ -43,7 +43,7 @@ repos:
   hooks:
   - id: nbqa-black
     additional_dependencies:
-    - black==22.6.0
+    - black==22.8.0
     args:
     - --nbqa-mutate
   - id: nbqa-isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   - id: black
 
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.3.1
+  rev: 1.4.0
   hooks:
   - id: nbqa-black
     additional_dependencies:
@@ -74,7 +74,7 @@ repos:
     exclude: docs/plasmapy_sphinx
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.34.0
+  rev: v2.37.3
   hooks:
   - id: pyupgrade
     args: [--keep-runtime-typing, --py38-plus]

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -936,7 +936,7 @@ def test_that_object_can_be_dict_key(key):
         dictionary = {key: value}
     except Exception as exc:
         error_message = f"{key} is not a valid key for a dict. "
-        if not isinstance(key, collections.Hashable):
+        if not isinstance(key, collections.abc.Hashable):
             error_message += f"{key} is not hashable. "
         try:
             key_equals_itself = key == key


### PR DESCRIPTION
This PR updates the version of `black` from 22.6.0 to 22.8.0,  `nbqa` from 1.3.1 to 1.4.0, and `pyupgrade` from 2.34.0 to 2.37.3.  There is one minor autoformatting fix from `pyupgrade`.