### PR TITLE
Update target version of Python in `ruff` configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ type_incorrect = "Incorrect changelog entry type (see list in changelog README)"
 type_incorrect_long = "The changelog entry for this PR must have one of the types (as in NUMBER.TYPE.rst) as described in the changelog README)."
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 exclude = [
     ".direnv",
     "docs/plasmapy_sphinx",


### PR DESCRIPTION
This PR updates the target version of Python in the configuration for [`ruff`](https://beta.ruff.rs/docs/) (a linter and code reformatter that we began using recently) from 3.8 to 3.9.  I forgot to do this in #1885.