### PR TITLE
Update requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = [
 dependencies = [
   "astropy>=5.0.1",
   "h5py>=3.1",
-  "ipykernel",
+  "ipykernel>=6.6.1",
   "ipywidgets>=7.6.5",
   "lmfit>=1",
   "matplotlib>=3.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = [
 dependencies = [
   "astropy>=5.0.1",
   "h5py>=3.1",
+  "ipykernel",
   "ipywidgets>=7.6.5",
   "lmfit>=1",
   "matplotlib>=3.3",
@@ -55,7 +56,6 @@ dependencies = [
 [project.optional-dependencies]
 docs = [
   "docutils>=0.18.1",
-  "ipykernel",
   "jinja2!=3.1",
   "nbsphinx>=0.9.1",
   "numpydoc",

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ babel==2.12.1
     #   sphinx
 backcall==0.2.0
     # via ipython
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.0
     # via nbconvert
 bleach==6.0.0
     # via nbconvert
@@ -56,7 +56,7 @@ click-default-group==1.2.2
     # via towncrier
 colorama==0.4.6
     # via tox
-comm==0.1.2
+comm==0.1.3
     # via ipykernel
 contourpy==1.0.7
     # via matplotlib
@@ -116,7 +116,7 @@ flake8-simplify==0.19.3
     # via plasmapy (setup.py)
 flake8-use-fstring==1.4
     # via plasmapy (setup.py)
-fonttools==4.39.0
+fonttools==4.39.2
     # via matplotlib
 future==0.18.3
     # via uncertainties
@@ -124,7 +124,7 @@ h5py==3.8.0
     # via plasmapy (setup.py)
 hypothesis==6.70.0
     # via plasmapy (setup.py)
-identify==2.5.20
+identify==2.5.21
     # via pre-commit
 idna==3.4
     # via
@@ -136,15 +136,13 @@ incremental==22.10.0
     # via towncrier
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.21.3
-    # via
-    #   ipywidgets
-    #   plasmapy (setup.py)
+ipykernel==6.22.0
+    # via plasmapy (setup.py)
 ipython==8.11.0
     # via
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.0.4
+ipywidgets==8.0.5
     # via plasmapy (setup.py)
 jedi==0.18.2
     # via ipython
@@ -187,7 +185,7 @@ jupyterlab-pygments==0.2.2
     # via nbconvert
 jupyterlab-server==2.20.0
     # via voila
-jupyterlab-widgets==3.0.5
+jupyterlab-widgets==3.0.6
     # via ipywidgets
 kiwisolver==1.4.4
     # via matplotlib
@@ -226,7 +224,7 @@ nbconvert==7.2.10
     #   jupyter-server
     #   nbsphinx
     #   voila
-nbformat==5.7.3
+nbformat==5.8.0
     # via
     #   jupyter-server
     #   nbclient
@@ -296,7 +294,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-pre-commit==3.1.1
+pre-commit==3.2.0
     # via plasmapy (setup.py)
 prometheus-client==0.16.0
     # via jupyter-server
@@ -322,7 +320,7 @@ pycparser==2.21
     # via cffi
 pydocstyle==6.3.0
     # via plasmapy (setup.py)
-pyerfa==2.0.0.1
+pyerfa==2.0.0.2
     # via astropy
 pyflakes==3.0.1
     # via flake8
@@ -366,7 +364,7 @@ pyyaml==6.0
     #   pre-commit
     #   pybtex
     #   pytest-regressions
-pyzmq==25.0.1
+pyzmq==25.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -521,7 +519,7 @@ websocket-client==1.5.1
     # via jupyter-server
 websockets==10.4
     # via voila
-widgetsnbextension==4.0.5
+widgetsnbextension==4.0.6
     # via ipywidgets
 wrapt==1.15.0
     # via plasmapy (setup.py)

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,7 @@ extras = tests
 deps =
     astropy == 5.0.1
     h5py == 3.1.0
+    ipykernel == 6.6.1
     ipywidgets == 7.6.5
     hypothesis
     lmfit == 1.0.0
@@ -127,6 +128,7 @@ deps =
     scipy == 1.6.0
     tqdm == 4.41.0
     voila == 0.3.0
+    wrapt == 1.12.0
     xarray == 0.17.0
 setenv =
     PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals


### PR DESCRIPTION
We've been having an CI issue over the last few days, apparently from `ipykernel` not having been found.  This PR updates the pinned requirements as a means of investigating the issue.  

I'm curious if a way to fix this would be to change `ipykernel` from an optional to a required dependency in `pyproject.toml`, but I haven't tried that on my first commit.