### PR TITLE
Repair GitHub Action that labels pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,32 +1,45 @@
-Analysis: plasmapy/analysis/**/*
+Breaking:
+- changelog/*.breaking*rst
 
-Continuous integration: .github/**/*
+Contributor Guide:
+- docs/contributing/**/*
 
-Contributor Guide: docs/contributing/*
+dependencies:
+- requirements.txt
 
-Diagnostics: plasmapy/diagnostics/**/*
-
-Dispersion: plasmapy/dispersion/**/*
-
-Formulary: plasmapy/formulary/**/*
-
-Mathematics: plasmapy/formulary/mathematics.py
-
-parameters.quantum: plasmapy/formulary/quantum.py
-
-Particles: plasmapy/particles/**/*
-
-# Add Documentation label to any change in docs but notebooks
 Documentation:
 - any: [docs/**/*]
   all: ['!docs/notebooks/**/*', '!docs/contributing/*']
 
-Notebooks: docs/notebooks/**/*
+GitHub Actions:
+- .github/**/*
 
-Plasma class: plasmapy/plasma/**/*
+Notebooks:
+- docs/notebooks/**/*
 
-simulations: plasmapy/simulation/**/*
+plasmapy.analysis:
+- plasmapy/analysis/**/*
 
-Utilities: plasmapy/utils/**/*
+plasmapy.diagnostics:
+- plasmapy/diagnostics/**/*
 
-Breaking: changelog/*.breaking*rst
+plasmapy.dispersion:
+- plasmapy/dispersion/**/*
+
+plasmapy.formulary:
+- plasmapy/formulary/**/*
+
+plasmapy.formulary.quantum:
+- any: [plasmapy/formulary/quantum.py, plasmapy/formulary/tests/test_quantum.py]
+
+plasmapy.particles:
+- plasmapy/particles/**/*
+
+plasmapy.plasma:
+- plasmapy/plasma/**/*
+
+plasmapy.simulation:
+- plasmapy/simulation/**/*
+
+plasmapy.utils:
+- plasmapy/utils/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,17 @@
 Breaking:
 - changelog/*.breaking*rst
 
+Continuous Integration:
+- any: [.codecov.yaml, .pre-commit-config.yaml, CODEOWNERS, noxfile.py, tox.ini]
+
 Contributor Guide:
-- docs/contributing/**/*
+- any: [changelog/README.rst, docs/contributing/**/*]
 
 dependencies:
 - requirements.txt
 
 Documentation:
-- any: [docs/**/*]
+- any: [docs/**/*, changelog/*doc*.rst, README.md, .readthedocs.yml]
   all: ['!docs/notebooks/**/*', '!docs/contributing/*']
 
 GitHub Actions:
@@ -16,6 +19,9 @@ GitHub Actions:
 
 Notebooks:
 - docs/notebooks/**/*
+
+Packaging:
+- any: [MANIFEST.in, pyproject.toml, setup.cfg, setup.py]
 
 plasmapy.analysis:
 - plasmapy/analysis/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: Pull Request Labeler
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,3 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4
+      with:
+        sync-labels: true


### PR DESCRIPTION
This PR (hopefully!) repairs our implementation of the [labeler](https://github.com/marketplace/actions/labeler) GitHub Action. 

It appears that the problem was that we deleted our `.github/workflows/labeler.yml` action in #1800, when we were trying to repair the size-labeler GitHub Action.  My bad!

This is one of those pull requests where we won't be able to test it until after we merge it, but if there are any problems with it, then I'll submit a follow-up pull request shortly thereafter.

Closes #2042. Hopefully!