### PR TITLE
Remove pydocstyle from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ tests = [
   "flake8-use-fstring",
   "hypothesis",
   "pre-commit",
-  "pydocstyle",
   "pytest-regressions",
   "pytest-xdist",
   "tomli",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ asteval==0.9.29
     # via lmfit
 astor==0.8.1
     # via flake8-simplify
-astropy==5.2.1
+astropy==5.2.2
     # via plasmapy (setup.py)
 asttokens==2.2.1
     # via stack-data
@@ -31,7 +31,7 @@ babel==2.12.1
     #   sphinx
 backcall==0.2.0
     # via ipython
-beautifulsoup4==4.12.0
+beautifulsoup4==4.12.1
     # via nbconvert
 bleach==6.0.0
     # via nbconvert
@@ -62,7 +62,7 @@ contourpy==1.0.7
     # via matplotlib
 cycler==0.11.0
     # via matplotlib
-debugpy==1.6.6
+debugpy==1.6.7
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -92,7 +92,7 @@ executing==1.2.0
     # via stack-data
 fastjsonschema==2.16.3
     # via nbformat
-filelock==3.10.7
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
@@ -112,7 +112,7 @@ flake8-mutable==1.2.0
     # via plasmapy (setup.py)
 flake8-rst-docstrings==0.3.0
     # via plasmapy (setup.py)
-flake8-simplify==0.19.3
+flake8-simplify==0.20.0
     # via plasmapy (setup.py)
 flake8-use-fstring==1.4
     # via plasmapy (setup.py)
@@ -122,9 +122,9 @@ future==0.18.3
     # via uncertainties
 h5py==3.8.0
     # via plasmapy (setup.py)
-hypothesis==6.70.0
+hypothesis==6.70.2
     # via plasmapy (setup.py)
-identify==2.5.21
+identify==2.5.22
     # via pre-commit
 idna==3.4
     # via
@@ -137,12 +137,14 @@ incremental==22.10.0
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.22.0
-    # via plasmapy (setup.py)
+    # via
+    #   ipywidgets
+    #   plasmapy (setup.py)
 ipython==8.12.0
     # via
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.0.5
+ipywidgets==8.0.6
     # via plasmapy (setup.py)
 jedi==0.18.2
     # via ipython
@@ -185,7 +187,7 @@ jupyterlab-pygments==0.2.2
     # via nbconvert
 jupyterlab-server==2.22.0
     # via voila
-jupyterlab-widgets==3.0.6
+jupyterlab-widgets==3.0.7
     # via ipywidgets
 kiwisolver==1.4.4
     # via matplotlib
@@ -215,11 +217,11 @@ mistune==2.0.5
     # via nbconvert
 mpmath==1.3.0
     # via plasmapy (setup.py)
-nbclient==0.7.2
+nbclient==0.7.3
     # via
     #   nbconvert
     #   voila
-nbconvert==7.2.10
+nbconvert==7.3.0
     # via
     #   jupyter-server
     #   nbsphinx
@@ -281,11 +283,11 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==9.4.0
+pillow==9.5.0
     # via
     #   matplotlib
     #   plasmapy (setup.py)
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   jupyter-core
     #   tox
@@ -294,7 +296,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-pre-commit==3.2.0
+pre-commit==3.2.2
     # via plasmapy (setup.py)
 prometheus-client==0.16.0
     # via jupyter-server
@@ -318,9 +320,7 @@ pycodestyle==2.10.0
     # via flake8
 pycparser==2.21
     # via cffi
-pydocstyle==6.3.0
-    # via plasmapy (setup.py)
-pyerfa==2.0.0.2
+pyerfa==2.0.0.3
     # via astropy
 pyflakes==3.0.1
     # via flake8
@@ -356,7 +356,7 @@ python-dateutil==2.8.2
     #   jupyter-client
     #   matplotlib
     #   pandas
-pytz==2022.7.1
+pytz==2023.3
     # via pandas
 pyyaml==6.0
     # via
@@ -376,7 +376,7 @@ requests==2.28.2
     #   sphinx
 restructuredtext-lint==1.4.0
     # via flake8-rst-docstrings
-rich==13.3.2
+rich==13.3.3
     # via tryceratops
 scipy==1.10.1
     # via
@@ -394,9 +394,7 @@ six==1.16.0
 sniffio==1.3.0
     # via anyio
 snowballstemmer==2.2.0
-    # via
-    #   pydocstyle
-    #   sphinx
+    # via sphinx
 sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.4
@@ -478,7 +476,7 @@ towncrier==22.12.0
     # via
     #   plasmapy (setup.py)
     #   sphinx-changelog
-tox==4.4.8
+tox==4.4.11
     # via plasmapy (setup.py)
 tqdm==4.65.0
     # via plasmapy (setup.py)
@@ -517,13 +515,13 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.5.1
     # via jupyter-server
-websockets==10.4
+websockets==11.0.1
     # via voila
-widgetsnbextension==4.0.6
+widgetsnbextension==4.0.7
     # via ipywidgets
 wrapt==1.15.0
     # via plasmapy (setup.py)
-xarray==2023.2.0
+xarray==2023.3.0
     # via plasmapy (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tox.ini
+++ b/tox.ini
@@ -146,7 +146,6 @@ deps =
     flake8-simplify
     flake8-use-fstring
     flake8-use-pathlib
-    pydocstyle
     pygments
     tryceratops
 commands =


### PR DESCRIPTION
Looking through `pyproject.toml` and `tox.ini`, I don't see where `pydocstyle` is getting used now.  This PR attempts to remove `pydocstyle`.  There's a chance that it's getting used by flake8, however, which I need to look into a bit more.