### PR TITLE
Enable ruff rule for cyclomatic (McCabe) complexity

### DIFF
--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -558,7 +558,7 @@ def _reduction(vspace, cell):
     return passX and passY and passZ
 
 
-def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):
+def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):  # noqa: C901
     r"""
     Return the roots of a pair of bilinear equations of the following
     format.

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -629,7 +629,7 @@ def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):
             return np.array([(x1, y1), (x2, y2)])
 
 
-def _trilinear_analysis(vspace, cell):
+def _trilinear_analysis(vspace, cell):  # noqa: C901
     r"""
     Return a true or false value based on whether a grid cell which has
     passed the reduction step, contains a null point, using trilinear

--- a/plasmapy/analysis/swept_langmuir/floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/floating_potential.py
@@ -53,7 +53,7 @@ class VFExtras(NamedTuple):
     """
 
 
-def find_floating_potential(
+def find_floating_potential(  # noqa: C901
     voltage: np.ndarray,
     current: np.ndarray,
     threshold: int = 1,

--- a/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/plasmapy/analysis/swept_langmuir/helpers.py
@@ -5,7 +5,7 @@ import astropy.units as u
 import numpy as np
 
 
-def check_sweep(
+def check_sweep(  # noqa: C901
     voltage: np.ndarray,
     current: np.ndarray,
     strip_units: bool = True,

--- a/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -1355,7 +1355,7 @@ class Tracker:
 # *************************************************************************
 
 
-def synthetic_radiograph(
+def synthetic_radiograph(  # noqa: C901
     obj, size=None, bins=None, ignore_grid=False, optical_density=False
 ):
     r"""

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -14,7 +14,7 @@ from plasmapy.diagnostics.charged_particle_radiography import (
 from plasmapy.plasma.grids import CartesianGrid
 
 
-def _test_grid(
+def _test_grid(  # noqa: C901
     name,
     L=1 * u.mm,
     num=100,

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -90,7 +90,7 @@ def spectral_density_args_kwargs(kwargs):
     return args, kwargs
 
 
-def args_to_lite_args(kwargs):
+def args_to_lite_args(kwargs):  # noqa: C901
     """
     Converts a dict of args for the spectral density function and converts
     them to input for the lite function.
@@ -669,7 +669,7 @@ def test_param_to_array_fcns():
     assert np.mean(arr) == 2
 
 
-def run_fit(
+def run_fit(  # noqa: C901
     wavelengths,
     params,
     settings,

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -261,7 +261,7 @@ def spectral_density_lite(
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
 @bind_lite_func(spectral_density_lite)
-def spectral_density(
+def spectral_density(  # noqa: C901
     wavelengths: u.nm,
     probe_wavelength: u.nm,
     n: u.m**-3,
@@ -679,7 +679,7 @@ def _spectral_density_model(wavelengths, settings=None, **params):
     return model_Skw
 
 
-def spectral_density_model(wavelengths, settings, params):
+def spectral_density_model(wavelengths, settings, params):  # noqa: C901
     r"""
     Returns a `lmfit.model.Model` function for Thomson spectral density
     function.

--- a/plasmapy/dispersion/analytical/stix_.py
+++ b/plasmapy/dispersion/analytical/stix_.py
@@ -21,7 +21,7 @@ c_si_unitless = c.value
     n_i={"can_be_negative": False},
     w={"can_be_negative": False, "can_be_zero": False},
 )
-def stix(
+def stix(  # noqa: C901
     B: u.T,
     w: u.rad / u.s,
     ions: Particle,

--- a/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/plasmapy/dispersion/analytical/two_fluid_.py
@@ -25,7 +25,7 @@ from plasmapy.utils.exceptions import PhysicsWarning
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def two_fluid(
+def two_fluid(  # noqa: C901
     *,
     B: u.T,
     ion: Union[str, Particle],

--- a/plasmapy/dispersion/numerical/hollweg_.py
+++ b/plasmapy/dispersion/numerical/hollweg_.py
@@ -27,7 +27,7 @@ c_si_unitless = c.value
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def hollweg(
+def hollweg(  # noqa: C901
     *,
     B: u.T,
     ion: Union[str, Particle],

--- a/plasmapy/dispersion/numerical/kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/kinetic_alfven_.py
@@ -28,7 +28,7 @@ c_si_unitless = c.value
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def kinetic_alfven(
+def kinetic_alfven(  # noqa: C901
     *,
     B: u.T,
     ion: ParticleLike,

--- a/plasmapy/formulary/collisions/lengths.py
+++ b/plasmapy/formulary/collisions/lengths.py
@@ -108,7 +108,7 @@ def impact_parameter_perp(
     n_e={"can_be_negative": False},
     V={"none_shall_pass": True},
 )
-def impact_parameter(
+def impact_parameter(  # noqa: C901
     T: u.K,
     n_e: u.m**-3,
     species,

--- a/plasmapy/formulary/collisions/tests/test_frequencies.py
+++ b/plasmapy/formulary/collisions/tests/test_frequencies.py
@@ -108,7 +108,7 @@ class TestSingleParticleCollisionFrequencies:
         assert MKS_result == CGS_result
 
     @staticmethod
-    def get_limit_value(interaction_type, limit_type, cases):
+    def get_limit_value(interaction_type, limit_type, cases):  # noqa: C901
         """
         Get the limiting values for frequencies given the two particles
         interacting, and their frequencies class.

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -100,7 +100,7 @@ lambdaD_ = Debye_length
     validations_on_return={"equivalencies": u.dimensionless_angles()},
 )
 @particle_input(any_of={"charged", "uncharged"})
-def gyroradius(
+def gyroradius(  # noqa: C901
     B: u.T,
     particle: ParticleLike,
     *,

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -223,7 +223,7 @@ def extract_charge(arg: str):
     return isotope_info, Z_from_arg
 
 
-def parse_and_check_atomic_input(
+def parse_and_check_atomic_input(  # noqa: C901
     argument: Union[str, Integral],
     mass_numb: Optional[Integral] = None,
     Z: Optional[Integral] = None,

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -149,7 +149,7 @@ def invalid_particle_errmsg(
     return errmsg
 
 
-def extract_charge(arg: str):
+def extract_charge(arg: str):  # noqa: C901
     """
     Receive a `str` representing an element, isotope, or ion.
     Return a `tuple` containing a `str` that should represent an

--- a/plasmapy/particles/_special_particles.py
+++ b/plasmapy/particles/_special_particles.py
@@ -136,7 +136,7 @@ An instance of `~plasmapy.particles._special_particles.ParticleZoo`.
 """
 
 
-def create_particles_dict() -> dict[str, dict]:
+def create_particles_dict() -> dict[str, dict]:  # noqa: C901
     """
     Create a dictionary of dictionaries that contains physical
     information for particles and antiparticles that are not elements or

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -400,7 +400,7 @@ class IonizationStateCollection:
         return self._ionic_fractions
 
     @ionic_fractions.setter
-    def ionic_fractions(self, inputs: Union[dict, list, tuple]):
+    def ionic_fractions(self, inputs: Union[dict, list, tuple]):  # noqa: C901
         """
         Set the ionic fractions.
 

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -227,7 +227,7 @@ class IonizationStateCollection:
                 number_density=self.number_densities[particle][int_charge],
             )
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value):  # noqa: C901
         errmsg = (
             f"Cannot set item for this IonizationStateCollection instance for "
             f"key = {key!r} and value = {value!r}"

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -108,7 +108,7 @@ def mass_energy(particle: Particle, mass_numb: Optional[Integral] = None) -> u.J
     return particle.mass_energy
 
 
-def nuclear_reaction_energy(*args, **kwargs) -> u.J:
+def nuclear_reaction_energy(*args, **kwargs) -> u.J:  # noqa: C901
     """
     Return the released energy from a nuclear reaction.
 

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -666,7 +666,7 @@ class AbstractGrid(ABC):
         """
         return list(self.ds.data_vars)
 
-    def _make_grid(
+    def _make_grid(  # noqa: C901
         self,
         start: Union[int, float, u.Quantity],
         stop: Union[int, float, u.Quantity],

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -273,7 +273,12 @@ class CheckValues(CheckBase):
 
         return out_checks
 
-    def _check_value(self, arg, arg_name: str, arg_checks: dict[str, bool]):
+    def _check_value(  # noqa: C901
+        self,
+        arg,
+        arg_name: str,
+        arg_checks: dict[str, bool],
+    ):
         """
         Perform checks ``arg_checks`` on function argument ``arg``.
 
@@ -523,7 +528,7 @@ class CheckUnits(CheckBase):
 
         return wrapper
 
-    def _get_unit_checks(
+    def _get_unit_checks(  # noqa: C901
         self, bound_args: inspect.BoundArguments
     ) -> dict[str, dict[str, Any]]:
         """
@@ -781,7 +786,7 @@ class CheckUnits(CheckBase):
         if err is not None:
             raise err
 
-    def _check_unit_core(
+    def _check_unit_core(  # noqa: C901
         self, arg, arg_name: str, arg_checks: dict[str, Any]
     ) -> tuple[
         Optional[u.Quantity],

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -287,7 +287,12 @@ class ValidateQuantities(CheckUnits, CheckValues):
 
         return validations
 
-    def _validate_quantity(self, arg, arg_name: str, arg_validations: dict[str, Any]):
+    def _validate_quantity(  # noqa: C901
+        self,
+        arg,
+        arg_name: str,
+        arg_validations: dict[str, Any],
+    ):
         """
         Perform validations `arg_validations` on function argument `arg`
         named `arg_name`.

--- a/plasmapy/utils/pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers/pytest_helpers.py
@@ -65,7 +65,7 @@ def _process_input(wrapped_function: Callable):  # coverage: ignore
 
 
 @_process_input
-def run_test(
+def run_test(  # noqa: C901
     func,
     args: Any = (),
     kwargs: dict = None,
@@ -412,7 +412,10 @@ def run_test(
     raise UnexpectedResultFail(errmsg)
 
 
-def run_test_equivalent_calls(*test_inputs, require_same_type: bool = True):
+def run_test_equivalent_calls(  # noqa: C901
+    *test_inputs,
+    require_same_type: bool = True,
+):
     """
     Test that different functions/inputs return equivalent results.
 
@@ -621,7 +624,7 @@ def run_test_equivalent_calls(*test_inputs, require_same_type: bool = True):
         raise UnexpectedResultFail(errmsg)
 
 
-def assert_can_handle_nparray(
+def assert_can_handle_nparray(  # noqa: C901
     function_to_test,
     insert_some_nans=None,
     insert_all_nans=None,
@@ -677,7 +680,7 @@ def assert_can_handle_nparray(
     if kwargs is None:
         kwargs = {}
 
-    def _prepare_input(
+    def _prepare_input(  # noqa: C901
         param_name, param_default, insert_some_nans, insert_all_nans, kwargs
     ):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,7 @@ pandas = "pd"
 ignore-variadic-names = true
 
 [tool.ruff.mccabe]
-max-complexity = 15
+max-complexity = 10
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402", "F401", "F402", "F403"]  # ignore import errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ extend-select = [
   "B",  # flake8-bugbear
   "BLE", # flake8-blind-except
   "C4", # flake8-comprehensions
+  "C90", # mccabe
   "COM818", # trailing-comma-on-bare-tuple
   "D",  # pydocstyle
   "FBT003", # flake8-boolean-trap
@@ -306,7 +307,7 @@ pandas = "pd"
 ignore-variadic-names = true
 
 [tool.ruff.mccabe]
-max-complexity = 20
+max-complexity = 15
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402", "F401", "F402", "F403"]  # ignore import errors


### PR DESCRIPTION
[Cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) is "a quantitative measure of the number of linearly independent paths through a program's source code."  When cyclomatic complexity is high, functions tend to be harder to understand, modify, & test.

This PR enables ruff rule [`C901`](https://beta.ruff.rs/docs/rules/#mccabe-c90) that issues warnings when the cyclomatic complexity exceeds a certain threshold.  I set the threshold to the default value of 10, but we may want to adjust it later since I don't know if that's the best value for scientific software development.  

A good first strategy for [reducing cyclomatic complexity](https://blog.codacy.com/reduce-cyclomatic-complexity/) is to write small functions that do one thing with no side effects.  A high level (big picture) function can call other mid-level functions, and the mid-level functions can call functions implementing low-level implementation details.  It also helps to reduce the number of decision structures that show up, and to avoid having too many flags in functions.  When we're making good use of Python classes, we can also [replace conditionals with polymorphism](https://refactoring.guru/replace-conditional-with-polymorphism).

If we have a good reason for exceeding the maximum cyclomatic complexity, we can add a `# noqa: C901` comment on the line with the `def` or `class` statement.  I also did that for the functions/methods that have a higher cyclomatic complexity than the threshold.