### PR TITLE
Update YAML file defining labels to apply to pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,16 +2,16 @@ Breaking:
 - changelog/*.breaking*rst
 
 Continuous Integration:
-- any: [.codecov.yaml, .pre-commit-config.yaml, CODEOWNERS, noxfile.py, tox.ini]
+- any: ['.codecov.yaml', '.pre-commit-config.yaml', 'CODEOWNERS', 'noxfile.py', 'tox.ini']
 
 Contributor Guide:
-- any: [changelog/README.rst, docs/contributing/**/*]
+- any: ['changelog/README.rst', 'docs/contributing/**/*']
 
 dependencies:
 - requirements.txt
 
 Documentation:
-- any: [docs/**/*, changelog/*doc*.rst, README.md, .readthedocs.yml]
+- any: ['docs/**/*', 'changelog/*doc*.rst', 'README.md', '.readthedocs.yml']
   all: ['!docs/notebooks/**/*', '!docs/contributing/*']
 
 GitHub Actions:
@@ -21,7 +21,7 @@ Notebooks:
 - docs/notebooks/**/*
 
 Packaging:
-- any: [MANIFEST.in, pyproject.toml, setup.cfg, setup.py]
+- any: ['MANIFEST.in', 'pyproject.toml', 'setup.cfg', 'setup.py']
 
 plasmapy.analysis:
 - plasmapy/analysis/**/*
@@ -36,7 +36,7 @@ plasmapy.formulary:
 - plasmapy/formulary/**/*
 
 plasmapy.formulary.quantum:
-- any: [plasmapy/formulary/quantum.py, plasmapy/formulary/tests/test_quantum.py]
+- any: ['plasmapy/formulary/quantum.py', 'plasmapy/formulary/tests/test_quantum.py']
 
 plasmapy.particles:
 - plasmapy/particles/**/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix]
+    exclude: .github/labeler.yml
 
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: 0.9.2


### PR DESCRIPTION
The GitHub Action for labeling PRs has been working inconsistently.  My suspicion is that there need to be quotes surrounding the patterns in lists in `.github/labeler.yml`. I'm thinking (guessing?) that the quotes are needed because all of the examples in the [labeler documentation](https://github.com/actions/labeler#pull-request-labeler) have quotes.  

The quotes were being deleted by the YAML reformatter in our pre-commit configuration, so I set it to exclude that particular file.

I'm going to merge this quickly since it's one of those PRs that need to be merged before they can be tested (sigh).
