### PR TITLE
Restrict version of ipykernel

### DIFF
--- a/changelog/1810.doc.rst
+++ b/changelog/1810.doc.rst
@@ -1,0 +1,1 @@
+Changed requirement for ``ipykernel`` to exclude ``v6.18.0``.

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,7 +5,7 @@
 -r extras.txt
 -r install.txt
 docutils
-ipykernel
+ipykernel != 6.18.0
 jinja2 != 3.1
 nbsphinx
 numpydoc

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,7 +5,7 @@
 -r extras.txt
 -r install.txt
 docutils
-ipykernel < 6.18.0
+ipykernel < 6.18.0, >= 6.18.2
 jinja2 != 3.1
 nbsphinx
 numpydoc

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,7 +5,7 @@
 -r extras.txt
 -r install.txt
 docutils
-ipykernel < 6.18.0, >= 6.18.2
+ipykernel >= 6.18.2
 jinja2 != 3.1
 nbsphinx
 numpydoc

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,7 +5,7 @@
 -r extras.txt
 -r install.txt
 docutils
-ipykernel != 6.18.0
+ipykernel < 6.18.0
 jinja2 != 3.1
 nbsphinx
 numpydoc

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ docs =
     # ought to mirror requirements/docs.txt
     %(extras)s
     docutils
-    ipykernel < 6.18.0, >= 6.18.2
+    ipykernel >= 6.18.2
     # TODO: release of 3.1 broke CI tests, this should be revisited later (2022-03-24)
     jinja2 != 3.1
     nbsphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ docs =
     # ought to mirror requirements/docs.txt
     %(extras)s
     docutils
-    ipykernel < 6.18.0
+    ipykernel < 6.18.0, >= 6.18.2
     # TODO: release of 3.1 broke CI tests, this should be revisited later (2022-03-24)
     jinja2 != 3.1
     nbsphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ docs =
     # ought to mirror requirements/docs.txt
     %(extras)s
     docutils
-    ipykernel
+    ipykernel != 6.18.0
     # TODO: release of 3.1 broke CI tests, this should be revisited later (2022-03-24)
     jinja2 != 3.1
     nbsphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ docs =
     # ought to mirror requirements/docs.txt
     %(extras)s
     docutils
-    ipykernel != 6.18.0
+    ipykernel < 6.18.0
     # TODO: release of 3.1 broke CI tests, this should be revisited later (2022-03-24)
     jinja2 != 3.1
     nbsphinx


### PR DESCRIPTION
This PR enforces pins the version of `ipykernel` for the notebooks to be not `6.18.0`.  See https://github.com/holoviz/hvplot/issues/983.

`ipykernel` `6.18.0` was yanked from PyPI, and `6.18.1` was released which hopefully fixes it.  Since the release with this issue was yanked, this PR might not be necessary, but it wouldn't hurt to have it in here anyway.

Closes #1809.  Hopefully.