### PR TITLE
Expand charge number functionality for `CustomParticle`

### DIFF
--- a/changelog/1866.feature.1.rst
+++ b/changelog/1866.feature.1.rst
@@ -1,0 +1,2 @@
+Added ``Z`` as a |keyword-only| |parameter| representing the
+|charge number| to |CustomParticle|.

--- a/changelog/1866.feature.2.rst
+++ b/changelog/1866.feature.2.rst
@@ -1,0 +1,2 @@
+Added the `~plasmapy.particles.particle_class.CustomParticle.charge_number`
+attribute to |CustomParticle|.

--- a/changelog/1866.removal.rst
+++ b/changelog/1866.removal.rst
@@ -1,0 +1,2 @@
+Deprecated providing a real number to the ``charge`` parameter of
+|CustomParticle| to represent the |charge number|. Use ``Z`` instead.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2155,20 +2155,22 @@ class CustomParticle(AbstractPhysicalParticle):
             'module': 'plasmapy.particles.particle_class',
             'date_created': '...',
             '__init__': {'args': (), 'kwargs': {'mass': '5.12 kg', 'charge': '6.2 C',
-            'symbol': 'ξ'}}}}
+            'charge_number': '3.869735626...e+19', 'symbol': 'ξ'}}}}
         >>> import pytest
         >>> custom_particle = CustomParticle(mass=1.5e-26 * u.kg)
         >>> custom_particle.json_dict
         {'plasmapy_particle': {'type': 'CustomParticle',
             'module': 'plasmapy.particles.particle_class',
             'date_created': '...',
-            '__init__': {'args': (), 'kwargs': {'mass': '1.5e-26 kg', 'charge': 'nan C',
+            '__init__': {'args': (), 'kwargs': {'mass': '1.5e-26 kg',
+            'charge': 'nan C', 'charge_number': 'nan',
             'symbol': 'CustomParticle(mass=1.5e-26 kg, charge=nan C)'}}}}
         """
         particle_dictionary = super().json_dict
         particle_dictionary["plasmapy_particle"]["__init__"]["kwargs"] = {
             "mass": str(self.mass),
             "charge": str(self.charge),
+            "charge_number": str(self.charge_number),
             "symbol": self.symbol,
         }
         return particle_dictionary

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from numbers import Integral, Real
-from typing import Iterable, NoReturn, Optional, Sequence, Set, Union
+from typing import Dict, Iterable, NoReturn, Optional, Sequence, Set, Union
 
 from plasmapy.particles import _elements, _isotopes, _parsing, _special_particles
 from plasmapy.particles.exceptions import (
@@ -2079,9 +2079,9 @@ class CustomParticle(AbstractPhysicalParticle):
         self,
         mass: u.kg = None,
         charge: u.C = None,
-        symbol=None,
+        symbol: Optional[str] = None,
         *,
-        Z: Real = None,
+        Z: Optional[Real] = None,
     ):
 
         if isinstance(charge, Real):
@@ -2107,7 +2107,7 @@ class CustomParticle(AbstractPhysicalParticle):
                 f"{mass} and a charge of {charge}."
             ) from exc
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         """
         Return a string representation of a |CustomParticle|.
 
@@ -2136,7 +2136,7 @@ class CustomParticle(AbstractPhysicalParticle):
         )
 
     @property
-    def json_dict(self) -> dict:
+    def json_dict(self) -> Dict[str, str]:
         """
         A `json` friendly dictionary representation of the |CustomParticle|.
 
@@ -2223,7 +2223,7 @@ class CustomParticle(AbstractPhysicalParticle):
             )
 
     @property
-    def charge_number(self):
+    def charge_number(self) -> Real:
         """The ratio of the charge to the elementary charge."""
         return self.charge / const.e.si
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2082,10 +2082,11 @@ class CustomParticle(AbstractPhysicalParticle):
         Z: Optional[Real] = None,
     ):
 
+        # TODO py3.10 replace ifology with structural pattern matching
         if isinstance(charge, Real):
             warnings.warn(
-                "Providing a real number to 'charge' is deprecated. Use "
-                "'Z' as a keyword argument instead.",
+                "Providing a real number to 'charge' is deprecated. To specify the charge as a multiple of the elementary charge, use "
+                "'Z' as a keyword argument instead, or pass e.g. `2 * u.e.si` into `charge`.",
                 PlasmaPyDeprecationWarning,
             )
 
@@ -2105,7 +2106,7 @@ class CustomParticle(AbstractPhysicalParticle):
                 f"{mass} and a charge of {charge}."
             ) from exc
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a string representation of a |CustomParticle|.
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2194,6 +2194,12 @@ class CustomParticle(AbstractPhysicalParticle):
             warnings.warn(
                 f"CustomParticle charge set to {q} times the elementary charge."
             )
+            warnings.warn(
+                "The ability to provide a real number to the 'charge' "
+                "parameter to has been deprecated and will be removed "
+                "in a future release of PlasmaPy. Use 'Z' instead.",
+                PlasmaPyDeprecationWarning,
+            )
         elif isinstance(q, u.Quantity):
             if not isinstance(q.value, Real):
                 raise InvalidParticleError(

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2083,12 +2083,6 @@ class CustomParticle(AbstractPhysicalParticle):
     ):
 
         # TODO py3.10 replace ifology with structural pattern matching
-        if isinstance(charge, Real):
-            warnings.warn(
-                "Providing a real number to 'charge' is deprecated. To specify the charge as a multiple of the elementary charge, use "
-                "'Z' as a keyword argument instead, or pass e.g. `2 * u.e.si` into `charge`.",
-                PlasmaPyDeprecationWarning,
-            )
 
         if Z is not None and charge is not None:
             raise TypeError("CustomParticle can accept only one of Z and charge.")
@@ -2194,9 +2188,10 @@ class CustomParticle(AbstractPhysicalParticle):
                 f"CustomParticle charge set to {q} times the elementary charge."
             )
             warnings.warn(
-                "The ability to provide a real number to the 'charge' "
-                "parameter to has been deprecated and will be removed "
-                "in a future release of PlasmaPy. Use 'Z' instead.",
+                "Providing a real number to 'charge' is deprecated. To "
+                "specify the charge as a multiple of the elementary "
+                "charge, use 'Z' as a keyword argument instead, or pass, "
+                "e.g., '2 * astropy.constants.e.si' into 'charge'.",
                 PlasmaPyDeprecationWarning,
             )
         elif isinstance(q, u.Quantity):
@@ -2225,6 +2220,10 @@ class CustomParticle(AbstractPhysicalParticle):
     def charge_number(self) -> Real:
         """The ratio of the charge to the elementary charge."""
         return self.charge / const.e.si
+
+    @charge_number.setter
+    def charge_number(self, Z: int):
+        self._charge = Z * const.e.si
 
     @property
     def mass(self) -> u.kg:

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2020,7 +2020,7 @@ class CustomParticle(AbstractPhysicalParticle):
         The mass of the custom particle in units of mass.  Defaults to
         |nan| kg.
 
-    charge : ~astropy.units.Quantity, optional
+    charge : ~astropy.units.Quantity or ~numbers.Real, optional
         The electric charge of the custom particle.  If provided as a
         `~astropy.units.Quantity`, then it must be in units of electric
         charge. Defaults to |nan| C.
@@ -2060,7 +2060,6 @@ class CustomParticle(AbstractPhysicalParticle):
     <Quantity 1.2e-26 kg>
     >>> custom_particle.charge
     <Quantity 9.2e-19 C>
-
     >>> average_particle = CustomParticle(
     ...     mass=1.5e-26 * u.kg,
     ...     Z = -1.5,
@@ -2070,7 +2069,6 @@ class CustomParticle(AbstractPhysicalParticle):
     <Quantity 1.5e-26 kg>
     >>> average_particle.charge
     <Quantity -2.40326...e-19 C>
-
     >>> average_particle.symbol
     'Ξ'
     """

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2215,6 +2215,11 @@ class CustomParticle(AbstractPhysicalParticle):
             )
 
     @property
+    def charge_number(self):
+        """The ratio of the charge to the elementary charge."""
+        return self.charge / const.e.si
+
+    @property
     def mass(self) -> u.kg:
         """The mass of the |CustomParticle|."""
         return self._mass

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1381,12 +1381,13 @@ particle_json_repr_table = [
     ),
     (
         CustomParticle,
-        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C, "symbol": "ξ"},
+        {"mass": 5.12 * u.kg, "charge": 6.2e-19 * u.C, "symbol": "ξ"},
         '{"plasmapy_particle": {"type": "CustomParticle", \
         "module": "plasmapy.particles.particle_class", \
         "date_created": "...", "__init__": {\
             "args": [], \
-            "kwargs": {"mass": "5.12 kg", "charge": "6.2 C", "symbol": "ξ"}}}}',
+            "kwargs": {"mass": "5.12 kg", "charge": "6.2e-19 C", \
+            "charge_number": "3.869735626165673", "symbol": "ξ"}}}}',
     ),
     (
         DimensionlessParticle,

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1477,6 +1477,22 @@ def test_CustomParticle_cmp():
     assert particle1 != 1
 
 
+@pytest.mark.parametrize(
+    "attr, input",
+    [
+        ("charge", 2 * u.C),
+        ("mass", 2 * u.kg),
+        ("charge_number", 2),
+        ("symbol", "😺"),
+    ],
+)
+def test_CustomParticle_setters(attr, input):
+    custom_particle = CustomParticle()
+    setattr(custom_particle, attr, input)
+    output = getattr(custom_particle, attr)
+    assert input == output
+
+
 test_molecule_table = [
     (2 * 126.90447 * u.u, 0 * u.C, "I2", "I2", None),
     (2 * 126.90447 * u.u, e.si, "I2 1+", "I2 1+", None),

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -975,7 +975,7 @@ customized_particle_tests = [
 
 
 @pytest.mark.parametrize("cls, kwargs, attr, expected", customized_particle_tests)
-def test_customized_particles(cls, kwargs, attr, expected):
+def test_custom_particles(cls, kwargs, attr, expected):
     """Test the attributes of dimensionless and custom particles."""
     instance = cls(**kwargs)
     value = getattr(instance, attr)

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -967,6 +967,10 @@ customized_particle_tests = [
     (CustomParticle, {"mass": "100.0 g"}, "mass", 100.0 * u.g),
     (CustomParticle, {"charge": -np.inf * u.kC}, "charge", -np.inf * u.C),
     (CustomParticle, {"charge": "5.0 C"}, "charge", 5.0 * u.C),
+    (CustomParticle, {"Z": 1}, "charge", const.e.si),
+    (CustomParticle, {"Z": 1.5}, "charge", 1.5 * const.e.si),
+    (CustomParticle, {"Z": 1.5}, "charge_number", 1.5),
+    (CustomParticle, {"charge": 1.3 * const.e.si}, "charge_number", 1.3),
 ]
 
 
@@ -1073,6 +1077,7 @@ custom_particle_errors = [
     (CustomParticle, {"mass": np.complex128(5 + 2j) * u.kg}, InvalidParticleError),
     (CustomParticle, {"charge": "not a charge"}, InvalidParticleError),
     (CustomParticle, {"charge": "5.0 km"}, InvalidParticleError),
+    (CustomParticle, {"charge": 1 * u.C, "charge_number": -1}, TypeError),
 ]
 
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1073,7 +1073,7 @@ custom_particle_errors = [
     (CustomParticle, {"mass": np.complex128(5 + 2j) * u.kg}, InvalidParticleError),
     (CustomParticle, {"charge": "not a charge"}, InvalidParticleError),
     (CustomParticle, {"charge": "5.0 km"}, InvalidParticleError),
-    (CustomParticle, {"charge": 1 * u.C, "charge_number": -1}, TypeError),
+    (CustomParticle, {"charge": 1 * u.C, "Z": -1}, TypeError),
 ]
 
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -945,10 +945,6 @@ def test_that_object_can_be_dict_key(key):
     assert dictionary[key] is value
 
 
-# TODO: These tests may be refactored using forthcoming functionality in
-#       plasmapy.tests.helpers.  It may be necessary to case the expected
-#       results as certain types (e.g., numpy.float64).
-
 customized_particle_tests = [
     (DimensionlessParticle, {"mass": 1.0, "charge": -1.0}, "mass", 1.0),
     (DimensionlessParticle, {"mass": 0.0, "charge": -1.0}, "charge", -1.0),


### PR DESCRIPTION
## Description

I made the following changes to `CustomParticle`:

- Added `Z` as a keyword-only parameter (which can be real, and not just an integer)
- Added the `charge_number` attribute
- Updated the serialization functionality

## Motivation and context

Long story short, this is to make it easier to change `particle_input` and the particle factory function to allow non-integer charges, which will allow `particle_input` to decorate functions that have `Z_mean` as a parameter, and thus let us deprecate `Z_mean` in favor of `Z`.