### PR TITLE
Allow `@particle_input` to accept custom ions when parameter is named `ion`

### DIFF
--- a/changelog/2034.breaking.rst
+++ b/changelog/2034.breaking.rst
@@ -1,0 +1,3 @@
+|particle_input| no longer enforces that |parameters| named
+``ionic_level`` are ions or neutral atoms. For equivalent behavior,
+name the parameter ``ion`` instead.

--- a/changelog/2034.trivial.rst
+++ b/changelog/2034.trivial.rst
@@ -1,5 +1,5 @@
 Modified |particle_input| to allow positively charged |CustomParticle|\
 -like objects to be passed through to decorated functions when an
-appropriately annotated parameter is named ``ion``. Previously, only
-|Particle| objects representing ions or neutral atoms were allowed to
-pass through.
+appropriately annotated |parameter| to that function is named ``ion``.
+Previously, only |Particle| objects representing ions or neutral atoms
+were allowed to pass through when the parameter was named ``ion``.

--- a/changelog/2034.trivial.rst
+++ b/changelog/2034.trivial.rst
@@ -1,4 +1,5 @@
 Modified |particle_input| to allow positively charged |CustomParticle|\
--like objects to be passed through when an appropriately annotated
-parameter is named ``ion``. Previously, only |Particle| objects
-representing ions or neutral atoms were allowed to pass through.
+-like objects to be passed through to decorated functions when an
+appropriately annotated parameter is named ``ion``. Previously, only
+|Particle| objects representing ions or neutral atoms were allowed to
+pass through.

--- a/changelog/2034.trivial.rst
+++ b/changelog/2034.trivial.rst
@@ -1,0 +1,4 @@
+Modified |particle_input| to allow positively charged |CustomParticle|\
+-like objects to be passed through when an appropriately annotated
+parameter is named ``ion``. Previously, only |Particle| objects
+representing ions or neutral atoms were allowed to pass through.

--- a/changelog/2034.trivial.rst
+++ b/changelog/2034.trivial.rst
@@ -1,5 +1,6 @@
-Modified |particle_input| to allow positively charged |CustomParticle|\
--like objects to be passed through to decorated functions when an
-appropriately annotated |parameter| to that function is named ``ion``.
-Previously, only |Particle| objects representing ions or neutral atoms
-were allowed to pass through when the parameter was named ``ion``.
+Modified |particle_input| to allow |CustomParticle|\ -like objects with
+a defined charge to be passed through to decorated functions when a
+|parameter| to that function annotated with |ParticleLike| is named
+``ion``. Previously, only |Particle| objects representing ions or
+neutral atoms were allowed to pass through when the parameter was named
+``ion``.

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -619,7 +619,7 @@ def particle_input(
     allow_custom_particles: bool = True,
     allow_particle_lists: bool = True,
 ) -> Callable:
-    """
+    r"""
     Convert |particle-like| |arguments| into particle objects.
 
     When a callable is |decorated| with |particle_input|,
@@ -634,33 +634,47 @@ def particle_input(
     annotated.
 
     If the annotation is created using `typing.Optional` (e.g.,
-    ``Optional[ParticleLike]``), then `None` can be provided to
+    :py:`Optional[ParticleLike]`), then `None` can be provided to
     ``callable_``.
 
     If the particle representation does not satisfy any categorization
     criteria that have been provided, then |particle_input| will raise
     an exception.
 
-    If the annotated parameter is named ``element``, ``isotope``,
-    ``ion``, or ``ionic_level``, then |particle_input| will raise an
-    exception if the argument provided to the callable is not
-    consistent with the parameter.
+    If the annotated parameter is named ``element``, ``isotope``, or
+    ``ion``, then |particle_input| will raise an exception if the
+    argument provided to the callable is not consistent with the
+    parameter.
 
     .. note::
 
-       An annotated parameter named ``ion`` and ``ionic_level`` accept
-       neutral atoms as long as the |charge number| is explicitly
-       defined. To enforce that the particle be charged, provide
-       ``require={"charged"}`` to |particle_input|.
+       An annotated parameter named ``ion`` will accept neutral atoms
+       and |CustomParticle|\ -like objects as long as the
+       |charge number| is explicitly defined. To enforce that the
+       particle be charged, provide :py:`require={"charged"}` to
+       |particle_input|.
 
     .. note::
 
        When both |particle_input| and |validate_quantities| are used to
        decorate a :term:`function`, they may be used in either order.
        When using both |particle_input| and |validate_quantities| to
-       decorate a :term:`method`, |particle_input| should be the outer
-       decorator and |validate_quantities| should be the inner
+       decorate an instance :term:`method`, |particle_input| should be
+       the outer decorator and |validate_quantities| should be the inner
        decorator.
+
+       .. code-block:: python
+
+          import astropy.units as u
+          from plasmapy.particles import particle_input, ParticleLike
+          from plasmapy.utils.decorators.validators import validate_quantities
+
+
+          class SomeClass:
+              @particle_input
+              @validate_quantities
+              def instance_method(self, particle: ParticleLike, B: u.T):
+                  ...
 
     .. note::
 
@@ -725,8 +739,8 @@ def particle_input(
     |ChargeError|
         If ``"charged"`` is in the ``require`` argument and the particle
         is not explicitly charged, or if
-        ``any_of = {"charged", "uncharged"}`` and the particle does not
-        have charge information associated with it.
+        :py:`any_of = {"charged", "uncharged"}` and the particle does
+        not have charge information associated with it.
 
     |ParticleError|
         If the returned particle(s) do not meet the categorization
@@ -775,7 +789,7 @@ def particle_input(
     >>> get_particle(1e-26 * u.kg)
     CustomParticle(mass=1e-26 kg, charge=nan C)
 
-    To allow `None` to pass, use ``Optional[ParticleLike]`` as the
+    To allow `None` to pass, use :py:`Optional[ParticleLike]` as the
     annotation.
 
     >>> from typing import Optional
@@ -840,11 +854,11 @@ def particle_input(
     >>> return_ionic_level("Fe-56 0+")
     Particle("Fe-56 0+")
 
-    When the parameter is named ``element``, ``isotope``, ``ion``, or
-    ``ionic_level``, then the corresponding argument must be consistent
-    with the name. When the parameter is named ``ion`` or
-    ``ionic_charge``, then the particle(s) may also be neutral atoms as
-    long as the |charge number| is explicitly defined.
+    When the parameter is named ``element``, ``isotope``, or ``ion``,
+    then the corresponding argument must be consistent with the name.
+    When the parameter is named ``ion``, then the particle(s) may also
+    be a neutral atom as long as the |charge number| is explicitly
+    defined.
 
     >>> @particle_input
     ... def mass_number(isotope: ParticleLike):

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -416,15 +416,8 @@ class _ParticleInput:
         name_categorization_exception = [
             ("element", {"require": "element"}, InvalidElementError),
             ("isotope", {"require": "isotope"}, InvalidIsotopeError),
-            # TODO: In the future, "ion" should be changed to allow only
-            # ions and not neutral atoms with an explicit charge.
             (
                 "ion",
-                {"require": "element", "any_of": {"charged", "uncharged"}},
-                InvalidIonError,
-            ),
-            (
-                "ionic_level",
                 {"require": "element", "any_of": {"charged", "uncharged"}},
                 InvalidIonError,
             ),

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -413,6 +413,14 @@ class _ParticleInput:
         categorization criteria.
         """
 
+        if (
+            parameter == "ion"
+            and isinstance(particle, CustomParticle)
+            and particle.charge.value > 0
+            and particle.mass.value > 0
+        ):
+            return
+
         name_categorization_exception = [
             ("element", {"require": "element"}, InvalidElementError),
             ("isotope", {"require": "isotope"}, InvalidIsotopeError),

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -4,6 +4,7 @@ __all__ = ["particle_input"]
 
 import functools
 import inspect
+import numpy as np
 import warnings
 import wrapt
 
@@ -416,7 +417,7 @@ class _ParticleInput:
         if (
             parameter == "ion"
             and isinstance(particle, CustomParticle)
-            and particle.charge.value > 0
+            and not np.isnan(particle.charge)
             and particle.mass.value > 0
         ):
             return

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -432,7 +432,7 @@ def test_annotated_init():
             particle_input(),
             marks=pytest.mark.xfail(
                 reason="For instance methods, particle_input must currently "
-                "be the outer decorator."
+                "be the outer decorator. See #2035."
             ),
         ),
     ],

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -424,7 +424,7 @@ def test_annotated_init():
             particle_input,
             marks=pytest.mark.xfail(
                 reason="For instance methods, particle_input must currently "
-                "be the outer decorator."
+                "be the outer decorator. See #2035."
             ),
         ),
         pytest.param(

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -624,3 +624,18 @@ def test_particle_input_warning_for_float_z_mean():
     Z = result.charge / const.e.si
 
     assert u.isclose(Z, z_mean)
+
+
+def test_custom_particle_for_parameter_named_ion():
+    """
+    Test that a positively charged CustomParticle is treated as a valid
+    ion when the parameter is named ``ion``.
+    """
+
+    @particle_input
+    def return_ion(ion: ParticleLike):
+        return ion
+
+    custom_ion = CustomParticle(mass=2e-27 * u.kg, charge=3e-19 * u.C)
+    result = return_ion(custom_ion)
+    assert result == custom_ion

--- a/tox.ini
+++ b/tox.ini
@@ -216,6 +216,7 @@ rst-roles =
     abbr
     any
     attr
+    bash
     cite
     cite:ct
     cite:cts
@@ -252,6 +253,7 @@ rst-roles =
     pep
     pr
     program
+    py
     ref
     regexp
     rst:dir


### PR DESCRIPTION
A feature of `@particle_input` is that if a parameter to a function is named `ion`, then it will ensure that the particle is indeed an ion. This feature is syntactic sugar for the categorization criteria that can be specified in `@particle_input`.  

However, this feature doesn't work for positively charged particles that represent (for example) *mean* ions. The purpose of this pull request is to enable `@particle_input` to accept `CustomParticle` objects that have a mass and are positively charged.  

This is needed for #2022 to enable compatibility with charge numbers that are not integers.