### PR TITLE
Update codeowners for different files and subpackages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,18 +1,42 @@
-# in decreasing order of priority
+# Define individuals or teams who are responsible for code in a
+# repository (i.e. who gets requested for a review).
 
-# any file, anywhere
-*                                                        @PlasmaPy/plasmapy-reviewers
-.pre-commit-config.yaml                                  @namurphy
-requirements.txt                                         @StanczakDominik
+# Order is important; the last matching pattern takes the most
+# precedence.
 
-plasmapy/particles/                                      @namurphy
+* @PlasmaPy/plasmapy-reviewers
 
-plasmapy/analysis/                                       @rocco8773
-plasmapy/diagnostics/                                    @rocco8773
+# subpackages
 
-plasmapy/simulation/                                     @StanczakDominik
+plasmapy/analysis/ @rocco8773
+plasmapy/diagnostics/ @rocco8773
+plasmapy/diagnostics/charged_particle_radiography/ @pheuer
+plasmapy/dispersion/ @ejohnson-96
+plasmapy/particles/ @namurphy
+plasmapy/simulation/ @StanczakDominik
+plasmapy/tests/ @namurphy
 
-# any conftest.py, anywhere
-conftest.py                                              @StanczakDominik
+# specific subpackage files
 
-plasmapy/diagnostics/proton_radiography.py               @pheuer
+plasmapy/analysis/nullpoint.py @namurphy
+plasmapy/diagnostics/thomson.py @pheuer
+plasmapy/formulary/relativity.py @namurphy
+
+# documentation
+
+.readthedocs.yml @namurphy
+docs/conf.py @namurphy
+docs/contributing/ @namurphy
+docs/plasmapy_sphinx/ @rocco8773
+
+# project files
+
+pyproject.toml @namurphy
+requirements.txt @namurphy
+
+# tests, linters, CI
+
+.github @namurphy
+.pre-commit-config.yaml @namurphy
+**/conftest.py @StanczakDominik
+tox.ini @namurphy

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Define individuals or teams who are responsible for code in a
-# repository (i.e. who gets requested for a review).
+# repository (i.e. who gets requested for a review by default).
 
 # Order is important; the last matching pattern takes the most
 # precedence.
@@ -16,11 +16,11 @@ plasmapy/particles/ @namurphy
 plasmapy/simulation/ @StanczakDominik
 plasmapy/tests/ @namurphy
 
-# specific subpackage files
+# specific subpackage files (use wildcards to include test files also)
 
-plasmapy/analysis/nullpoint.py @namurphy
-plasmapy/diagnostics/thomson.py @pheuer
-plasmapy/formulary/relativity.py @namurphy
+plasmapy/analysis/**/*nullpoint.py @namurphy
+plasmapy/diagnostics/**/*thomson.py @pheuer
+plasmapy/formulary/**/*relativity.py @namurphy
 
 # documentation
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,13 +8,15 @@
 
 # subpackages
 
-plasmapy/analysis/ @rocco8773
-plasmapy/diagnostics/ @rocco8773
+# plasmapy/analysis/ @rocco8773
+# plasmapy/diagnostics/ @rocco8773
 plasmapy/diagnostics/charged_particle_radiography/ @pheuer
 plasmapy/dispersion/ @ejohnson-96
 plasmapy/particles/ @namurphy
 # plasmapy/simulation/ @StanczakDominik
 plasmapy/tests/ @namurphy
+# plasmapy/utils/decorators/ @rocco8773
+plasmapy/utils/pytest_helpers/ @namurphy
 
 # specific subpackage files (with wildcards to include tests)
 
@@ -31,6 +33,7 @@ docs/plasmapy_sphinx/ @rocco8773
 
 # project files
 
+plasmapy/__init__.py @namurphy
 pyproject.toml @namurphy
 requirements.txt @namurphy
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,8 +8,8 @@
 
 # subpackages
 
-# plasmapy/analysis/ @rocco8773
-# plasmapy/diagnostics/ @rocco8773
+plasmapy/analysis/ @rocco8773
+plasmapy/diagnostics/ @rocco8773
 plasmapy/diagnostics/charged_particle_radiography/ @pheuer
 plasmapy/dispersion/ @ejohnson-96
 plasmapy/particles/ @namurphy
@@ -18,7 +18,7 @@ plasmapy/tests/ @namurphy
 # plasmapy/utils/decorators/ @rocco8773
 plasmapy/utils/pytest_helpers/ @namurphy
 
-# specific subpackage files (with wildcards to include tests)
+# subpackage files (with wildcards to include tests)
 
 plasmapy/analysis/**/*nullpoint.py @namurphy
 plasmapy/diagnostics/**/*thomson.py @pheuer
@@ -36,10 +36,11 @@ docs/plasmapy_sphinx/ @rocco8773
 plasmapy/__init__.py @namurphy
 pyproject.toml @namurphy
 requirements.txt @namurphy
+setup.py @namurphy
 
 # tests, linters, CI
 
 .github @namurphy
 .pre-commit-config.yaml @namurphy
-**/conftest.py @StanczakDominik
+# **/conftest.py @StanczakDominik
 tox.ini @namurphy

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@ plasmapy/diagnostics/ @rocco8773
 plasmapy/diagnostics/charged_particle_radiography/ @pheuer
 plasmapy/dispersion/ @ejohnson-96
 plasmapy/particles/ @namurphy
-plasmapy/simulation/ @StanczakDominik
+# plasmapy/simulation/ @StanczakDominik
 plasmapy/tests/ @namurphy
 
 # specific subpackage files (with wildcards to include tests)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@ plasmapy/particles/ @namurphy
 plasmapy/simulation/ @StanczakDominik
 plasmapy/tests/ @namurphy
 
-# specific subpackage files (use wildcards to include test files also)
+# specific subpackage files (with wildcards to include tests)
 
 plasmapy/analysis/**/*nullpoint.py @namurphy
 plasmapy/diagnostics/**/*thomson.py @pheuer


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file, which is used to specify who gets requested for review by default.  I attempted to make it more fine-grained, which will make it less likely that we'll need to change reviewers around and that we preferentially get assigned reviews of subpackages that we're familiar with.  

I've also commented out a few lines so that those of us who aren't available to review right now are less likely to get assigned reviews, but I'd be happy to uncomment those lines when they're available to review again.  (By the way, I hope you're doing okay!)