### PR TITLE
Use `pyproject-fmt` instead of `pretty-format-toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,13 @@ repos:
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
-  - id: pretty-format-toml
-    args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix]
+
+- repo: https://github.com/tox-dev/pyproject-fmt
+  rev: 0.4.1
+  hooks:
+  - id: pyproject-fmt
 
 - repo: https://github.com/pre-commit/mirrors-csslint
   rev: v1.0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   "setuptools>=61.2",
   "setuptools-scm",
   "wheel>=0.29",
-]  # ought to mirror 'requirements/build.txt'
+]
 
 [project]
 name = "plasmapy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,46 @@
 [build-system]
-requires = ["setuptools>=61.2",
-            "setuptools-scm",
-            "wheel >= 0.29.0"]  # ought to mirror 'requirements/build.txt'
 build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools>=61.2",
+  "setuptools-scm",
+  "wheel>=0.29",
+]  # ought to mirror 'requirements/build.txt'
 
 [project]
 name = "plasmapy"
 description = "Python package for plasma physics"
 readme = "README.md"
+keywords = [
+  "atomic",
+  "plasma",
+  "plasma physics",
+  "science",
+]
 license = {file = "LICENSE.md"}
-keywords = ["plasma physics", "plasma", "science", "atomic"]
-dynamic = ["version"]
+requires-python = ">=3.8"
+dependencies = [
+  "astropy>=5.0.1",
+  "cached-property>=1.5.2",
+  "h5py>=3",
+  "ipywidgets>=7.6.5",
+  "lmfit>=1",
+  "matplotlib>=3.3",
+  "mpmath>=1.2.1",
+  "numba",
+  "numpy>=1.20",
+  "packaging",
+  "pandas>=1",
+  "pytest>=6",
+  "requests>=2.27.1",
+  "scipy>=1.5",
+  "tqdm>=4.41",
+  "voila>=0.2.15",
+  "wrapt",
+  "xarray>=0.15",
+]
+dynamic = [
+  "version",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
@@ -24,81 +54,60 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
-requires-python = ">=3.8"
-dependencies = [
-    "astropy >= 5.0.1",
-    "cached-property >= 1.5.2",
-    "h5py >= 3.0.0",
-    "ipywidgets >= 7.6.5",
-    "lmfit >= 1.0.0",
-    "matplotlib >= 3.3.0",
-    "mpmath >= 1.2.1",
-    "numba",
-    "numpy >= 1.20.0",
-    "packaging",
-    "pandas >= 1.0.0",
-    "pytest >= 6.0",
-    "scipy >= 1.5.0",
-    "tqdm >= 4.41.0",
-    "voila >= 0.2.15",
-    "wrapt",
-    "xarray >= 0.15.0",
-    "requests >= 2.27.1",
+[project.optional-dependencies]
+docs = [
+  "docutils",
+  "ipykernel",
+  "jinja2!=3.1",
+  "nbsphinx",
+  "numpydoc",
+  "pillow",
+  "pygments>=2.11",
+  "sphinx!=5.1,>=4.4",
+  "sphinx-changelog>=1.2",
+  "sphinx-copybutton",
+  "sphinx-gallery<0.11.0",
+  "sphinx-hoverxref>=1.1.1",
+  "sphinx-issues>=3.0.1",
+  "sphinx-notfound-page>=0.8",
+  "sphinx-reredirects",
+  "sphinx_rtd_theme>=1",
+  "sphinxcontrib-bibtex",
+  "towncrier==22.8",
+  "tox<4",
+]
+tests = [
+  "codespell@ git+https://github.com/codespell-project/codespell/",
+  "dlint",
+  "flake8",
+  "flake8-absolute-import",
+  "flake8-implicit-str-concat",
+  "flake8-mutable",
+  "flake8-rst-docstrings",
+  "flake8-simplify",
+  "flake8-use-fstring",
+  "hypothesis",
+  "pre-commit",
+  "pydocstyle",
+  "pytest-regressions",
+  "pytest-xdist",
+  "tomli",
+  "tox<4",
+  "tryceratops",
 ]
 
-[project.optional-dependencies]
-tests = [
-    "codespell @ git+https://github.com/codespell-project/codespell/",
-    "pre-commit",
-    "tox<4",
-    "dlint",
-    "flake8",
-    "flake8-absolute-import",
-    "flake8-implicit-str-concat",
-    "flake8-mutable",
-    "flake8-rst-docstrings",
-    "flake8-simplify",
-    "flake8-use-fstring",
-    "hypothesis",
-    "pydocstyle",
-    "pytest-regressions",
-    "pytest-xdist",
-    "tomli",
-    "tryceratops",
-]
-docs = [
-    "tox<4",
-    "docutils",
-    "ipykernel",
-    "jinja2 != 3.1",
-    "nbsphinx",
-    "numpydoc",
-    "pillow",
-    "pygments >= 2.11.0",
-    "sphinx >= 4.4, != 5.1",
-    "sphinx-changelog >= 1.2.0",
-    "sphinx-copybutton",
-    "sphinx-gallery < 0.11.0",
-    "sphinx-hoverxref >= 1.1.1",
-    "sphinx-issues >= 3.0.1",
-    "sphinx-notfound-page >= 0.8",
-    "sphinx-reredirects",
-    "sphinx_rtd_theme >= 1.0.0",
-    "sphinxcontrib-bibtex",
-    "towncrier == 22.8.0",
-]
+[project.urls]
+Changelog = "https://docs.plasmapy.org/en/stable/whatsnew/index.html"
+Chat = "https://plasmapy.org/chat"
+Documentation = "https://docs.plasmapy.org/"
+Issues = "https://github.com/plasmapy/plasmapy/issues/"
+Source = "https://github.com/plasmapy/plasmapy"
+Twitter = "https://twitter.com/PlasmaPy"
+website = "https://www.plasmapy.org"
 
 [project.scripts]
 plasma-calculator = "plasmapy.utils.calculator:main"
 
-[project.urls]
-website = "https://www.plasmapy.org"
-Documentation = "https://docs.plasmapy.org/"
-Changelog = "https://docs.plasmapy.org/en/stable/whatsnew/index.html"
-Source = "https://github.com/plasmapy/plasmapy"
-Issues = "https://github.com/plasmapy/plasmapy/issues/"
-Twitter = "https://twitter.com/PlasmaPy"
-Chat = "https://plasmapy.org/chat"
 
 [tool.build_docs]
 source-dir = "docs"


### PR DESCRIPTION
## Description

This PR adds a pre-commit hook using [`pyproject-fmt`](https://pyproject-fmt.readthedocs.io/en/latest/) and drops the pre-commit hook using `pretty-format-toml`.  

## Motivation and context

It looks like the only TOML file that we have is our `pyproject.toml`, so it makes sense to use a tool that has more specific and standardized formatting for `pyproject.toml`s.  (Or is it `pyprojects.toml`?  I don't know what the plural of `pyproject.toml` is.)

We're also running into a problem with our pre-commit config due to a new inconsistency upstream of `pretty-format-toml`.  Removing `pretty-format-toml` will address this problem (though that issue will probably get fixed in a few days anyway).

This time I did *not* hear about this tool from a podcast!  I read about it in the show notes of a podcast instead. 😬 


<!-- Please link to any related issues and PRs. If this PR will fully resolve and issue, include text like "Closes #1542" so that the issue will be automatically closed when this PR is merged. -->
