### PR TITLE
Pin GitHub Action to a specific commit

### DIFF
--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: harupy/comment-on-pr@v0.1.0
+    - uses: harupy/comment-on-pr@dcff01407df59b61be9db68aeb3d1c6ddb21a3c0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
This follows up on the error I introduced in #1850 and successfully didn't fix in #1855.  I'm going to briefly give myself admin superpowers once again to merge this to make sure it works.