### PR TITLE
Bumping `astropy` dependency to `>= 5.0.1` due to `numpy.asscalar` deprecation

### DIFF
--- a/changelog/1727.trivial.rst
+++ b/changelog/1727.trivial.rst
@@ -1,1 +1,1 @@
-Increased minimum version of Astropy_ to 5.0.
+Increased minimum version of Astropy_ to 5.0.1.

--- a/changelog/1727.trivial.rst
+++ b/changelog/1727.trivial.rst
@@ -1,0 +1,1 @@
+Set minimum dependency version for numba to 0.56.0 in minimal test environment

--- a/changelog/1727.trivial.rst
+++ b/changelog/1727.trivial.rst
@@ -1,1 +1,1 @@
-Bump minimum astropy version to 5.0
+Bump minimum astropy version to 5.0.1

--- a/changelog/1727.trivial.rst
+++ b/changelog/1727.trivial.rst
@@ -1,1 +1,1 @@
-Bump minimum astropy version to 5.0.1
+Increased minimum version of Astropy_ to 5.0.

--- a/changelog/1727.trivial.rst
+++ b/changelog/1727.trivial.rst
@@ -1,1 +1,1 @@
-Set minimum dependency version for numba to 0.56.0 in minimal test environment
+Bump minimum astropy version to 5.0

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,7 +1,7 @@
 # these are dependencies required to use the package
 # ought to mirror 'install_requires' under 'options' in setup.cfg
 -r build.txt
-astropy >= 5.0
+astropy >= 5.0.1
 cached-property >= 1.5.2
 h5py >= 3.0.0
 ipywidgets >= 7.6.5

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,7 +1,7 @@
 # these are dependencies required to use the package
 # ought to mirror 'install_requires' under 'options' in setup.cfg
 -r build.txt
-astropy >= 4.3.1
+astropy >= 5.0
 cached-property >= 1.5.2
 h5py >= 3.0.0
 ipywidgets >= 7.6.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ setup_requires =
     # build dependencies...they should be defined under build-system.requires
 install_requires =
     # ought to mirror requirements/install.txt
-    astropy >= 4.3.1
+    astropy >= 5.0
     cached-property >= 1.5.2
     h5py >= 3.0.0
     ipywidgets >= 7.6.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ setup_requires =
     # build dependencies...they should be defined under build-system.requires
 install_requires =
     # ought to mirror requirements/install.txt
-    astropy >= 5.0
+    astropy >= 5.0.1
     cached-property >= 1.5.2
     h5py >= 3.0.0
     ipywidgets >= 7.6.5

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ deps =
     lmfit == 1.0.0
     matplotlib == 3.3.0
     mpmath == 1.2.1
-    numba
+    numba == 0.56.0
     numpy == 1.19.0
     pandas == 1.0.0
     pillow

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ conda_deps =
 basepython = python3.8
 extras = tests
 deps =
-    astropy == 5.0
+    astropy == 5.0.1
     cached-property == 1.5.2
     ipywidgets == 7.6.5
     h5py == 3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ conda_deps =
 basepython = python3.8
 extras = tests
 deps =
-    astropy == 4.3.1
+    astropy == 5.0
     cached-property == 1.5.2
     ipywidgets == 7.6.5
     h5py == 3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ deps =
     lmfit == 1.0.0
     matplotlib == 3.3.0
     mpmath == 1.2.1
-    numba == 0.56.0
+    numba
     numpy == 1.19.0
     pandas == 1.0.0
     pillow


### PR DESCRIPTION
CI failures regarding `numpy.asscalar` began popping up ~2 days ago, which correlates with numba release 0.56.2. This pull request declares a strict version of 0.56.0 to be used for the python 3.8 minimal environment

- [x] I have added a changelog entry for this pull request.
- [x] If adding new functionality, I have added tests and
      docstrings.
- [x] I have fixed any newly failing tests.