### PR TITLE
Made minor edits to changelog entries

### DIFF
--- a/changelog/1656.doc.3.rst
+++ b/changelog/1656.doc.3.rst
@@ -1,1 +1,2 @@
-Removed :file:`docs/contributing/install_dev.rst`.
+Removed outdated instructions on installing the development version
+of PlasmaPy contained in :file:`docs/contributing/install_dev.rst`.

--- a/changelog/1665.feature.rst
+++ b/changelog/1665.feature.rst
@@ -1,1 +1,2 @@
-Added a Kinetic Alfvén numerical solver to `plasmapy.dispersion`.
+Added `~plasmapy.dispersion.numerical.kinetic_alfven_.kinetic_alfven`,
+which numerically solves dispersion relations for kinetic Alfvén waves.

--- a/changelog/1864.trivial.rst
+++ b/changelog/1864.trivial.rst
@@ -1,1 +1,2 @@
-Brought back Dependabot and turned the root-level :file:`requirements.txt` into a lockfile for CI purposes.
+Brought back Dependabot and turned the root-level :file:`requirements.txt`
+into a lockfile for continuous integration purposes.

--- a/changelog/1992.bugfix.rst
+++ b/changelog/1992.bugfix.rst
@@ -1,3 +1,3 @@
-When attempted to create a |Particle| object representing a proton,
+When attempting to create a |Particle| object representing a proton,
 calls like :py:`Particle("H", Z=1, mass_numb=1)` no longer incorrectly
 issue a |ParticleWarning| for redundant particle information.

--- a/changelog/2038.doc.rst
+++ b/changelog/2038.doc.rst
@@ -1,1 +1,2 @@
-Restructured the |documentation guide|.
+Restructured the |documentation guide| by putting information on writing
+documentation prior to instructions for building documentation.

--- a/changelog/2041.doc.rst
+++ b/changelog/2041.doc.rst
@@ -1,1 +1,2 @@
-Restructured the |testing guide|.
+Restructured the |testing guide| by putting information on writing
+tests prior to instructions for running tests.


### PR DESCRIPTION
We plan to release PlasmaPy 2023.5.0 next month.  This PR contains a few minor edits to changelog entries for other PRs in advance of that release.  The changes include more details and/or reST links to functions that were added.