### PR TITLE
Drop codespell from pyproject.toml reqs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ docs = [
   "tox<4",
 ]
 tests = [
-  "codespell@ git+https://github.com/codespell-project/codespell/",
   "dlint",
   "flake8",
   "flake8-absolute-import",


### PR DESCRIPTION
I tried doing the release yesterday, but [as seen in the logs](https://github.com/PlasmaPy/PlasmaPy/actions/runs/3904848534/jobs/6671146694), when you upload a pyproject.toml-based package to pypi it can't depend on "floating" dependencies such as
```
         "codespell @ git+https://github.com/codespell-project/codespell/ ;   
```

Which is, of course, a smart decision from them. So I'm removing that one from test dependencies, but it'll still be specified in the tox env we have for codespell. So it should be fine.