### PR TITLE
Fix doc build warning about frozen modules being used

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -81,16 +81,16 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install graphviz and pandoc
+      run: sudo apt-get install graphviz pandoc
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
 
-    - name: Install Python dependencies
+    - name: Install tox
       run: python -m pip install --progress-bar off --upgrade tox
-
-    - name: Install language-pack-fr and tzdata
-      run: sudo apt-get install graphviz pandoc
 
     - name: Build docs
       run: tox -e build_docs_pins -- -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,6 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 asteval==0.9.29
     # via lmfit
-astor==0.8.1
-    # via flake8-simplify
 astropy==5.2.2
     # via plasmapy (setup.py)
 asttokens==2.2.1
@@ -36,7 +34,7 @@ bleach==6.0.0
     # via nbconvert
 cachetools==5.3.0
     # via tox
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via argon2-cffi-bindings
@@ -50,7 +48,6 @@ click==8.1.3
     # via
     #   click-default-group
     #   towncrier
-    #   tryceratops
 click-default-group==1.2.2
     # via towncrier
 colorama==0.4.6
@@ -93,21 +90,10 @@ filelock==3.12.0
     #   virtualenv
 flake8==6.0.0
     # via
-    #   flake8-absolute-import
-    #   flake8-mutable
     #   flake8-rst-docstrings
-    #   flake8-simplify
     #   flake8-use-fstring
     #   plasmapy (setup.py)
-flake8-absolute-import==1.0.0.1
-    # via plasmapy (setup.py)
-flake8-implicit-str-concat==0.4.0
-    # via plasmapy (setup.py)
-flake8-mutable==1.2.0
-    # via plasmapy (setup.py)
 flake8-rst-docstrings==0.3.0
-    # via plasmapy (setup.py)
-flake8-simplify==0.20.0
     # via plasmapy (setup.py)
 flake8-use-fstring==1.4
     # via plasmapy (setup.py)
@@ -117,7 +103,7 @@ future==0.18.3
     # via uncertainties
 h5py==3.8.0
     # via plasmapy (setup.py)
-hypothesis==6.75.1
+hypothesis==6.75.2
     # via plasmapy (setup.py)
 identify==2.5.24
     # via pre-commit
@@ -135,7 +121,7 @@ ipykernel==6.22.0
     # via
     #   ipywidgets
     #   plasmapy (setup.py)
-ipython==8.13.1
+ipython==8.13.2
     # via
     #   ipykernel
     #   ipywidgets
@@ -192,8 +178,6 @@ llvmlite==0.40.0
     # via numba
 lmfit==1.2.1
     # via plasmapy (setup.py)
-markdown-it-py==2.2.0
-    # via rich
 markupsafe==2.1.2
     # via
     #   jinja2
@@ -206,8 +190,6 @@ matplotlib-inline==0.1.6
     #   ipython
 mccabe==0.7.0
     # via flake8
-mdurl==0.1.2
-    # via markdown-it-py
 mistune==2.0.5
     # via nbconvert
 mpmath==1.3.0
@@ -325,7 +307,6 @@ pygments==2.15.1
     #   ipython
     #   nbconvert
     #   plasmapy (setup.py)
-    #   rich
     #   sphinx
     #   sphinx-tabs
 pyparsing==3.0.9
@@ -364,15 +345,13 @@ pyzmq==25.0.2
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-requests==2.29.0
+requests==2.30.0
     # via
     #   jupyterlab-server
     #   plasmapy (setup.py)
     #   sphinx
 restructuredtext-lint==1.4.0
     # via flake8-rst-docstrings
-rich==13.3.5
-    # via tryceratops
 scipy==1.10.1
     # via
     #   lmfit
@@ -452,8 +431,6 @@ terminado==0.17.1
     # via jupyter-server
 tinycss2==1.2.1
     # via nbconvert
-toml==0.10.2
-    # via tryceratops
 tomli==2.0.1
     # via plasmapy (setup.py)
 tornado==6.3.1
@@ -485,13 +462,11 @@ traitlets==5.9.0
     #   nbformat
     #   nbsphinx
     #   voila
-tryceratops==2.0.0
-    # via plasmapy (setup.py)
 tzdata==2023.3
     # via pandas
 uncertainties==3.1.7
     # via lmfit
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 virtualenv==20.23.0
     # via
@@ -507,7 +482,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.5.1
     # via jupyter-server
-websockets==11.0.2
+websockets==11.0.3
     # via voila
 widgetsnbextension==4.0.7
     # via ipywidgets

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ commands =
 changedir = {toxinidir}
 setenv =
     HOME = {envtmpdir}
+    PYDEVD_DISABLE_FILE_VALIDATION=1
 commands =
     sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
     echo "Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting"


### PR DESCRIPTION
When we updated to Python 3.11 (yay!) it appears that we started getting a noisy warning in our doc builds:
```
Debugger warning: It seems that frozen modules are being used, which may
make the debugger miss breakpoints. Please pass -Xfrozen_modules=off
to python to disable frozen modules.
Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
```
This didn't cause a doc build warning/failure, but it made it hard to find and parse actual warnings.  The goal of this PR is to make it so that we don't see this warning.

Possible alternatives for our doc builds would include dropping down to Python 3.10 or not using a strict `requirements.txt` file.