### PR TITLE
Update doc landing page and citation instructions

### DIFF
--- a/changelog/2055.doc.rst
+++ b/changelog/2055.doc.rst
@@ -1,0 +1,2 @@
+Updated the introduction on the documentation landing page and the
+citation instructions.

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -9,7 +9,7 @@ Acknowledging and Citing
 
 If you use PlasmaPy for a project that results in a publication, we ask
 that you cite the Zenodo_ record for the specific version of PlasmaPy
-used in your project.Citing a software package promotes scientific
+used in your project. Citing a software package promotes scientific
 reproducibility, gives credit to its developers, and highlights the
 importance of software as a vital research product.
 

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -9,7 +9,7 @@ Acknowledging and Citing
 
 If you use PlasmaPy for a project that results in a publication, we ask
 that you cite the Zenodo_ record for the specific version of PlasmaPy
-used in your project.  Citing a software package promotes scientific
+used in your project.Citing a software package promotes scientific
 reproducibility, gives credit to its developers, and highlights the
 importance of software as a vital research product.
 
@@ -20,7 +20,7 @@ reference:
    |version_to_cite|, Zenodo, |doi_hyperlink|
 
 This reference may be made, for example, by adding the following line to
-the methods  or acknowledgments section of a paper.
+the methods or acknowledgments section of a paper.
 
    This research made use of PlasmaPy version |version_to_cite|, a
    community-developed open source Python package for plasma research

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -20,31 +20,34 @@ reference:
    |version_to_cite|, Zenodo, |doi_hyperlink|
 
 This reference may be made, for example, by adding the following line to
-the methods or acknowledgments section of a paper.
+the methods  or acknowledgments section of a paper.
 
    This research made use of PlasmaPy version |version_to_cite|, a
    community-developed open source Python package for plasma research
    and education (PlasmaPy Community et al. |citation_year|).
 
-A paper written using `AASTeX <https://journals.aas.org/aastexguide>`__
-should use the ``\software{PlasmaPy}`` command to cite PlasmaPy.
-
-All public releases of PlasmaPy, as well as many informational resources
-on PlasmaPy, are openly archived in the `PlasmaPy Community
-<https://zenodo.org/communities/plasmapy>`__ on Zenodo_.
-
 We encourage authors to acknowledge the packages that PlasmaPy depends
-on, including but not limited to
-`Astropy <https://www.astropy.org/acknowledging.html>`__,
+on, such as `Astropy <https://www.astropy.org/acknowledging.html>`__,
 `NumPy <https://numpy.org/citing-numpy>`__, and
 `SciPy <https://scipy.org/citing-scipy>`__.
 
-.. note::
-
-   Citation information and project metadata are stored in
-   |CITATION.cff|_, which uses the `Citation File Format`_.
-
 .. important::
+
+   If you use a function that implements a technique originally from a
+   research article referenced in its documentation, please also cite
+   that research article.
+
+.. caution::
 
    A development version of PlasmaPy should not be cited or used in
    published work.
+
+.. tip::
+
+   A paper written using `AASTeX <https://journals.aas.org/aastexguide>`__
+   should use the ``\software{PlasmaPy}`` command to cite PlasmaPy.
+
+.. note::
+
+   All public releases of PlasmaPy are openly archived in the `PlasmaPy
+   Community <https://zenodo.org/communities/plasmapy>`__ on Zenodo_.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,3 +1,5 @@
+.. _examples:
+
 Examples
 ========
 
@@ -6,6 +8,8 @@ the various functionality contained in `plasmapy`.
 
 .. contents::
    :local:
+
+.. _getting-started-notebooks:
 
 Getting started
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,16 +14,31 @@ PlasmaPy Documentation
 PlasmaPy_ is an open source community-developed Python_ |minpython|\ +
 package for plasma research and education.
 
-New users should check out our `getting started notebooks
-<getting-started-notebooks>`_, followed by PlasmaPy's
-:ref:`example gallery <examples>`.
+.. toctree::
+   :caption: First Steps
+   :maxdepth: 1
 
-Please feel free to ask questions in our `Matrix chat room`_, during
-our weekly virtual `office hours`_, or in a `new discussion on
-GitHub`_.
+   Installing <install>
+   getting_started
+   examples
+   COMMUNICATION
+   Code of Conduct <CODE_OF_CONDUCT.rst>
+   about/citation
 
-PlasmaPy is developed openly `on GitHub <PlasmaPy's GitHubrepository>`_. Please check out our |contributor guide| and
-:ref:`code of conduct <plasmapy-code-of-conduct>`
+.. New users should check out our `getting started notebooks
+   <getting-started-notebooks>`_, followed by PlasmaPy's
+   :ref:`example gallery <examples>`.
+
+.. note::
+
+   PlasmaPy is developed openly `on GitHub <PlasmaPy's GitHubrepository>`_.
+   Please check out our |contributor guide| if you would like to
+   contribute.
+
+.. tip::
+
+   Please feel free to ask questions in our `Matrix chat room`_, during
+   our weekly virtual `office hours`_, or in a `new discussion on GitHub`_.
 
 .. important::
 
@@ -43,17 +58,6 @@ Example highlights
    notebooks/diagnostics/thomson
    notebooks/analysis/swept_langmuir/find_floating_potential
    notebooks/formulary/thermal_bremsstrahlung
-
-.. toctree::
-   :caption: First Steps
-   :maxdepth: 1
-
-   Installing <install>
-   getting_started
-   examples
-   COMMUNICATION
-   Code of Conduct <CODE_OF_CONDUCT.rst>
-   about/citation
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,17 +12,17 @@ PlasmaPy Documentation
 ######################
 
 PlasmaPy_ is an open source community-developed Python_ |minpython|\ +
-package for plasma research and education.
+package for plasma research and education. PlasmaPy is a platform by
+which the plasma community can share code and collaboratively develop
+new software tools for plasma research.
 
-New users should check out our `getting started notebooks
-<getting-started-notebooks>`_, followed by PlasmaPy's
-:ref:`example gallery <examples>`. Please feel free to ask questions in
-our `Matrix chat room`_, during our weekly virtual `office hours`_, or
-in a `new discussion on GitHub`_.
+If you are new to PlasmaPy, please check out our `getting started
+notebooks <getting-started-notebooks>`_ and our :ref:`example gallery
+<examples>`. We invite you to share ideas and ask questions in our
+`Matrix chat room`_ or during our weekly virtual `office hours`_.
 
-PlasmaPy is developed openly `on GitHub <PlasmaPy's GitHubrepository>`_.
-Please check out our |contributor guide| if you would like to
-contribute.
+PlasmaPy is developed openly `on GitHub <PlasmaPy's GitHub repository>`_,
+where you can `request a new feature`_ or `report a bug`_.
 
 .. important::
 
@@ -94,3 +94,5 @@ Example highlights
    GitHub Repository <https://github.com/PlasmaPy/PlasmaPy>
 
 .. _new discussion on GitHub: https://github.com/PlasmaPy/PlasmaPy/discussions/new/choose
+.. _report a bug: https://github.com/PlasmaPy/PlasmaPy/issues/new?assignees=&labels=Bug&template=bug_report.yml
+.. _request a new feature: https://github.com/PlasmaPy/PlasmaPy/issues/new?assignees=&labels=Feature+request&template=feature_request.yml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,22 @@ PlasmaPy Documentation
 PlasmaPy_ is an open source community-developed Python_ |minpython|\ +
 package for plasma research and education.
 
+New users should check out our `getting started notebooks
+<getting-started-notebooks>`_, followed by PlasmaPy's
+:ref:`example gallery <examples>`. Please feel free to ask questions in
+our `Matrix chat room`_, during our weekly virtual `office hours`_, or
+in a `new discussion on GitHub`_.
+
+PlasmaPy is developed openly `on GitHub <PlasmaPy's GitHubrepository>`_.
+Please check out our |contributor guide| if you would like to
+contribute.
+
+.. important::
+
+   If you use PlasmaPy for work presented in a publication or talk,
+   please help the project by following these instructions to
+   :ref:`cite or acknowledge <citation>` PlasmaPy.
+
 .. toctree::
    :caption: First Steps
    :maxdepth: 1
@@ -24,27 +40,6 @@ package for plasma research and education.
    COMMUNICATION
    Code of Conduct <CODE_OF_CONDUCT.rst>
    about/citation
-
-.. New users should check out our `getting started notebooks
-   <getting-started-notebooks>`_, followed by PlasmaPy's
-   :ref:`example gallery <examples>`.
-
-.. note::
-
-   PlasmaPy is developed openly `on GitHub <PlasmaPy's GitHubrepository>`_.
-   Please check out our |contributor guide| if you would like to
-   contribute.
-
-.. tip::
-
-   Please feel free to ask questions in our `Matrix chat room`_, during
-   our weekly virtual `office hours`_, or in a `new discussion on GitHub`_.
-
-.. important::
-
-   If you use PlasmaPy for work presented in a publication or talk,
-   please help the project by following these instructions to
-   :ref:`cite or acknowledge <citation>` PlasmaPy.
 
 Example highlights
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,17 @@ PlasmaPy Documentation
 PlasmaPy_ is an open source community-developed Python_ |minpython|\ +
 package for plasma research and education.
 
+New users should check out our `getting started notebooks
+<getting-started-notebooks>`_, followed by PlasmaPy's
+:ref:`example gallery <examples>`.
+
+Please feel free to ask questions in our `Matrix chat room`_, during
+our weekly virtual `office hours`_, or in a `new discussion on
+GitHub`_.
+
+PlasmaPy is developed openly `on GitHub <PlasmaPy's GitHubrepository>`_. Please check out our |contributor guide| and
+:ref:`code of conduct <plasmapy-code-of-conduct>`
+
 .. important::
 
    If you use PlasmaPy for work presented in a publication or talk,
@@ -82,3 +93,5 @@ Example highlights
    PlasmaPy Enhancement Proposals <https://github.com/PlasmaPy/PlasmaPy-PLEPs>
    PlasmaPy.org <https://www.plasmapy.org>
    GitHub Repository <https://github.com/PlasmaPy/PlasmaPy>
+
+.. _new discussion on GitHub: https://github.com/PlasmaPy/PlasmaPy/discussions/new/choose

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,14 @@
 PlasmaPy Documentation
 ######################
 
-PlasmaPy_ is an open source community-developed core Python_
-|minpython|\ + package for plasma physics currently under development.
+PlasmaPy_ is an open source community-developed Python_ |minpython|\ +
+package for plasma research and education.
+
+.. important::
+
+   If you use PlasmaPy for work presented in a publication or talk,
+   please help the project by following these instructions to
+   :ref:`cite or acknowledge <citation>` PlasmaPy.
 
 Example highlights
 ------------------


### PR DESCRIPTION
 - I updated the first paragraph on the landing page of PlasmaPy's documentation.
 - I added an admonition on the landing page on citing PlasmaPy, largely based on Astropy's.
 - I made some edits to the citation instructions, such as by organizing content in admonitions and noting that people using a technique originally from a paper referenced in a docstring should also cite that paper.
