### PR TITLE
Fix weekly test configuration error

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,7 +27,7 @@ jobs:
 
         - name: Python 3.10
           os: ubuntu-latest
-          python: 3.10
+          python: '3.10'
           toxenv: py310
 
         - name: Python 3.9 with Astropy dev
@@ -47,7 +47,7 @@ jobs:
 
         - name: Documentation with Sphinx dev
           os: ubuntu-latest
-          python: 3.10
+          python: '3.10'
           toxenv: build_docs-sphinxdev
           toxposargs: -q
 


### PR DESCRIPTION
Our weekly tests are failing because `3.10` was being treated as `3.1` in `.github/workflows/weekly.yml`.  This PR fixes that by making the `3.10` into a string.  

If only this was the first time I've introduced this error! 👀 😅 😹 🎈 🎆 🎂  