### PR TITLE
Fixed functional typo in testing_guide.rst

### DIFF
--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -503,7 +503,7 @@ positional arguments (``a`` and ``b``) and one optional keyword argument
 
    def add(a, b, reverse_order=False):
        if reverse_order:
-           return a + b
+           return b + a
        return a + b
 
 Argument unpacking_ lets us provide positional arguments in a `tuple` or


### PR DESCRIPTION
Minor/trivial change to the testing guide.
I was reading the sample code output, but the sample output did do what the sample code said it should do.
Reversed order in reverse_order 'if' statement (a+b) -> (b+a)