### PR TITLE
Fix version of GitHub Action

### DIFF
--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -36,7 +36,7 @@ jobs:
     name: Checklist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v0.1.0
+    - uses: actions/checkout@v3
     - uses: harupy/comment-on-pr@v0.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the error I introduced in #1852 (oops!) by reverting the version of `actions/checkout` to `v3` instead of the incorrect `v0.1.0`.