### PR TITLE
Remove deprecated `pytest-xdist` option and update `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 
 # any file, anywhere
 *                                                        @PlasmaPy/plasmapy-reviewers
+.pre-commit-config.yaml                                  @namurphy
 requirements.txt                                         @StanczakDominik
 
 plasmapy/particles/                                      @namurphy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,6 @@ ELLIPSIS
 NUMBER"""
 addopts = "--doctest-modules --doctest-continue-on-failure"
 filterwarnings = ["ignore:.*Creating", "a"]
-looponfailroots = "plasmapy"
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
This PR removes the `looponfailroots` option, which has been deprecated for `pytest-xdist`.  I also added myself as the code owner for the `pre-commit` configuration file.  