### PR TITLE
Add GitHub Action to validate `CITATION.cff`

### DIFF
--- a/.github/workflows/cff.yml
+++ b/.github/workflows/cff.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    paths:
+    - CITATION.cff
+  workflow_dispatch:
+
+name: CITATION.cff
+jobs:
+  Validate-CITATION-cff:
+    runs-on: ubuntu-latest
+    name: Validate CITATION.cff
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Validate CITATION.cff
+      uses: dieghernan/cff-validator@main


### PR DESCRIPTION
We use `CITATION.cff` as one of our tools to record metadata for our project. I've been thinking that it would be helpful to generate the author list in `docs/about/credits.rst` directly from `CITATION.cff`, in which case new contributors would be editing `CITATION.cff` directly. Hence, a validation tool would help find bugs & typos in it to save us some effort with code review.  

This GA comes from: https://github.com/marketplace/actions/cff-validator

And it even has a DOI! For the latest release: 10.5281/zenodo.5348443

I don't think this will automagically fix errors/formatting though.

Though `CITATION.cff` is a YAML file, it doesn't get autoformatted via our `pretty-yaml-format` pre-commit hook because it doesn't have a `.yaml` or `.yml` extension.