### PR TITLE
Drop `dlint` from linters

### DIFF
--- a/changelog/1906.trivial.rst
+++ b/changelog/1906.trivial.rst
@@ -1,0 +1,2 @@
+Dropped ``dlint`` from the the tests requirements, as it is no longer
+being maintained.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ docs = [
   "tox<4",
 ]
 tests = [
-  "dlint",
   "flake8",
   "flake8-absolute-import",
   "flake8-implicit-str-concat",

--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,6 @@ setenv =
 [testenv:linters]
 deps =
     cffconvert
-    dlint
     flake8
     flake8-absolute-import
     flake8-builtins


### PR DESCRIPTION
[`dlint`](https://github.com/duo-labs/dlint) is a nice tool to help enforce coding best practices and improve code security.  Because: 

 - The repo has been archived, with the last commit/release in 2020, and
 - `dlint` has an upper limit of `flake8<6`,

we should drop `dlint` from our linters.  In particular, using up-to-date versions of `flake8` is more important than to keep using `dlint`.  If `dlint` starts being maintained again and drops the flake8 upper limit, I'd be happy to bring it back.