### PR TITLE
Revert fail-on-warning option for Read the Docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,9 +19,6 @@ build:
     post_build:
     - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
-sphinx:
-  fail_on_warning: true
-
 python:
   install:
   - method: pip


### PR DESCRIPTION
Based on discussion at community meeting, to make sure we keep the preview for the RTD build.