### PR TITLE
Run packaging GitHub Action sooner

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -146,9 +146,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
     - initial-tests
-    - comprehensive-tests
-    - documentation
-    - import-plasmapy
     steps:
     - uses: actions/checkout@v3
     - name: Get history and tags for SCM versioning to work


### PR DESCRIPTION
This PR modifies when the GitHub Action to check packaging PlasmaPy is run during continuous integration.  

At the moment, the packaging check is started after all other checks have passed. This means that the time to finish our continuous integration checks is $t_\mathrm{doc build} + t_\mathrm{packaging}$ (since the doc build takes significantly longer than everything else and is thus our CI critical path).

This PR makes it so that the packaging check is done after the initial tests are run without waiting for the comprehensive tests and the documentation build. As a consequence, our CI timescale will become $∼t_\mathrm{doc build}$.