### PR TITLE
Fix and update Read the Docs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ build:
   os: ubuntu-22.04
   tools:
     # Use most recent version supported by Numba
-    python: '3.9'
+    python: '3.11'
   apt_packages:
   - graphviz
   jobs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,10 +10,12 @@ build:
   os: ubuntu-22.04
   tools:
     # Use most recent version supported by Numba
-    python: '3.10'
+    python: '3.9'
   apt_packages:
   - graphviz
   jobs:
+    pre_create_environment:
+    - python -m pip install --upgrade setuptools pip
     post_build:
     - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,4 +25,3 @@ python:
     path: .
     extra_requirements:
     - docs
-  system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ build:
   - graphviz
   jobs:
     post_build:
-    - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
+    - echo $'\n'For help deciphering documentation build error messages, see:$'\n\n'\ \ https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,8 +14,6 @@ build:
   apt_packages:
   - graphviz
   jobs:
-    pre_create_environment:
-    - python -m pip install --upgrade setuptools pip
     post_build:
     - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,6 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    # Use most recent version supported by Numba
     python: '3.11'
   apt_packages:
   - graphviz


### PR DESCRIPTION
Our Read the Docs (RTD) configuration started failing within the last day, presumably after their newest release of [v9.12.0](https://docs.readthedocs.io/en/stable/changelog.html#version-9-12-0).

The purposes of this PR are to:
 - Fix the RTD build somehow.
 - See what happens when we use the melty face emoji in a branch name.