### PR TITLE
Add `flake8` extensions

### DIFF
--- a/changelog/1777.trivial.rst
+++ b/changelog/1777.trivial.rst
@@ -1,0 +1,3 @@
+Added the flake8_ extensions ``flake8-use-pathlib``,
+``flake8-builtins``, and ``flake8-comments`` to the testing
+requirements.

--- a/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/plasmapy/analysis/swept_langmuir/helpers.py
@@ -97,7 +97,6 @@ def check_sweep(
     elif not np.all(np.diff(voltage) >= 0):
         raise ValueError("The voltage array is not monotonically increasing.")
 
-    # strip units
     if isinstance(voltage, u.Quantity) and strip_units:
         voltage = voltage.value
 
@@ -143,7 +142,6 @@ def check_sweep(
             f" as the 'current' size {current.size}."
         )
 
-    # strip units
     if isinstance(current, u.Quantity) and strip_units:
         current = current.value
 

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -93,34 +93,25 @@ class PlasmaBlob(GenericPlasma):
         Generate a comprehensive description of the plasma regimes
         based on plasma properties and consequent plasma parameters.
         """
-        # getting dimensionless parameters
         coupling = self.coupling()
         quantum_theta = self.quantum_theta()
 
-        # determining regimes based off dimensionless parameters
-        # coupling
         if coupling <= 0.01:
-            # weakly coupled
             coupling_str = f"Weakly coupled regime: Gamma = {coupling}."
         elif coupling >= 100:
-            # strongly coupled
             coupling_str = f"Strongly coupled regime: Gamma = {coupling}."
         else:
-            # intermediate regime
             coupling_str = f"Intermediate coupling regime: Gamma = {coupling}."
-        # quantum_theta
+
         if quantum_theta <= 0.01:
-            # Fermi energy dominant
             quantum_theta_str = (
                 f"Fermi quantum energy dominant: Theta = {quantum_theta}"
             )
         elif quantum_theta >= 100:
-            # thermal kinetic energy dominant
             quantum_theta_str = (
                 f"Thermal kinetic energy dominant: Theta = {quantum_theta}"
             )
         else:
-            # intermediate regime
             quantum_theta_str = (
                 f"Both Fermi and thermal energy important: Theta = {quantum_theta}"
             )

--- a/plasmapy/utils/calculator/main_interface.py
+++ b/plasmapy/utils/calculator/main_interface.py
@@ -7,6 +7,7 @@ import astropy.units as units
 import json
 
 from ipywidgets import widgets
+from pathlib import Path
 
 from plasmapy.utils.calculator.widget_helpers import (
     _calculate_button,
@@ -148,7 +149,9 @@ def _create_output_layout():
     app = widgets.Tab()
     children = []
 
-    with open("properties_metadata.json") as f:
+    properties_metadata = Path("properties_metadata.json")
+
+    with properties_metadata.open() as f:
         data = json.load(f)
 
     for i, title in enumerate(data):

--- a/plasmapy/utils/calculator/widget_helpers.py
+++ b/plasmapy/utils/calculator/widget_helpers.py
@@ -257,17 +257,17 @@ class _FloatBox(_GenericWidget):
     property_name: `str`
         Name of the property the widget is associated with.
 
-    min: `float`
+    minval: `float`
         Minimum value the widget can take
 
-    max: `float`
+    maxval: `float`
         Maximum value the widget can take
     """
 
-    def __init__(self, property_name, min=-1e50, max=1e50):
+    def __init__(self, property_name, minval=-1e50, maxval=1e50):
         super().__init__(property_name)
-        self.min = min
-        self.max = max
+        self.minval = minval
+        self.maxval = maxval
 
     def create_widget(self, style={"description_width": "initial"}):
         """
@@ -276,8 +276,8 @@ class _FloatBox(_GenericWidget):
         """
         self.widget = widgets.BoundedFloatText(
             name=self.property_name,
-            min=self.min,
-            max=self.max,
+            min=self.minval,
+            max=self.maxval,
             value=0,
             step=0.1,
             style=style,

--- a/plasmapy/utils/calculator/widget_helpers.py
+++ b/plasmapy/utils/calculator/widget_helpers.py
@@ -257,17 +257,17 @@ class _FloatBox(_GenericWidget):
     property_name: `str`
         Name of the property the widget is associated with.
 
-    minval: `float`
+    min_: `float`
         Minimum value the widget can take
 
-    maxval: `float`
+    max_: `float`
         Maximum value the widget can take
     """
 
-    def __init__(self, property_name, minval=-1e50, maxval=1e50):
+    def __init__(self, property_name, min_=-1e50, max_=1e50):
         super().__init__(property_name)
-        self.minval = minval
-        self.maxval = maxval
+        self.min_ = min_
+        self.max_ = max_
 
     def create_widget(self, style={"description_width": "initial"}):
         """
@@ -276,8 +276,8 @@ class _FloatBox(_GenericWidget):
         """
         self.widget = widgets.BoundedFloatText(
             name=self.property_name,
-            min=self.minval,
-            max=self.maxval,
+            min=self.min_,
+            max=self.max_,
             value=0,
             step=0.1,
             style=style,

--- a/plasmapy/utils/calculator/widget_helpers.py
+++ b/plasmapy/utils/calculator/widget_helpers.py
@@ -257,17 +257,17 @@ class _FloatBox(_GenericWidget):
     property_name: `str`
         Name of the property the widget is associated with.
 
-    min_: `float`
+    min: `float`
         Minimum value the widget can take
 
-    max_: `float`
+    max: `float`
         Maximum value the widget can take
     """
 
-    def __init__(self, property_name, min_=-1e50, max_=1e50):
+    def __init__(self, property_name, min=-1e50, max=1e50):  # noqa
         super().__init__(property_name)
-        self.min_ = min_
-        self.max_ = max_
+        self.min = min
+        self.max = max
 
     def create_widget(self, style={"description_width": "initial"}):
         """
@@ -276,8 +276,8 @@ class _FloatBox(_GenericWidget):
         """
         self.widget = widgets.BoundedFloatText(
             name=self.property_name,
-            min=self.min_,
-            max=self.max_,
+            min=self.min,
+            max=self.max,
             value=0,
             step=0.1,
             style=style,

--- a/plasmapy/utils/data/downloader.py
+++ b/plasmapy/utils/data/downloader.py
@@ -43,7 +43,6 @@ def get_file(basename, base_url=_BASE_URL, directory=None):
     -------
     path : str
         The full local path to the downloaded file.
-
     """
 
     if "." not in str(basename):
@@ -72,7 +71,7 @@ def get_file(basename, base_url=_BASE_URL, directory=None):
                 "URL provided."
             )
 
-        with open(path, "wb") as f:
+        with path.open(mode="wb") as f:
             f.write(reply.content)
 
     return path

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -372,7 +372,6 @@ class ValidateQuantities(CheckUnits, CheckValues):
         elif err is not None:
             raise err
 
-        # check value
         self._check_value(arg, arg_name, arg_validations)
 
         return arg

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -16,7 +16,6 @@ flake8-rst-docstrings
 flake8-simplify
 flake8-use-fstring
 flake8-use-pathlib
-flake8-useless-assert
 hypothesis
 pydocstyle
 pytest-regressions

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,11 +8,15 @@ cffconvert
 dlint
 flake8
 flake8-absolute-import
+flake8-builtins
+flake8-comments
 flake8-implicit-str-concat
 flake8-mutable
 flake8-rst-docstrings
 flake8-simplify
 flake8-use-fstring
+flake8-use-pathlib
+flake8-useless-assert
 hypothesis
 pydocstyle
 pytest-regressions

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,6 @@ tests =
     flake8-simplify
     flake8-use-fstring
     flake8-use-pathlib
-    flake8-useless-assert
     hypothesis
     pydocstyle
     pytest-regressions

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,11 +77,15 @@ tests =
     dlint
     flake8
     flake8-absolute-import
+    flake8-builtins
+    flake8-comments
     flake8-implicit-str-concat
     flake8-mutable
     flake8-rst-docstrings
     flake8-simplify
     flake8-use-fstring
+    flake8-use-pathlib
+    flake8-useless-assert
     hypothesis
     pydocstyle
     pytest-regressions

--- a/tox.ini
+++ b/tox.ini
@@ -122,11 +122,15 @@ deps =
     dlint
     flake8
     flake8-absolute-import
+    flake8-builtins
+    flake8-comments
     flake8-implicit-str-concat
     flake8-mutable
     flake8-rst-docstrings
     flake8-simplify
     flake8-use-fstring
+    flake8-use-pathlib
+    flake8-useless-assert
     pydocstyle
     pygments
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,6 @@ deps =
     flake8-simplify
     flake8-use-fstring
     flake8-use-pathlib
-    flake8-useless-assert
     pydocstyle
     pygments
 commands =


### PR DESCRIPTION
This PR adds the following flake8 extensions:

 - ~~flake8-useless-assert — to make sure that `assert` statements won't always pass or fail~~
 - flake8-use-pathlib — to enforce recommend usage of `pathlib`
 - flake8-builtins — to avoid name conflicts with Python builtins (like `min` and `max`)
 - flake8-comments — to avoid redundant comments

This PR also makes a few minor edits in order for the new flake8 extensions to pass.

Before merging, I'll need to:

 - [ ] Test the plasma calculator