### PR TITLE
Link to GitHub repository from documentation landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,3 +74,4 @@ Example highlights
    Vision Statement <about/vision_statement>
    plasmaPy.org <https://www.plasmapy.org>
    GitHub Repository <https://github.com/PlasmaPy/PlasmaPy>
+   Contact Us <mailto:team@plasmapy.org>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,4 +74,3 @@ Example highlights
    Vision Statement <about/vision_statement>
    plasmaPy.org <https://www.plasmapy.org>
    GitHub Repository <https://github.com/PlasmaPy/PlasmaPy>
-   Contact Us <mailto:team@plasmapy.org>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,5 +72,5 @@ Example highlights
    bibliography
    glossary
    Vision Statement <about/vision_statement>
-   plasmaPy.org <https://www.plasmapy.org>
+   PlasmaPy.org <https://www.plasmapy.org>
    GitHub Repository <https://github.com/PlasmaPy/PlasmaPy>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,10 +72,5 @@ Example highlights
    bibliography
    glossary
    Vision Statement <about/vision_statement>
-   PlasmaPy.org <https://www.plasmapy.org>
-
-.. The about PlasmaPy section has some important information that would
-   be helpful to have more readily accessible from the main doc index
-   page.
-
-.. TODO: Add feedback link: .. _feedback@plasmapy.org: mailto:feedback@plasmapy.org
+   plasmaPy.org <https://www.plasmapy.org>
+   GitHub Repository <https://github.com/PlasmaPy/PlasmaPy>


### PR DESCRIPTION
This PR adds a link to the GitHub repository in the documentation sidebar for the landing page.  Yet another PR inspired by a [podcast](https://pythonbytes.fm/episodes/show/310/calling-all-tools-for-readmes).  📻 