### PR TITLE
Update requirements and fix issue with version conflict related to coverage

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade "tox" codecov
+      run: python -m pip install --progress-bar off --upgrade "tox"
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
   comprehensive-tests:
@@ -89,7 +89,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade tox codecov
+      run: python -m pip install --progress-bar off --upgrade tox
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade "tox<4" codecov
+      run: python -m pip install --progress-bar off --upgrade "tox" codecov
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
   comprehensive-tests:
@@ -89,7 +89,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade "tox<4" codecov
+      run: python -m pip install --progress-bar off --upgrade tox codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc
@@ -116,7 +116,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade "tox<4"
+      run: python -m pip install --progress-bar off --upgrade tox
     - name: Install language-pack-fr and tzdata
       run: sudo apt-get install graphviz pandoc
     - name: Run tests
@@ -137,7 +137,7 @@ jobs:
       with:
         python-version: 3.9
     - name: Install Python dependencies
-      run: python -m pip install --progress-bar off --upgrade "tox<4"
+      run: python -m pip install --progress-bar off --upgrade tox
     - name: Import PlasmaPy
       run: tox -e py39-minimal-pypi-import
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ asteval==0.9.29
     # via lmfit
 astor==0.8.1
     # via flake8-simplify
-astropy==5.2.1
+astropy==5.2.2
     # via plasmapy (setup.py)
 asttokens==2.2.1
     # via stack-data
@@ -24,14 +24,13 @@ attrs==22.2.0
     # via
     #   hypothesis
     #   jsonschema
-    #   pytest
 babel==2.12.1
     # via
     #   jupyterlab-server
     #   sphinx
 backcall==0.2.0
     # via ipython
-beautifulsoup4==4.12.0
+beautifulsoup4==4.12.2
     # via nbconvert
 bleach==6.0.0
     # via nbconvert
@@ -62,7 +61,7 @@ contourpy==1.0.7
     # via matplotlib
 cycler==0.11.0
     # via matplotlib
-debugpy==1.6.6
+debugpy==1.6.7
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -92,7 +91,7 @@ executing==1.2.0
     # via stack-data
 fastjsonschema==2.16.3
     # via nbformat
-filelock==3.10.7
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
@@ -112,7 +111,7 @@ flake8-mutable==1.2.0
     # via plasmapy (setup.py)
 flake8-rst-docstrings==0.3.0
     # via plasmapy (setup.py)
-flake8-simplify==0.19.3
+flake8-simplify==0.20.0
     # via plasmapy (setup.py)
 flake8-use-fstring==1.4
     # via plasmapy (setup.py)
@@ -122,9 +121,9 @@ future==0.18.3
     # via uncertainties
 h5py==3.8.0
     # via plasmapy (setup.py)
-hypothesis==6.70.0
+hypothesis==6.71.0
     # via plasmapy (setup.py)
-identify==2.5.21
+identify==2.5.22
     # via pre-commit
 idna==3.4
     # via
@@ -137,12 +136,14 @@ incremental==22.10.0
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.22.0
-    # via plasmapy (setup.py)
+    # via
+    #   ipywidgets
+    #   plasmapy (setup.py)
 ipython==8.12.0
     # via
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.0.5
+ipywidgets==8.0.6
     # via plasmapy (setup.py)
 jedi==0.18.2
     # via ipython
@@ -185,7 +186,7 @@ jupyterlab-pygments==0.2.2
     # via nbconvert
 jupyterlab-server==2.22.0
     # via voila
-jupyterlab-widgets==3.0.6
+jupyterlab-widgets==3.0.7
     # via ipywidgets
 kiwisolver==1.4.4
     # via matplotlib
@@ -193,7 +194,7 @@ latexcodec==2.0.1
     # via pybtex
 llvmlite==0.39.1
     # via numba
-lmfit==1.1.0
+lmfit==1.2.0
     # via plasmapy (setup.py)
 markdown-it-py==2.2.0
     # via rich
@@ -215,11 +216,11 @@ mistune==2.0.5
     # via nbconvert
 mpmath==1.3.0
     # via plasmapy (setup.py)
-nbclient==0.7.2
+nbclient==0.7.3
     # via
     #   nbconvert
     #   voila
-nbconvert==7.2.10
+nbconvert==7.3.1
     # via
     #   jupyter-server
     #   nbsphinx
@@ -255,7 +256,7 @@ numpy==1.23.5
     #   xarray
 numpydoc==1.5.0
     # via plasmapy (setup.py)
-packaging==23.0
+packaging==23.1
     # via
     #   astropy
     #   ipykernel
@@ -281,11 +282,11 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==9.4.0
+pillow==9.5.0
     # via
     #   matplotlib
     #   plasmapy (setup.py)
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   jupyter-core
     #   tox
@@ -294,7 +295,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-pre-commit==3.2.0
+pre-commit==3.2.2
     # via plasmapy (setup.py)
 prometheus-client==0.16.0
     # via jupyter-server
@@ -320,11 +321,11 @@ pycparser==2.21
     # via cffi
 pydocstyle==6.3.0
     # via plasmapy (setup.py)
-pyerfa==2.0.0.2
+pyerfa==2.0.0.3
     # via astropy
 pyflakes==3.0.1
     # via flake8
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   flake8-rst-docstrings
     #   ipython
@@ -339,7 +340,7 @@ pyproject-api==1.5.1
     # via tox
 pyrsistent==0.19.3
     # via jsonschema
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   plasmapy (setup.py)
     #   pytest-datadir
@@ -356,7 +357,7 @@ python-dateutil==2.8.2
     #   jupyter-client
     #   matplotlib
     #   pandas
-pytz==2022.7.1
+pytz==2023.3
     # via pandas
 pyyaml==6.0
     # via
@@ -376,7 +377,7 @@ requests==2.28.2
     #   sphinx
 restructuredtext-lint==1.4.0
     # via flake8-rst-docstrings
-rich==13.3.2
+rich==13.3.4
     # via tryceratops
 scipy==1.10.1
     # via
@@ -478,7 +479,7 @@ towncrier==22.12.0
     # via
     #   plasmapy (setup.py)
     #   sphinx-changelog
-tox==4.4.8
+tox==4.4.11
     # via plasmapy (setup.py)
 tqdm==4.65.0
     # via plasmapy (setup.py)
@@ -517,13 +518,13 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.5.1
     # via jupyter-server
-websockets==10.4
+websockets==11.0.1
     # via voila
-widgetsnbextension==4.0.6
+widgetsnbextension==4.0.7
     # via ipywidgets
 wrapt==1.15.0
     # via plasmapy (setup.py)
-xarray==2023.2.0
+xarray==2023.3.0
     # via plasmapy (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
The goal of this PR is to fix an issue we just started having with codecov.

```
  python -m pip install --progress-bar off --upgrade "tox<4" codecov
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.10/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.10/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.10/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.10/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.10/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.10/x64/lib
Collecting tox<4
  Downloading tox-3.28.0-py2.py3-none-any.whl (86 kB)
ERROR: Could not find a version that satisfies the requirement codecov (from versions: none)
ERROR: No matching distribution found for codecov
Error: Process completed with exit code 1.
```