### PR TITLE
Adjust ruff for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
   rev: v0.0.192
   hooks:
   - id: ruff
-    args: [--force-exclude]
+    args: [--force-exclude, --fix]
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1


### PR DESCRIPTION
`ruff`, added in #1854, was missing the `--fix` flag. We can use that one to have pre-commit.ci autofix work as expected.
