### PR TITLE
Update changelog entries and author lists

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,7 +44,6 @@ authors:
 - given-names: Dominik
   family-names: Stańczak-Marikin
   email: stanczakdominik@gmail.com
-  affiliation: IPPLM  # double check!
   orcid: https://orcid.org/0000-0001-6291-8843
   alias: StanczakDominik
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -133,6 +133,12 @@ authors:
   family-names: Deal
   alias: Jac0bDeal
 
+- given-names: Gregor
+  family-names: Decristoforo
+  affiliation: UiT The Arctic University of Norway
+  orcid: 0000-0002-7616-0946
+  alias: gregordecristoforo
+
 - given-names: Diego A.
   family-names: Diaz Riega
   alias: diego7319
@@ -308,6 +314,11 @@ authors:
 - given-names: Joao Victor
   family-names: Martinelli
   alias: JvPy
+
+- given-names: Muhammad
+  family-names: Masood
+  affiliation: University of Edinburgh
+  alias: MuhammadHMasood
 
 - given-names: Isaias
   family-names: McHardy
@@ -500,15 +511,21 @@ authors:
   orcid: https://orcid.org/0000-0002-8335-1441
   alias: tien-vo
 
-- given-names: Tingfeng
-  family-names: Wu
-  orcid: https://orcid.org/0000-0001-8745-204X
-  alias: elliotwutingfeng
-
 - given-names: Veronica
   family-names: Tranquilino
   affiliation: University of Michigan
   alias: tranqver
+
+- given-names: Steve
+  family-names: Vincena
+  affiliation: UCLA
+  orcid: https://orcid.org/0000-0002-6468-5710
+  alias: svincena
+
+- given-names: Tingfeng
+  family-names: Wu
+  orcid: https://orcid.org/0000-0001-8745-204X
+  alias: elliotwutingfeng
 
 - given-names: Sixue
   family-names: Xu

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,9 +42,9 @@ authors:
   alias: rocco8773
 
 - given-names: Dominik
-  family-names: Stańczak
+  family-names: Stańczak-Marikin
   email: stanczakdominik@gmail.com
-  affiliation: IPPLM
+  affiliation: IPPLM  # double check!
   orcid: https://orcid.org/0000-0001-6291-8843
   alias: StanczakDominik
 
@@ -465,6 +465,11 @@ authors:
   family-names: Smirnov
   alias: Nismirno
 
+- given-names: Stuart
+  family-names: Sobeske
+  affiliation: University of Michigan
+  alias: Sobeskes
+
 - given-names: David
   family-names: Stansby
   affiliation: Mullard Space Science Laboratory
@@ -499,6 +504,11 @@ authors:
   family-names: Wu
   orcid: https://orcid.org/0000-0001-8745-204X
   alias: elliotwutingfeng
+
+- given-names: Veronica
+  family-names: Tranquilino
+  affiliation: University of Michigan
+  alias: tranqver
 
 - given-names: Sixue
   family-names: Xu

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -136,7 +136,7 @@ authors:
 - given-names: Gregor
   family-names: Decristoforo
   affiliation: UiT The Arctic University of Norway
-  orcid: 0000-0002-7616-0946
+  orcid: https://orcid.org/0000-0002-7616-0946
   alias: gregordecristoforo
 
 - given-names: Diego A.

--- a/changelog/1813.feature.rst
+++ b/changelog/1813.feature.rst
@@ -1,2 +1,4 @@
-Added ``lorentzfactor`` optional keyword to `~plasmapy.formulary.lengths.gyroradius` depending on needs of user.
-Also added ``relativistic`` optional keyword which can be set to `False` for the nonrelativistic approximation.
+Added ``lorentzfactor`` as an optional keyword-only argument
+to `~plasmapy.formulary.lengths.gyroradius`. Also added ``relativistic``
+as an optional keyword-only argument which can be set to `False` for the
+non-relativistic approximation.

--- a/changelog/1816.trivial.rst
+++ b/changelog/1816.trivial.rst
@@ -1,1 +1,0 @@
-Added a flake8_ check to limit line length in docstrings.

--- a/changelog/1824.breaking.rst
+++ b/changelog/1824.breaking.rst
@@ -1,1 +1,0 @@
-Changed the `~plasmapy.formulary.lengths.gyroradius` function so it no longer accepts deprecated ``T_i``.

--- a/changelog/1824.removal.rst
+++ b/changelog/1824.removal.rst
@@ -1,0 +1,2 @@
+Changed the `~plasmapy.formulary.lengths.gyroradius` function so it no
+longer accepts deprecated ``T_i``.

--- a/changelog/1825.feature.rst
+++ b/changelog/1825.feature.rst
@@ -1,1 +1,2 @@
-Modified ~plasmapy.particles.particle_class attributes to return NaN when undefined rather than raising exceptions.
+Modified |Particle| attributes to return |nan| in the appropriate units
+when undefined rather than raising exceptions.

--- a/changelog/1854.trivial.rst
+++ b/changelog/1854.trivial.rst
@@ -1,1 +1,1 @@
-Added `ruff <https://github.com/charliermarsh/ruff>`__ and `refurb <https://github.com/dosisod/refurb>`__ to the ``pre-commit`` configuration.
+Added `ruff <https://github.com/charliermarsh/ruff>`__ to the ``pre-commit`` configuration.

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -117,6 +117,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * `Silvina Guidoni <https://www.american.edu/cas/faculty/guidoni.cfm>`_
 * :user:`Sixue Xu <hzxusx>`
 * :user:`Steve Richardson <arichar6>` (:orcid:`0000-0002-3056-6334`)
+* :user:`Steve Vincena <svincena>` (:orcid:`0000-0002-6468-5710`)
 * :user:`Stuart Mumford <Cadair>` (:orcid:`0000-0003-4217-4642`)
 * :user:`Stuart Sobeske <Sobeskes>`
 * :user:`Suzanne Nie <suzannenie>`

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -5,9 +5,9 @@ Authors and Credits
 PlasmaPy Coordinating Committee
 ===============================
 
-* Erik Everson
-* Nicholas Murphy
-* Dominik Stańczak
+* :user:`Erik Everson <rocco8773>`
+* :user:`Nicholas Murphy <namurphy>`
+* :user:`Dominik Stańczak-Marikin <StanczakDominik>`
 
 PlasmaPy Contributors
 =====================
@@ -55,7 +55,7 @@ in parentheses are `ORCID author identifiers <https://orcid.org>`__.
 * :user:`Dawa Nurbu Sherpa <nurbu5>`
 * :user:`Dhawal Modi <Dhawal-Modi>`
 * :user:`Diego A. Diaz Riega <diego7319>`
-* :user:`Dominik Stańczak <StanczakDominik>` (:orcid:`0000-0001-6291-8843`)
+* :user:`Dominik Stańczak-Marikin <StanczakDominik>` (:orcid:`0000-0001-6291-8843`)
 * :user:`Drew Leonard <SolarDrew>` (:orcid:`0000-0001-5270-7487`)
 * :user:`Elliot Johnson <ejohnson-96>`
 * :user:`Erik Everson <rocco8773>` (:orcid:`0000-0001-6079-8307`)


### PR DESCRIPTION
This PR makes a few minor updates to changelog entries, and updates the author lists in `credits.rst` and `CITATION.cff` prior to `2023.1.0`. 

Tasks remaining: 
 - [x] Make sure that all new contributors are included in `credits.rst` and `CITATION.cff`