### PR TITLE
Add `ruff` section to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,32 @@ addopts = "--doctest-modules --doctest-continue-on-failure"
 filterwarnings = ["ignore:.*Creating", "a"]
 looponfailroots = "plasmapy"
 
+[tool.ruff]
+ignore = ["E501", "F401"]
+target-version = "py38"
+
+[tool.ruff.flake8-import-conventions.aliases]
+"astropy.units" = "u"
+"matplotlib.pyplot" = "plt"
+numpy = "np"
+pandas = "pd"
+exclude = [
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".mypy_cache",
+    ".nox",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "__pypackages__",
+    "_build",
+    "build",
+    "dist",
+    "venv",
+]
+
 [tool.setuptools]
 include-package-data = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,14 +244,7 @@ filterwarnings = ["ignore:.*Creating", "a"]
 looponfailroots = "plasmapy"
 
 [tool.ruff]
-ignore = ["E501", "F401"]
 target-version = "py38"
-
-[tool.ruff.flake8-import-conventions.aliases]
-"astropy.units" = "u"
-"matplotlib.pyplot" = "plt"
-numpy = "np"
-pandas = "pd"
 exclude = [
     ".direnv",
     ".eggs",
@@ -268,6 +261,16 @@ exclude = [
     "dist",
     "venv",
 ]
+ignore = ["E501"]
+
+[tool.ruff.flake8-import-conventions.aliases]
+"astropy.units" = "u"
+"matplotlib.pyplot" = "plt"
+numpy = "np"
+pandas = "pd"
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E402", "F401", "F402", "F403"]
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,7 @@ exclude = [
     "dist",
     "venv",
 ]
-ignore = ["E501"]
+ignore = ["E501"]  # ignore line length violations
 
 [tool.ruff.flake8-import-conventions.aliases]
 "astropy.units" = "u"
@@ -270,7 +270,7 @@ numpy = "np"
 pandas = "pd"
 
 [tool.ruff.per-file-ignores]
-"__init__.py" = ["E402", "F401", "F402", "F403"]
+"__init__.py" = ["E402", "F401", "F402", "F403"]  # ignore import errors
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
This PR adds sections to `pyproject.toml` for [configuring](https://github.com/charliermarsh/ruff#configuration) [`ruff`](https://github.com/charliermarsh/ruff).  

Related to #1845, #1846, and #1847.