### PR TITLE
Return NaN values instead of throw exceptions for particle attributes

### DIFF
--- a/changelog/1825.feature.rst
+++ b/changelog/1825.feature.rst
@@ -1,0 +1,1 @@
+Moddified ~plasmapy.particles.particle_class artibutes to return numpy NaN when undefined.

--- a/changelog/1825.feature.rst
+++ b/changelog/1825.feature.rst
@@ -1,1 +1,1 @@
-Moddified ~plasmapy.particles.particle_class artibutes to return numpy NaN when undefined.
+Modified ~plasmapy.particles.particle_class attributes to return NaN when undefined rather than raising exceptions.

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -118,6 +118,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * :user:`Sixue Xu <hzxusx>`
 * :user:`Steve Richardson <arichar6>` (:orcid:`0000-0002-3056-6334`)
 * :user:`Stuart Mumford <Cadair>` (:orcid:`0000-0003-4217-4642`)
+* :user:`Stuart Sobeske <Sobeskes>`
 * :user:`Suzanne Nie <suzannenie>`
 * :user:`Terrance Takho Lee <tlee0818>`
 * :user:`Thomas Fan <thomasjpfan>`

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1123,10 +1123,9 @@ class Particle(AbstractPhysicalParticle):
         """
         The particle's electrical charge in coulombs.
 
-        Raises
-        ------
-        `~plasmapy.particles.exceptions.ChargeError`
-            If the charge has not been specified.
+        If the charge has not been specified, this attribute will
+        return |nan| C
+
 
         Examples
         --------
@@ -1135,7 +1134,7 @@ class Particle(AbstractPhysicalParticle):
         <Quantity -1.60217662e-19 C>
         """
         if self._attributes["charge"] is None:
-            raise ChargeError(f"The charge of particle {self} has not been specified.")
+            return np.nan * u.C
         if self._attributes["charge number"] == 1:
             return const.e.si
 
@@ -1146,15 +1145,15 @@ class Particle(AbstractPhysicalParticle):
         """
         The element's standard atomic weight in kg.
 
+        If the element does not have a defined standard atomic
+        weight, this attribute will return |nan| kg.
+
         Raises
         ------
         `~plasmapy.particles.exceptions.InvalidElementError`
             If the particle is not an element or corresponds to an
             isotope or ion.
 
-        `~plasmapy.particles.exceptions.MissingParticleDataError`
-            If the element does not have a defined standard atomic
-            weight.
 
         Examples
         --------
@@ -1165,9 +1164,7 @@ class Particle(AbstractPhysicalParticle):
         if self.isotope or self.is_ion or not self.element:
             raise InvalidElementError(_category_errmsg(self, "element"))
         if self._attributes["standard atomic weight"] is None:  # coverage: ignore
-            raise MissingParticleDataError(
-                f"The standard atomic weight of {self} is unavailable."
-            )
+            return np.nan * u.kg
         return self._attributes["standard atomic weight"].to(u.kg)
 
     @property
@@ -1190,11 +1187,8 @@ class Particle(AbstractPhysicalParticle):
         For special particles, this attribute will return the standard
         value for the particle's mass.
 
-        Raises
-        ------
-        `~plasmapy.particles.exceptions.MissingParticleDataError`.
-            If the mass is unavailable (e.g., for neutrinos or elements
-            with no standard atomic weight.
+        If the mass of the particles is unavailable, this attribute
+        will return |nan| kg.
 
         Examples
         --------
@@ -1219,9 +1213,7 @@ class Particle(AbstractPhysicalParticle):
                 base_mass = self._attributes["standard atomic weight"]
 
             if base_mass is None:
-                raise MissingParticleDataError(
-                    f"The mass of ion '{self.ionic_symbol}' is not available."
-                )
+                return np.nan * u.kg
 
             mass = base_mass - self.charge_number * const.m_e
 
@@ -1237,20 +1229,21 @@ class Particle(AbstractPhysicalParticle):
             if mass is not None:
                 return mass.to(u.kg)
 
-        raise MissingParticleDataError(f"The mass of {self} is not available.")
+        return np.nan * u.kg
 
     @property
     def nuclide_mass(self) -> u.kg:
         """
         The mass of the bare nucleus of an isotope or a neutron.
 
+        If the particle's base mass is unavailable, this attribute
+        will return |nan| kg.
+
         Raises
         ------
         `~plasmapy.particles.exceptions.InvalidIsotopeError`
             If the particle is not an isotope or neutron.
 
-        `~plasmapy.particles.exceptions.MissingParticleDataError`
-            If the isotope mass is not available.
 
         Examples
         --------
@@ -1274,9 +1267,7 @@ class Particle(AbstractPhysicalParticle):
         base_mass = self._attributes["isotope mass"]
 
         if base_mass is None:  # coverage: ignore
-            raise MissingParticleDataError(
-                f"The mass of a {self.isotope} nuclide is not available."
-            )
+            return np.nan * u.kg
 
         _nuclide_mass = (
             self._attributes["isotope mass"] - self.atomic_number * const.m_e
@@ -1292,8 +1283,8 @@ class Particle(AbstractPhysicalParticle):
         If the particle is an isotope or nuclide, return the mass energy
         of the nucleus only.
 
-        If the mass of the particle is not known, then raise a
-        `~plasmapy.particles.exceptions.MissingParticleDataError`.
+        If the mass of the particle is unavailable, this attribute will
+        return |nan| kg.
 
         Examples
         --------
@@ -1313,10 +1304,7 @@ class Particle(AbstractPhysicalParticle):
             mass = self.nuclide_mass if self.isotope else self.mass
             energy = mass * const.c**2
         except MissingParticleDataError:
-            raise MissingParticleDataError(
-                f"The mass energy of {self.symbol} is not available "
-                f"because the mass is unknown."
-            ) from None
+            return np.nan * u.J
         else:
             return energy.to(u.J)
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1124,7 +1124,7 @@ class Particle(AbstractPhysicalParticle):
         The particle's electrical charge in coulombs.
 
         If the charge has not been specified, this attribute will
-        return |nan| C
+        return |nan| C.
 
 
         Examples
@@ -1153,7 +1153,6 @@ class Particle(AbstractPhysicalParticle):
         `~plasmapy.particles.exceptions.InvalidElementError`
             If the particle is not an element or corresponds to an
             isotope or ion.
-
 
         Examples
         --------

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -516,8 +516,7 @@ class TestReducedMassInput:
             reduced_mass("N", 6e-26 * u.l)
 
     def test_missing_atomic_data(self):
-        with pytest.raises(MissingParticleDataError):
-            reduced_mass("Og", "H")
+        assert u.isclose(reduced_mass("Og", "H"), np.nan * u.kg, equal_nan=True)
 
 
 def test_ion_list_example():

--- a/plasmapy/particles/tests/test_exceptions.py
+++ b/plasmapy/particles/tests/test_exceptions.py
@@ -925,7 +925,6 @@ tests_from_atomic = [
     [isotope_symbol, ("h-3",), {}, pytest.raises(InvalidParticleError)],
     [isotope_symbol, ("h",), {}, pytest.raises(InvalidParticleError)],
     [isotope_symbol, ("d+",), {}, pytest.raises(InvalidParticleError)],
-    [particle_mass, ["Og 1+"], {}, pytest.raises(MissingParticleDataError)],
     [particle_mass, ["Fe-56"], {"Z": 1.4}, pytest.raises(TypeError)],
     [particle_mass, ["H-1 +1"], {"Z": 0}, pytest.raises(InvalidParticleError)],
     [particle_mass, [26], {"Z": 1, "mass_numb": "a"}, pytest.raises(TypeError)],
@@ -935,7 +934,6 @@ tests_from_atomic = [
         {"Z": 27, "mass_numb": 56},
         pytest.raises(InvalidParticleError),
     ],
-    [particle_mass, ["Og"], {"Z": 1}, pytest.raises(MissingParticleDataError)],
     [
         particle_mass,
         ["Og"],

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -234,7 +234,7 @@ test_Particle_table = [
             "ionic_symbol": None,
             "roman_symbol": ChargeError,
             "is_ion": False,
-            "charge": ChargeError,
+            "charge": np.nan * u.C,
             "charge_number": ChargeError,
             "mass_number": InvalidIsotopeError,
             "baryon_number": ParticleError,
@@ -466,8 +466,8 @@ test_Particle_table = [
             "element": None,
             "isotope": None,
             "isotope_name": InvalidElementError,
-            "mass": MissingParticleDataError,
-            "mass_energy": MissingParticleDataError,
+            "mass": np.nan * u.kg,
+            "mass_energy": np.nan * u.J,
             "charge_number": 0,
             "mass_number": InvalidIsotopeError,
             "element_name": InvalidElementError,
@@ -549,7 +549,7 @@ def test_Particle_class(arg, kwargs, expected_dict):
 
             try:
                 result = eval(f"particle.{key}")
-                assert result == expected or u.isclose(result, expected)
+                assert result == expected or u.isclose(result, expected, equal_nan=True)
             except AssertionError:
                 errmsg += (
                     f"\n{call}.{key} returns {result} instead "
@@ -604,11 +604,8 @@ test_Particle_error_table = [
     (["neutron"], {}, ".atomic_number", InvalidElementError),
     (["H"], {"Z": 0}, ".mass_number", InvalidIsotopeError),
     (["neutron"], {}, ".mass_number", InvalidIsotopeError),
-    (["He"], {"mass_numb": 4}, ".charge", ChargeError),
     (["He"], {"mass_numb": 4}, ".charge_number", ChargeError),
     (["Fe"], {}, ".spin", MissingParticleDataError),
-    (["nu_e"], {}, ".mass", MissingParticleDataError),
-    (["Og"], {}, ".standard_atomic_weight", MissingParticleDataError),
     ([Particle("C-14")], {"mass_numb": 13}, "", InvalidParticleError),
     ([Particle("Au 1+")], {"Z": 2}, "", InvalidParticleError),
     ([[]], {}, "", TypeError),
@@ -1518,3 +1515,23 @@ def test_molecule_other():
         assert CustomParticle(2 * 126.90447 * u.u, e.si, "I2 1+") == molecule(
             "I2 1+", Z=1
         )
+
+def test_undefined_charge():
+    """Test that a particle with an undefined charge retruns |nan| C"""
+    H_particle = Particle("H")
+    assert u.isclose(H_particle.charge, np.nan * u.C, equal_nan=True)
+
+def test_undefined_standard_atomic_weight():
+    """Test that a particle with an undefined standard atomic weight retruns |nan| kg"""
+    Pm_particle = Particle("Pm")
+    assert u.isclose(Pm_particle.standard_atomic_weight, np.nan * u.kg, equal_nan=True)
+
+def test_undefined_mass():
+    """Test that a particle with an undefined mass retruns |nan| kg"""
+    tau_neutrino_particle = Particle("tau neutrino")
+    assert u.isclose(tau_neutrino_particle.mass, np.nan * u.kg, equal_nan=True)
+
+def test_undefined_mass_energy():
+    """Test that a particle with an undefined mass energy retruns |nan| J"""
+    nu_tau_particle = Particle("nu_tau")
+    assert u.isclose(nu_tau_particle.mass_energy, np.nan * u.J, equal_nan=True)

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1517,21 +1517,21 @@ def test_molecule_other():
         )
 
 def test_undefined_charge():
-    """Test that a particle with an undefined charge retruns |nan| C"""
+    """Test that a particle with an undefined charge returns |nan| C."""
     H_particle = Particle("H")
     assert u.isclose(H_particle.charge, np.nan * u.C, equal_nan=True)
 
 def test_undefined_standard_atomic_weight():
-    """Test that a particle with an undefined standard atomic weight retruns |nan| kg"""
+    """Test that a particle with an undefined standard atomic weight returns |nan| kg."""
     Pm_particle = Particle("Pm")
     assert u.isclose(Pm_particle.standard_atomic_weight, np.nan * u.kg, equal_nan=True)
 
 def test_undefined_mass():
-    """Test that a particle with an undefined mass retruns |nan| kg"""
+    """Test that a particle with an undefined mass returns |nan| kg."""
     tau_neutrino_particle = Particle("tau neutrino")
     assert u.isclose(tau_neutrino_particle.mass, np.nan * u.kg, equal_nan=True)
 
 def test_undefined_mass_energy():
-    """Test that a particle with an undefined mass energy retruns |nan| J"""
+    """Test that a particle with an undefined mass energy returns |nan| J."""
     nu_tau_particle = Particle("nu_tau")
     assert u.isclose(nu_tau_particle.mass_energy, np.nan * u.J, equal_nan=True)

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1516,20 +1516,24 @@ def test_molecule_other():
             "I2 1+", Z=1
         )
 
+
 def test_undefined_charge():
     """Test that a particle with an undefined charge returns |nan| C."""
     H_particle = Particle("H")
     assert u.isclose(H_particle.charge, np.nan * u.C, equal_nan=True)
+
 
 def test_undefined_standard_atomic_weight():
     """Test that a particle with an undefined standard atomic weight returns |nan| kg."""
     Pm_particle = Particle("Pm")
     assert u.isclose(Pm_particle.standard_atomic_weight, np.nan * u.kg, equal_nan=True)
 
+
 def test_undefined_mass():
     """Test that a particle with an undefined mass returns |nan| kg."""
     tau_neutrino_particle = Particle("tau neutrino")
     assert u.isclose(tau_neutrino_particle.mass, np.nan * u.kg, equal_nan=True)
+
 
 def test_undefined_mass_energy():
     """Test that a particle with an undefined mass energy returns |nan| J."""


### PR DESCRIPTION
## Description

In particle_class, NaN values are now returned instead of throwing exceptions.

In addition, test_atomic, test_exceptions, and test_particle_class are changed to reflect changes to particle_class and new tests are added to test_particle_class to ensure that NaN values are returned when accessing undefined properties.

## Motivation and context

By returning NaN values, numpy.nan can keep track of what is undefined and what is not, avoiding dealing with exceptions as a special case. Also makes the behavior of Particles and CustomParticles more consistent

## Related issues

This issue was brought up in #1061 
