### PR TITLE
Edit the docstring for `particle_input`

### DIFF
--- a/changelog/1883.doc.rst
+++ b/changelog/1883.doc.rst
@@ -1,0 +1,1 @@
+Updated the docstring for |particle_input|.

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -618,9 +618,9 @@ def particle_input(
     |charge number| of an ion and mass number of an isotope,
     respectively, as long as ``Z`` and/or ``mass_numb`` are |parameters|
     accepted by the callable and only one |parameter| is appropriately
-    |annotated|.
+    annotated.
 
-    If the |annotation| is created using `typing.Optional` (e.g.,
+    If the annotation is created using `typing.Optional` (e.g.,
     ``Optional[ParticleLike]``), then `None` can be provided to
     ``callable_``.
 
@@ -628,16 +628,17 @@ def particle_input(
     criteria that have been provided, then |particle_input| will raise
     an exception.
 
-    If the |annotated| |parameter| is named ``element``, ``isotope``,
+    If the annotated parameter is named ``element``, ``isotope``,
     ``ion``, or ``ionic_level``, then |particle_input| will raise an
-    exception if the |argument| provided to the callable is not
-    consistent with the |parameter|.
+    exception if the argument provided to the callable is not
+    consistent with the parameter.
 
     .. note::
 
-       An |annotated| |parameter| named ``ion`` and ``ionic_level``
-       accept neutral atoms as long as the charge number is explicitly
-       defined.
+       An annotated parameter named ``ion`` and ``ionic_level`` accept
+       neutral atoms as long as the charge number is explicitly defined.
+       To enforce that the particle be charged, provide
+       ``require={"charged"}`` to |particle_input|.
 
     .. note::
 
@@ -669,10 +670,10 @@ def particle_input(
     exclude : `str`, `set`, `list`, or `tuple`, |keyword-only|, optional
         Categories that each particle cannot be in.
 
-    allow_custom_particles : bool, |keyword-only|, optional, default: `True`
+    allow_custom_particles : bool, |keyword-only|, default: `True`
         If `True`, allow |CustomParticle| instances to be passed through.
 
-    allow_particle_lists : bool, |keyword-only|, optional, default: `True`
+    allow_particle_lists : bool, |keyword-only|, default: `True`
         If `True`, allow |ParticleList| instances to be passed through.
 
     Returns
@@ -717,16 +718,16 @@ def particle_input(
     |ParticleError|
         If the returned particle(s) do not meet the categorization
         criteria specified through ``require``, ``any_of``, or
-        ``exclude``; or if none of the |parameters| of ``callable_``
-        have been appropriately annotated.
+        ``exclude``; or if none of the parameters of ``callable_`` have
+        been appropriately annotated.
 
-    |UnitConversionError|
+    `~astropy.units.UnitConversionError`
         If the annotated argument is a |Quantity|, but does not have a
         physical type of mass or charge.
 
     Warns
     -----
-    : |ParticleWarning|
+    : `~plasmapy.particles.exceptions.ParticleWarning`
         If decorated argument has charge and/or mass number information,
         and ``Z`` and/or ``mass_numb`` contain redundant information.
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -620,7 +620,7 @@ def particle_input(
     accepted by the callable and only one |parameter| is appropriately
     |annotated|.
 
-    If the |annotation| is created using `~typing.Optional` (e.g.,
+    If the |annotation| is created using `typing.Optional` (e.g.,
     ``Optional[ParticleLike]``), then `None` can be provided to
     ``callable_``.
 
@@ -654,8 +654,7 @@ def particle_input(
        When decorating a class method with |particle_input|,
        `classmethod` should be the outer decorator and |particle_input|
        should be the inner decorator, and the first argument
-       (representing the class) must be named ``cls``. However,
-       stacking `classmethod` and |particle_input| requires Python 3.9+.
+       (representing the class) must be named ``cls``.
 
     Parameters
     ----------
@@ -712,9 +711,9 @@ def particle_input(
 
     |ChargeError|
         If ``"charged"`` is in the ``require`` argument and the particle
-        is not explicitly charged, or if ``any_of = {"charged",
-        "uncharged"}`` and the particle does not have charge information
-        associated with it.
+        is not explicitly charged, or if
+        ``any_of = {"charged", "uncharged"}`` and the particle does not
+        have charge information associated with it.
 
     |ParticleError|
         If the returned particle(s) do not meet the categorization
@@ -728,7 +727,7 @@ def particle_input(
 
     Warns
     -----
-    |ParticleWarning|
+    : |ParticleWarning|
         If decorated argument has charge and/or mass number information,
         and ``Z`` and/or ``mass_numb`` contain redundant information.
 
@@ -763,8 +762,8 @@ def particle_input(
     >>> get_particle(1e-26 * u.kg)
     CustomParticle(mass=1e-26 kg, charge=nan C)
 
-    If the annotation is constructed using `typing.Optional`, then the
-    decorated callable will allow `None` to pass.
+    To allow `None` to pass, use ``Optional[ParticleLike]`` as the
+    annotation.
 
     >>> from typing import Optional
     >>> @particle_input

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -610,14 +610,14 @@ def particle_input(
     Convert |particle-like| |arguments| into particle objects.
 
     When a callable is |decorated| with |particle_input|,
-    |particle-like| |arguments| that are appropriately |annotated|
-    (i.e., with |ParticleLike| or |ParticleListLike|) will be converted
-    into a |Particle|, |CustomParticle|, or |ParticleList|.
+    |particle-like| arguments that are appropriately |annotated| (i.e.,
+    with |ParticleLike| or |ParticleListLike|) will be converted into a
+    |Particle|, |CustomParticle|, or |ParticleList|.
 
     The parameters ``Z`` and ``mass_numb`` may be used to specify the
     |charge number| of an ion and mass number of an isotope,
     respectively, as long as ``Z`` and/or ``mass_numb`` are |parameters|
-    accepted by the callable and only one |parameter| is appropriately
+    accepted by the callable and only one parameter is appropriately
     annotated.
 
     If the annotation is created using `typing.Optional` (e.g.,
@@ -636,8 +636,8 @@ def particle_input(
     .. note::
 
        An annotated parameter named ``ion`` and ``ionic_level`` accept
-       neutral atoms as long as the charge number is explicitly defined.
-       To enforce that the particle be charged, provide
+       neutral atoms as long as the |charge number| is explicitly
+       defined. To enforce that the particle be charged, provide
        ``require={"charged"}`` to |particle_input|.
 
     .. note::
@@ -827,9 +827,9 @@ def particle_input(
     >>> return_ionic_level("Fe-56 0+")
     Particle("Fe-56 0+")
 
-    When the |parameter| is named ``element``, ``isotope``, ``ion``, or
-    ``ionic_level``, then the corresponding |argument| must be
-    consistent with the name. When the |parameter| is named ``ion`` or
+    When the parameter is named ``element``, ``isotope``, ``ion``, or
+    ``ionic_level``, then the corresponding argument must be consistent
+    with the name. When the parameter is named ``ion`` or
     ``ionic_charge``, then the particle(s) may also be neutral atoms as
     long as the |charge number| is explicitly defined.
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -635,10 +635,9 @@ def particle_input(
 
     .. note::
 
-       |Annotated| |parameters| named ``ion`` and ``ionic_level`` accept
-       neutral atoms as long as the charge number is explicitly defined.
-       In the future, this functionality may change so that |parameters|
-       named ``ion`` require a nonzero |charge number|.
+       An |annotated| |parameter| named ``ion`` and ``ionic_level``
+       accept neutral atoms as long as the charge number is explicitly
+       defined.
 
     .. note::
 


### PR DESCRIPTION
This PR makes a few minor updates to the docstring for `@particle_input`, including some edits to the content and fixes for minor formatting issues.

The docstring is also significantly more verbose than would be optimal, which makes it hard to parse and find things in it.  I might try to add subsections to the examples and/or notes sections (though I'm not sure if Sphinx can handle it), or maybe a bullet point list near the top of what `@particle_input` can do.  This might end up needing an example notebook though.

It also removes a mention regarding Python 3.9+, so this should be merged **after** the `2023.1.0` release when we drop support for Python 3.8 (#1796).