### PR TITLE
Revert updates to GitHub Action

### DIFF
--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -1,7 +1,7 @@
 name: Add comment
 
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   greeting:

--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -1,7 +1,7 @@
 name: Add comment
 
 on:
-- pull_request_target
+- pull_request
 
 jobs:
   greeting:

--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -36,8 +36,8 @@ jobs:
     name: Checklist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v0.1.0
-    - uses: harupy/comment-on-pr@v0.1.0
+    - uses: actions/checkout@master
+    - uses: harupy/comment-on-pr@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: harupy/comment-on-pr@dcff01407df59b61be9db68aeb3d1c6ddb21a3c0
+    - uses: harupy/comment-on-pr@v0.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -36,7 +36,7 @@ jobs:
     name: Checklist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: harupy/comment-on-pr@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_comments.yml
+++ b/.github/workflows/add_comments.yml
@@ -36,7 +36,7 @@ jobs:
     name: Checklist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v0.1.0
     - uses: harupy/comment-on-pr@v0.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR reverts #1857, #1855, and #1852 to go back to...I hope...the last commit where the GitHub Action to post the code review checklist was actually working.  This has been an adventure (sigh).  

I'm temporarily changing `pull_request_target` to `pull_request`, which after reading the docs, I think will let me test this GA while it's still in the PR stage.  

Update: ↑ doesn't actually let me check the action, since it requires permissions (sigh).  