### PR TITLE
Drop dependency on `cached-property` in favor of `functools.cached_property`

### DIFF
--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -17,8 +17,8 @@ import warnings
 import xarray as xr
 
 from abc import ABC, abstractmethod
-from cached_property import cached_property
 from collections import namedtuple
+from functools import cached_property
 from scipy.spatial import distance
 from typing import List, Union
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ license = {file = "LICENSE.md"}
 requires-python = ">=3.8"
 dependencies = [
   "astropy>=5.0.1",
-  "cached-property>=1.5.2",
   "h5py>=3",
   "ipywidgets>=7.6.5",
   "lmfit>=1",

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,6 @@ basepython = python3.8
 extras = tests
 deps =
     astropy == 5.0.1
-    cached-property == 1.5.2
     ipywidgets == 7.6.5
     h5py == 3.0.0
     hypothesis


### PR DESCRIPTION
## Description

This PR drops the dependency on `cached-property` in favor of `@functools.cached_property`.



## Motivation and context

<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->

While PlasmaPy was still supporting Python 3.7, we added a dependency on `cached-property` so that we could use it prior to it being added in Python 3.8.  We now support Python 3.8+ (soon to be Python 3.9+), which has `@functools.cached_property`, so the dependency on `cached-property` is no longer necessary.