### PR TITLE
Add `blacken-docs` to `pre-commit` & apply minor reST fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,5 +138,6 @@ auto_examples
 
 # Version file
 plasmapy/version.py
+plasmapy/_version.py
 tags
 docs/notebooks/*.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==22.10.0]
+    exclude: docs/contributing/coding_guide.rst
 
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.5.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,12 +38,18 @@ repos:
   hooks:
   - id: black
 
+- repo: https://github.com/asottile/blacken-docs
+  rev: v1.12.1
+  hooks:
+  - id: blacken-docs
+    additional_dependencies: [black==22.10.0]
+
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.5.3
   hooks:
   - id: nbqa-black
     additional_dependencies:
-    - black==22.8.0
+    - black==22.10.0
     args:
     - --nbqa-mutate
   - id: nbqa-isort

--- a/changelog/1807.trivial.rst
+++ b/changelog/1807.trivial.rst
@@ -1,0 +1,2 @@
+Added `blacken-docs <https://github.com/adamchainz/blacken-docs>`__ to
+the |pre-commit| configuration.

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -708,7 +708,7 @@ Equations and Physical Formulae
 
   .. code-block:: pycon
 
-     >>> omega_ce = 1.76e7 * (B / u.G) * u.rad / u.s  # doctest: +SKIP
+     >>> omega_ce = 1.76e7*(B/u.G)*u.rad/u.s  # doctest: +SKIP
 
   In contrast, the following line of code shows the exact formula
   which makes the code much more readable.

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -59,7 +59,7 @@ Coding guidelines
 
   .. code-block:: python
 
-     f(T_i = 1e6 * u.K, T_e = 2e6 * u.K)
+     f(T_i=1e6 * u.K, T_e=2e6 * u.K)
 
   Similarly, when a function has parameters named ``T_e`` and ``T_i``,
   these parameters should be made |keyword-only| to avoid ambiguity and
@@ -252,7 +252,8 @@ the code is supposed to be doing.
 
   .. code-block:: python
 
-     if u[0] < x < u[1] and v[0] < y < v[1] and w[0] < z < w[1]: ...
+     if u[0] < x < u[1] and v[0] < y < v[1] and w[0] < z < w[1]:
+         ...
 
   Defining an intermediate variable allows us to communicate the meaning
   and intent of the expression.
@@ -283,10 +284,10 @@ Imports
 
   .. code-block:: python
 
-     import numpy as np
-     import astropy.units as u
      import astropy.constants as const
+     import astropy.units as u
      import matplotlib.pyplot as plt
+     import numpy as np
      import pandas as pd
 
 * PlasmaPy uses isort_ to organize import statements via a |pre-commit|_
@@ -479,13 +480,13 @@ unmaintained comment may contain inaccurate or misleading information
   .. code-block:: python
 
      # collision frequency
-     nu = 1e6 * u.s ** -1
+     nu = 1e6 * u.s**-1
 
   could be achieved with no comment by doing:
 
   .. code-block:: python
 
-     collision_frequency = 1e6 * u.s ** -1
+     collision_frequency = 1e6 * u.s**-1
 
 * Use comments to communicate information that you wish you knew before
   starting to work on a particular section of code, including
@@ -528,9 +529,11 @@ unmaintained comment may contain inaccurate or misleading information
          ...
          return calibrated_data
 
+
      def normalize_data(data):
          ...
          return normalized_data
+
 
      def analyze_experiment(data):
          calibrated_data = calibrate_data(data)
@@ -634,7 +637,7 @@ adjacent fields such as astronomy and heliophysics. To get started with
         n={"can_be_negative": False},
         validations_on_return={"equivalencies": u.dimensionless_angles()},
      )
-     def inertial_length(n: u.m ** -3, ...) -> u.m:
+     def inertial_length(n: u.m ** -3, particle) -> u.m:
          ...
 
   .. caution::
@@ -688,11 +691,12 @@ notebook on particles`_.
 
   .. code-block:: python
 
-     from plasmapy.particles import particle_input, ParticleLike
+     from plasmapy.particles import ParticleLike, particle_input
+
 
      @particle_input
      def get_particle(particle: ParticleLike):
-          return particle
+         return particle
 
   If we use ``get_particle`` on something |particle-like|, it will
   return the corresponding particle object.
@@ -776,8 +780,10 @@ defined in :file:`plasmapy/subpackage/module.py`.
 
    __all__ += __aliases__
 
+
    def function():
        ...
+
 
    f_ = function
    """Alias to `~plasmapy.subpackage.module.function`."""
@@ -841,11 +847,13 @@ that corresponds to ``function`` as would be defined in
    __all__ = ["function"]
    __lite_funcs__ = ["function_lite"]
 
-   from numba import njit
    from numbers import Real
+
+   from numba import njit
    from plasmapy.utils.decorators import bind_lite_func, preserve_signature
 
    __all__ += __lite_funcs__
+
 
    @preserve_signature
    @njit
@@ -855,6 +863,7 @@ that corresponds to ``function`` as would be defined in
        assumed SI units.
        """
        ...
+
 
    @bind_lite_func(function_lite)
    def function(v):

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -633,11 +633,12 @@ adjacent fields such as astronomy and heliophysics. To get started with
 
      from plasmapy.utils.decorators.validators import validate_quantities
 
+
      @validate_quantities(
-        n={"can_be_negative": False},
-        validations_on_return={"equivalencies": u.dimensionless_angles()},
+         n={"can_be_negative": False},
+         validations_on_return={"equivalencies": u.dimensionless_angles()},
      )
-     def inertial_length(n: u.m ** -3, particle) -> u.m:
+     def inertial_length(n: u.m**-3, particle) -> u.m:
          ...
 
   .. caution::

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -85,20 +85,8 @@ Coding guidelines
 
   .. code-block:: pycon
 
-     >>> [x ** 2 for x in range(17) if x % 2 == 0]
+     >>> [x**2 for x in range(17) if x % 2 == 0]
      [0, 4, 16, 36, 64, 100, 144, 196, 256]
-
-  A comprehension might be more readable when spread out over multiple
-  lines.
-
-  .. code-block:: pycon
-
-     >>> {
-     ...     x: x ** 2
-     ...     for x in range(17)
-     ...     if x % 2 == 0
-     ... }
-     {0: 0, 2: 4, 4: 16, 6: 36, 8: 64, 10: 100, 12: 144, 14: 196, 16: 256}
 
 * Avoid putting any significant implementation code in
   :file:`__init__.py` files. Implementation details should be contained
@@ -139,6 +127,7 @@ Coding guidelines
      >>> def function(l=[]):
      ...     l.append("x")
      ...     print(l)
+     ...
      >>> function()
      ['x']
      >>> function()
@@ -719,7 +708,7 @@ Equations and Physical Formulae
 
   .. code-block:: pycon
 
-     >>> omega_ce = 1.76e7*(B/u.G)*u.rad/u.s  # doctest: +SKIP
+     >>> omega_ce = 1.76e7 * (B / u.G) * u.rad / u.s  # doctest: +SKIP
 
   In contrast, the following line of code shows the exact formula
   which makes the code much more readable.

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -552,74 +552,74 @@ Here is an example docstring in the numpydoc_ format:
 
        .. math::
 
-          f(a, b) = a - b
+           f(a, b) = a - b
 
-      Parameters
-      ----------
-      a : `float`
-          The left multiplicand.
+       Parameters
+       ----------
+       a : `float`
+           The left multiplicand.
 
-      b : `float`
-          The right multiplicand.
+       b : `float`
+           The right multiplicand.
 
-      switch_order : `bool`, optional, |keyword-only|
-          If `True`, return :math:`a - b`. If `False`, then return
-          :math:`b - a`. Defaults to `True`.
+       switch_order : `bool`, optional, |keyword-only|
+           If `True`, return :math:`a - b`. If `False`, then return
+           :math:`b - a`. Defaults to `True`.
 
-      Returns
-      -------
-      float
-          The difference between ``a`` and ``b``.
+       Returns
+       -------
+       float
+           The difference between ``a`` and ``b``.
 
-      Raises
-      ------
-      `ValueError`
-          If ``a`` or ``b`` is `~numpy.inf`.
+       Raises
+       ------
+       `ValueError`
+           If ``a`` or ``b`` is `~numpy.inf`.
 
-      Warns
-      -----
-      `UserWarning`
-          If ``a`` or ``b`` is `~numpy.nan`.
+       Warns
+       -----
+       `UserWarning`
+           If ``a`` or ``b`` is `~numpy.nan`.
 
-      See Also
-      --------
-      add : Add two numbers.
+       See Also
+       --------
+       add : Add two numbers.
 
-      Notes
-      -----
-      The "Notes" section provides extra information that cannot fit in
-      the extended summary near the beginning of the docstring. This
-      section should include a discussion of the physics behind a
-      particular concept that should be understandable to someone who is
-      taking their first plasma physics class. This section can include
-      a derivation of the quantity being calculated or a description of
-      a particular algorithm.
+       Notes
+       -----
+       The "Notes" section provides extra information that cannot fit in
+       the extended summary near the beginning of the docstring. This
+       section should include a discussion of the physics behind a
+       particular concept that should be understandable to someone who is
+       taking their first plasma physics class. This section can include
+       a derivation of the quantity being calculated or a description of
+       a particular algorithm.
 
-      Examples
-      --------
-      Include a few example usages of the function here. Start with
-      simple examples and then increase complexity when necessary.
+       Examples
+       --------
+       Include a few example usages of the function here. Start with
+       simple examples and then increase complexity when necessary.
 
-      >>> from package.subpackage.module import subtract
-      >>> subtract(9, 6)
-      3
+       >>> from package.subpackage.module import subtract
+       >>> subtract(9, 6)
+       3
 
-      Here is an example of a multi-line function call.
+       Here is an example of a multi-line function call.
 
-      >>> subtract(
-      ...     9, 6, switch_order=True,
-      ... )
-      -3
+       >>> subtract(
+       ...     9, 6, switch_order=True,
+       ... )
+       -3
 
-      PlasmaPy's test suite will check that these commands provide the
-      output that follows each function call.
-      """
-      if np.isinf(a) or np.isinf(b):
-          raise ValueError("Cannot perform subtraction operations involving infinity.")
+       PlasmaPy's test suite will check that these commands provide the
+       output that follows each function call.
+       """
+       if np.isinf(a) or np.isinf(b):
+           raise ValueError("Cannot perform subtraction operations involving infinity.")
 
-      warnings.warn("The subtract function encountered a nan value.", UserWarning)
+       warnings.warn("The subtract function encountered a nan value.", UserWarning)
 
-      return b - a if switch_order else a - b
+       return b - a if switch_order else a - b
 
 Template docstring
 ~~~~~~~~~~~~~~~~~~

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -539,8 +539,10 @@ Here is an example docstring in the numpydoc_ format:
 .. code-block:: python
    :caption: Example docstring
 
-   import numpy as np
    import warnings
+
+   import numpy as np
+
 
    def subtract(a, b, *, switch_order=False):
        r"""

--- a/docs/contributing/release_guide.rst
+++ b/docs/contributing/release_guide.rst
@@ -206,6 +206,7 @@ Publish the release
     .. code-block:: python
 
        import plasmapy
+
        print(plasmapy.__version__)
 
 * Merge the ``v0.9.x`` branch into the ``stable`` branch on GitHub:

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -415,8 +415,10 @@ To test that a function raises an appropriate exception, use
 
    import pytest
 
+
    def raise_exception():
        raise Exception
+
 
    def test_that_an_exception_is_raised():
        with pytest.raises(Exception):

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -395,10 +395,14 @@ To test that a function issues an appropriate warning, use
 
 .. code-block:: python
 
-   import pytest, warnings
+   import warnings
+
+   import pytest
+
 
    def issue_warning():
        warnings.warn("warning message", UserWarning)
+
 
    def test_that_a_warning_is_issued():
        with pytest.warns(UserWarning):
@@ -409,7 +413,7 @@ To test that a function raises an appropriate exception, use
 
 .. code-block:: python
 
-  import pytest
+   import pytest
 
    def raise_exception():
        raise Exception
@@ -440,8 +444,8 @@ function.
 .. code-block:: python
 
    def test_proof_by_riemann_hypothesis():
-        assert proof_by_riemann(False)
-        assert proof_by_riemann(True)  # will only be run if the previous test passes
+       assert proof_by_riemann(False)
+       assert proof_by_riemann(True)  # will only be run if the previous test passes
 
 If the first test were to fail, then the second test would never be run.
 We would therefore not know the potentially useful results of the second
@@ -451,10 +455,11 @@ both will be run.
 .. code-block:: python
 
    def test_proof_if_riemann_false():
-        assert proof_by_riemann(False)
+       assert proof_by_riemann(False)
+
 
    def test_proof_if_riemann_true():
-        assert proof_by_riemann(True)
+       assert proof_by_riemann(True)
 
 However, this approach can lead to cumbersome, repeated code if you are
 calling the same function over and over. If you wish to run multiple
@@ -465,7 +470,7 @@ tests for the same function, the preferred method is to decorate it with
 
    @pytest.mark.parametrize("truth_value", [True, False])
    def test_proof_if_riemann(truth_value):
-        assert proof_by_riemann(truth_value)
+       assert proof_by_riemann(truth_value)
 
 This code snippet will run :py:`proof_by_riemann(truth_value)` for each
 ``truth_value`` in :py:`[True, False]`. Both of the above
@@ -494,7 +499,7 @@ positional arguments (``a`` and ``b``) and one optional keyword argument
 
 .. code-block:: python
 
-   def add(a, b, reverse_order = False):
+   def add(a, b, reverse_order=False):
        if reverse_order:
            return a + b
        return a + b
@@ -531,7 +536,7 @@ and unpacking_ them inside of the test function.
            (["1", "2"], {"reverse_order": True}, "21"),
            # test that add("1", "2") == "12"
            (["1", "2"], {}, "12"),  # if no keyword arguments, use an empty dict
-       ]
+       ],
    )
    def test_add(args, kwargs, expected):
        assert add(*args, **kwargs) == expected

--- a/docs/particles/decorators.rst
+++ b/docs/particles/decorators.rst
@@ -28,6 +28,7 @@ Here is an example of a decorated function.
 
   from plasmapy.particles import Particle, particle_input
 
+
   @particle_input
   def particle_mass(particle: Particle):
       return particle.mass
@@ -78,9 +79,11 @@ associated with an element, isotope, or ion; respectively.
   def capitalized_element_name(element: Particle):
       return element.element_name
 
+
   @particle_input
   def number_of_neutrons(isotope: Particle):
       return isotope.mass_number - isotope.atomic_number
+
 
   @particle_input
   def number_of_bound_electrons(ion: Particle):
@@ -93,17 +96,19 @@ inputs.  These keywords are used as in
 
 .. code-block:: python
 
-  @particle_input(require='charged')
+  @particle_input(require="charged")
   def sign_of_charge(charged_particle: Particle):
       """Require a charged particle."""
-      return '+' if charged_particle.charge_number > 0 else '-'
+      return "+" if charged_particle.charge_number > 0 else "-"
 
-  @particle_input(any_of=['charged', 'uncharged'])
+
+  @particle_input(any_of=["charged", "uncharged"])
   def charge_number(particle: Particle) -> int:
       """Accept only particles with charge information."""
       return particle.charge_number
 
-  @particle_input(exclude={'antineutrino', 'neutrino'})
+
+  @particle_input(exclude={"antineutrino", "neutrino"})
   def particle_mass(particle: Particle):
       """
       Exclude neutrinos/antineutrinos because these particles have

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -160,7 +160,7 @@ in one of these categories.
 
 .. code-block:: python
 
-    particles = [Particle('e-'), Particle('Fe-56'), Particle('alpha')]
+    particles = [Particle("e-"), Particle("Fe-56"), Particle("alpha")]
 
     for particle in particles:
         if particle.element:

--- a/docs/plasma/index.rst
+++ b/docs/plasma/index.rst
@@ -121,13 +121,14 @@ demonstrated by the following example.
 
 .. code-block:: python
 
-    import plasmapy.plasma
     import astropy.units as u
+    import plasmapy.plasma
+
 
     class FuturePlasma(plasmapy.plasma.GenericPlasma):
         def __init__(self, **kwargs):
 
-            super(FuturePlasma, self).__init__(**kwargs)
+            super().__init__(**kwargs)
 
         # Specify a classmethod that determines if the input data matches
         # this new subclass

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -131,25 +131,23 @@ class AbstractParticle(ABC):
 
         .. code-block:: python
 
-            {"plasmapy_particle": {
-                # string representation of the particle class
-                "type": "Particle",
-
-                # string representation of the module contains the particle class
-                "module": "plasmapy.particles.particle_class",
-
-                # date stamp of when the object was created
-                "date_created": "2020-07-20 17:46:13 UTC",
-
-                # parameters used to initialized the particle class
-                "__init__": {
-                    # tuple of positional arguments
-                    "args": (),
-
-                    # dictionary of keyword arguments
-                    "kwargs": {},
-                },
-            }}
+            {
+                "plasmapy_particle": {
+                    # string representation of the particle class
+                    "type": "Particle",
+                    # string representation of the module contains the particle class
+                    "module": "plasmapy.particles.particle_class",
+                    # date stamp of when the object was created
+                    "date_created": "2020-07-20 17:46:13 UTC",
+                    # parameters used to initialized the particle class
+                    "__init__": {
+                        # tuple of positional arguments
+                        "args": (),
+                        # dictionary of keyword arguments
+                        "kwargs": {},
+                    },
+                }
+            }
 
         Only the ``"__init__"`` entry should be modified by the subclass.
         """

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -64,12 +64,7 @@ class AbstractGrid(ABC):
 
        .. code-block:: python
 
-          AbstractGrid(
-              start=[x0, y0, z0],
-              stop=[x1, y1, z1],
-              num=[Nx, Ny, Nz],
-              **kwargs
-          )
+          AbstractGrid(start=[x0, y0, z0], stop=[x1, y1, z1], num=[Nx, Ny, Nz], **kwargs)
 
        In this case, any additional keyword arguments ``**kwargs`` provided
        will be passed directly to `~numpy.linspace`.

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -102,17 +102,23 @@ class CheckValues(CheckBase):
 
         from plasmapy.utils.decorators.checks import CheckValues
 
-        @CheckValues(arg1={'can_be_negative': False, 'can_be_nan': False},
-                     arg2={'can_be_inf': False},
-                     checks_on_return={'none_shall_pass': True})
+
+        @CheckValues(
+            arg1={"can_be_negative": False, "can_be_nan": False},
+            arg2={"can_be_inf": False},
+            checks_on_return={"none_shall_pass": True},
+        )
         def foo(arg1, arg2):
             return None
 
+
         # on a method
         class Foo:
-            @CheckValues(arg1={'can_be_negative': False, 'can_be_nan': False},
-                         arg2={'can_be_inf': False},
-                         checks_on_return={'none_shall_pass': True})
+            @CheckValues(
+                arg1={"can_be_negative": False, "can_be_nan": False},
+                arg2={"can_be_inf": False},
+                checks_on_return={"none_shall_pass": True},
+            )
             def bar(self, arg1, arg2):
                 return None
     """
@@ -1226,17 +1232,23 @@ def check_values(
 
         from plasmapy.utils.decorators import check_values
 
-        @check_values(arg1={'can_be_negative': False, 'can_be_nan': False},
-                      arg2={'can_be_inf': False},
-                      checks_on_return={'none_shall_pass': True)
+
+        @check_values(
+            arg1={"can_be_negative": False, "can_be_nan": False},
+            arg2={"can_be_inf": False},
+            checks_on_return={"none_shall_pass": True},
+        )
         def foo(arg1, arg2):
             return None
 
+
         # on a method
         class Foo:
-            @check_values(arg1={'can_be_negative': False, 'can_be_nan': False},
-                          arg2={'can_be_inf': False},
-                          checks_on_return={'none_shall_pass': True)
+            @check_values(
+                arg1={"can_be_negative": False, "can_be_nan": False},
+                arg2={"can_be_inf": False},
+                checks_on_return={"none_shall_pass": True},
+            )
             def bar(self, arg1, arg2):
                 return None
     """

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -104,7 +104,7 @@ class CheckValues(CheckBase):
 
         @CheckValues(arg1={'can_be_negative': False, 'can_be_nan': False},
                      arg2={'can_be_inf': False},
-                     checks_on_return={'none_shall_pass': True)
+                     checks_on_return={'none_shall_pass': True})
         def foo(arg1, arg2):
             return None
 
@@ -112,7 +112,7 @@ class CheckValues(CheckBase):
         class Foo:
             @CheckValues(arg1={'can_be_negative': False, 'can_be_nan': False},
                          arg2={'can_be_inf': False},
-                         checks_on_return={'none_shall_pass': True)
+                         checks_on_return={'none_shall_pass': True})
             def bar(self, arg1, arg2):
                 return None
     """

--- a/plasmapy/utils/decorators/lite_func.py
+++ b/plasmapy/utils/decorators/lite_func.py
@@ -44,17 +44,26 @@ def bind_lite_func(lite_func, attrs: Dict[str, Callable] = None):
 
     .. code-block:: python
 
-        def foo_lite(x)
+        def foo_lite(x):
             return x
+
 
         def bar():
             print("Supporting function.")
 
-        @bind_lite_func(foo_lite, attrs=[("bar", bar),])
+
+        @bind_lite_func(
+            foo_lite,
+            attrs=[
+                ("bar", bar),
+            ],
+        )
         def foo(x):
             if not isinstance(x, float):
                 raise TypeError("Argument x can only be a float.")
             return x
+
+    .. code-block:: pycon
 
         >>> foo(5)  # doctest: +SKIP
         5
@@ -65,7 +74,6 @@ def bind_lite_func(lite_func, attrs: Dict[str, Callable] = None):
 
     Notes
     -----
-
     In addition to binding the functionality defined by the inputs, a
     ``__bound_lite_func__`` dunder is bound.  This dunder is a
     dictionary where a key is a string representing the bound name of

--- a/plasmapy/utils/pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers/pytest_helpers.py
@@ -175,6 +175,7 @@ def run_test(
             warn("", UserWarning)
             return x
 
+
         run_test(return_arg_and_warn, 1, {}, (1, UserWarning))
 
     This function is also flexible enough that it can accept a `tuple`
@@ -196,6 +197,7 @@ def run_test(
 
         import pytest
 
+
         def func(x, raise_exception=False, issue_warning=False):
             if raise_exception:
                 raise ValueError("I'm sorry, Dave. I'm afraid I can't do that.")
@@ -203,15 +205,17 @@ def run_test(
                 warn("Open the pod bay doors, HAL.", UserWarning)
             return x
 
+
         inputs_table = [
             (func, 1, 1),
             (func, (2,), {}, 2),
-            (func, 3, {'raise_exception': True}, ValueError),
-            (func, 4, {'issue_warning': True}, UserWarning),
-            (func, 5, {'issue_warning': True}, (5, UserWarning)),
+            (func, 3, {"raise_exception": True}, ValueError),
+            (func, 4, {"issue_warning": True}, UserWarning),
+            (func, 5, {"issue_warning": True}, (5, UserWarning)),
         ]
 
-        @pytest.mark.parametrize('inputs', inputs_table)
+
+        @pytest.mark.parametrize("inputs", inputs_table)
         def test_func(inputs):
             run_test(inputs)
 


### PR DESCRIPTION
This PR adds a pre-commit hook for [blacken-docs](https://github.com/adamchainz/blacken-docs) and applies a bunch of the changes.  It also applies some issues with examples in code blocks that I found with [shed](https://github.com/Zac-HD/shed), which I learned about in a podcast and was trying out for fun.  