### PR TITLE
Add `strict` and `allowed_physical_types` keyword arguments to `_get_physical_type_dict`

### DIFF
--- a/changelog/1880.trivial.rst
+++ b/changelog/1880.trivial.rst
@@ -1,0 +1,2 @@
+Added the ``strict`` and ``allowed_physical_types`` parameters to
+``plasmapy.utils._units_helpers._get_physical_type_dict``.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2132,8 +2132,8 @@ class CustomParticle(AbstractPhysicalParticle):
         physical_type_dict = _get_physical_type_dict(
             quantities,
             only_quantities=True,
-            # strict=True,
-            # allowed_physical_types={u.physical.mass, u.physical.electrical_charge},
+            strict=True,
+            allowed_physical_types={u.physical.mass, u.physical.electrical_charge},
         )
 
         quantity_kwargs = {}

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2086,7 +2086,9 @@ class CustomParticle(AbstractPhysicalParticle):
         # TODO py3.10 replace ifology with structural pattern matching
 
         if Z is not None and charge is not None:
-            raise TypeError("CustomParticle can accept only one of 'Z' and 'charge'.")
+            raise InvalidParticleError(
+                "CustomParticle can accept only one of 'Z' and 'charge'."
+            )
 
         if Z is not None:
             charge = Z * const.e.si
@@ -2096,9 +2098,10 @@ class CustomParticle(AbstractPhysicalParticle):
             self.charge = charge
             self.symbol = symbol
         except (ValueError, TypeError, u.UnitsError) as exc:
+            charge_info = f"{charge = !r}" if Z is None else f"{Z = !r}"
             raise InvalidParticleError(
-                f"Unable to create a custom particle with a mass of "
-                f"{mass} and a charge of {charge}."
+                f"Unable to create a custom particle with {mass = !r}, "
+                f"{charge_info}, and {symbol = !r}."
             ) from exc
 
     @classmethod
@@ -2129,22 +2132,28 @@ class CustomParticle(AbstractPhysicalParticle):
         if not quantities:
             return CustomParticle(symbol=symbol, Z=Z)
 
-        physical_type_dict = _get_physical_type_dict(
-            quantities,
-            only_quantities=True,
-            strict=True,
-            allowed_physical_types={u.physical.mass, u.physical.electrical_charge},
-        )
+        try:
+            physical_type_dict = _get_physical_type_dict(
+                quantities,
+                only_quantities=True,
+                strict=True,
+                allowed_physical_types={u.physical.mass, u.physical.electrical_charge},
+            )
+        except (TypeError, ValueError) as exc:
+            raise InvalidParticleError(
+                f"Unable to create CustomParticle from {quantities}, "
+                f"{Z = !r}, and {symbol = !r}."
+            ) from exc
 
-        quantity_kwargs = {}
+        new_kwargs = {"symbol": symbol, "Z": Z}
 
         if u.physical.mass in physical_type_dict:
-            quantity_kwargs["mass"] = physical_type_dict[u.physical.mass]
+            new_kwargs["mass"] = physical_type_dict[u.physical.mass]
 
         if u.physical.electrical_charge in physical_type_dict:
-            quantity_kwargs["charge"] = physical_type_dict[u.physical.electrical_charge]
+            new_kwargs["charge"] = physical_type_dict[u.physical.electrical_charge]
 
-        return CustomParticle(**quantity_kwargs, symbol=symbol, Z=Z)
+        return CustomParticle(**new_kwargs)
 
     def __repr__(self) -> str:
         """

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2086,7 +2086,7 @@ class CustomParticle(AbstractPhysicalParticle):
         # TODO py3.10 replace ifology with structural pattern matching
 
         if Z is not None and charge is not None:
-            raise TypeError("CustomParticle can accept only one of Z and charge.")
+            raise TypeError("CustomParticle can accept only one of 'Z' and 'charge'.")
 
         if Z is not None:
             charge = Z * const.e.si

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1518,6 +1518,19 @@ def test_CustomParticle_from_quantities(args, kwargs, expected):
     assert actual == expected
 
 
+@pytest.mark.parametrize(
+    "args, kwargs, exception",
+    [
+        ([1 * u.C], {"Z": 2}, InvalidParticleError),
+        ([3 * u.m], {}, InvalidParticleError),
+        ([4 * u.kg, "invalid"], {}, InvalidParticleError),
+    ],
+)
+def test_CustomParticle_from_quantities_errors(args, kwargs, exception):
+    with pytest.raises(exception):
+        CustomParticle._from_quantities(*args, **kwargs)
+
+
 @pytest.mark.parametrize("m, Z, symbol, m_symbol, m_Z", test_molecule_table)
 def test_molecule(m, Z, symbol, m_symbol, m_Z):
     """Test ``molecule`` function."""

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1073,7 +1073,7 @@ custom_particle_errors = [
     (CustomParticle, {"mass": np.complex128(5 + 2j) * u.kg}, InvalidParticleError),
     (CustomParticle, {"charge": "not a charge"}, InvalidParticleError),
     (CustomParticle, {"charge": "5.0 km"}, InvalidParticleError),
-    (CustomParticle, {"charge": 1 * u.C, "Z": -1}, TypeError),
+    (CustomParticle, {"charge": 1 * u.C, "Z": -1}, InvalidParticleError),
 ]
 
 

--- a/plasmapy/utils/_units_helpers.py
+++ b/plasmapy/utils/_units_helpers.py
@@ -7,14 +7,16 @@ __all__ = []
 import astropy.units as u
 
 from numbers import Number
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Optional, Union
 
 
 def _get_physical_type_dict(
     iterable: Iterable,
     *,
-    only_quantities=False,
-    numbers_become_quantities=False,
+    only_quantities: Optional[bool] = False,
+    numbers_become_quantities: Optional[bool] = False,
+    strict: Optional[bool] = False,
+    allowed_physical_types: Optional[set[Union[str, u.PhysicalType]]] = None,
 ) -> Dict[u.PhysicalType, u.Quantity]:
     """
     Return a `dict` that contains `~astropy.units.PhysicalType` objects
@@ -36,10 +38,19 @@ def _get_physical_type_dict(
         converted to a |Quantity| or that has a physical type will be
         included in the `dict`. Defaults to `False`.
 
-    numbers_become_quantities : `bool`, |keyword-only|, optional
+    numbers_become_quantities : `bool`, |keyword-only|, default: `False`
         If `True`, `~numbers.Number` objects will be converted into
         dimensionless |Quantity| instances. If `False`,
         `~numbers.Number` objects will be skipped. Defaults to `False`.
+
+    strict : `bool`, |keyword-only|, default: False
+        If `True`, raise a `TypeError` if ``iterable`` provides an
+        object that does not have a physical type.
+
+    allowed_physical_types : `set` of `~astropy.units.PhysicalType`
+        If provided, then if any objects provided by ``iterable`` do not
+        have a physical type in ``allowed_physical_types``, then a
+        ValueError will be raised.
 
     Returns
     -------
@@ -63,13 +74,22 @@ def _get_physical_type_dict(
             obj = u.Quantity(obj, u.dimensionless_unscaled)
 
         if only_quantities and not isinstance(obj, u.Quantity):
+            if strict:
+                raise TypeError(f"{obj} is not a Quantity, but should be.")
             continue
 
         try:
             physical_type = u.get_physical_type(obj)
-        except (TypeError, ValueError):
-            pass
+        except (TypeError, ValueError) as exc:
+            if strict:
+                raise TypeError(f"{obj} does not have a physical type.") from exc
         else:
+            if allowed_physical_types and physical_type not in allowed_physical_types:
+                raise ValueError(
+                    f"{obj} has a physical type of {physical_type}, but "
+                    "only the following physical types are allowed: "
+                    f"{allowed_physical_types}."
+                )
             if physical_type in physical_types:
                 raise ValueError(f"Duplicate physical type: {physical_type}")
             physical_types[physical_type] = obj

--- a/plasmapy/utils/_units_helpers.py
+++ b/plasmapy/utils/_units_helpers.py
@@ -50,7 +50,7 @@ def _get_physical_type_dict(
     allowed_physical_types : `set` of `~astropy.units.PhysicalType`
         If provided, then if any objects provided by ``iterable`` do not
         have a physical type in ``allowed_physical_types``, then a
-        ValueError will be raised.
+        `ValueError` will be raised.
 
     Returns
     -------

--- a/plasmapy/utils/tests/test_units_helpers.py
+++ b/plasmapy/utils/tests/test_units_helpers.py
@@ -70,6 +70,21 @@ test_cases_exceptions = [
         kwargs={},
         expected=ValueError,
     ),
+    test_case(
+        collection=(5 * u.kg, 6 * u.T, 7 * u.m / u.s),
+        kwargs={"allowed_physical_types": {mass, velocity}},
+        expected=ValueError,
+    ),
+    test_case(
+        collection=(6 * u.m, u.kg),
+        kwargs={"strict": True, "only_quantities": True},
+        expected=TypeError,
+    ),
+    test_case(
+        collection=(6 * u.m, "not a Quantity"),
+        kwargs={"strict": True, "only_quantities": False},
+        expected=TypeError,
+    ),
 ]
 
 


### PR DESCRIPTION
## Description

Added additional keyword arguments to `plasmapy.utils._units_helpers._get_physical_type_dict`.

## Motivation and context

This PR adds capabilities that will be used when implementing a custom constructor method for `CustomParticle`.

## Related issues

This PR was originally part of #1874, which I'm splitting up into different pull requests.