### PR TITLE
Ensure ordering for particles in tests

### DIFF
--- a/changelog/1822.trivial.rst
+++ b/changelog/1822.trivial.rst
@@ -1,2 +1,0 @@
-Removed ``pytest-xdist`` from the testing requirements (see also
-:issue:`750`).

--- a/plasmapy/particles/tests/conftest.py
+++ b/plasmapy/particles/tests/conftest.py
@@ -20,3 +20,23 @@ def opposite(particle):
             f"antiparticle of {particle}."
         ) from exc
     return opposite_particle
+
+
+@pytest.fixture(
+    params=list(
+        sorted(
+            [
+                ("e-", "e+"),
+                ("mu-", "mu+"),
+                ("tau-", "tau+"),
+                ("p+", "p-"),
+                ("n", "antineutron"),
+                ("nu_e", "anti_nu_e"),
+                ("nu_mu", "anti_nu_mu"),
+                ("nu_tau", "anti_nu_tau"),
+            ]
+        )
+    )
+)
+def particle_antiparticle_pair(request):
+    return request.param

--- a/plasmapy/particles/tests/conftest.py
+++ b/plasmapy/particles/tests/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+
+from plasmapy.particles import Particle
+from plasmapy.particles._special_particles import particle_zoo
+from plasmapy.particles.exceptions import InvalidParticleError
+
+
+@pytest.fixture(params=list(sorted(particle_zoo.everything)))
+def particle(request):
+    return Particle(request.param)
+
+
+@pytest.fixture()
+def opposite(particle):
+    try:
+        opposite_particle = ~particle
+    except Exception as exc:
+        raise InvalidParticleError(
+            f"The unary ~ (invert) operator is unable to find the "
+            f"antiparticle of {particle}."
+        ) from exc
+    return opposite_particle

--- a/plasmapy/particles/tests/conftest.py
+++ b/plasmapy/particles/tests/conftest.py
@@ -39,4 +39,4 @@ def opposite(particle):
     )
 )
 def particle_antiparticle_pair(request):
-    return request.param
+    return [Particle(p) for p in request.param]

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -136,314 +136,287 @@ test_cases = {
     },
 }
 
-test_names = test_cases.keys()
+
+@pytest.fixture(params=list(test_cases.values()), ids=list(test_cases.keys()))
+def test_ionization_state(request):
+    return IonizationState(**request.param)
 
 
 # TODO: Refactor these tests using fixtures
 
 
-class Test_IonizationState:
-    """Test instances of IonizationState."""
+def test_charge_numbers(test_ionization_state):
+    """
+    Test that an `IonizationState` instance has the correct charge
+    numbers.
+    """
+    expected_charge_numbers = np.arange(test_ionization_state.atomic_number + 1)
+    assert np.allclose(test_ionization_state.charge_numbers, expected_charge_numbers)
 
-    @classmethod
-    def setup_class(cls):
-        cls.instances = {}
 
-    @pytest.mark.parametrize("test_name", test_names)
-    def test_instantiation(self, test_name):
-        """
-        Test that each IonizationState test case can be instantiated.
-        """
-        self.instances[test_name] = IonizationState(**test_cases[test_name])
+@pytest.mark.xfail
+def test_ionic_fractions(test_ionization_state):
+    """
+    Test that each `IonizationState` instance has the expected
+    ionic fractions.
+    """
+    if "ionic_fractions" not in test_cases[test_name]:
+        return
+    instance = test_ionization_state
+    inputted_fractions = test_cases[test_name]["ionic_fractions"]
+    if isinstance(inputted_fractions, u.Quantity):
+        inputted_fractions = inputted_fractions.to(u.m**-3)
+        inputted_fractions = (inputted_fractions / inputted_fractions.sum()).value
+    if not np.allclose(test_ionization_state.ionic_fractions, inputted_fractions):
+        pytest.fail(f"Mismatch in ionic fractions for test {test_name}.")
 
-    @pytest.mark.parametrize("test_name", test_names)
-    def test_charge_numbers(self, test_name):
-        """
-        Test that an `IonizationState` instance has the correct charge
-        numbers.
-        """
-        instance = self.instances[test_name]
-        expected_charge_numbers = np.arange(instance.atomic_number + 1)
-        assert np.allclose(instance.charge_numbers, expected_charge_numbers)
 
-    @pytest.mark.parametrize(
-        "test_name",
-        [name for name in test_names if "ionic_fractions" in test_cases[name]],
+def test_equal_to_itself(He_ionization_state):
+    """
+    Test that `IonizationState.__eq__` returns `True for two identical
+    `IonizationState` instances.
+    """
+    assert He_ionization_state == He_ionization_state
+
+
+@pytest.mark.parametrize("tolerance, output", [(1e-8, True), (1e-9001, False)])
+def test_equal_to_within_tolerance(tolerance, output):
+    """
+    Test that `IonizationState.__eq__` returns `True` for two
+    `IonizationState` instances that differ within the inputted
+    tolerance.
+    """
+    H = IonizationState(
+        **{"particle": "H", "ionic_fractions": [0.6, 0.4], "tol": tolerance}
     )
-    def test_ionic_fractions(self, test_name):
-        """
-        Test that each `IonizationState` instance has the expected
-        ionic fractions.
-        """
-        instance = self.instances[test_name]
-        inputted_fractions = test_cases[test_name]["ionic_fractions"]
-        if isinstance(inputted_fractions, u.Quantity):
-            inputted_fractions = inputted_fractions.to(u.m**-3)
-            inputted_fractions = (inputted_fractions / inputted_fractions.sum()).value
-        if not np.allclose(instance.ionic_fractions, inputted_fractions):
-            pytest.fail(f"Mismatch in ionic fractions for test {test_name}.")
-
-    def test_equal_to_itself(self):
-        """
-        Test that `IonizationState.__eq__` returns `True for two identical
-        `IonizationState` instances.
-        """
-        assert (
-            self.instances["Li"] == self.instances["Li"]
-        ), "Identical IonizationState instances are not equal."
-
-    def test_equal_to_within_tolerance(self):
-        """
-        Test that `IonizationState.__eq__` returns `True` for two
-        `IonizationState` instances that differ within the inputted
-        tolerance.
-        """
-        assert self.instances["H"] == self.instances["H acceptable error"], (
-            "Two IonizationState instances that are approximately the "
-            "same to within the tolerance are not testing as equal."
-        )
-
-    def test_inequality(self):
-        """
-        Test that instances with different ionic fractions are not equal
-        to each other.
-        """
-        assert (
-            self.instances["Li ground state"] != self.instances["Li"]
-        ), "Different IonizationState instances are equal."
-
-    def test_inequality_with_different_type(self):
-        assert self.instances["Li ground state"] != "different type"
-
-    def test_equality_no_more_exception(self):
-        """
-        Test that comparisons of `IonizationState` instances for
-        different elements does not fail.
-        """
-        assert self.instances["Li"] != self.instances["H"]
-
-    @pytest.mark.parametrize("test_name", test_names)
-    def test_iteration(self, test_name: str):
-        """Test that `IonizationState` instances iterate impeccably."""
-        states = list(self.instances[test_name])
-
-        charge_numbers = [state.charge_number for state in states]
-        ionic_fractions = np.array([state.ionic_fraction for state in states])
-        ionic_symbols = [state.ionic_symbol for state in states]
-
-        try:
-            base_symbol = isotope_symbol(ionic_symbols[0])
-        except InvalidIsotopeError:
-            base_symbol = atomic_symbol(ionic_symbols[0])
-        finally:
-            atomic_numb = atomic_number(ionic_symbols[1])
-
-        errors = []
-
-        expected_charges = np.arange(atomic_numb + 1)
-        if not np.all(charge_numbers == expected_charges):
-            errors.append(
-                f"The resulting charge numbers are {charge_numbers}, "
-                f"which are not equal to the expected charge numbers, "
-                f"which are {expected_charges}."
-            )
-
-        expected_fracs = test_cases[test_name]["ionic_fractions"]
-        if isinstance(expected_fracs, u.Quantity):
-            expected_fracs = (expected_fracs / expected_fracs.sum()).value
-
-        if not np.allclose(ionic_fractions, expected_fracs):
-            errors.append(
-                f"The resulting ionic fractions are {ionic_fractions}, "
-                f"which are not equal to the expected ionic fractions "
-                f"of {expected_fracs}."
-            )
-
-        expected_particles = [
-            Particle(base_symbol, Z=charge) for charge in charge_numbers
-        ]
-        expected_symbols = [particle.ionic_symbol for particle in expected_particles]
-        if ionic_symbols != expected_symbols:
-            errors.append(
-                f"The resulting ionic symbols are {ionic_symbols}, "
-                f"which are not equal to the expected ionic symbols of "
-                f"{expected_symbols}."
-            )
-
-        if errors:
-            errors.insert(
-                0,
-                (
-                    f"The test of IonizationState named '{test_name}' has "
-                    f"resulted in the following errors when attempting to "
-                    f"iterate."
-                ),
-            )
-            errmsg = " ".join(errors)
-            pytest.fail(errmsg)
-
-    @pytest.mark.parametrize("index", [-1, 4, "Li"])
-    def test_indexing_error(self, index):
-        """
-        Test that an `IonizationState` instance cannot be indexed
-        outside of the bounds of allowed charge numbers.
-        """
-        with pytest.raises(ParticleError):
-            self.instances["Li"][index]
-
-    def test_normalization(self):
-        """
-        Test that `_is_normalized` returns `False` when there is an
-        error greater than the tolerance, and `True` after normalizing.
-        """
-        H = self.instances["H acceptable error"]
-        assert not H._is_normalized(tol=1e-15)
-        H.normalize()
-        assert H._is_normalized(tol=1e-15)
-
-    @pytest.mark.parametrize("test_name", test_names)
-    def test_identifications(self, test_name):
-        """
-        Test that the identification attributes for test
-        `IonizationState` instances match the expected values from the
-        `Particle` instance.
-        """
-
-        Identifications = collections.namedtuple(
-            "Identifications", ["element", "isotope", "atomic_number"]
-        )
-
-        expected_identifications = Identifications(
-            self.instances[test_name].element,
-            self.instances[test_name].isotope,
-            self.instances[test_name].atomic_number,
-        )
-
-        expected_element = self.instances[test_name]._particle.element
-        expected_isotope = self.instances[test_name]._particle.isotope
-        expected_atomic_number = self.instances[test_name]._particle.atomic_number
-
-        resulting_identifications = Identifications(
-            expected_element, expected_isotope, expected_atomic_number
-        )
-
-        assert resulting_identifications == expected_identifications, (
-            f"For IonizationState test {test_name}, the resulting "
-            f"identifications of {resulting_identifications} differ "
-            f"from the expected identifications of "
-            f"{expected_identifications}."
-        )
-
-    @pytest.mark.parametrize("tol", [-1e-16, 1.0000001])
-    def test_invalid_tolerances(self, tol):
-        """Test that invalid tolerances raise appropriate errors."""
-        test_name = "Li"
-        instance = self.instances[test_name]
-        with pytest.raises(ValueError):
-            instance.tol = tol
-
-    @pytest.mark.parametrize("test_name", test_cases.keys())
-    def test_as_particle_list(self, test_name):
-        """
-        Test that `IonizationState` returns the correct `Particle`
-        instances.
-        """
-        instance = self.instances[test_name]
-        atom = instance.base_particle
-        nstates = instance.atomic_number + 1
-        expected_particles = [Particle(atom, Z=Z) for Z in range(nstates)]
-        actual_particles = instance.to_list()
-        assert expected_particles == actual_particles, (
-            f"The expected Particle instances of {expected_particles} "
-            f"are not all equal to the IonizationState particles of "
-            f"{actual_particles} for test {test_name}."
-        )
-
-    @pytest.mark.parametrize(
-        "test_name",
-        [name for name in test_names if "n_elem" in test_cases[name]],
+    H_acceptable_error = IonizationState(
+        **{
+            "particle": "H",
+            "ionic_fractions": [0.6, 0.400_000_001],
+            "tol": 1e-8,  # trick because the first one's tolerance is taken - or the smallest one, I think?
+        }
     )
-    def test_electron_density_from_n_elem_ionic_fractions(self, test_name):
-        instance = self.instances[test_name]
-        n_elem = test_cases[test_name]["n_elem"]
-        ionic_fractions = test_cases[test_name]["ionic_fractions"]
-        assert (
-            instance.n_elem == n_elem
-        ), f"n_elem is not being stored correctly for test {test_name}"
-        assert np.isclose(
-            instance.n_e,
-            np.sum(n_elem * ionic_fractions * np.arange(instance.atomic_number + 1)),
-            rtol=1e-12,
-            atol=0 * u.m**-3,
-        ), "n_e is not the expected value."
+    assert (H == H_acceptable_error) == output
 
-    @pytest.mark.parametrize("test_name", test_names)
-    def test_getitem(self, test_name):
-        """
-        Test that `IonizationState.__getitem__` returns the same value
-        when using equivalent keys (charge number, particle symbol, and
-        `Particle` instance).
 
-        For example, if we create
+def test_equality_no_more_exception(test_ionization_state, He_ionization_state):
+    """
+    Test that comparisons of `IonizationState` instances for
+    different elements does not fail.
+    """
+    if test_ionization_state == He_ionization_state:
+        return
+    assert test_ionization_state != He_ionization_state
 
-        >>> He_states = IonizationState('He', [0.2, 0.3, 0.5])
 
-        then this checks to make sure that `He_states[2]`,
-        `He_states['He 2+']`, and `He_states[Particle('He 2+')]` all
-        return the same result.
+def test_iteration(test_ionization_state):
+    """Test that `IonizationState` instances iterate impeccably."""
+    states = list(test_ionization_state)
 
-        """
-        instance = self.instances[test_name]
-        particle_name = instance.base_particle
+    charge_numbers = [state.charge_number for state in states]
+    ionic_symbols = [state.ionic_symbol for state in states]
 
-        charge_numbers = np.arange(instance.atomic_number + 1)
-        symbols = [particle_symbol(particle_name, Z=Z) for Z in charge_numbers]
-        particles = instance.to_list()
+    try:
+        base_symbol = isotope_symbol(ionic_symbols[0])
+    except InvalidIsotopeError:
+        base_symbol = atomic_symbol(ionic_symbols[0])
+    finally:
+        atomic_numb = atomic_number(ionic_symbols[1])
 
-        errors = []
+    errors = []
 
-        # In the following loop, instance[key] will return a namedtuple
-        # or class which may contain Quantity objects with values of
-        # numpy.nan.  Because of the difficulty of comparing nans in
-        # these objects, we compare the string representations instead
-        # (see Astropy issue #7901 on GitHub).
+    expected_charges = np.arange(atomic_numb + 1)
+    if not np.all(charge_numbers == expected_charges):
+        errors.append(
+            f"The resulting charge numbers are {charge_numbers}, "
+            f"which are not equal to the expected charge numbers, "
+            f"which are {expected_charges}."
+        )
 
-        for keys in zip(charge_numbers, symbols, particles):
+    np.testing.assert_allclose(sum(test_ionization_state.ionic_fractions), 1)
 
-            set_of_str_values = {str(instance[key]) for key in keys}
-            if len(set_of_str_values) != 1:
-                errors.append(
-                    f"\n\n"
-                    f"The following keys in test '{test_name}' did not "
-                    f"produce identical outputs as required: {keys}. "
-                    f"The set containing string representations of"
-                    f"the values is:\n\n{set_of_str_values}"
-                )
+    expected_particles = [Particle(base_symbol, Z=charge) for charge in charge_numbers]
+    expected_symbols = [particle.ionic_symbol for particle in expected_particles]
+    if ionic_symbols != expected_symbols:
+        errors.append(
+            f"The resulting ionic symbols are {ionic_symbols}, "
+            f"which are not equal to the expected ionic symbols of "
+            f"{expected_symbols}."
+        )
 
-        if errors:
-            pytest.fail(str.join("", errors))
+    if errors:
+        errors.insert(
+            0,
+            (
+                f"The test of {test_ionization_state} has "
+                f"resulted in the following errors when attempting to "
+                f"iterate."
+            ),
+        )
+        errmsg = " ".join(errors)
+        pytest.fail(errmsg)
 
-    @pytest.mark.parametrize(
-        "attr", ["charge_number", "ionic_fraction", "ionic_symbol"]
+
+def test_normalization():
+    """
+    Test that `_is_normalized` returns `False` when there is an
+    error greater than the tolerance, and `True` after normalizing.
+    """
+    H = IonizationState(particle="H", ionic_fractions=[0.6, 0.400_000_001], tol=1e-8)
+    assert not H._is_normalized(tol=1e-15)
+    H.normalize()
+    assert H._is_normalized(tol=1e-15)
+
+
+def test_identifications(test_ionization_state):
+    """
+    Test that the identification attributes for test
+    `IonizationState` instances match the expected values from the
+    `Particle` instance.
+    """
+
+    Identifications = collections.namedtuple(
+        "Identifications", ["element", "isotope", "atomic_number"]
     )
-    def test_State_attrs(self, attr):
-        """
-        Test that an IonizationState instance returns something with the
-        correct attributes (be it a `collections.namedtuple` or a
-        `class`).
-        """
-        test_name = "He"
-        state = self.instances[test_name][1]
-        assert hasattr(state, attr)
 
-    def test_State_equality_and_getitem(self):
-        test_name = "He"
-        instance = self.instances[test_name]
-        charge = 2
-        symbol = "He 2+"
-        result_from_charge = instance[charge]
-        result_from_symbol = instance[symbol]
-        assert result_from_charge == result_from_symbol
+    expected_identifications = Identifications(
+        test_ionization_state.element,
+        test_ionization_state.isotope,
+        test_ionization_state.atomic_number,
+    )
+
+    expected_element = test_ionization_state._particle.element
+    expected_isotope = test_ionization_state._particle.isotope
+    expected_atomic_number = test_ionization_state._particle.atomic_number
+
+    resulting_identifications = Identifications(
+        expected_element, expected_isotope, expected_atomic_number
+    )
+
+    assert resulting_identifications == expected_identifications, (
+        f"For {test_ionization_state}, the resulting "
+        f"identifications of {resulting_identifications} differ "
+        f"from the expected identifications of "
+        f"{expected_identifications}."
+    )
+
+
+def test_as_particle_list(test_ionization_state):
+    """
+    Test that `IonizationState` returns the correct `Particle`
+    instances.
+    """
+    atom = test_ionization_state.base_particle
+    nstates = test_ionization_state.atomic_number + 1
+    expected_particles = [Particle(atom, Z=Z) for Z in range(nstates)]
+    actual_particles = test_ionization_state.to_list()
+    assert expected_particles == actual_particles
+
+
+@pytest.mark.xfail
+def test_electron_density_from_n_elem_ionic_fractions(test_ionization_state):
+    # if "n_elem" not in test_cases[test_name]:
+    #     return
+    n_elem = test_cases[test_name]["n_elem"]
+    ionic_fractions = test_cases[test_name]["ionic_fractions"]
+    assert (
+        test_ionization_state.n_elem == n_elem
+    ), f"n_elem is not being stored correctly for test {test_name}"
+    assert np.isclose(
+        test_ionization_state.n_e,
+        np.sum(
+            n_elem
+            * ionic_fractions
+            * np.arange(test_ionization_state.atomic_number + 1)
+        ),
+        rtol=1e-12,
+        atol=0 * u.m**-3,
+    )
+
+
+def test_getitem(test_ionization_state):
+    """
+    Test that `IonizationState.__getitem__` returns the same value
+    when using equivalent keys (charge number, particle symbol, and
+    `Particle` instance).
+
+    For example, if we create
+
+    >>> He_states = IonizationState('He', [0.2, 0.3, 0.5])
+
+    then this checks to make sure that `He_states[2]`,
+    `He_states['He 2+']`, and `He_states[Particle('He 2+')]` all
+    return the same result.
+
+    """
+    particle_name = test_ionization_state.base_particle
+
+    charge_numbers = np.arange(test_ionization_state.atomic_number + 1)
+    symbols = [particle_symbol(particle_name, Z=Z) for Z in charge_numbers]
+    particles = test_ionization_state.to_list()
+
+    errors = []
+
+    # In the following loop, instance[key] will return a namedtuple
+    # or class which may contain Quantity objects with values of
+    # numpy.nan.  Because of the difficulty of comparing nans in
+    # these objects, we compare the string representations instead
+    # (see Astropy issue #7901 on GitHub).
+
+    for keys in zip(charge_numbers, symbols, particles):
+
+        set_of_str_values = {str(test_ionization_state[key]) for key in keys}
+        if len(set_of_str_values) != 1:
+            errors.append(
+                f"\n\n"
+                f"The following keys for {test_ionization_state} did not "
+                f"produce identical outputs as required: {keys}. "
+                f"The set containing string representations of"
+                f"the values is:\n\n{set_of_str_values}"
+            )
+
+    if errors:
+        pytest.fail(str.join("", errors))
+
+
+@pytest.fixture
+def He_ionization_state():
+    return IonizationState(
+        **{
+            "particle": "He",
+            "ionic_fractions": [0.5, 0.3, 0.2],
+            "n_elem": 1e20 * u.m**-3,
+        },
+    )
+
+
+@pytest.mark.parametrize("index", [-1, 4, "Li"])
+def test_indexing_error(He_ionization_state, index):
+    """
+    Test that an `IonizationState` instance cannot be indexed
+    outside of the bounds of allowed charge numbers.
+    """
+    with pytest.raises(ParticleError):
+        He_ionization_state[index]
+
+
+def test_inequality_with_different_type(He_ionization_state):
+    assert He_ionization_state != "different type"
+
+
+@pytest.mark.parametrize("tol", [-1e-16, 1.0000001])
+def test_invalid_tolerances(He_ionization_state, tol):
+    """Test that invalid tolerances raise appropriate errors."""
+    with pytest.raises(ValueError):
+        He_ionization_state.tol = tol
+
+
+def test_State_equality_and_getitem(He_ionization_state):
+    charge = 2
+    symbol = "He 2+"
+    result_from_charge = He_ionization_state[charge]
+    result_from_symbol = He_ionization_state[symbol]
+    assert result_from_charge == result_from_symbol
 
 
 ions = ["Fe 6+", "p", "He-4 0+", "triton", "alpha", "Ne +0"]

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -151,23 +151,6 @@ def test_charge_numbers(test_ionization_state):
     assert np.allclose(test_ionization_state.charge_numbers, expected_charge_numbers)
 
 
-@pytest.mark.xfail
-def test_ionic_fractions(test_ionization_state):
-    """
-    Test that each `IonizationState` instance has the expected
-    ionic fractions.
-    """
-    if "ionic_fractions" not in test_cases[test_name]:
-        return
-    instance = test_ionization_state
-    inputted_fractions = test_cases[test_name]["ionic_fractions"]
-    if isinstance(inputted_fractions, u.Quantity):
-        inputted_fractions = inputted_fractions.to(u.m**-3)
-        inputted_fractions = (inputted_fractions / inputted_fractions.sum()).value
-    if not np.allclose(test_ionization_state.ionic_fractions, inputted_fractions):
-        pytest.fail(f"Mismatch in ionic fractions for test {test_name}.")
-
-
 def test_equal_to_itself(He_ionization_state):
     """
     Test that `IonizationState.__eq__` returns `True for two identical
@@ -308,27 +291,6 @@ def test_as_particle_list(test_ionization_state):
     expected_particles = [Particle(atom, Z=Z) for Z in range(nstates)]
     actual_particles = test_ionization_state.to_list()
     assert expected_particles == actual_particles
-
-
-@pytest.mark.xfail
-def test_electron_density_from_n_elem_ionic_fractions(test_ionization_state):
-    # if "n_elem" not in test_cases[test_name]:
-    #     return
-    n_elem = test_cases[test_name]["n_elem"]
-    ionic_fractions = test_cases[test_name]["ionic_fractions"]
-    assert (
-        test_ionization_state.n_elem == n_elem
-    ), f"n_elem is not being stored correctly for test {test_name}"
-    assert np.isclose(
-        test_ionization_state.n_e,
-        np.sum(
-            n_elem
-            * ionic_fractions
-            * np.arange(test_ionization_state.atomic_number + 1)
-        ),
-        rtol=1e-12,
-        atol=0 * u.m**-3,
-    )
 
 
 def test_getitem(test_ionization_state):

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -142,9 +142,6 @@ def test_ionization_state(request):
     return IonizationState(**request.param)
 
 
-# TODO: Refactor these tests using fixtures
-
-
 def test_charge_numbers(test_ionization_state):
     """
     Test that an `IonizationState` instance has the correct charge

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -331,16 +331,17 @@ def test_parse_InvalidParticleErrors(arg, kwargs):
         )
 
 
-@pytest.mark.parametrize("arg", particle_zoo.everything - {"p+"})
-def test_parse_InvalidElementErrors(arg):
+def test_parse_InvalidElementErrors(particle):
     r"""Tests that _parse_and_check_atomic_input raises an
     InvalidElementError when the input corresponds to a valid
     particle but not a valid element, isotope, or ion."""
+    if particle == Particle("p+"):
+        return  # TODO verify this case should still be a skip
     with pytest.raises(InvalidElementError):
-        parse_and_check_atomic_input(arg)
+        parse_and_check_atomic_input(particle)
         pytest.fail(
             "An InvalidElementError was expected to be raised by "
-            f"{call_string(parse_and_check_atomic_input, arg)}, "
+            f"{call_string(parse_and_check_atomic_input, particle)}, "
             f"but no exception was raised."
         )
 

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -336,7 +336,7 @@ def test_parse_InvalidElementErrors(particle):
     InvalidElementError when the input corresponds to a valid
     particle but not a valid element, isotope, or ion."""
     if particle == Particle("p+"):
-        return  # TODO verify this case should still be a skip
+        return
     with pytest.raises(InvalidElementError):
         parse_and_check_atomic_input(particle.symbol)
         pytest.fail(

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -7,7 +7,6 @@ from plasmapy.particles._parsing import (
     dealias_particle_aliases,
     parse_and_check_atomic_input,
 )
-from plasmapy.particles._special_particles import particle_zoo
 from plasmapy.particles.exceptions import (
     InvalidElementError,
     InvalidParticleError,

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -338,7 +338,7 @@ def test_parse_InvalidElementErrors(particle):
     if particle == Particle("p+"):
         return  # TODO verify this case should still be a skip
     with pytest.raises(InvalidElementError):
-        parse_and_check_atomic_input(particle)
+        parse_and_check_atomic_input(particle.symbol)
         pytest.fail(
             "An InvalidElementError was expected to be raised by "
             f"{call_string(parse_and_check_atomic_input, particle)}, "

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -11,7 +11,6 @@ from astropy.constants import c, e, m_e, m_n, m_p
 
 from plasmapy.particles import json_load_particle, json_loads_particle, molecule
 from plasmapy.particles._isotopes import data_about_isotopes
-from plasmapy.particles._special_particles import particle_zoo
 from plasmapy.particles.atomic import known_isotopes
 from plasmapy.particles.exceptions import (
     ChargeError,

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -782,35 +782,19 @@ def test_particle_bool_error():
         bool(Particle("e-"))
 
 
-particle_antiparticle_pairs = list(
-    sorted(
-        [
-            ("p+", "p-"),
-            ("n", "antineutron"),
-            ("e-", "e+"),
-            ("mu-", "mu+"),
-            ("tau-", "tau+"),
-            ("nu_e", "anti_nu_e"),
-            ("nu_mu", "anti_nu_mu"),
-            ("nu_tau", "anti_nu_tau"),
-        ]
-    )
-)
-
-
-@pytest.mark.parametrize("particle, antiparticle", particle_antiparticle_pairs)
-def test_particle_inversion(particle, antiparticle):
+def test_particle_inversion(particle_antiparticle_pair):
     """Test that particles have the correct antiparticles."""
-    assert Particle(particle).antiparticle == Particle(antiparticle), (
+    particle, antiparticle = particle_antiparticle_pair
+    assert particle.antiparticle == antiparticle, (
         f"The antiparticle of {particle} is found to be "
         f"{~Particle(particle)} instead of {antiparticle}."
     )
 
 
-@pytest.mark.parametrize("particle, antiparticle", particle_antiparticle_pairs)
-def test_antiparticle_inversion(particle, antiparticle):
+def test_antiparticle_inversion(particle_antiparticle_pair):
     """Test that antiparticles have the correct antiparticles."""
-    assert Particle(antiparticle).antiparticle == Particle(particle), (
+    particle, antiparticle = particle_antiparticle_pair
+    assert antiparticle.antiparticle == particle, (
         f"The antiparticle of {antiparticle} is found to be "
         f"{~Particle(antiparticle)} instead of {particle}."
     )

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -782,16 +782,20 @@ def test_particle_bool_error():
         bool(Particle("e-"))
 
 
-particle_antiparticle_pairs = [
-    ("p+", "p-"),
-    ("n", "antineutron"),
-    ("e-", "e+"),
-    ("mu-", "mu+"),
-    ("tau-", "tau+"),
-    ("nu_e", "anti_nu_e"),
-    ("nu_mu", "anti_nu_mu"),
-    ("nu_tau", "anti_nu_tau"),
-]
+particle_antiparticle_pairs = list(
+    sorted(
+        [
+            ("p+", "p-"),
+            ("n", "antineutron"),
+            ("e-", "e+"),
+            ("mu-", "mu+"),
+            ("tau-", "tau+"),
+            ("nu_e", "anti_nu_e"),
+            ("nu_mu", "anti_nu_mu"),
+            ("nu_tau", "anti_nu_tau"),
+        ]
+    )
+)
 
 
 @pytest.mark.parametrize("particle, antiparticle", particle_antiparticle_pairs)
@@ -815,23 +819,6 @@ def test_antiparticle_inversion(particle, antiparticle):
 def test_unary_operator_for_elements():
     with pytest.raises(ParticleError):
         Particle("C").antiparticle
-
-
-@pytest.fixture(params=particle_zoo.everything)
-def particle(request):
-    return Particle(request.param)
-
-
-@pytest.fixture()
-def opposite(particle):
-    try:
-        opposite_particle = ~particle
-    except Exception as exc:
-        raise InvalidParticleError(
-            f"The unary ~ (invert) operator is unable to find the "
-            f"antiparticle of {particle}."
-        ) from exc
-    return opposite_particle
 
 
 class Test_antiparticle_properties_inversion:

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -62,7 +62,6 @@ required_keys = [
 ]
 
 
-@pytest.mark.parametrize("particle", list(sorted(particle_zoo.everything)))
 def test_Particles_required_keys(particle):
     r"""Test that required keys are present for all particles."""
 
@@ -70,12 +69,12 @@ def test_Particles_required_keys(particle):
 
     for key in required_keys:
         try:
-            data_about_special_particles[particle][key]
+            data_about_special_particles[particle.symbol][key]
         except KeyError:
             missing_keys.append(key)
 
     if missing_keys:
         raise KeyError(
-            f"_Particles[{repr(particle)}] is missing the following "
+            f"_Particles[{particle.symbol}] is missing the following "
             f"keys: {missing_keys}"
         )

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -5,26 +5,11 @@ from plasmapy.particles._special_particles import (
     particle_zoo,
 )
 
-particle_antiparticle_pairs = list(
-    sorted(
-        [
-            ("e-", "e+"),
-            ("mu-", "mu+"),
-            ("tau-", "tau+"),
-            ("p+", "p-"),
-            ("n", "antineutron"),
-            ("nu_e", "anti_nu_e"),
-            ("nu_mu", "anti_nu_mu"),
-            ("nu_tau", "anti_nu_tau"),
-        ]
-    )
-)
 
-
-@pytest.mark.parametrize("particle,antiparticle", particle_antiparticle_pairs)
-def test_particle_antiparticle_pairs(particle, antiparticle):
+def test_particle_antiparticle_pairs(particle_antiparticle_pair):
     """Test that particles and antiparticles have the same or exact
     opposite properties in the _Particles dictionary."""
+    particle, antiparticle = particle_antiparticle_pair
 
     assert not data_about_special_particles[particle][
         "antimatter"
@@ -77,8 +62,8 @@ required_keys = [
 ]
 
 
-@pytest.mark.parametrize("particle", particle_zoo.everything)
-def test__Particles_required_keys(particle):
+@pytest.mark.parametrize("particle", list(sorted(particle_zoo.everything)))
+def test_Particles_required_keys(particle):
     r"""Test that required keys are present for all particles."""
 
     missing_keys = []

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -77,7 +77,8 @@ required_keys = [
 ]
 
 
-def test_Particles_required_keys(particle):
+@pytest.mark.parametrize("particle", particle_zoo.everything)
+def test__Particles_required_keys(particle):
     r"""Test that required keys are present for all particles."""
 
     missing_keys = []

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -5,16 +5,20 @@ from plasmapy.particles._special_particles import (
     particle_zoo,
 )
 
-particle_antiparticle_pairs = [
-    ("e-", "e+"),
-    ("mu-", "mu+"),
-    ("tau-", "tau+"),
-    ("p+", "p-"),
-    ("n", "antineutron"),
-    ("nu_e", "anti_nu_e"),
-    ("nu_mu", "anti_nu_mu"),
-    ("nu_tau", "anti_nu_tau"),
-]
+particle_antiparticle_pairs = list(
+    sorted(
+        [
+            ("e-", "e+"),
+            ("mu-", "mu+"),
+            ("tau-", "tau+"),
+            ("p+", "p-"),
+            ("n", "antineutron"),
+            ("nu_e", "anti_nu_e"),
+            ("nu_mu", "anti_nu_mu"),
+            ("nu_tau", "anti_nu_tau"),
+        ]
+    )
+)
 
 
 @pytest.mark.parametrize("particle,antiparticle", particle_antiparticle_pairs)
@@ -73,8 +77,7 @@ required_keys = [
 ]
 
 
-@pytest.mark.parametrize("particle", particle_zoo.everything)
-def test__Particles_required_keys(particle):
+def test_Particles_required_keys(particle):
     r"""Test that required keys are present for all particles."""
 
     missing_keys = []

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -9,7 +9,7 @@ from plasmapy.particles._special_particles import (
 def test_particle_antiparticle_pairs(particle_antiparticle_pair):
     """Test that particles and antiparticles have the same or exact
     opposite properties in the _Particles dictionary."""
-    particle, antiparticle = particle_antiparticle_pair
+    particle, antiparticle = (p.symbol for p in particle_antiparticle_pair)
 
     assert not data_about_special_particles[particle][
         "antimatter"

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -1,9 +1,4 @@
-import pytest
-
-from plasmapy.particles._special_particles import (
-    data_about_special_particles,
-    particle_zoo,
-)
+from plasmapy.particles._special_particles import data_about_special_particles
 
 
 def test_particle_antiparticle_pairs(particle_antiparticle_pair):

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ allowlist_externals =
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals -n=auto --dist=loadfile
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
@@ -21,6 +21,7 @@ deps =
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
     cov: pytest-cov
+    !minimal: pytest-xdist
     pytest-github-actions-annotate-failures
 commands =
     !cov: {env:PYTEST_COMMAND} {posargs} -m 'not slow'
@@ -76,6 +77,7 @@ extras =
 deps =
     lmfit
     pytest-cov
+    pytest-xdist
 conda_deps =
     astropy >= 4.3.1
     h5py >= 3.0.0


### PR DESCRIPTION
## Description

- I wrapped most of the lists of particles that go into `pytest.mark.parametrize` into `list(sorted(...))`. Turns out that's enough. Not entirely sure why, tbh. See https://pytest-xdist.readthedocs.io/en/latest/known-limitations.html#workarounds for where I found this trick.
- I reverted the removal of pytest-xdist.




## Motivation and context

https://github.com/StanczakDominik/PlasmaPy/actions/runs/3701946161 was just one example of the recently happening test failure resulting from parameters for tests in the particle subpackage being "insufficiently ordered", as it turns out. See commit message for the first one, because I'm still pretty confused about it. We previously removed pytest-xdist from dependencies as a temporary measure in https://github.com/PlasmaPy/PlasmaPy/pull/1822, where I promised to fix the root cause. Well, here it is.



## Related issues

<!-- Please link to any related issues and PRs. If this PR will fully resolve and issue, include text like "Closes #1542" so that the issue will be automatically closed when this PR is merged. -->
