### PR TITLE
Update pre-commit versions and fix linter error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autofix_prs: false
-  autoupdate_schedule: monthly
+  autoupdate_schedule: weekly
 
 repos:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   - id: check-yaml
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.7.0
+  rev: v2.8.0
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
@@ -60,7 +60,7 @@ repos:
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.2
+  rev: v2.2.4
   hooks:
   - id: codespell
     args: [--write-changes]
@@ -68,7 +68,7 @@ repos:
     - tomli
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.254
+  rev: v0.0.260
   hooks:
   - id: ruff
     args: [--fix]
@@ -85,7 +85,7 @@ repos:
     - python
 
 - repo: https://github.com/psf/black
-  rev: 23.1.0
+  rev: 23.3.0
   hooks:
   - id: black
 
@@ -97,7 +97,7 @@ repos:
     exclude: docs/contributing/coding_guide.rst
 
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.6.3
+  rev: 1.6.4
   hooks:
   - id: nbqa-black
     additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,6 @@ ci:
   autofix_prs: false
   autoupdate_schedule: monthly
 
-default_language_version:
-  node: 16.15.0
-
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -228,7 +228,7 @@ class _ParticleInput:
         -------
         `dict` of `str` to `object`
         """
-        return self._data.get("annotations", None)
+        return self._data.get("annotations")
 
     @property
     def require(self) -> Optional[set]:
@@ -517,7 +517,7 @@ class _ParticleInput:
             other annotations, this method will return ``argument``
             without alteration.
         """
-        annotation = self.annotations.get(parameter, None)
+        annotation = self.annotations.get(parameter)
 
         if annotation not in _particle_input_annotations:
             return argument

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -747,16 +747,16 @@ class Particle(AbstractPhysicalParticle):
             this_isotope = _isotopes.data_about_isotopes[isotope]
 
             attributes["baryon number"] = this_isotope["mass number"]
-            attributes["isotope mass"] = this_isotope.get("mass", None)
+            attributes["isotope mass"] = this_isotope.get("mass")
             attributes["isotopic abundance"] = this_isotope.get("abundance", 0.0)
 
             if this_isotope["stable"]:
                 attributes["half-life"] = np.inf * u.s
             else:
-                attributes["half-life"] = this_isotope.get("half-life", None)
+                attributes["half-life"] = this_isotope.get("half-life")
 
         if element and not isotope:
-            attributes["standard atomic weight"] = this_element.get("atomic mass", None)
+            attributes["standard atomic weight"] = this_element.get("atomic mass")
 
         if ion in _special_particles.special_ion_masses:
             attributes["mass"] = _special_particles.special_ion_masses[ion]


### PR DESCRIPTION
We just got a new linter error, which is essentially that we should switch `something.get('key', None)` with `something.get('key')`.  

I'm also going to take a moment to update our pre-commit configuration, I think.