### PR TITLE
Remove pip installation of `codecov` in weekly tests

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -76,7 +76,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --upgrade "tox<4" codecov
+      run: python -m pip install --upgrade tox
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc


### PR DESCRIPTION
This follows up on #2073 by removing `pip install codecov` from our weekly tests.  See #2073 for more details.