### PR TITLE
Make `@particle_input` accept `z_mean` instead of `Z` whilst issuing a deprecation warning

### DIFF
--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -22,6 +22,7 @@ from plasmapy.particles.exceptions import (
 )
 from plasmapy.particles.particle_class import CustomParticle, Particle, ParticleLike
 from plasmapy.particles.particle_collections import ParticleList, ParticleListLike
+from plasmapy.utils import PlasmaPyDeprecationWarning
 
 _basic_particle_input_annotations = (
     Particle,  # deprecated
@@ -595,7 +596,8 @@ class _ParticleInput:
                 Z = z_mean
                 warnings.warn(
                     "The z_mean parameter has been deprecated. "
-                    "Define the charge number with Z instead."
+                    "Define the charge number with Z instead.",
+                    category=PlasmaPyDeprecationWarning,
                 )
 
         self.perform_pre_validations(Z, mass_numb)

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -4,6 +4,7 @@ __all__ = ["particle_input"]
 
 import functools
 import inspect
+import warnings
 import wrapt
 
 from collections.abc import Iterable
@@ -578,6 +579,24 @@ class _ParticleInput:
 
         Z = arguments.pop("Z", None)
         mass_numb = arguments.pop("mass_numb", None)
+
+        # The code that does special handling of z_mean arguments should
+        # only be removed ≥ 3 releases after the last time
+        # particle_input is used to decorate a function that accepts
+        # z_mean.
+        z_mean = arguments.pop("z_mean", None)
+        if z_mean is not None:
+            if Z is not None:
+                raise TypeError(
+                    "The charge number has been provided using both Z and "
+                    "z_mean. Use only Z instead."
+                )
+            else:
+                Z = z_mean
+                warnings.warn(
+                    "The z_mean parameter has been deprecated. "
+                    "Define the charge number with Z instead."
+                )
 
         self.perform_pre_validations(Z, mass_numb)
 


### PR DESCRIPTION
This PR adds a clause within `particle_input` so that functions decorated with it can accept `z_mean` as a keyword argument that then gets passed to `Z`.  If `z_mean` is provided, then then a deprecation warning will be issued.

Closes #2025.

To do:

 - [ ] Add tests
 - [ ] Decide if we'd want to do this for other parameters, like `m` for a particle's mass (see #1871), in which case we might want to change this into an instance method.