### PR TITLE
Pin GitHub Action to specific version for posting code review checklists

### DIFF
--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -36,8 +36,8 @@ jobs:
     name: Checklist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: harupy/comment-on-pr@master
+    - uses: actions/checkout@v0.1.0
+    - uses: harupy/comment-on-pr@v0.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
## Description

This PR pins the GitHub Action used for posting the code review checklist to v0.1.0 instead of the development branch.

## Motivation and context

Whilst hanging out on another repository, I heard some good security advice that it is best to pin GitHub Actions to specific releases.  This is to prepare for the unlikely eventuality that malicious code ends up getting put into a development branch.  Pinning it to a specific release is better than pinning it to a particular commit also (because a force push could have the same commit hash).  

## Related issues

#1729 