### PR TITLE
Mark tests as slow

### DIFF
--- a/plasmapy/analysis/tests/test_nullpoint.py
+++ b/plasmapy/analysis/tests/test_nullpoint.py
@@ -244,6 +244,7 @@ class Test_locate_null_point:
         ).all()
 
 
+@pytest.mark.slow
 def test_null_point_find1():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Uniform grid
@@ -260,6 +261,7 @@ def test_null_point_find1():
     assert np.isclose(loc, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
 
 
+@pytest.mark.slow
 def test_null_point_find2():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Non-uniform grid
@@ -293,6 +295,7 @@ def test_null_point_find3():
     assert np.isclose(loc3, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
 
 
+@pytest.mark.slow
 def test_null_point_find4():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Two null points
@@ -311,6 +314,7 @@ def test_null_point_find4():
     assert np.isclose(second_loc4, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
 
 
+@pytest.mark.slow
 def test_null_point_find5():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Many null points because a y vector dimension is zero
@@ -340,6 +344,7 @@ def test_null_point_find5():
             )
 
 
+@pytest.mark.slow
 def test_null_point_find6():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Many null points; All vector dimensions zero
@@ -354,6 +359,7 @@ def test_null_point_find6():
     assert len(npoints6) == 0
 
 
+@pytest.mark.slow
 def test_null_point_find7():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # No null points, discriminant less than zero
@@ -368,6 +374,7 @@ def test_null_point_find7():
     assert len(npoints7) == 0
 
 
+@pytest.mark.slow
 def test_null_point_find8():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Non-linear field
@@ -386,6 +393,7 @@ def test_null_point_find8():
     assert np.allclose(loc2, [5.5, 5.5, 5.5], atol=_TESTING_ATOL)
 
 
+@pytest.mark.slow
 class Test_classify_null_point:
     r"""Test `~plasmapy.analysis.nullpoint._classify_null_point`."""
 
@@ -470,6 +478,7 @@ def test_null_point_find9():
 
 
 # Tests that capture the degenerate nulls/2D nulls
+@pytest.mark.slow
 def test_null_point_find10():
     nullpoint10_args = {
         "x_range": [-0.1, 0.1],
@@ -491,6 +500,7 @@ def test_null_point_find10():
             assert p.classification == "Continuous concentric ellipses"
 
 
+@pytest.mark.slow
 def test_null_point_find11():
     nullpoint10_args = {
         "x_range": [-0.1, 0.1],

--- a/plasmapy/diagnostics/tests/test_charged_particle_radiography.py
+++ b/plasmapy/diagnostics/tests/test_charged_particle_radiography.py
@@ -322,6 +322,7 @@ def test_input_validation():
         hax, vax, values = cpr.synthetic_radiograph(sim, size=size)
 
 
+@pytest.mark.slow
 def test_init():
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
@@ -348,6 +349,7 @@ def test_init():
     assert all(sim.det_hdir == np.array([1, 0, 0]))
 
 
+@pytest.mark.slow
 def test_create_particles():
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
@@ -607,6 +609,7 @@ class TestSyntheticRadiograph:
         assert np.all(np.isposinf(od_results[2][zero_mask]))
 
 
+@pytest.mark.slow
 def test_saving_output(tmp_path):
     """Test behavior of Tracker.save_results."""
 
@@ -632,6 +635,7 @@ def test_saving_output(tmp_path):
         assert np.allclose(results_1[key], results_2[key])
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "case",
     ["creating particles", "loading particles", "adding a wire mesh"],

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -189,6 +189,7 @@ def single_species_collective_spectrum(single_species_collective_args):
     return (alpha, wavelengths, Skw)
 
 
+@pytest.mark.slow
 def test_single_species_collective_spectrum(single_species_collective_spectrum):
     """
     Compares the generated spectrum to previously determined values
@@ -217,6 +218,7 @@ def test_single_species_collective_spectrum(single_species_collective_spectrum):
     )
 
 
+@pytest.mark.slow
 def test_spectral_density_minimal_arguments(single_species_collective_args):
     """
     Check that spectral density runs with minimal arguments
@@ -408,6 +410,7 @@ def single_species_non_collective_spectrum(single_species_non_collective_args):
     return (alpha, wavelengths, Skw)
 
 
+@pytest.mark.slow
 def test_single_species_non_collective_spectrum(single_species_non_collective_spectrum):
     """
     Compares the generated spectrum to previously determined values
@@ -542,6 +545,7 @@ def test_spectral_density_input_errors(
                 assert msg in str(excinfo.value)
 
 
+@pytest.mark.slow
 def test_split_populations():
     """
     This test makes sure that splitting a single population of ions or electrons
@@ -1034,6 +1038,7 @@ def noncollective_single_species_settings_params():
     return kwargs
 
 
+@pytest.mark.slow
 def test_fit_epw_single_species(epw_single_species_settings_params):
     wavelengths, params, settings = spectral_density_model_settings_params(
         epw_single_species_settings_params
@@ -1042,6 +1047,7 @@ def test_fit_epw_single_species(epw_single_species_settings_params):
     run_fit(wavelengths, params, settings, notch=(531, 533))
 
 
+@pytest.mark.slow
 def test_fit_epw_multi_species(epw_multi_species_settings_params):
     wavelengths, params, settings = spectral_density_model_settings_params(
         epw_multi_species_settings_params
@@ -1050,6 +1056,7 @@ def test_fit_epw_multi_species(epw_multi_species_settings_params):
     run_fit(wavelengths, params, settings, notch=(531, 533))
 
 
+@pytest.mark.slow
 def test_fit_iaw_single_species(iaw_single_species_settings_params):
 
     wavelengths, params, settings = spectral_density_model_settings_params(
@@ -1059,6 +1066,7 @@ def test_fit_iaw_single_species(iaw_single_species_settings_params):
     run_fit(wavelengths, params, settings)
 
 
+@pytest.mark.slow
 def test_fit_iaw_instr_func(iaw_single_species_settings_params):
     """
     Tests fitting with an instrument function
@@ -1074,6 +1082,7 @@ def test_fit_iaw_instr_func(iaw_single_species_settings_params):
     run_fit(wavelengths, params, settings)
 
 
+@pytest.mark.slow
 def test_fit_iaw_multi_species(iaw_multi_species_settings_params):
     wavelengths, params, settings = spectral_density_model_settings_params(
         iaw_multi_species_settings_params
@@ -1082,6 +1091,7 @@ def test_fit_iaw_multi_species(iaw_multi_species_settings_params):
     run_fit(wavelengths, params, settings)
 
 
+@pytest.mark.slow
 def test_fit_noncollective_single_species(noncollective_single_species_settings_params):
 
     wavelengths, params, settings = spectral_density_model_settings_params(
@@ -1091,6 +1101,7 @@ def test_fit_noncollective_single_species(noncollective_single_species_settings_
     run_fit(wavelengths, params, settings)
 
 
+@pytest.mark.slow
 def test_fit_with_instr_func(epw_single_species_settings_params):
     """
 
@@ -1139,6 +1150,7 @@ def test_fit_with_invalid_instr_func(instr_func, iaw_single_species_settings_par
         run_fit(wavelengths, params, settings)
 
 
+@pytest.mark.slow
 def test_fit_with_minimal_parameters():
     # Create example data for fitting
     probe_wavelength = 532 * u.nm

--- a/plasmapy/formulary/tests/test_collisions.py
+++ b/plasmapy/formulary/tests/test_collisions.py
@@ -1599,6 +1599,7 @@ class Test_Knudsen_number:
         assert_can_handle_nparray(Knudsen_number, insert_some_nans, insert_all_nans, {})
 
 
+@pytest.mark.slow
 class Test_coupling_parameter:
     @classmethod
     def setup_class(cls):

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -156,6 +156,7 @@ def test_Wigner_Seitz_radius():
     assert testTrue, errStr
 
 
+@pytest.mark.slow
 class TestChemicalPotential:
 
     value_test_parameters = (


### PR DESCRIPTION
This PR decorates a bunch of tests with `@pytest.mark.slow` so that they can be skipped with `pytest -m "not slow"`. 

I've been thinking of slow tests as lasting ≳ 0.1 s.  That's a pretty short cutoff, but given that we have a few thousand tests, the 0.1 s tests can really slow things down.  

There are a few longer tests in docstrings which I don't know how to mark, but we might want to do so.

On my computer, running `pytest -m slow` takes ∼32 s whereas running `pytest -m "not slow"` takes...well...I'll add it in when it finishes.  Edited to add: ∼143 s.

Also: some of the lite functions seem to take ∼0.1–0.5 seconds to run for the first time because they need to be jitted.