### PR TITLE
Add separate constructor for `CustomParticle`

### DIFF
--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -38,6 +38,7 @@ from plasmapy.particles.exceptions import (
     ParticleWarning,
 )
 from plasmapy.utils import PlasmaPyDeprecationWarning, roman
+from plasmapy.utils._units_helpers import _get_physical_type_dict
 
 _classification_categories = {
     "lepton",
@@ -2099,6 +2100,51 @@ class CustomParticle(AbstractPhysicalParticle):
                 f"Unable to create a custom particle with a mass of "
                 f"{mass} and a charge of {charge}."
             ) from exc
+
+    @classmethod
+    def _from_quantities(
+        cls,
+        *quantities,
+        symbol: Optional[str] = None,
+        Z: Optional[Real] = None,
+    ) -> CustomParticle:
+        """
+        An alternate constructor for |CustomParticle| objects where the
+        positional arguments correspond to the mass and/or charge in
+        any order.
+
+        Parameters
+        ----------
+        *quantities : tuple of |Quantity|
+            The mass and/or electrical charge of the |CustomParticle|,
+            in any order.
+
+        symbol : str, |keyword-only|, optional
+            The symbol of the |CustomParticle|.
+
+        Z : real number, |keyword-only|, optional
+            The |charge number|, if not provided in ``quantities``.
+        """
+
+        if not quantities:
+            return CustomParticle(symbol=symbol, Z=Z)
+
+        physical_type_dict = _get_physical_type_dict(
+            quantities,
+            only_quantities=True,
+            # strict=True,
+            # allowed_physical_types={u.physical.mass, u.physical.electrical_charge},
+        )
+
+        quantity_kwargs = {}
+
+        if u.physical.mass in physical_type_dict:
+            quantity_kwargs["mass"] = physical_type_dict[u.physical.mass]
+
+        if u.physical.electrical_charge in physical_type_dict:
+            quantity_kwargs["charge"] = physical_type_dict[u.physical.electrical_charge]
+
+        return CustomParticle(**quantity_kwargs, symbol=symbol, Z=Z)
 
     def __repr__(self) -> str:
         """

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1501,6 +1501,23 @@ test_molecule_table = [
 ]
 
 
+@pytest.mark.parametrize(
+    "args, kwargs, expected",
+    [
+        ([], {}, CustomParticle()),
+        ([1 * u.kg], {}, CustomParticle(mass=1 * u.kg)),
+        ([2 * u.C], {}, CustomParticle(charge=2 * u.C)),
+        ([3 * u.kg, 4 * u.C], {}, CustomParticle(mass=3 * u.kg, charge=4 * u.C)),
+        ([5 * u.C, 6 * u.kg], {}, CustomParticle(mass=6 * u.kg, charge=5 * u.C)),
+        ([7 * u.kg], {"Z": 8.9}, CustomParticle(mass=7 * u.kg, Z=8.9)),
+        ([], {"symbol": "..."}, CustomParticle(symbol="...")),
+    ],
+)
+def test_CustomParticle_from_quantities(args, kwargs, expected):
+    actual = CustomParticle._from_quantities(*args, **kwargs)
+    assert actual == expected
+
+
 @pytest.mark.parametrize("m, Z, symbol, m_symbol, m_Z", test_molecule_table)
 def test_molecule(m, Z, symbol, m_symbol, m_Z):
     """Test ``molecule`` function."""


### PR DESCRIPTION
## Description

This adds a new private method to `CustomParticle` that acts as an alternative to `__init__`.  This method accepts the `charge` and `mass` of `CustomParticle` as positional arguments in either order (along with `CustomParticle` keyword arguments).  This pattern was suggested by @StanczakDominik.

## Motivation and context

The places where this will be directly applied (in future PRs) are:
 - `ParticleList` methods, including `__init__`, `append`, `extend`, etc. 
 - The particle factory function in `plasmapy.particles._factory`.

For the latter, these changes will help expand the capabilities of `particle_input`.

## Related issues

This PR takes an alternate approach to #1874. Closes #1873. This PR will need a few minor updates after #1880 is merged to handle cases where it should raise exceptions.