### PR TITLE
Make `ParticleList` accept `Quantity` arrays

### DIFF
--- a/changelog/1987.feature.rst
+++ b/changelog/1987.feature.rst
@@ -1,0 +1,2 @@
+Enabled |ParticleList| to accept |Quantity| objects of physical type
+mass or electrical charge.

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -19,7 +19,28 @@ from plasmapy.particles.particle_class import (
 )
 
 
-def _turn_quantity_into_custom_particle(quantity):
+def _turn_quantity_into_custom_particle(
+    quantity: u.Quantity[u.physical.electrical_charge, u.physical.mass]
+) -> CustomParticle:
+    """
+    Convert a |Quantity| of physical type mass or electrical charge
+    into the corresponding |CustomParticle|.
+
+    Parameters
+    ----------
+    quantity : |Quantity|
+        A |Quantity| of physical type mass or electrical charge.
+
+    Returns
+    -------
+    |CustomParticle|
+
+    Raises
+    ------
+    |InvalidParticleError|
+        If ``quantity`` does not have a physical type of mass or
+        electrical charge.
+    """
     physical_type = u.get_physical_type(quantity)
     if physical_type == u.physical.mass:
         return CustomParticle(mass=quantity)

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -135,12 +135,16 @@ class ParticleList(collections.UserList):
                 )
             elif isinstance(obj, u.Quantity):
                 physical_type = u.get_physical_type(obj)
-                if physical_type not in (u.physical.mass, u.physical.electrical_charge):
+                if physical_type == u.physical.mass:
+                    new_particles.append(CustomParticle(mass=obj))
+                elif physical_type == u.physical.electrical_charge:
+                    new_particles.append(CustomParticle(charge=obj))
+                else:
                     raise InvalidParticleError(
-                        f"{obj} does not have a physical type of mass "
-                        f"or electrical charge."
+                        f"Cannot convert {obj} into a CustomParticle for "
+                        f"inclusion in a ParticleList because it does not have"
+                        f"a physical type of mass or electrical charge."
                     )
-                new_particles.append(CustomParticle(obj))
             else:
                 try:
                     new_particles.append(Particle(obj))

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -152,11 +152,18 @@ class ParticleList(collections.UserList):
     @staticmethod
     def _list_of_particles_and_custom_particles(
         particles: Optional[Iterable[ParticleLike]],
-    ) -> list[Union[Particle, CustomParticle]]:  # TODO #687
+    ) -> list[Union[Particle, CustomParticle]]:
         """
         Convert an iterable that provides |particle-like| objects into a
         `list` containing |Particle| and |CustomParticle| instances.
         """
+        if isinstance(particles, str):
+            raise TypeError(
+                "ParticleList does not accept strings, but does accept "
+                "lists and tuples containing strings. Did you mean to "
+                f"do `ParticleList([{particles!r}])` instead?"
+            )
+
         new_particles = []
         if particles is None:
             return new_particles

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -216,7 +216,17 @@ class ParticleList(collections.UserList):
     def append(self, particle: ParticleLike):
         """Append a particle to the end of the |ParticleList|."""
         if isinstance(particle, u.Quantity):
-            particle = CustomParticle(particle)
+            physical_type = u.get_physical_type(particle)
+            if physical_type == u.physical.mass:
+                particle = CustomParticle(mass=particle)
+            elif physical_type == u.physical.electrical_charge:
+                particle = CustomParticle(charge=particle)
+            else:
+                raise InvalidParticleError(
+                    f"Cannot convert {particle} into a CustomParticle for "
+                    f"inclusion in a ParticleList because it does not have"
+                    f"a physical type of mass or electrical charge."
+                )
         elif not isinstance(particle, (Particle, CustomParticle)):
             particle = Particle(particle)
         self.data.append(particle)

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -481,11 +481,11 @@ class ParticleList(collections.UserList):
             parameter. If not provided, the particles contained in the
             |ParticleList| are assumed to be equally abundant.
 
-        use_rms_charge : `bool`, optional, |keyword-only|, default: `False`
+        use_rms_charge : `bool`, |keyword-only|, default: `False`
             If `True`, use the root-mean-square charge instead of the
             mean charge.
 
-        use_rms_mass : `bool`, optional, |keyword-only|, default: `False`
+        use_rms_mass : `bool`, |keyword-only|, default: `False`
             If `True`, use the root-mean-square mass instead of the mean
             mass.
 

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -42,6 +42,8 @@ def various_particles():
             CustomParticle(),
             CustomParticle(mass=7 * u.kg),
             CustomParticle(charge=11 * u.C),
+            5 * u.kg,
+            5 * u.C,
         ]
     )
 
@@ -161,7 +163,7 @@ def test_particle_list_insert(various_particles):
     assert _everything_is_particle_or_custom_particle(various_particles)
 
 
-invalid_particles = (0, "not a particle", DimensionlessParticle())
+invalid_particles = (0, "not a particle", DimensionlessParticle(), 5 * u.m)
 
 
 def test_particle_list_instantiate_with_invalid_particles():
@@ -492,7 +494,20 @@ def test_particle_list_with_no_arguments():
     assert len(empty_particle_list) == 0
 
 
-@pytest.mark.parametrize("arg", ["", "H", "He"])
-def test_particle_list_string_exception(arg):
-    with pytest.raises(TypeError):
-        ParticleList(arg)
+@pytest.mark.parametrize(
+    "quantities",
+    (
+        (1, 2) * u.kg,
+        (3, 4) * u.C,
+        (5 * u.kg, 6 * u.C),
+        (7 * u.C, 8 * u.kg),
+    ),
+)
+def test_particle_list_from_quantity_array(quantities):
+    """
+    Test that ParticleList can accept a Quantity array of an appropriate
+    physical type.
+    """
+    particle_list = ParticleList(quantities)
+    assert particle_list[0] == CustomParticle(quantities[0])
+    assert particle_list[1] == CustomParticle(quantities[1])

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -495,19 +495,28 @@ def test_particle_list_with_no_arguments():
 
 
 @pytest.mark.parametrize(
-    "quantities",
+    "quantities, expected",
     (
-        (1, 2) * u.kg,
-        (3, 4) * u.C,
-        (5 * u.kg, 6 * u.C),
-        (7 * u.C, 8 * u.kg),
+        ((1, 2) * u.kg, (CustomParticle(mass=1 * u.kg), CustomParticle(mass=2 * u.kg))),
+        (
+            (3, 4) * u.C,
+            (CustomParticle(charge=3 * u.C), CustomParticle(charge=4 * u.C)),
+        ),
+        (
+            (5 * u.kg, 6 * u.C),
+            (CustomParticle(mass=5 * u.kg), CustomParticle(charge=6 * u.C)),
+        ),
+        (
+            (7 * u.C, 8 * u.kg),
+            (CustomParticle(charge=7 * u.C), CustomParticle(mass=8 * u.kg)),
+        ),
     ),
 )
-def test_particle_list_from_quantity_array(quantities):
+def test_particle_list_from_quantity_array(quantities, expected):
     """
     Test that ParticleList can accept a Quantity array of an appropriate
     physical type.
     """
     particle_list = ParticleList(quantities)
-    assert particle_list[0] == CustomParticle(quantities[0])
-    assert particle_list[1] == CustomParticle(quantities[1])
+    assert particle_list[0] == expected[0]
+    assert particle_list[1] == expected[1]


### PR DESCRIPTION
The goal of this PR is to make `ParticleList` accept `Quantity` arrays with physical types of mass or electrical charge.  This also makes `ParticleList.append` accept `Quantity` non-arrays.  Each `Quantity` of the appropriate physical type will be converted into a `CustomParticle`.  

The motivation is primarily to allow `particle_input` to process `Quantity` arrays, which is needed for #1871 (if I recall correctly).

This PR originated as part of #1874.