### PR TITLE
Remove warning and improve error messages for invalid protons

### DIFF
--- a/changelog/1992.bugfix.rst
+++ b/changelog/1992.bugfix.rst
@@ -1,0 +1,3 @@
+When attempted to create a |Particle| object representing a proton,
+calls like :py:`Particle("H", Z=1, mass_numb=1)` no longer incorrectly
+issue a |ParticleWarning| for redundant particle information.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -695,20 +695,24 @@ class Particle(AbstractPhysicalParticle):
         if self.symbol == "p+":
             categories.update({"element", "isotope", "ion"})
 
-        _, mass_numb, Z = self.__inputs
+        argument, mass_numb, Z = self.__inputs
 
-        if mass_numb is not None or Z is not None:
-            if self.symbol == "p+" and 1 in (mass_numb, Z):
-                warnings.warn(
-                    "Redundant mass number or charge information.", ParticleWarning
-                )
-            else:
-                raise InvalidParticleError(
-                    "The keywords 'mass_numb' and 'Z' cannot be used when "
-                    "creating Particle objects for special particles. To "
-                    f"create a Particle object for {attributes['name']}s, "
-                    f"use:  Particle({attributes['particle']!r})"
-                )
+        if mass_numb is None and Z is None:
+            return
+
+        if self.symbol != "p+":
+            raise InvalidParticleError(
+                "The keywords 'mass_numb' and 'Z' cannot be used when "
+                "creating Particle objects for special particles. To "
+                f"create a Particle object for {attributes['name']}s, "
+                f"use: Particle({attributes['particle']!r})"
+            )
+
+        if mass_numb not in (1, None) or Z not in (1, None):
+            raise InvalidParticleError(
+                "Cannot create a Particle representing a proton for a "
+                "mass number or charge number not equal to 1."
+            )
 
     def _assign_atom_attributes(self) -> NoReturn:
         """Assign attributes and categories to elements, isotopes, and ions."""

--- a/plasmapy/particles/tests/test_exceptions.py
+++ b/plasmapy/particles/tests/test_exceptions.py
@@ -1031,12 +1031,6 @@ def test_unnamed_tests_exceptions(tested_object, args, kwargs, expected):
     Test that appropriate exceptions are raised for inappropriate inputs
     to different functions.
     """
-
-    print(f"{tested_object=}")
-    print(f"{args=}")
-    print(f"{kwargs=}")
-    print(f"{expected=}")
-
     with expected as exc_info:
         tested_object(*args, **kwargs)
 

--- a/plasmapy/particles/tests/test_exceptions.py
+++ b/plasmapy/particles/tests/test_exceptions.py
@@ -953,7 +953,6 @@ tests_from_atomic = [
     [isotope_symbol, ("Li-6",), {"mass_numb": 6}, pytest.warns(ParticleWarning)],
     [isotope_symbol, ("lithium-6",), {"mass_numb": 6}, pytest.warns(ParticleWarning)],
     [isotope_symbol, ("alpha",), {"mass_numb": 4}, pytest.warns(ParticleWarning)],
-    [isotope_symbol, ("p",), {"mass_numb": 1}, pytest.warns(ParticleWarning)],
 ]
 
 
@@ -1032,6 +1031,12 @@ def test_unnamed_tests_exceptions(tested_object, args, kwargs, expected):
     Test that appropriate exceptions are raised for inappropriate inputs
     to different functions.
     """
+
+    print(f"{tested_object=}")
+    print(f"{args=}")
+    print(f"{kwargs=}")
+    print(f"{expected=}")
+
     with expected as exc_info:
         tested_object(*args, **kwargs)
 


### PR DESCRIPTION
Previously, calling `Particle("H", Z=1, mass_numb=1)` mistakenly issued an unnecessary warning for redundant particle information.  This PR removes that warning and adds a specific error message for protons.  

Closes #1991.