### PR TITLE
Change license header to match OSI format

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-# PlasmaPy License
+BSD 3-Clause License
 
 Copyright (c) 2015–2022, PlasmaPy Developers.
 


### PR DESCRIPTION
## Description

Edited `LICENSE.md` to match the text in https://choosealicense.com/licenses/bsd-3-clause.

## Motivation and context

The `LICENSE.md` file does not include the `BSD 3-Clause License` title which allows GitHub to recognise it as a 3-Clause BSD license.

|  **Before** | **After**  |
|---|---|
| ![image](https://user-images.githubusercontent.com/30223404/196804196-4c226da5-4ab1-47fd-9325-ed1ca6c9950c.png) | ![image](https://user-images.githubusercontent.com/30223404/196804118-b6b2847d-04a4-4870-a3e4-6f2fdfabbd61.png) |

This repository will now show up in GitHub search results as "BSD-3-Clause" licensed, instead of "Other" license, great for users looking for a permissively-licensed package.

## Related issues

nil
