### PR TITLE
Fix weekly test against development version of NumPy

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,11 +30,6 @@ jobs:
           python: 3.8
           toxenv: linters
 
-        - name: Python 3.9 with NumPy dev
-          os: ubuntu-latest
-          python: 3.9
-          toxenv: py39-numpydev
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox<4 codecov
+      run: python -m pip install --progress-bar off --upgrade "tox<4" codecov
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
   comprehensive-tests:
@@ -94,7 +94,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox<4 codecov
+      run: python -m pip install --progress-bar off --upgrade "tox<4" codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc
@@ -121,7 +121,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox<4
+      run: python -m pip install --progress-bar off --upgrade "tox<4"
     - name: Install language-pack-fr and tzdata
       run: sudo apt-get install graphviz pandoc
     - name: Run tests
@@ -142,7 +142,7 @@ jobs:
       with:
         python-version: 3.9
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox<4
+      run: python -m pip install --progress-bar off --upgrade "tox<4"
     - name: Run tests
       run: tox -e codespell -q
 
@@ -161,7 +161,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox<4
+      run: python -m pip install --progress-bar off --upgrade "tox<4"
     - name: Import PlasmaPy
       run: tox -e py38-minimal-pypi-import
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,6 +30,11 @@ jobs:
           python: 3.8
           toxenv: linters
 
+        - name: Python 3.9 with NumPy dev
+          os: ubuntu-latest
+          python: 3.9
+          toxenv: py39-numpydev
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox codecov
+      run: python -m pip install --progress-bar off --upgrade tox<4 codecov
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
   comprehensive-tests:
@@ -89,7 +89,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox codecov
+      run: python -m pip install --progress-bar off --upgrade tox<4 codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc
@@ -116,7 +116,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox
+      run: python -m pip install --progress-bar off --upgrade tox<4
     - name: Install language-pack-fr and tzdata
       run: sudo apt-get install graphviz pandoc
     - name: Run tests
@@ -137,7 +137,7 @@ jobs:
       with:
         python-version: 3.9
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox
+      run: python -m pip install --progress-bar off --upgrade tox<4
     - name: Run tests
       run: tox -e codespell -q
 
@@ -156,7 +156,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox
+      run: python -m pip install --progress-bar off --upgrade tox<4
     - name: Import PlasmaPy
       run: tox -e py38-minimal-pypi-import
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --upgrade tox<4 codecov
+      run: python -m pip install --upgrade "tox<4" codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --upgrade tox codecov
+      run: python -m pip install --upgrade tox<4 codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 tests = [
     "codespell @ git+https://github.com/codespell-project/codespell/",
     "pre-commit",
-    "tox",
+    "tox<4",
     "dlint",
     "flake8",
     "flake8-absolute-import",
@@ -70,7 +70,7 @@ tests = [
 docs = [
     "codespell",
     "pre-commit",
-    "tox",
+    "tox<4",
     "docutils",
     "ipykernel",
     "jinja2 != 3.1",
@@ -93,7 +93,7 @@ docs = [
 dev = [
     "codespell",
     "pre-commit",
-    "tox",
+    "tox<4",
     "docutils",
     "ipykernel",
     "jinja2 != 3.1",
@@ -114,10 +114,8 @@ dev = [
     "towncrier >= 22.8.0",
     "codespell",
     "pre-commit",
-    "tox",
     "codespell",
     "pre-commit",
-    "tox",
     "dlint",
     "flake8",
     "flake8-absolute-import",

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
     matplotlibdev: git+https://github.com/matplotlib/matplotlib
-    numpydev: git+https://github.com/numpy/numpy.git
+    numpydev: :NIGHTLY:numpy
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
     cov: pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
     matplotlibdev: git+https://github.com/matplotlib/matplotlib
-    numpydev: :NIGHTLY:numpy
+    numpydev: git+https://github.com/numpy/numpy.git
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
     cov: pytest-cov


### PR DESCRIPTION
The weekly tests have been failing because apparently the `NIGHTLY` builds of NumPy are no longer pointing to the right place.  This PR aims to update the test setup to point it to the right location.

My first try is to point to NumPy's GitHub repository, which would unfortunately mean that it would have to rebuild NumPy (which could be time-consuming and unnecessary).  Going with this route would be a temporary fix, and I'd raise another issue to fix that.