### PR TITLE
Pin version of `towncrier` to address doc build error

### DIFF
--- a/docs/whatsnew/0.9.1.rst
+++ b/docs/whatsnew/0.9.1.rst
@@ -1,0 +1,8 @@
+PlasmaPy v0.9.1 (2022-11-15)
+============================
+
+Trivial/Internal Changes
+------------------------
+
+- Removed a test of requirement file consistency to allow tests to pass on
+  conda-forge.

--- a/docs/whatsnew/dev.rst
+++ b/docs/whatsnew/dev.rst
@@ -1,7 +1,8 @@
-:orphan:
-
+==================
 Unreleased changes
 ==================
+
+These are the changes that have not yet been released:
 
 .. changelog::
    :towncrier: ../../

--- a/docs/whatsnew/dev.rst
+++ b/docs/whatsnew/dev.rst
@@ -1,3 +1,6 @@
+Unreleased changes
+==================
+
 :orphan:
 
 .. changelog::

--- a/docs/whatsnew/dev.rst
+++ b/docs/whatsnew/dev.rst
@@ -1,7 +1,7 @@
+:orphan:
+
 Unreleased changes
 ==================
-
-:orphan:
 
 .. changelog::
    :towncrier: ../../

--- a/docs/whatsnew/dev.rst
+++ b/docs/whatsnew/dev.rst
@@ -1,8 +1,8 @@
+:orphan:
+
 ==================
 Unreleased changes
 ==================
-
-These are the changes that have not yet been released:
 
 .. changelog::
    :towncrier: ../../

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -12,6 +12,7 @@ including bug fixes and changes to the application programming interface
    :maxdepth: 1
 
    dev
+   0.9.1
    0.9.0
    0.8.1
    0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ docs = [
     "sphinx-reredirects",
     "sphinx_rtd_theme >= 1.0.0",
     "sphinxcontrib-bibtex",
-    "towncrier == 22.8.0",
+    "towncrier >= 22.8.0",
 ]
 dev = [
     "codespell",
@@ -111,7 +111,7 @@ dev = [
     "sphinx-reredirects",
     "sphinx_rtd_theme >= 1.0.0",
     "sphinxcontrib-bibtex",
-    "towncrier == 22.8.0",
+    "towncrier >= 22.8.0",
     "codespell",
     "pre-commit",
     "codespell",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ docs = [
     "sphinx-reredirects",
     "sphinx_rtd_theme >= 1.0.0",
     "sphinxcontrib-bibtex",
-    "towncrier >= 22.8.0",
+    "towncrier == 22.8.0",
 ]
 dev = [
     "codespell",
@@ -111,7 +111,7 @@ dev = [
     "sphinx-reredirects",
     "sphinx_rtd_theme >= 1.0.0",
     "sphinxcontrib-bibtex",
-    "towncrier >= 22.8.0",
+    "towncrier == 22.8.0",
     "codespell",
     "pre-commit",
     "codespell",


### PR DESCRIPTION
There was a doc build failure that started in #1847:

```
/home/runner/work/PlasmaPy/PlasmaPy/docs/whatsnew/index.rst:11: WARNING: toctree contains reference to document 'whatsnew/dev' that doesn't have a title: no link will be generated
```

There was just a release of towncrier `22.12.0`, so I suspect it might have something to do with that.

This PR is to try two separate things for fixing it.
 - Pin `towncrier` an older version (preferred)
 - Add a title to `whatsnew/dev.rst` and make sure it looks okay in the outputted docs

I'm also adding the brief changelog from `0.9.1` that I forgot to copy over from #1819 and #1820.
