### PR TITLE
Remove pytest-xdist from test requirements

### DIFF
--- a/changelog/1822.trivial.rst
+++ b/changelog/1822.trivial.rst
@@ -1,0 +1,2 @@
+Removed ``pytest-xdist`` from the testing requirements (see also
+:issue:`750`).

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -19,6 +19,5 @@ flake8-use-pathlib
 hypothesis
 pydocstyle
 pytest-regressions
-pytest-xdist
 tomli
 tryceratops

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,6 @@ tests =
     hypothesis
     pydocstyle
     pytest-regressions
-    pytest-xdist
     tomli
     tryceratops
 docs =

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ allowlist_externals =
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals -n=auto --dist=loadfile
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
     cov: pytest-cov
-    !minimal: pytest-xdist
     pytest-github-actions-annotate-failures
 commands =
     !cov: {env:PYTEST_COMMAND} {posargs} -m 'not slow'
@@ -74,7 +73,6 @@ extras =
 deps =
     lmfit
     pytest-cov
-    pytest-xdist
 conda_deps =
     astropy >= 4.3.1
     h5py >= 3.0.0


### PR DESCRIPTION
Right now we have an issue where tests run via `pytest-xdist` with more than one process are not able to be run because the test order is not deterministic (i.e., because sets or dicts are used when parametrizing tests).  See also #750.  This has apparently recently caused the tests to fail when they're run via GitHub Actions.

This PR removes `pytest-xdist` from our requirements as a way to (hopefully) resolve this issue.  