### PR TITLE
Update the labeler GitHub Action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,7 @@ Bug:
 'Continuous Integration':
 - .codecov.yaml
 - .github/workflows/*test*.yml
+- .pre-commit-config.yaml
 - CODEOWNERS
 - noxfile.py
 - tox.ini

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,17 +1,20 @@
 # This file defines which GitHub labels get applied when files
-# matching certain minimatch globs are changed.
+# matching certain minimatch glob patterns are changed.
 #
 # Documentation: https://github.com/actions/labeler#pull-request-labeler
 #
-# If a label includes spaces or special characters, enclose it in
-# quotes.
+# If a label includes a space or a pattern begins with an asterisk or
+# special character, enclose it in quotes.
 
 Breaking:
 - changelog/*.breaking*.rst
 
+Bug:
+- changelog/*.bugfix*.rst
+
 'Continuous Integration':
 - .codecov.yaml
-- .pre-commit-config.yaml
+- .github/workflows/*test*.yml
 - CODEOWNERS
 - noxfile.py
 - tox.ini
@@ -36,6 +39,8 @@ Notebooks:
 - docs/notebooks/**/*
 
 Packaging:
+- .github/workflows/*publish*
+- .github/workflows/*release*
 - MANIFEST.in
 - pyproject.toml
 - setup.*
@@ -66,3 +71,11 @@ plasmapy.simulation:
 
 plasmapy.utils:
 - plasmapy/utils/**/*
+
+Testing:
+- '**/test*.py'
+- '**/conftest.py'
+- .github/workflows/weekly.yml
+- .codecov.yaml
+- noxfile.py
+- tox.ini

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix]
+    exclude: .github/labeler.yml
 
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: 0.9.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,10 @@ repos:
     args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix]
+    # For the labeler GitHub Action, labels with spaces in them must
+    # be put in quotes. However, the pretty-format-yaml hook will
+    # remove the quotes which will break that action, so we should not
+    # run this hook on `labeler.yml`.
     exclude: .github/labeler.yml
 
 - repo: https://github.com/tox-dev/pyproject-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
     args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix]
-    exclude: .github/labeler.yml
 
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: 0.9.2


### PR DESCRIPTION
This PR updates the [labeler](https://github.com/actions/labeler) GitHub Action with some more rules for when GitHub labels get applied to PRs.

