### PR TITLE
Move codespell to pre-commit

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -122,25 +122,6 @@ jobs:
     - name: Run tests
       run: tox -e build_docs_pins -- -q
 
-  codespell:
-    name: codespell
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade "tox<4"
-    - name: Run tests
-      run: tox -e codespell -q
-
   import-plasmapy:
     name: Importing PlasmaPy
     runs-on: windows-latest
@@ -167,7 +148,6 @@ jobs:
     - initial-tests
     - comprehensive-tests
     - documentation
-    - codespell
     - import-plasmapy
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,14 @@ repos:
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+  - id: codespell
+    args: [--write-changes]
+    additional_dependencies:
+    - tomli
+
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.237
   hooks:

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -204,7 +204,7 @@ The following checks are performed with each pull request.
   .. note::
 
      When using pre-commit, a hook for codespell_ will check for and fix
-     common misspellings. If you encounter and words caught by
+     common misspellings. If you encounter any words caught by
      codespell_ that should *not* be fixed, please add these false
      positives to ``ignore-words-list`` under ``codespell`` in
      :file:`pyproject.toml`.

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -129,7 +129,7 @@ The recommended way for new contributors to run PlasmaPy's full test
 suite is to `create a pull request`_ from your development branch to
 `PlasmaPy's GitHub repository`_. The test suite will be run
 automatically when the pull request is created and every time changes
-are pushed to the development branch on GitHub_. Most of these checks\
+are pushed to the development branch on GitHub_. Most of these checks
 have been automated using `GitHub Actions`_.
 
 The following image shows how the results of the checks will appear in
@@ -201,25 +201,20 @@ The following checks are performed with each pull request.
      syntax errors. This approach is much more efficient than making the
      style fixes manually. Remember to ``git pull`` afterwards!
 
+  .. note::
+
+     When using pre-commit, a hook for codespell_ will check for and fix
+     common misspellings. If you encounter and words caught by
+     codespell_ that should *not* be fixed, please add these false
+     positives to ``ignore-words-list`` under ``codespell`` in
+     :file:`pyproject.toml`.
+
 * The **CI / Packaging (pull request)** check verifies that no errors
   arise that would prevent an official release of PlasmaPy from being
   made.
 
 * The **Pull Request Labeler / triage (pull_request_target)** check
   applies appropriate GitHub_ labels to pull requests.
-
-* The **CI / codespell (pull request)** check runs codespell_ to catch
-  by looking for common misspellings.
-
-  * If codespell_ has been installed (e.g., by ``pip install codespell``),
-    then it may be run by going into the appropriate directory and
-    running ``codespell -i 2 -w``. This command will identify common
-    misspellings, interactively suggest replacements, and then write the
-    replacements into the file.
-
-  * Occasionally codespell_ will report false positives. Please add
-    false positives to ``ignore-words-list`` under ``codespell`` in
-    :file:`pyproject.toml`.
 
 .. note::
 

--- a/tox.ini
+++ b/tox.ini
@@ -158,24 +158,6 @@ extras =
 deps =
 commands = python -c 'import plasmapy'
 
-[testenv:codespell]
-deps =
-    codespell
-commands_pre =
-    echo
-    echo "Codespell finds typos in source code. Rather than checking if each word"
-    echo "matches a dictionary entry, it looks for a set of common misspellings"
-    echo "in order to reduce the number of false positives."
-    echo
-commands =
-    codespell .
-commands_post =
-    echo
-    echo "After codespell has been installed locally (`pip install codespell`),"
-    echo "running the command `codespell -i 2 -w` will interactively go through"
-    echo "misspellings and suggest one or more replacements. Add any false"
-    echo "positives under ignore-words-list under [codespell] in pyproject.toml."
-
 [flake8]
 convention = numpy
 max-doc-length = 88


### PR DESCRIPTION
## Description

This PR moves `codespell` from `tox` and into the `pre-commit` configuration.

## Motivation and context

We use `codespell` to catch common misspellings.  We currently have a separate `tox` environment and GitHub Action for codespell. However, if we move `codespell` to `pre-commit`, we can remove both the `tox` environment and the GitHub Action.

## Related issues

This is based off of https://github.com/astropy/astropy/pull/13982 and https://github.com/astropy/astropy/pull/13985.