### PR TITLE
Use `ruff` and `refurb` on remainder of `plasmapy`

### DIFF
--- a/changelog/1853.trivial.rst
+++ b/changelog/1853.trivial.rst
@@ -1,0 +1,1 @@
+Apply changes from ``ruff`` and ``refurb`` to `plasmapy.analysis`, `plasmapy.diagnostics`, `plasmapy.dispersion`, and `plasmapy.plasma`.

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -231,8 +231,8 @@ class AbstractFitFunction(ABC):
         """The fitted parameters for the fit function."""
         if self._params is None:
             return self._params
-        else:
-            return self.FitParamTuple(*self._params)
+
+        return self.FitParamTuple(*self._params)
 
     @params.setter
     def params(self, val) -> None:
@@ -253,8 +253,8 @@ class AbstractFitFunction(ABC):
         """The associated errors of the fitted :attr:`params`."""
         if self._param_errors is None:
             return self._param_errors
-        else:
-            return self.FitParamTuple(*self._param_errors)
+
+        return self.FitParamTuple(*self._param_errors)
 
     @param_errors.setter
     def param_errors(self, val) -> None:

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -628,7 +628,7 @@ def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):
     elif not (np.isclose((c2 + d2 * x2), 0, atol=_EQUALITY_ATOL)):
         y2 = (-a2 - b2 * x2) / (c2 + d2 * x2)
 
-    if y1 is None and y2 is None:
+    if y1 is y2 is None:
         return np.array([])
     elif y1 is None:
         return np.array([(x2, y2)])
@@ -1060,7 +1060,7 @@ def _trilinear_analysis(vspace, cell):
             return True
 
     # Check Grid Resolution
-    if len(BxByEndpoints) == 0 and len(BxBzEndpoints) == 0 and len(ByBzEndpoints) == 0:
+    if len(BxByEndpoints) == len(BxBzEndpoints) == len(ByBzEndpoints) == 0:
         warnings.warn(
             "Multiple null points suspected. Trilinear method may not work as intended.",
             MultipleNullPointWarning,
@@ -1090,16 +1090,16 @@ def _trilinear_analysis(vspace, cell):
             return True
         if np.sign(first_endpoint) * np.sign(second_endpoint) > 0:
             return False
-        else:
-            return True
+
+        return True
 
     opposite_sign_z = endpoint_sign_check(BxByEndpoints, "z")
     opposite_sign_y = endpoint_sign_check(BxBzEndpoints, "y")
     opposite_sign_x = endpoint_sign_check(ByBzEndpoints, "x")
     if opposite_sign_x and opposite_sign_y and opposite_sign_z:
         return True
-    else:
-        return False
+
+    return False
 
 
 def _locate_null_point(vspace, cell, n, err):
@@ -1209,7 +1209,7 @@ def _locate_null_point(vspace, cell, n, err):
         )
         return is_x_in_bound and is_y_in_bound and is_z_in_bound
 
-    starting_pos = []
+    starting_pos = []  # noqa: FURB138
     # Adding the Corners
     for point in corners:
         starting_pos.append(

--- a/plasmapy/analysis/swept_langmuir/floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/floating_potential.py
@@ -264,7 +264,7 @@ def find_floating_potential(
         isl_stop = np.concatenate(
             (cp_candidates[threshold_indices] + 1, [cp_candidates[-1] + 1])
         )
-        rtn_extras["islands"] = [
+        rtn_extras["islands"] = [  # noqa: FURB140
             slice(start, stop) for start, stop in zip(isl_start, isl_stop)
         ]
 

--- a/plasmapy/analysis/swept_langmuir/ion_saturation_current.py
+++ b/plasmapy/analysis/swept_langmuir/ion_saturation_current.py
@@ -188,7 +188,7 @@ def find_ion_saturation_current(
     voltage, current = check_sweep(voltage, current, strip_units=True)
 
     # condition kwargs voltage_bound and current_bound
-    if voltage_bound is None and current_bound is None:
+    if voltage_bound is current_bound is None:
         current_bound = default_current_bound
     elif voltage_bound is not None and current_bound is not None:
         raise ValueError(

--- a/plasmapy/analysis/tests/test_nullpoint.py
+++ b/plasmapy/analysis/tests/test_nullpoint.py
@@ -463,7 +463,7 @@ def test_null_point_find9():
         "func": lambda x, y, z: [x, y, z],
     }
     with pytest.raises(NonZeroDivergence):
-        npoints = uniform_null_point_find(**nullpoint9_args)
+        uniform_null_point_find(**nullpoint9_args)
 
 
 # Tests that capture the degenerate nulls/2D nulls

--- a/plasmapy/analysis/tests/test_nullpoint.py
+++ b/plasmapy/analysis/tests/test_nullpoint.py
@@ -55,25 +55,17 @@ def vspace_func_7(x, y, z):
 
 def test_trilinear_coeff_cal():
     r"""Test `~plasmapy.analysis.nullpoint.trilinear_coeff_cal`."""
-    vspace1_args = {
-        "x_range": [0, 10],
-        "y_range": [0, 10],
-        "z_range": [0, 10],
-        "precision": [10 / 46, 10 / 46, 10 / 46],
-        "func": vspace_func_1,
-    }
-    vspace1 = _vector_space(**vspace1_args)
-    vspace2_args = {
+    vspace_args = {
         "x_range": [0, 10],
         "y_range": [0, 10],
         "z_range": [0, 10],
         "precision": [10 / 46, 10 / 46, 10 / 46],
         "func": vspace_func_2,
     }
-    vspace2 = _vector_space(**vspace2_args)
+    vspace = _vector_space(**vspace_args)
     test_trilinear_coeff_cal_values = [
         (
-            {"vspace": vspace2, "cell": [25, 25, 25]},
+            {"vspace": vspace, "cell": [25, 25, 25]},
             [
                 [-5.5, 0, 2, -1, 0, 0, 0, 0],
                 [-22, 3, 0, 1, 0, 0, 0, 0],

--- a/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -235,14 +235,14 @@ class Tracker:
                     np.array(
                         [
                             np.max(a)
-                            for a in [
+                            for a in (
                                 arr[0, :, :],
                                 arr[-1, :, :],
                                 arr[:, 0, :],
                                 arr[:, -1, :],
                                 arr[:, :, 0],
                                 arr[:, :, -1],
-                            ]
+                            )
                         ]
                     )
                 )
@@ -286,9 +286,9 @@ class Tracker:
 
         for i, grid in enumerate(self.grids):
             ind = 0
-            for x in [0, -1]:
-                for y in [0, -1]:
-                    for z in [0, -1]:
+            for x in (0, -1):
+                for y in (0, -1):
+                    for z in (0, -1):
                         # Source to grid corner vector
                         vec = self.grids_arr[i][x, y, z, :] - self.source
 

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_detector_stacks.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_detector_stacks.py
@@ -62,14 +62,14 @@ def test_create_layer_with_different_stopping_powers(tmp_path):
     mass_density = 2.7 * u.g / u.cm**3
 
     # No error should be raised initializing one of these ways
-    layer = Layer(100 * u.um, eaxis, mass_stopping_power * mass_density)
-    layer = Layer(100 * u.um, eaxis, mass_stopping_power, mass_density=mass_density)
+    Layer(100 * u.um, eaxis, mass_stopping_power * mass_density)
+    Layer(100 * u.um, eaxis, mass_stopping_power, mass_density=mass_density)
 
     # Error should be raised if the wrong units are provided
     with pytest.raises(ValueError):
-        layer = Layer(100 * u.um, eaxis, mass_stopping_power.value * u.kg)
+        Layer(100 * u.um, eaxis, mass_stopping_power.value * u.kg)
     with pytest.raises(ValueError):
-        layer = Layer(
+        Layer(
             100 * u.um,
             eaxis,
             mass_stopping_power,
@@ -79,7 +79,7 @@ def test_create_layer_with_different_stopping_powers(tmp_path):
     # Error should be raised if mass_density keyword is not provided when
     # the mass stopping power is given
     with pytest.raises(ValueError):
-        layer = Layer(100 * u.um, eaxis, mass_stopping_power, mass_density=None)
+        Layer(100 * u.um, eaxis, mass_stopping_power, mass_density=None)
 
 
 def test_film_stack_num_layers(hdv2_stack):

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -707,7 +707,7 @@ def test_gaussian_sphere_analytical_comparison():
     phi0 = 1.4e5
     W = 15e6
 
-    l = 10
+    l = 10  # noqa: E741
     L = 200
 
     # Define and run the problem
@@ -897,7 +897,7 @@ def test_add_wire_mesh():
     assert np.isclose(measured_spacing, true_spacing, 0.5)
 
 
-def test_multiple_grids():
+def test_multiple_grids2():
     """
     Test that a case with two grids runs.
     TODO: automate test by including two fields with some obvious analytical

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -693,7 +693,7 @@ def run_fit(
 
     wavelengths = (wavelengths * u.m).to(u.nm)
 
-    true_params = copy.deepcopy(params)
+    true_params = copy.deepcopy(params)  # noqa: F841
 
     skeys = list(settings.keys())
     pkeys = list(params.keys())
@@ -778,7 +778,11 @@ def run_fit(
             )
 
     # Make the model, then perform the fit
-    model = thomson.spectral_density_model(wavelengths.to(u.m).value, settings, params)
+    model = thomson.spectral_density_model(
+        wavelengths.to(u.m).value,
+        settings,
+        params,
+    )
 
     if run_fit:
         result = model.fit(
@@ -1207,7 +1211,7 @@ def test_fit_with_minimal_parameters():
     # Make the model, then perform the fit
     model = thomson.spectral_density_model(wavelengths.to(u.m).value, settings, params)
 
-    result = model.fit(
+    result = model.fit(  # noqa: F841
         data,
         params,
         wavelengths=wavelengths.to(u.m).value,

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -658,7 +658,7 @@ def test_param_to_array_fcns():
 
     prefix = "ion_vel"
     for i in range(2):
-        for j in ["x", "y", "z"]:
+        for j in ("x", "y", "z"):
             params.add(f"{prefix}_{j}_{i}", value=2)
 
     arr = thomson._params_to_array(params, "T_e", vector=False)

--- a/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/plasmapy/dispersion/analytical/two_fluid_.py
@@ -271,7 +271,7 @@ def two_fluid(
 
     # validate argument k
     k = k.squeeze()
-    if k.ndim not in [0, 1]:
+    if k.ndim not in (0, 1):
         raise ValueError(
             f"Argument 'k' needs to be a single valued or 1D array astropy Quantity,"
             f" got array of shape {k.shape}."
@@ -281,7 +281,7 @@ def two_fluid(
 
     # validate argument theta
     theta = theta.squeeze()
-    if theta.ndim not in [0, 1]:
+    if theta.ndim not in (0, 1):
         raise ValueError(
             f"Argument 'theta' needs to be a single valued or 1D array astropy "
             f"Quantity, got array of shape {k.shape}."

--- a/plasmapy/dispersion/numerical/hollweg_.py
+++ b/plasmapy/dispersion/numerical/hollweg_.py
@@ -250,7 +250,7 @@ def hollweg(
 
     # validate argument k
     k = k.squeeze()
-    if k.ndim not in [0, 1]:
+    if k.ndim not in (0, 1):
         raise ValueError(
             f"Argument 'k' needs to be single valued or a 1D array astropy Quantity,"
             f" got array of shape {k.shape}."

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -591,7 +591,7 @@ def test_ionic_levels_example():
         ("C", 3, 5, [3, 4, 5]),
     ],
 )
-def test_ion_list(particle, min_charge, max_charge, expected_charge_numbers):
+def test_ion_list2(particle, min_charge, max_charge, expected_charge_numbers):
     """Test that inputs to ionic_levels are interpreted correctly."""
     particle = Particle(particle)
     ions = ionic_levels(particle, min_charge, max_charge)
@@ -604,6 +604,6 @@ def test_ion_list(particle, min_charge, max_charge, expected_charge_numbers):
 @pytest.mark.parametrize(
     "element, min_charge, max_charge", [("Li", 0, 4), ("Li", 3, 2)]
 )
-def test_invalid_inputs_to_ion_list(element, min_charge, max_charge):
+def test_invalid_inputs_to_ion_list2(element, min_charge, max_charge):
     with pytest.raises(ChargeError):
         ionic_levels(element, min_charge, max_charge)

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -169,7 +169,7 @@ class TestIonizationStateCollection:
     def test_that_abundances_kwarg_sets_abundances(self, test_name):
         try:
             actual_abundances = self.instances[test_name].abundances
-        except Exception as exc:
+        except Exception:
             pytest.fail("Unable to access abundances.")
 
         elements = set(self.instances[test_name].base_particles)
@@ -258,15 +258,15 @@ class TestIonizationStateCollection:
 
             try:
                 expected = instance.ionic_fractions[key]
-            except Exception as exc:
+            except Exception:
                 pytest.fail(
                     f"Unable to get ionic_fractions for '{key}' in test='{test_name}'."
                 )
 
             try:
                 actual = instance[key].ionic_fractions
-            except Exception as exc:
-                pytest(f"Unable to get item {key} in test={test_name}.")
+            except Exception:
+                pytest.fail(f"Unable to get item {key} in test={test_name}.")
 
             try:
                 if all(np.isnan(expected)):
@@ -850,7 +850,7 @@ def test_iteration_with_nested_iterator():
 
 @pytest.mark.xfail()
 def test_two_isotopes_of_same_element():
-    instance = IonizationStateCollection(["H-1", "D"])
+    IonizationStateCollection(["H-1", "D"])
 
 
 example_ionic_fractions = [

--- a/plasmapy/particles/tests/test_nuclear.py
+++ b/plasmapy/particles/tests/test_nuclear.py
@@ -96,7 +96,7 @@ def test_nuclear_reaction_energy_kwargs(reactants, products, expectedMeV, tol):
     assert np.isclose(expected.value, energy.value, atol=tol)
 
 
-def test_nuclear_reaction_energy():
+def test_nuclear_reaction_energy2():
     reactants = ["D", "T"]
     products = ["alpha", "n"]
     expected = 17.6 * u.MeV

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -518,7 +518,7 @@ def test_Particle_class(arg, kwargs, expected_dict):
     errmsg = ""
 
     try:
-        particle = Particle(arg, **kwargs)
+        particle = Particle(arg, **kwargs)  # noqa: F841
     except Exception as exc:
         raise ParticleError(f"Problem creating {call}") from exc
 
@@ -1502,7 +1502,7 @@ test_molecule_error_table = [
 def test_molecule_error(symbol, Z):
     """Test the error raised in case of a bad molecule symbol."""
     with pytest.raises(InvalidParticleError):
-        m = molecule(symbol, Z)
+        molecule(symbol, Z)
 
 
 def test_molecule_other():

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -426,7 +426,6 @@ particle_multiplicities = [
     {CustomParticle(mass=1 * u.kg, charge=1 * u.C): 1},
     {"p+": 5, CustomParticle(mass=1 * u.kg, charge=1 * u.C): 1},
     {CustomParticle(): 1},
-    {"p+": 2, "p+": 1},
 ]
 
 

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -211,7 +211,7 @@ class AbstractGrid(ABC):
         ax_units = self.units
         ax_dtypes = [self.ds[i].dtype for i in coords]
 
-        coord_lbls = [f"{str(i)}: {str(j)}" for i, j in zip(coords, shape)]
+        coord_lbls = [f"{i}: {j}" for i, j in zip(coords, shape)]
 
         s = f"*** Grid Summary ***\n{type(self)}\n"
 
@@ -285,8 +285,8 @@ class AbstractGrid(ABC):
         r"""Shape of the grid"""
         if self.is_uniform:
             return (self.ax0.size, self.ax1.size, self.ax2.size)
-        else:
-            return self.ds.coords["ax0"].shape
+
+        return self.ds.coords["ax0"].shape
 
     @property
     def grids(self):
@@ -370,7 +370,7 @@ class AbstractGrid(ABC):
         `ValueError`
             If all grid dimensions do not have identical units.
         """
-        if self.units[0] == self.units[1] and self.units[0] == self.units[2]:
+        if self.units[0] == self.units[1] == self.units[2]:
             return self.units[0]
         else:
             raise ValueError(
@@ -713,7 +713,7 @@ class AbstractGrid(ABC):
         # Ensure that start and stop end up as a list of three u.Quantity objs
         # and num a list of three integers
         # TODO python3.10: simplify using structural pattern matching
-        for k in ["start", "stop"]:
+        for k in ("start", "stop"):
             # Convert tuple to list
             if isinstance(var[k], tuple):
                 var[k] = list(var[k])
@@ -1305,14 +1305,14 @@ class CartesianGrid(AbstractGrid):
 
         # Split output array into arrays with units
         # Apply units to output arrays
-        output = []
-        for arg in range(nargs):
-            output.append(weighted_ave[..., arg] * self._interp_units[arg])
+        output = [
+            weighted_ave[..., arg] * self._interp_units[arg] for arg in range(nargs)
+        ]
 
         if len(output) == 1:
             return output[0]
-        else:
-            return tuple(output)
+
+        return tuple(output)
 
 
 class NonUniformCartesianGrid(AbstractGrid):
@@ -1440,11 +1440,6 @@ class NonUniformCartesianGrid(AbstractGrid):
 
         vals[mask_particle_off] = np.nan
 
-        output = []
-        for arg in range(len(args)):
-            output.append(vals[:, arg] * self._interp_units[arg])
+        output = [vals[:, arg] * self._interp_units[arg] for arg in range(len(args))]
 
-        if len(output) == 1:
-            return output[0]
-        else:
-            return tuple(output)
+        return output[0] if len(output) == 1 else tuple(output)

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -18,7 +18,7 @@ class BasePlasma(ABC):
     """
 
     # GenericPlasma subclass registry
-    _registry = dict()
+    _registry = {}
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -908,9 +908,6 @@ def test_NonUniformCartesianGrid():
 
     pts0, pts1, pts2 = grid.grids
 
-    shape = grid.shape
-    units = grid.units
-
     grid.add_quantities(x=pts0)
     print(grid)
 

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -939,7 +939,7 @@ def test_NonUniformCartesianGrid():
     L0 = [-1 * u.mm, 0 * u.rad, -1 * u.mm]
     L1 = [1 * u.mm, 2 * np.pi * u.rad, 1 * u.mm]
     with pytest.raises(ValueError):
-        grid = grids.NonUniformCartesianGrid(L0, L1, num=10)
+        grids.NonUniformCartesianGrid(L0, L1, num=10)
 
 
 def debug_volume_avg_interpolator():


### PR DESCRIPTION
This PR applies changes from `ruff` and `refurb` on a few other subpackages.  This follows up on #1845, #1846, and #1847. 