### PR TITLE
Add `ruff` to `pre-commit` configuration

### DIFF
--- a/.github/workflows/citation_updater.py
+++ b/.github/workflows/citation_updater.py
@@ -43,7 +43,7 @@ def update_citation_files(args):
     citation_rst_file = pathlib.Path(args.citation_rst_file)
     citation_rst_text = citation_rst_file.read_text()
 
-    for source_regex, target_value in [
+    for source_regex, target_value in (
         (
             r"\|version_to_cite\| replace:: (.*)",
             f"|version_to_cite| replace:: {args.version}",
@@ -54,9 +54,9 @@ def update_citation_files(args):
         ),
         (
             r"\|citation_year\| replace:: (.*)",
-            f"|citation_year| replace:: {str(args.date_released.year)}",
+            f"|citation_year| replace:: {args.date_released.year}",
         ),
-    ]:
+    ):
         citation_rst_text = re.compile(source_regex).sub(
             target_value, citation_rst_text
         )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,52 @@ repos:
   - id: check-toml
   - id: check-yaml
 
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+  - id: pretty-format-ini
+    args: [--autofix]
+  - id: pretty-format-toml
+    args: [--autofix]
+  - id: pretty-format-yaml
+    args: [--autofix]
+
+- repo: https://github.com/pre-commit/mirrors-csslint
+  rev: v1.0.5
+  hooks:
+  - id: csslint
+
+- repo: https://github.com/MarcoGorelli/absolufy-imports
+  rev: v0.3.1
+  hooks:
+  - id: absolufy-imports
+    exclude: docs/plasmapy_sphinx
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.2.2
+  hooks:
+  - id: pyupgrade
+    args: [--keep-runtime-typing, --py38-plus]
+    files: ^plasmapy/
+
+- repo: https://github.com/pre-commit/pygrep-hooks
+  rev: v1.9.0
+  hooks:
+  - id: rst-directive-colons
+  - id: rst-inline-touching-normal
+
+- repo: https://github.com/dosisod/refurb
+  rev: v1.9.0
+  hooks:
+  - id: refurb
+    exclude: docs/plasmapy_sphinx
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.192
+  hooks:
+  - id: ruff
+    args: [--force-exclude]
+
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:
@@ -58,37 +104,3 @@ repos:
     - isort==5.10.1
     args:
     - --nbqa-mutate
-
-- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.4.0
-  hooks:
-  - id: pretty-format-ini
-    args: [--autofix]
-  - id: pretty-format-toml
-    args: [--autofix]
-  - id: pretty-format-yaml
-    args: [--autofix]
-
-- repo: https://github.com/pre-commit/mirrors-csslint
-  rev: v1.0.5
-  hooks:
-  - id: csslint
-
-- repo: https://github.com/MarcoGorelli/absolufy-imports
-  rev: v0.3.1
-  hooks:
-  - id: absolufy-imports
-    exclude: docs/plasmapy_sphinx
-
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.2.2
-  hooks:
-  - id: pyupgrade
-    args: [--keep-runtime-typing, --py38-plus]
-    files: ^plasmapy/
-
-- repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.9.0
-  hooks:
-  - id: rst-directive-colons
-  - id: rst-inline-touching-normal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,12 +56,6 @@ repos:
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
 
-- repo: https://github.com/dosisod/refurb
-  rev: v1.9.0
-  hooks:
-  - id: refurb
-    exclude: docs/plasmapy_sphinx
-
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.192
   hooks:

--- a/changelog/1854.trivial.rst
+++ b/changelog/1854.trivial.rst
@@ -1,0 +1,1 @@
+Added `ruff <https://github.com/charliermarsh/ruff>`__ and `refurb <https://github.com/dosisod/refurb>`__ to the ``pre-commit`` configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,8 +247,10 @@ looponfailroots = "plasmapy"
 target-version = "py38"
 exclude = [
     ".direnv",
+    "docs/plasmapy_sphinx",
     ".eggs",
     ".git",
+    ".jupyter",
     ".mypy_cache",
     ".nox",
     ".ruff_cache",


### PR DESCRIPTION
This PR is the final in the series of PRs to get [`ruff`](https://github.com/charliermarsh/ruff) ~~and [`refurb`](https://github.com/dosisod/refurb)~~ applied to the repo and into our `pre-commit` suite.  

`ruff` is awesome in that it runs really quickly (since it's written in Rust) and automagically applies a lot of fixes that would be found by `flake8`. We might have some duplication between `flake8` and `ruff`, but it'd be helpful to keep both for the time being.

~~A less nice thing about `refurb` is that it takes a long time to run compared to other pre-commit hooks. However, some of the fixes that refurb caught were pretty important.  In particular, it caught a couple of cases where there were two tests named the same thing, which probably meant that the first of those tests were not being run.~~

We should also keep in mind if there are any `ruff` ~~or `refurb`~~ error codes that we'd want to ignore.  