### PR TITLE
Move pytest dep from tests to install and update `nitpick_ignore_regex` to fix new doc build warnings

### DIFF
--- a/changelog/1749.trivial.rst
+++ b/changelog/1749.trivial.rst
@@ -1,0 +1,2 @@
+Make ``pytest`` an ``install`` requirement instead of a ``testing``
+requirement.

--- a/changelog/1749.trivial.rst
+++ b/changelog/1749.trivial.rst
@@ -1,2 +1,2 @@
-Make ``pytest`` an ``install`` requirement instead of a ``testing``
+Made ``pytest`` an ``install`` requirement instead of a ``testing``
 requirement.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -347,12 +347,17 @@ nitpick_ignore_regex = [
     (python_role, "_pytest.*"),
     (python_role, "Failed"),
     # charged_particle_radiography
+    (python_role, "1"),
     (python_role, "2 ints"),
     (python_role, "a single int"),
+    (python_role, "same"),
     (python_role, "Tuple of 1"),
     # thomson
     (python_role, "Ne"),
     (python_role, "Ni"),
+    # utils
+    (python_role, "docstring of"),
+    (python_role, "validation specifications"),
     # for reST workarounds defined in docs/common_links.rst
     (python_role, "h5py"),
     (python_role, "IPython.sphinxext.ipython_console_highlighting"),

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -12,6 +12,7 @@ numba
 numpy >= 1.20.0
 packaging
 pandas >= 1.0.0
+pytest >= 5.4.0
 requests >= 2.27.1
 scipy >= 1.5.0
 tqdm >= 4.41.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -14,7 +14,6 @@ flake8-simplify
 flake8-use-fstring
 hypothesis
 pydocstyle
-pytest >= 5.4.0
 pytest-regressions
 pytest-xdist
 tomli

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     numpy >= 1.20.0
     packaging
     pandas >= 1.0.0
+    pytest >= 5.4.0
     scipy >= 1.5.0
     tqdm >= 4.41.0
     voila >= 0.2.15
@@ -82,7 +83,6 @@ tests =
     flake8-use-fstring
     hypothesis
     pydocstyle
-    pytest >= 5.4.0
     pytest-regressions
     pytest-xdist
     tomli

--- a/tox.ini
+++ b/tox.ini
@@ -47,14 +47,14 @@ changedir = {toxinidir}
 extras = docs
 setenv =
     HOME = {envtmpdir}
-commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
+commands = sphinx-build docs docs{/}_build{/}html -n --keep-going -b html {posargs}
 
 [testenv:build_docs-sphinxdev]
 changedir = {toxinidir}
 extras = docs
 setenv =
     HOME = {envtmpdir}
-commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
+commands = sphinx-build docs docs{/}_build{/}html -n --keep-going -b html {posargs}
 deps =
     git+https://github.com/sphinx-doc/sphinx
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -47,14 +47,14 @@ changedir = {toxinidir}
 extras = docs
 setenv =
     HOME = {envtmpdir}
-commands = sphinx-build docs docs{/}_build{/}html -n --keep-going -b html {posargs}
+commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
 
 [testenv:build_docs-sphinxdev]
 changedir = {toxinidir}
 extras = docs
 setenv =
     HOME = {envtmpdir}
-commands = sphinx-build docs docs{/}_build{/}html -n --keep-going -b html {posargs}
+commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
 deps =
     git+https://github.com/sphinx-doc/sphinx
 description =


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

<!-- Please summarize the changes here. -->



## Motivation and context

<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->



## Related issues

<!-- Please link to any related issues and PRs. If this PR will fully resolve and issue, include text like "Closes #1542" so that the issue will be automatically closed when this PR is merged. -->
