### PR TITLE
Enable NPY rules for ruff

### DIFF
--- a/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -535,10 +535,12 @@ class Tracker:
         prob *= 1 / np.sum(prob)
 
         # Randomly choose theta's weighted with the sine probabilities
-        theta = np.random.choice(arg, size=self.nparticles, replace=True, p=prob)
+        theta = np.random.choice(  # noqa: NPY002
+            arg, size=self.nparticles, replace=True, p=prob
+        )
 
         # Also generate a uniform phi distribution
-        phi = np.random.uniform(high=2 * np.pi, size=self.nparticles)
+        phi = np.random.uniform(high=2 * np.pi, size=self.nparticles)  # noqa: NPY002
 
         return theta, phi
 

--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -8,11 +8,11 @@ from astropy import units as u
 
 from plasmapy.diagnostics import langmuir
 
-np.random.seed(42)
+np.random.seed(42)  # noqa: NPY002
 N = 30  # array length of dummy probe characteristic
 
-current_arr = np.random.rand(N) * u.A
-bias_arr = np.random.rand(N) * u.V
+current_arr = np.random.rand(N) * u.A  # noqa: NPY002
+bias_arr = np.random.rand(N) * u.V  # noqa: NPY002
 
 
 class Test__fitting_functions:
@@ -71,16 +71,18 @@ class Test__fitting_functions:
 class Test__characteristic_errors:
     r"""Test the Characteristic class constructor in langmuir.py"""
 
-    bias_2darr = np.array((np.random.rand(N), np.random.rand(N))) * u.V
-    current_2darr = np.array((np.random.rand(N), np.random.rand(N))) * u.A
+    bias_2darr = np.array((np.random.rand(N), np.random.rand(N))) * u.V  # noqa: NPY002
+    current_2darr = (
+        np.array((np.random.rand(N), np.random.rand(N))) * u.A  # noqa: NPY002
+    )
 
-    bias_infarr = np.append(np.random.rand(N - 1), np.inf) * u.V
-    current_infarr = np.append(np.random.rand(N - 1), np.inf) * u.A
+    bias_infarr = np.append(np.random.rand(N - 1), np.inf) * u.V  # noqa: NPY002
+    current_infarr = np.append(np.random.rand(N - 1), np.inf) * u.A  # noqa: NPY002
 
-    bias_longarr = np.random.rand(N + 1) * u.V
-    current_longarr = np.random.rand(N + 1) * u.A
+    bias_longarr = np.random.rand(N + 1) * u.V  # noqa: NPY002
+    current_longarr = np.random.rand(N + 1) * u.A  # noqa: NPY002
 
-    current_arr2 = np.random.rand(N) * u.A
+    current_arr2 = np.random.rand(N) * u.A  # noqa: NPY002
 
     def test_invalid_dimensions(self):
         r"""Test 2D arrays work with Characteristic class"""
@@ -207,13 +209,15 @@ class DryCharacteristic(langmuir.Characteristic):
 class Test__Characteristic_inherited_methods:
     r"""Test methods on DryCharacteristic class."""
 
-    bias_2darr = np.array((np.random.rand(N), np.random.rand(N))) * u.V
-    current_2darr = np.array((np.random.rand(N), np.random.rand(N))) * u.A
+    bias_2darr = np.array((np.random.rand(N), np.random.rand(N))) * u.V  # noqa: NPY002
+    current_2darr = (
+        np.array((np.random.rand(N), np.random.rand(N))) * u.A  # noqa: NPY002
+    )
 
-    bias_4length_arr = np.array(np.random.rand(N - 1)) * u.V
-    current_5length_arr = np.array(np.random.rand(N)) * u.A
+    bias_4length_arr = np.array(np.random.rand(N - 1)) * u.V  # noqa: NPY002
+    current_5length_arr = np.array(np.random.rand(N)) * u.A  # noqa: NPY002
 
-    bias_duplicates_arr = np.array((1, 2) * int(N / 2)) * u.V
+    bias_duplicates_arr = np.array((1, 2) * int(N / 2)) * u.V  # noqa: NPY002
 
     def test_invalid_bias_dimensions(self):
         r"""Test error on non-1D bias array"""

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -765,14 +765,16 @@ def run_fit(
             data = np.delete(data, np.arange(x0, x1))
             wavelengths = np.delete(wavelengths, np.arange(x0, x1))
 
-    data *= 1 + np.random.normal(loc=0, scale=noise_amp, size=wavelengths.size)
+    data *= 1 + np.random.normal(  # noqa: NPY002
+        loc=0, scale=noise_amp, size=wavelengths.size
+    )
     data *= 1 / np.nanmax(data)
 
     # Randomly choose the starting values of the parameters within the
     # search space (to make the algorithm do some work!)
     for p in list(params.keys()):
         if params[p].vary:
-            params[p].value = np.random.uniform(
+            params[p].value = np.random.uniform(  # noqa: NPY002
                 low=params[p].min, high=params[p].max, size=1
             )
 
@@ -1170,7 +1172,9 @@ def test_fit_with_minimal_parameters():
     )
     data = Skw.value
 
-    data *= 1 + np.random.normal(loc=0, scale=0.1, size=wavelengths.size)
+    data *= 1 + np.random.normal(  # noqa: NPY002
+        loc=0, scale=0.1, size=wavelengths.size
+    )
     data *= 1 / np.nanmax(data)
 
     # Create settings and params using only the minimal parameters

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -1369,11 +1369,17 @@ class NonUniformCartesianGrid(AbstractGrid):
         function so it can be re-implemented to make non-uniform grids.
         """
         # Construct the axis arrays
-        ax0 = np.sort(np.random.uniform(low=start[0], high=stop[0], size=num[0]))
+        ax0 = np.sort(
+            np.random.uniform(low=start[0], high=stop[0], size=num[0])  # noqa: NPY002
+        )
 
-        ax1 = np.sort(np.random.uniform(low=start[1], high=stop[1], size=num[1]))
+        ax1 = np.sort(
+            np.random.uniform(low=start[1], high=stop[1], size=num[1])  # noqa: NPY002
+        )
 
-        ax2 = np.sort(np.random.uniform(low=start[2], high=stop[2], size=num[2]))
+        ax2 = np.sort(
+            np.random.uniform(low=start[2], high=stop[2], size=num[2])  # noqa: NPY002
+        )
 
         # Construct the coordinate arrays
         arr0, arr1, arr2 = np.meshgrid(ax0, ax1, ax2, indexing="ij")

--- a/plasmapy/simulation/tests/test_particletracker.py
+++ b/plasmapy/simulation/tests/test_particletracker.py
@@ -120,7 +120,7 @@ def test_particle_exb_drift(uniform_magnetic_field):
     )
 
     s = ParticleTracker(test_plasma, "p", 5, dt=1e-10 * u.s, nt=int(5e3))
-    s.v[:, 2] += np.random.normal(size=s.N) * u.m / u.s
+    s.v[:, 2] += np.random.normal(size=s.N) * u.m / u.s  # noqa: NPY002
 
     s.run()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,7 @@ extend-select = [
   "INT", # flake8-gettext
   "ISC", # flake8-implicit-str-concat
   "N", # pep8-naming
-  "NPY001", # numpy-deprecated-type-alias
+  "NPY", # numpy-deprecated-type-alias
   "PD", # pandas-vet
   "PGH", # pygrep-hooks
   "PIE", # flake8-pie


### PR DESCRIPTION
Following up on #2080, this PR enables both of the [NPY rules](https://beta.ruff.rs/docs/rules/#numpy-specific-rules-npy) for ruff.  Previously, only `NPY001` had been enabled.  `NPY002` warns about usage of deprecated NumPy random number generation tools.  I also added `# noqa: NPY002` to lines that currently use the deprecated tools to silence the warning.

I plan to create an issue to update to newer NumPy random number functionality, but I don't think we need to be in any hurry about it.