### PR TITLE
Adjust dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,12 @@ updates:
   directory: /
   schedule:
     interval: weekly
-
+  assignees:
+  - StanczakDominik
+  reviewers:
+  - StanczakDominik
+  labels:
+  - No changelog entry needed
   # Maintain dependencies for python
 - package-ecosystem: pip
   directory: /
@@ -15,3 +20,7 @@ updates:
     interval: daily  # TODO s/daily/weekly once dependabot has settled
   assignees:
   - StanczakDominik
+  reviewers:
+  - StanczakDominik
+  labels:
+  - No changelog entry needed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 
 # any file, anywhere
 *                                                        @PlasmaPy/plasmapy-reviewers
+requirements.txt                                         @StanczakDominik
 
 plasmapy/particles/                                      @namurphy
 


### PR DESCRIPTION
This does three things:
- assigns me to dependabot PRs and to their review 
- adjusts CODEOWNERS so it doesn't sidestep the former setup
-  automatically gives dependabot PRs the changelog skip label
