### PR TITLE
Update Read the Docs configuration and add `graphviz` dependency

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,7 @@ build:
     pre_create_environment:
     - python -m pip install --upgrade setuptools pip
     post_build:
-    - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
+    - echo "Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting"
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   tools:
     # Use most recent version supported by Numba
     python: '3.10'
-  apt-packages:
+  apt_packages:
   - graphviz
   jobs:
     pre_create_environment:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,8 @@ build:
     pre_create_environment:
     - python -m pip install --upgrade setuptools pip
     post_build:
-    - echo Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
+    - echo Troubleshooting guide:
+    - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,8 @@ build:
   os: ubuntu-20.04
   tools:
     python: '3.10'
+  apt-packages:
+  - graphviz
   jobs:
     pre_create_environment:
     - python -m pip install --upgrade setuptools pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,6 @@ build:
     pre_create_environment:
     - python -m pip install --upgrade setuptools pip
     post_build:
-    - echo Troubleshooting guide:
     - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,11 +11,13 @@ build:
   tools:
     # Use most recent version supported by Numba
     python: '3.10'
-  apt-packages:
+  apt_packages:
   - graphviz
   jobs:
     pre_create_environment:
     - python -m pip install --upgrade setuptools pip
+    post_build:
+    - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,8 +16,6 @@ build:
   jobs:
     pre_create_environment:
     - python -m pip install --upgrade setuptools pip
-    post_build:
-    - echo Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,7 @@ build:
     pre_create_environment:
     - python -m pip install --upgrade setuptools pip
     post_build:
-    - echo "Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting"
+    - echo Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   tools:
     # Use most recent version supported by Numba
     python: '3.10'
-  apt_packages:
+  apt-packages:
   - graphviz
   jobs:
     pre_create_environment:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,25 +1,27 @@
-# .readthedocs.yml
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
 
-# Required
 version: 2
 
 formats:
 - htmlzip
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
+    # Use most recent version supported by Numba
     python: '3.10'
   apt-packages:
   - graphviz
   jobs:
     pre_create_environment:
     - python -m pip install --upgrade setuptools pip
+    post_build:
+    - echo "Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting"
 
+sphinx:
+  fail_on_warning: true
 
-# Optionally set the version of Python and requirements required to build your docs
 python:
   install:
   - method: pip

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ setenv =
     HOME = {envtmpdir}
 commands =
     sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
-    echo "Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#documentation-tools"
+    echo "Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting"
 
 [testenv:build_docs-sphinxdev]
 changedir = {toxinidir}


### PR DESCRIPTION
- Fixes #1838 by adding a `graphviz` dependency (see also https://github.com/sphinx-doc/sphinx/issues/10948 and https://github.com/sphinx-doc/sphinx/pull/11040) in order to fix a problem with inheritance diagrams not showing up in the doc build
- Updates the Read the Docs configuration file
  - Adds a link to the troubleshooting guide
  - Sets `fail_on_warning` to `true` which is equivalent to the settings we have for the CI doc build
- Corrects the link anchor to the troubleshooting guide in `tox.ini` 

