### PR TITLE
Update changelog for 0.9.1 on `stable`

### DIFF
--- a/docs/whatsnew/0.9.1.rst
+++ b/docs/whatsnew/0.9.1.rst
@@ -1,0 +1,8 @@
+PlasmaPy v0.9.1 (2022-11-15)
+============================
+
+Trivial/Internal Changes
+------------------------
+
+- Removed a test of requirement file consistency to allow tests to pass on
+  conda-forge.

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -11,7 +11,7 @@ including bug fixes and changes to the application programming interface
 .. toctree::
    :maxdepth: 1
 
-   dev
+   0.9.1
    0.9.0
    0.8.1
    0.7.0

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -11,6 +11,7 @@ including bug fixes and changes to the application programming interface
 .. toctree::
    :maxdepth: 1
 
+   dev
    0.9.1
    0.9.0
    0.8.1

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -11,7 +11,6 @@ including bug fixes and changes to the application programming interface
 .. toctree::
    :maxdepth: 1
 
-   dev
    0.9.1
    0.9.0
    0.8.1


### PR DESCRIPTION
The changelog for on stable still lists `dev`, which is making it show up incorrectly.  This PR removes the `dev` and adds a brief changelog to 0.9.1.