### PR TITLE
Reorganize testing guide

### DIFF
--- a/changelog/2041.doc.rst
+++ b/changelog/2041.doc.rst
@@ -1,0 +1,1 @@
+Restructured the |testing guide|.

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -528,7 +528,7 @@ The following checks are performed with each pull request.
      include (or will include) significant improvements to common error
      messages.
 
-* The **CI / Documentation (pull request)** check verifies that
+* The **CI / Documentation (pull_request)** check verifies that
   `PlasmaPy's documentation`_ is able to build correctly from the pull
   request. Warnings are treated as errors.
 
@@ -551,8 +551,11 @@ The following checks are performed with each pull request.
   as passing when the test coverage is satisfactorily high. For more
   information, see the section on :ref:`code-coverage`.
 
+* The **CI / Importing PlasmaPy (pull_request)** checks that it is
+  possible to run :py:`import plasmapy`.
+
 * PlasmaPy uses black_ to format code and isort_ to sort ``import``
-  statements. The **CI / Linters (pull request)** and
+  statements. The **CI / Linters (pull_request)** and
   **pre-commit.ci - pr** checks verify that the pull request meets these
   style requirements. These checks will fail when inconsistencies with
   the output from black_ or isort_ are found or when there are syntax

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -363,6 +363,8 @@ code implementation of :math:`f(x)` — returns positive output for
 multiple values of :math:`x`. The hypothesis_ package simplifies
 `property-based testing`_ for Python.
 
+.. _testing-best-practices:
+
 Best practices
 ==============
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -522,7 +522,7 @@ The following checks are performed with each pull request.
      `Python 3.10 <https://docs.python.org/3.10/whatsnew/3.10.html>`__,
      `Python 3.11 <https://docs.python.org/3.11/whatsnew/3.11.html>`__,
      and
-     `Python 3.12 <https://docs.python.org/3.12/whatsnew/3.12.html>`__,
+     `Python 3.12 <https://docs.python.org/3.12/whatsnew/3.12.html>`__
      include (or will include) significant improvements to common error
      messages.
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -20,6 +20,14 @@ Summary
 * Tests are either functions beginning with ``test_`` or classes
   beginning with ``Test``.
 
+* Here is an example of a minimal ``pytest`` test that uses an
+  :py:`assert` statement:
+
+  .. code-block:: python
+
+      def test_multiplication():
+          assert 2 * 3 == 6
+
 * To install the packages needed to run the tests:
 
   - Open a terminal.
@@ -45,13 +53,7 @@ Summary
 * Run ``pytest`` in the command line in order to run tests in that
   directory and its subdirectories.
 
-* Here is an example of a minimal ``pytest`` test that uses an
-  :py:`assert` statement:
 
-  .. code-block:: python
-
-      def test_multiplication():
-          assert 2 * 3 == 6
 
 Introduction
 ============
@@ -95,246 +97,6 @@ with names of the form :file:`test_*.py`. For example, tests for
 of the package. Example code contained within docstrings is tested to
 make sure that the actual printed output matches what is in the
 docstring.
-
-Running tests
-=============
-
-PlasmaPy's tests can be run in the following ways:
-
-1. Creating and updating a pull request on GitHub_.
-2. Running pytest_ from the command line.
-3. Running tox_ from the command line.
-4. Running tests from an :wikipedia:`integrated development environment
-   <integrated_development_environment>` (IDE).
-
-We recommend that new contributors perform the tests via a pull request
-on GitHub_. Creating a draft pull request and keeping it updated will
-ensure that the necessary checks are run frequently. This approach is
-also appropriate for pull requests with a limited scope. This advantage
-of this approach is that the tests are run automatically and do not
-require any extra work. The disadvantages are that running the tests on
-GitHub_ is often slow and that navigating the test results is sometimes
-difficult.
-
-We recommend that experienced contributors run tests either by using
-pytest_ from the command line or by using your preferred IDE.
-Using tox_ is an alternative to pytest_, but running tests with tox_
-adds the overhead of creating an isolated environment for your test and
-can thus be slower.
-
-Using GitHub
-------------
-
-The recommended way for new contributors to run PlasmaPy's full test
-suite is to `create a pull request`_ from your development branch to
-`PlasmaPy's GitHub repository`_. The test suite will be run
-automatically when the pull request is created and every time changes
-are pushed to the development branch on GitHub_. Most of these checks
-have been automated using `GitHub Actions`_.
-
-The following image shows how the results of the checks will appear in
-each pull request near the end of the *Conversation* tab. Checks that
-pass are marked with ✔️, while tests that fail are marked with ❌. Click
-on *Details* for information about why a particular check failed.
-
-.. image:: ../_static/contributor_guide/CI_checks_for_a_PR_from_2021.png
-   :width: 700
-   :align: center
-   :alt: Continuous integration test results during a pull request
-
-The following checks are performed with each pull request.
-
-* Checks with labels like **CI / Python 3.x (pull request)** verify that
-  PlasmaPy works with different versions of Python and other
-  dependencies, and on different operating systems. These tests are set
-  up using tox_ and run with pytest_ via `GitHub Actions`_. When
-  multiple tests fail, investigate these tests first.
-
-  .. tip::
-
-     `Python 3.10 <https://docs.python.org/3.10/whatsnew/3.10.html>`__ and
-     `Python 3.11 <https://docs.python.org/3.11/whatsnew/3.11.html>`__
-     include (or will include) significant improvements to common error
-     messages.
-
-* Checks with labels like **CI / Python 3.x with NumPy dev (pull
-  request)** verify that PlasmaPy works the version of NumPy that is
-  currently being developed on GitHub_. Occasionally these tests will
-  fail due to upstream changes or conflicts.
-
-* The **CI / Documentation (pull request)** check verifies that
-  `PlasmaPy's documentation`_ is able to build correctly from the pull
-  request. Warnings are treated as errors.
-
-* The **docs/readthedocs.org:plasmapy** check allows us to preview
-  how the documentation will appear if the pull request is merged.
-  Click on *Details* to access this preview.
-
-* The check labeled **changelog: found** or **changelog: absent**
-  indicates whether or not a changelog entry with the correct number
-  is present, unless the pull request has been labeled with "No
-  changelog entry needed".
-
-  * The :file:`changelog/README.rst` file describes the process for
-    adding a changelog entry to a pull request.
-
-* The **codecov/patch** and **codecov/project** checks generate test
-  coverage reports that show which lines of code are run by the test
-  suite and which are not. Codecov_ will automatically post its report
-  as a comment to the pull request. The Codecov_ checks will be marked
-  as passing when the test coverage is satisfactorily high. For more
-  information, see the section on :ref:`code-coverage`.
-
-* PlasmaPy uses black_ to format code and isort_ to sort ``import``
-  statements. The **CI / Linters (pull request)** and
-  **pre-commit.ci - pr** checks verify that the pull request meets these
-  style requirements. These checks will fail when inconsistencies with
-  the output from black_ or isort_ are found or when there are syntax
-  errors. These checks can usually be ignored until the pull request is
-  nearing completion.
-
-  .. tip::
-
-     The required formatting fixes can be applied automatically by
-     writing a comment with the message ``pre-commit.ci autofix`` to the
-     *Conversation* tab on a pull request, as long as there are no
-     syntax errors. This approach is much more efficient than making the
-     style fixes manually. Remember to ``git pull`` afterwards!
-
-  .. note::
-
-     When using pre-commit, a hook for codespell_ will check for and fix
-     common misspellings. If you encounter any words caught by
-     codespell_ that should *not* be fixed, please add these false
-     positives to ``ignore-words-list`` under ``codespell`` in
-     :file:`pyproject.toml`.
-
-* The **CI / Packaging (pull request)** check verifies that no errors
-  arise that would prevent an official release of PlasmaPy from being
-  made.
-
-* The **Pull Request Labeler / triage (pull_request_target)** check
-  applies appropriate GitHub_ labels to pull requests.
-
-.. note::
-
-   For first-time contributors, existing maintainers `may need to
-   manually enable your `GitHub Action test runs
-   <https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks>`__.
-   This is, believe it or not, indirectly caused by the invention of
-   cryptocurrencies.
-
-.. note::
-
-   The continuous integration checks performed for pull requests change
-   frequently. If you notice that the above list has become out-of-date,
-   please `submit an issue that this section needs updating
-   <https://github.com/PlasmaPy/PlasmaPy/issues/new?title=Update%20information%20on%20GitHub%20checks%20in%20testing%20guide&labels=Documentation>`__.
-
-Using pytest
-------------
-
-To install the packages necessary to run tests on your local computer
-(including tox_ and pytest_), run:
-
-.. code-block:: shell
-
-   pip install -e .[tests]
-
-To run PlasmaPy's tests from the command line, go to a directory within
-PlasmaPy's repository and run:
-
-.. code-block:: shell
-
-   pytest
-
-This command will run all of the tests found within your current
-directory and all of its subdirectories. Because it takes time to run
-PlasmaPy's tests, it is usually most convenient to specify that only a
-subset of the tests be run. To run the tests contained within a
-particular file or directory, include its name after ``pytest``. If you
-are in the directory :file:`plasmapy/particles/tests/`, then the tests in
-in :file:`test_atomic.py` can be run with:
-
-.. code-block:: shell
-
-   pytest test_atomic.py
-
-The documentation for pytest_ describes `how to invoke pytest`_ and
-specify which tests will or will not be run. A few useful
-examples of flags you can use with it:
-
-* Use the ``--tb=short`` to shorten traceback reports, which is useful
-  when there are multiple related errors. Use ``--tb=long`` for
-  traceback reports with extra detail.
-
-* Use the ``-x`` flag to stop the tests after the first failure. To stop
-  after :math:`n` failures, use ``--maxfail=n`` where ``n`` is replaced
-  with a positive integer.
-
-* Use the ``-m 'not slow'`` flag to skip running slow (defined by the
-  ``@pytest.mark.slow`` marker) tests, which is
-  useful when the slow tests are unrelated to your changes. To exclusively
-  run slow tests, use ``-m slow``.
-
-* Use the ``--pdb`` flag to enter the `Python debugger`_ upon test
-  failures.
-
-Using tox
----------
-
-PlasmaPy's continuous integration tests on GitHub_ are typically run
-using tox_, a tool for automating Python testing. Using tox_ simplifies
-testing PlasmaPy with different releases of Python, with different
-versions of PlasmaPy's dependencies, and on different operating systems.
-While testing with tox_ is more robust than testing with pytest_, using
-tox_ to run tests is typically slower because tox_ creates its own
-virtual environments.
-
-To run PlasmaPy's tests for a particular environment, run:
-
-.. code-block:: shell
-
-   tox -e ⟨envname⟩
-
-where ``⟨envname⟩`` is replaced with the name of the tox_ environment,
-as described below.
-
-Some testing environments for tox_ are pre-defined.  For example, you
-can replace ``⟨envname⟩`` with ``py38`` if you are running Python 3.8.x,
-``py39`` if you are running Python 3.9.x, or ``py310`` if you are running
-Python 3.10.x. Running tox_ with any of these environments requires that
-the appropriate version of Python has been installed and can be found by
-tox_.  To find the version of Python that you are using, go to the
-command line and run ``python --version``.
-
-Additional `tox environments`_ are defined in :file:`tox.ini` in the
-top-level directory of PlasmaPy's repository. To find which testing
-environments are available, run:
-
-.. code-block:: shell
-
-   tox -a
-
-These commands can be run in any directory within PlasmaPy's repository
-with the same effect.
-
-Using an integrated development environment
--------------------------------------------
-
-Most IDEs have built-in tools that simplify software testing. IDEs like
-PyCharm_ and `Visual Studio`_ allow test configurations to be run with a
-click of the mouse or a few keystrokes. While IDEs require time to
-learn, they are among the most efficient methods to interactively
-perform tests. Here are instructions for running tests in several
-popular IDEs:
-
-* `Python testing in PyCharm
-  <https://www.jetbrains.com/help/pycharm/testing-your-first-python-application.html>`__
-* `Python testing in Visual Studio Code
-  <https://code.visualstudio.com/docs/python/testing>`__
-
-.. _writing-tests:
 
 Writing Tests
 =============
@@ -778,6 +540,247 @@ should be balanced with each other rather than absolute principles.
 * If the *act* phase of a |unit test| is more than a single line of
   code, consider revising the functionality being tested so that it can
   be called in a single line of code :cite:p:`khorikov:2020`.
+
+
+Running tests
+=============
+
+PlasmaPy's tests can be run in the following ways:
+
+1. Creating and updating a pull request on GitHub_.
+2. Running pytest_ from the command line.
+3. Running tox_ from the command line.
+4. Running tests from an :wikipedia:`integrated development environment
+   <integrated_development_environment>` (IDE).
+
+We recommend that new contributors perform the tests via a pull request
+on GitHub_. Creating a draft pull request and keeping it updated will
+ensure that the necessary checks are run frequently. This approach is
+also appropriate for pull requests with a limited scope. This advantage
+of this approach is that the tests are run automatically and do not
+require any extra work. The disadvantages are that running the tests on
+GitHub_ is often slow and that navigating the test results is sometimes
+difficult.
+
+We recommend that experienced contributors run tests either by using
+pytest_ from the command line or by using your preferred IDE.
+Using tox_ is an alternative to pytest_, but running tests with tox_
+adds the overhead of creating an isolated environment for your test and
+can thus be slower.
+
+Using GitHub
+------------
+
+The recommended way for new contributors to run PlasmaPy's full test
+suite is to `create a pull request`_ from your development branch to
+`PlasmaPy's GitHub repository`_. The test suite will be run
+automatically when the pull request is created and every time changes
+are pushed to the development branch on GitHub_. Most of these checks
+have been automated using `GitHub Actions`_.
+
+The following image shows how the results of the checks will appear in
+each pull request near the end of the *Conversation* tab. Checks that
+pass are marked with ✔️, while tests that fail are marked with ❌. Click
+on *Details* for information about why a particular check failed.
+
+.. image:: ../_static/contributor_guide/CI_checks_for_a_PR_from_2021.png
+   :width: 700
+   :align: center
+   :alt: Continuous integration test results during a pull request
+
+The following checks are performed with each pull request.
+
+* Checks with labels like **CI / Python 3.x (pull request)** verify that
+  PlasmaPy works with different versions of Python and other
+  dependencies, and on different operating systems. These tests are set
+  up using tox_ and run with pytest_ via `GitHub Actions`_. When
+  multiple tests fail, investigate these tests first.
+
+  .. tip::
+
+     `Python 3.10 <https://docs.python.org/3.10/whatsnew/3.10.html>`__ and
+     `Python 3.11 <https://docs.python.org/3.11/whatsnew/3.11.html>`__
+     include (or will include) significant improvements to common error
+     messages.
+
+* Checks with labels like **CI / Python 3.x with NumPy dev (pull
+  request)** verify that PlasmaPy works the version of NumPy that is
+  currently being developed on GitHub_. Occasionally these tests will
+  fail due to upstream changes or conflicts.
+
+* The **CI / Documentation (pull request)** check verifies that
+  `PlasmaPy's documentation`_ is able to build correctly from the pull
+  request. Warnings are treated as errors.
+
+* The **docs/readthedocs.org:plasmapy** check allows us to preview
+  how the documentation will appear if the pull request is merged.
+  Click on *Details* to access this preview.
+
+* The check labeled **changelog: found** or **changelog: absent**
+  indicates whether or not a changelog entry with the correct number
+  is present, unless the pull request has been labeled with "No
+  changelog entry needed".
+
+  * The :file:`changelog/README.rst` file describes the process for
+    adding a changelog entry to a pull request.
+
+* The **codecov/patch** and **codecov/project** checks generate test
+  coverage reports that show which lines of code are run by the test
+  suite and which are not. Codecov_ will automatically post its report
+  as a comment to the pull request. The Codecov_ checks will be marked
+  as passing when the test coverage is satisfactorily high. For more
+  information, see the section on :ref:`code-coverage`.
+
+* PlasmaPy uses black_ to format code and isort_ to sort ``import``
+  statements. The **CI / Linters (pull request)** and
+  **pre-commit.ci - pr** checks verify that the pull request meets these
+  style requirements. These checks will fail when inconsistencies with
+  the output from black_ or isort_ are found or when there are syntax
+  errors. These checks can usually be ignored until the pull request is
+  nearing completion.
+
+  .. tip::
+
+     The required formatting fixes can be applied automatically by
+     writing a comment with the message ``pre-commit.ci autofix`` to the
+     *Conversation* tab on a pull request, as long as there are no
+     syntax errors. This approach is much more efficient than making the
+     style fixes manually. Remember to ``git pull`` afterwards!
+
+  .. note::
+
+     When using pre-commit, a hook for codespell_ will check for and fix
+     common misspellings. If you encounter any words caught by
+     codespell_ that should *not* be fixed, please add these false
+     positives to ``ignore-words-list`` under ``codespell`` in
+     :file:`pyproject.toml`.
+
+* The **CI / Packaging (pull request)** check verifies that no errors
+  arise that would prevent an official release of PlasmaPy from being
+  made.
+
+* The **Pull Request Labeler / triage (pull_request_target)** check
+  applies appropriate GitHub_ labels to pull requests.
+
+.. note::
+
+   For first-time contributors, existing maintainers `may need to
+   manually enable your `GitHub Action test runs
+   <https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks>`__.
+   This is, believe it or not, indirectly caused by the invention of
+   cryptocurrencies.
+
+.. note::
+
+   The continuous integration checks performed for pull requests change
+   frequently. If you notice that the above list has become out-of-date,
+   please `submit an issue that this section needs updating
+   <https://github.com/PlasmaPy/PlasmaPy/issues/new?title=Update%20information%20on%20GitHub%20checks%20in%20testing%20guide&labels=Documentation>`__.
+
+Using pytest
+------------
+
+To install the packages necessary to run tests on your local computer
+(including tox_ and pytest_), run:
+
+.. code-block:: shell
+
+   pip install -e .[tests]
+
+To run PlasmaPy's tests from the command line, go to a directory within
+PlasmaPy's repository and run:
+
+.. code-block:: shell
+
+   pytest
+
+This command will run all of the tests found within your current
+directory and all of its subdirectories. Because it takes time to run
+PlasmaPy's tests, it is usually most convenient to specify that only a
+subset of the tests be run. To run the tests contained within a
+particular file or directory, include its name after ``pytest``. If you
+are in the directory :file:`plasmapy/particles/tests/`, then the tests in
+in :file:`test_atomic.py` can be run with:
+
+.. code-block:: shell
+
+   pytest test_atomic.py
+
+The documentation for pytest_ describes `how to invoke pytest`_ and
+specify which tests will or will not be run. A few useful
+examples of flags you can use with it:
+
+* Use the ``--tb=short`` to shorten traceback reports, which is useful
+  when there are multiple related errors. Use ``--tb=long`` for
+  traceback reports with extra detail.
+
+* Use the ``-x`` flag to stop the tests after the first failure. To stop
+  after :math:`n` failures, use ``--maxfail=n`` where ``n`` is replaced
+  with a positive integer.
+
+* Use the ``-m 'not slow'`` flag to skip running slow (defined by the
+  ``@pytest.mark.slow`` marker) tests, which is
+  useful when the slow tests are unrelated to your changes. To exclusively
+  run slow tests, use ``-m slow``.
+
+* Use the ``--pdb`` flag to enter the `Python debugger`_ upon test
+  failures.
+
+Using tox
+---------
+
+PlasmaPy's continuous integration tests on GitHub_ are typically run
+using tox_, a tool for automating Python testing. Using tox_ simplifies
+testing PlasmaPy with different releases of Python, with different
+versions of PlasmaPy's dependencies, and on different operating systems.
+While testing with tox_ is more robust than testing with pytest_, using
+tox_ to run tests is typically slower because tox_ creates its own
+virtual environments.
+
+To run PlasmaPy's tests for a particular environment, run:
+
+.. code-block:: shell
+
+   tox -e ⟨envname⟩
+
+where ``⟨envname⟩`` is replaced with the name of the tox_ environment,
+as described below.
+
+Some testing environments for tox_ are pre-defined.  For example, you
+can replace ``⟨envname⟩`` with ``py38`` if you are running Python 3.8.x,
+``py39`` if you are running Python 3.9.x, or ``py310`` if you are running
+Python 3.10.x. Running tox_ with any of these environments requires that
+the appropriate version of Python has been installed and can be found by
+tox_.  To find the version of Python that you are using, go to the
+command line and run ``python --version``.
+
+Additional `tox environments`_ are defined in :file:`tox.ini` in the
+top-level directory of PlasmaPy's repository. To find which testing
+environments are available, run:
+
+.. code-block:: shell
+
+   tox -a
+
+These commands can be run in any directory within PlasmaPy's repository
+with the same effect.
+
+Using an integrated development environment
+-------------------------------------------
+
+Most IDEs have built-in tools that simplify software testing. IDEs like
+PyCharm_ and `Visual Studio`_ allow test configurations to be run with a
+click of the mouse or a few keystrokes. While IDEs require time to
+learn, they are among the most efficient methods to interactively
+perform tests. Here are instructions for running tests in several
+popular IDEs:
+
+* `Python testing in PyCharm
+  <https://www.jetbrains.com/help/pycharm/testing-your-first-python-application.html>`__
+* `Python testing in Visual Studio Code
+  <https://code.visualstudio.com/docs/python/testing>`__
+
+.. _writing-tests:
 
 .. |integration test| replace:: :term:`integration test`
 .. |unit test| replace:: :term:`unit test`

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -96,6 +96,8 @@ of the package. Example code contained within docstrings is tested to
 make sure that the actual printed output matches what is in the
 docstring.
 
+.. _writing-tests:
+
 Writing Tests
 =============
 
@@ -777,8 +779,6 @@ popular IDEs:
   <https://www.jetbrains.com/help/pycharm/testing-your-first-python-application.html>`__
 * `Python testing in Visual Studio Code
   <https://code.visualstudio.com/docs/python/testing>`__
-
-.. _writing-tests:
 
 .. |integration test| replace:: :term:`integration test`
 .. |unit test| replace:: :term:`unit test`

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -519,8 +519,10 @@ The following checks are performed with each pull request.
 
   .. tip::
 
-     `Python 3.10 <https://docs.python.org/3.10/whatsnew/3.10.html>`__ and
-     `Python 3.11 <https://docs.python.org/3.11/whatsnew/3.11.html>`__
+     `Python 3.10 <https://docs.python.org/3.10/whatsnew/3.10.html>`__,
+     `Python 3.11 <https://docs.python.org/3.11/whatsnew/3.11.html>`__,
+     and
+     `Python 3.12 <https://docs.python.org/3.12/whatsnew/3.12.html>`__,
      include (or will include) significant improvements to common error
      messages.
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -334,6 +334,8 @@ popular IDEs:
 * `Python testing in Visual Studio Code
   <https://code.visualstudio.com/docs/python/testing>`__
 
+.. _writing-tests:
+
 Writing Tests
 =============
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -53,8 +53,6 @@ Summary
 * Run ``pytest`` in the command line in order to run tests in that
   directory and its subdirectories.
 
-
-
 Introduction
 ============
 
@@ -363,84 +361,6 @@ code implementation of :math:`f(x)` — returns positive output for
 multiple values of :math:`x`. The hypothesis_ package simplifies
 `property-based testing`_ for Python.
 
-.. _code-coverage:
-
-Code coverage
-=============
-
-:wikipedia:`Code coverage <Code_coverage>` refers to a metric "used to
-describe the degree to which the source code of a program is executed
-when a particular test suite runs." The most common code coverage metric
-is line coverage:
-
-.. math::
-
-   \mbox{line coverage} ≡
-   \frac{
-      \mbox{number of lines accessed by tests}
-   }{
-      \mbox{total number of lines}
-   }
-
-Line coverage reports show which lines of code have been used in a test
-and which have not. These reports show which lines of code remain to be
-tested, and sometimes indicate sections of code that are unreachable.
-
-.. tip::
-
-   Use test coverage reports to write tests that target untested
-   sections of code and to find unreachable sections of code.
-
-.. caution::
-
-   While a low value of line coverage indicates that the code is not
-   adequately tested, a high value does not necessarily indicate that
-   the testing is sufficient. A test that makes no assertions has little
-   value, but could still have high test coverage.
-
-PlasmaPy uses `coverage.py`_ and the `pytest-cov`_ plugin for pytest_ to
-measure code coverage and Codecov_ to provide reports on GitHub.
-
-Generating coverage reports with pytest
----------------------------------------
-
-Code coverage reports may be generated on your local computer to show
-which lines of code are covered by tests and which are not. To generate
-an HTML report, use the ``--cov`` flag for ``pytest``:
-
-.. code-block:: shell
-
-   pytest --cov
-   coverage html
-
-Open :file:`htmlcov/index.html` in your web browser to view the coverage
-reports.
-
-Excluding lines in coverage reports
------------------------------------
-
-Occasionally there will be certain lines that should not be tested. For
-example, it would be impractical to create a new testing environment to
-check that an `ImportError` is raised when attempting to import a
-missing package. There are also situations that coverage tools are not
-yet able to handle correctly.
-
-To exclude a line from a coverage report, end it with
-``# coverage: ignore``. Alternatively, we may add a line to
-``exclude_lines`` in the ``[coverage:report]`` section of
-:file:`setup.cfg` that consists of a
-a pattern that indicates that a line be excluded from coverage reports.
-In general, untested lines of code should remain marked as untested to
-give future developers a better idea of where tests should be added in
-the future and where potential bugs may exist.
-
-Coverage configurations
------------------------
-
-Configurations for coverage tests are given in the ``[coverage:run]``
-and ``[coverage:report]`` sections of :file:`setup.cfg`. Codecov_
-configurations are given in :file:`.codecov.yaml`.
-
 Best practices
 ==============
 
@@ -540,7 +460,6 @@ should be balanced with each other rather than absolute principles.
 * If the *act* phase of a |unit test| is more than a single line of
   code, consider revising the functionality being tested so that it can
   be called in a single line of code :cite:p:`khorikov:2020`.
-
 
 Running tests
 =============
@@ -764,6 +683,85 @@ environments are available, run:
 
 These commands can be run in any directory within PlasmaPy's repository
 with the same effect.
+
+
+.. _code-coverage:
+
+Code coverage
+-------------
+
+:wikipedia:`Code coverage <Code_coverage>` refers to a metric "used to
+describe the degree to which the source code of a program is executed
+when a particular test suite runs." The most common code coverage metric
+is line coverage:
+
+.. math::
+
+   \mbox{line coverage} ≡
+   \frac{
+      \mbox{number of lines accessed by tests}
+   }{
+      \mbox{total number of lines}
+   }
+
+Line coverage reports show which lines of code have been used in a test
+and which have not. These reports show which lines of code remain to be
+tested, and sometimes indicate sections of code that are unreachable.
+
+.. tip::
+
+   Use test coverage reports to write tests that target untested
+   sections of code and to find unreachable sections of code.
+
+.. caution::
+
+   While a low value of line coverage indicates that the code is not
+   adequately tested, a high value does not necessarily indicate that
+   the testing is sufficient. A test that makes no assertions has little
+   value, but could still have high test coverage.
+
+PlasmaPy uses `coverage.py`_ and the `pytest-cov`_ plugin for pytest_ to
+measure code coverage and Codecov_ to provide reports on GitHub.
+
+Generating coverage reports with pytest
+---------------------------------------
+
+Code coverage reports may be generated on your local computer to show
+which lines of code are covered by tests and which are not. To generate
+an HTML report, use the ``--cov`` flag for ``pytest``:
+
+.. code-block:: shell
+
+   pytest --cov
+   coverage html
+
+Open :file:`htmlcov/index.html` in your web browser to view the coverage
+reports.
+
+Excluding lines in coverage reports
+-----------------------------------
+
+Occasionally there will be certain lines that should not be tested. For
+example, it would be impractical to create a new testing environment to
+check that an `ImportError` is raised when attempting to import a
+missing package. There are also situations that coverage tools are not
+yet able to handle correctly.
+
+To exclude a line from a coverage report, end it with
+``# coverage: ignore``. Alternatively, we may add a line to
+``exclude_lines`` in the ``[coverage:report]`` section of
+:file:`setup.cfg` that consists of a
+a pattern that indicates that a line be excluded from coverage reports.
+In general, untested lines of code should remain marked as untested to
+give future developers a better idea of where tests should be added in
+the future and where potential bugs may exist.
+
+Coverage configurations
+-----------------------
+
+Configurations for coverage tests are given in the ``[coverage:run]``
+and ``[coverage:report]`` sections of :file:`setup.cfg`. Codecov_
+configurations are given in :file:`.codecov.yaml`.
 
 Using an integrated development environment
 -------------------------------------------

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -526,11 +526,6 @@ The following checks are performed with each pull request.
      include (or will include) significant improvements to common error
      messages.
 
-* Checks with labels like **CI / Python 3.x with NumPy dev (pull
-  request)** verify that PlasmaPy works the version of NumPy that is
-  currently being developed on GitHub_. Occasionally these tests will
-  fail due to upstream changes or conflicts.
-
 * The **CI / Documentation (pull request)** check verifies that
   `PlasmaPy's documentation`_ is able to build correctly from the pull
   request. Warnings are treated as errors.


### PR DESCRIPTION
This PR changes the order of sections in the testing guide so that the parts about writing tests come before the parts about running tests. I'll comment on the (minimal) changes to the content. 

Here's the [**preview of the testing guide**](https://plasmapy--2041.org.readthedocs.build/en/2041/contributing/testing_guide.html).