### PR TITLE
Show local variables in test failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ allowlist_externals =
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 -n=auto --dist=loadfile
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals -n=auto --dist=loadfile
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy

--- a/tox.ini
+++ b/tox.ini
@@ -114,7 +114,7 @@ deps =
     xarray == 0.15.0
     requests >= 2.27.1
 setenv =
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals
 
 [testenv:linters]
 deps =


### PR DESCRIPTION
This PR adds the `--showlocals` flag to our call to `pytest` in `tox.ini` in order to show local variables.  Here's example test output for a purposefully failing test:

```python
    def test_that_fails():
        x = 1
        y = 2
        z = 624
>       assert x == y
E       assert 1 == 2

x          = 1
y          = 2
z          = 624

plasmapy/tests/test_whatev.py:5: AssertionError
```

This can be really helpful for debugging, so I figured it'd be easier to have it on as the default.  The downside is that the test output is longer.