### PR TITLE
Rename label: "Good first contribution" → "good first issue"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 [example gallery]: https://docs.plasmapy.org/en/stable/examples.html
 [GitHub discussions]: https://github.com/PlasmaPy/PlasmaPy/discussions
 [Gitter]: https://gitter.im/PlasmaPy/Lobby
-[good first issues]: https://github.com/PlasmaPy/PlasmaPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+contribution%22
+[good first issues]: https://github.com/PlasmaPy/PlasmaPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [Google Summer of Code]: https://summerofcode.withgoogle.com
 [hack week]: https://doi.org/10.1073/pnas.1717196115
 [how to install plasmapy]: https://docs.plasmapy.org/en/stable/install.html

--- a/docs/contributing/workflow.rst
+++ b/docs/contributing/workflow.rst
@@ -22,8 +22,8 @@ for contributing!
 
 .. tip::
 
-   Issues labeled as a `good first contribution`_ are a great place to
-   get started with contributing.
+   Issues labeled as a `good first issue`_ are a great place to get
+   started with contributing.
 
 Making a code contribution
 ==========================
@@ -182,6 +182,6 @@ marked as a draft pull request. Thank you for contributing!
 .. _branch: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches
 .. _fork: https://docs.github.com/en/get-started/quickstart/fork-a-repo
 .. _GitHub Documentation: https://docs.github.com/
-.. _good first contribution: https://github.com/PlasmaPy/PlasmaPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+contribution%22
+.. _good first issue: https://github.com/PlasmaPy/PlasmaPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+issue%22
 .. _pull request: https://docs.github.com/en/github/collaborating-with-pull-requests
 .. _remote: https://github.com/git-guides/git-remote


### PR DESCRIPTION
This PR updates our documentation to refer to the "good first issue" label rather than the "Good first contribution" label.  The reason is that "good first issue" has become the most common wording for this, and there are sites that look specifically for "good first issue" labels.  So, it'd be helpful to update it for us too.