### PR TITLE
Use `pycln` to remove unused imports

### DIFF
--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -17,7 +17,7 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 from scipy.optimize import curve_fit, fsolve
 from scipy.stats import linregress
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 from warnings import warn
 
 from plasmapy.utils.decorators import modify_docstring

--- a/plasmapy/formulary/dielectric.py
+++ b/plasmapy/formulary/dielectric.py
@@ -6,7 +6,6 @@ __all__ = [
 ]
 __lite_funcs__ = ["permittivity_1D_Maxwellian_lite"]
 
-import numbers
 import numpy as np
 
 from astropy import units as u

--- a/plasmapy/tests/test_requirements.py
+++ b/plasmapy/tests/test_requirements.py
@@ -1,6 +1,5 @@
 """Tests for the consistency of requirements."""
 
-import os
 import pathlib
 import pytest
 import setuptools

--- a/plasmapy/utils/decorators/tests/test_lite_func.py
+++ b/plasmapy/utils/decorators/tests/test_lite_func.py
@@ -6,7 +6,6 @@ import pytest
 from numba import jit, njit
 
 from plasmapy.utils.decorators.lite_func import bind_lite_func
-from plasmapy.utils.exceptions import PlasmaPyWarning
 
 
 def foo(x):


### PR DESCRIPTION
This is a quick PR to remove a few unused imports that were found and removed by [pycln](https://hadialqattan.github.io/pycln/#/).  