### PR TITLE
Enable ruff rules for pylint refactorings

### DIFF
--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -629,7 +629,7 @@ def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):  # noqa: PLR0911, PLR0912
             return np.array([(x1, y1), (x2, y2)])
 
 
-def _trilinear_analysis(vspace, cell):  # noqa: PLR0911, PLR0912
+def _trilinear_analysis(vspace, cell):  # noqa: PLR0911, PLR0912, PLR0915
     r"""
     Return a true or false value based on whether a grid cell which has
     passed the reduction step, contains a null point, using trilinear

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -1316,7 +1316,7 @@ def _classify_null_point(vspace, cell, loc):
         if np.allclose(M, M.T, atol=_EQUALITY_ATOL):  # Checking if M is symmetric
             null_point_type = "Proper radial null"
         else:
-            if np.isclose(determinant, 0, atol=_EQUALITY_ATOL):
+            if np.isclose(determinant, 0, atol=_EQUALITY_ATOL):  # noqa: PLR5501
                 null_point_type = "Anti-parallel lines with null plane OR Planes of parabolae with null line"
             else:
                 null_point_type = "Critical spiral null"
@@ -1327,12 +1327,12 @@ def _classify_null_point(vspace, cell, loc):
             else:
                 null_point_type = "Improper radial null"
         else:
-            if np.isclose(determinant, 0, atol=_EQUALITY_ATOL):
+            if np.isclose(determinant, 0, atol=_EQUALITY_ATOL):  # noqa: PLR5501
                 null_point_type = "Continuous X-points"
             else:
                 null_point_type = "Skewed improper null"
     else:
-        if np.isclose(determinant, 0, atol=_EQUALITY_ATOL):
+        if np.isclose(determinant, 0, atol=_EQUALITY_ATOL):  # noqa: PLR5501
             null_point_type = "Continuous concentric ellipses"
         else:
             null_point_type = "Spiral null"

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -558,7 +558,7 @@ def _reduction(vspace, cell):
     return passX and passY and passZ
 
 
-def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):  # noqa: PLR0911
+def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):  # noqa: PLR0911, PLR0912
     r"""
     Return the roots of a pair of bilinear equations of the following
     format.
@@ -629,7 +629,7 @@ def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):  # noqa: PLR0911
             return np.array([(x1, y1), (x2, y2)])
 
 
-def _trilinear_analysis(vspace, cell):  # noqa: PLR0911
+def _trilinear_analysis(vspace, cell):  # noqa: PLR0911, PLR0912
     r"""
     Return a true or false value based on whether a grid cell which has
     passed the reduction step, contains a null point, using trilinear
@@ -1261,7 +1261,7 @@ def _locate_null_point(vspace, cell, n, err):
     return None
 
 
-def _classify_null_point(vspace, cell, loc):
+def _classify_null_point(vspace, cell, loc):  # noqa: PLR0912
     r"""
     Return the coordinates of a null point within a given grid cell in a
     vector space using the Newton-Rapshon method.

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -558,7 +558,7 @@ def _reduction(vspace, cell):
     return passX and passY and passZ
 
 
-def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):
+def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):  # noqa: PLR0911
     r"""
     Return the roots of a pair of bilinear equations of the following
     format.
@@ -629,7 +629,7 @@ def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):
             return np.array([(x1, y1), (x2, y2)])
 
 
-def _trilinear_analysis(vspace, cell):
+def _trilinear_analysis(vspace, cell):  # noqa: PLR0911
     r"""
     Return a true or false value based on whether a grid cell which has
     passed the reduction step, contains a null point, using trilinear

--- a/plasmapy/analysis/swept_langmuir/floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/floating_potential.py
@@ -53,7 +53,7 @@ class VFExtras(NamedTuple):
     """
 
 
-def find_floating_potential(  # noqa: PLR0912
+def find_floating_potential(  # noqa: PLR0912, PLR0915
     voltage: np.ndarray,
     current: np.ndarray,
     threshold: int = 1,

--- a/plasmapy/analysis/swept_langmuir/floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/floating_potential.py
@@ -53,7 +53,7 @@ class VFExtras(NamedTuple):
     """
 
 
-def find_floating_potential(
+def find_floating_potential(  # noqa: PLR0912
     voltage: np.ndarray,
     current: np.ndarray,
     threshold: int = 1,

--- a/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/plasmapy/analysis/swept_langmuir/helpers.py
@@ -5,7 +5,7 @@ import astropy.units as u
 import numpy as np
 
 
-def check_sweep(
+def check_sweep(  # noqa: PLR0912
     voltage: np.ndarray,
     current: np.ndarray,
     strip_units: bool = True,

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -14,7 +14,7 @@ from plasmapy.diagnostics.charged_particle_radiography import (
 from plasmapy.plasma.grids import CartesianGrid
 
 
-def _test_grid(
+def _test_grid(  # noqa: PLR0912
     name,
     L=1 * u.mm,
     num=100,

--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -208,7 +208,7 @@ class Characteristic:
 @validate_quantities(
     probe_area={"can_be_negative": False, "can_be_inf": False, "can_be_nan": False}
 )
-def swept_probe_analysis(
+def swept_probe_analysis(  # noqa: PLR0915
     probe_characteristic,
     probe_area: u.m**2,
     gas_argument,

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -261,7 +261,7 @@ def spectral_density_lite(
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
 @bind_lite_func(spectral_density_lite)
-def spectral_density(
+def spectral_density(  # noqa: PLR0912
     wavelengths: u.nm,
     probe_wavelength: u.nm,
     n: u.m**-3,
@@ -679,7 +679,7 @@ def _spectral_density_model(wavelengths, settings=None, **params):
     return model_Skw
 
 
-def spectral_density_model(wavelengths, settings, params):
+def spectral_density_model(wavelengths, settings, params):  # noqa: PLR0912
     r"""
     Returns a `lmfit.model.Model` function for Thomson spectral density
     function.

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -261,7 +261,7 @@ def spectral_density_lite(
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
 @bind_lite_func(spectral_density_lite)
-def spectral_density(  # noqa: PLR0912
+def spectral_density(  # noqa: PLR0912, PLR0915
     wavelengths: u.nm,
     probe_wavelength: u.nm,
     n: u.m**-3,
@@ -679,7 +679,7 @@ def _spectral_density_model(wavelengths, settings=None, **params):
     return model_Skw
 
 
-def spectral_density_model(wavelengths, settings, params):  # noqa: PLR0912
+def spectral_density_model(wavelengths, settings, params):  # noqa: PLR0912, PLR0915
     r"""
     Returns a `lmfit.model.Model` function for Thomson spectral density
     function.

--- a/plasmapy/dispersion/analytical/stix_.py
+++ b/plasmapy/dispersion/analytical/stix_.py
@@ -21,7 +21,7 @@ c_si_unitless = c.value
     n_i={"can_be_negative": False},
     w={"can_be_negative": False, "can_be_zero": False},
 )
-def stix(  # noqa: PLR0912
+def stix(  # noqa: PLR0912, PLR0915
     B: u.T,
     w: u.rad / u.s,
     ions: Particle,

--- a/plasmapy/dispersion/analytical/stix_.py
+++ b/plasmapy/dispersion/analytical/stix_.py
@@ -21,7 +21,7 @@ c_si_unitless = c.value
     n_i={"can_be_negative": False},
     w={"can_be_negative": False, "can_be_zero": False},
 )
-def stix(
+def stix(  # noqa: PLR0912
     B: u.T,
     w: u.rad / u.s,
     ions: Particle,

--- a/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/plasmapy/dispersion/analytical/two_fluid_.py
@@ -25,7 +25,7 @@ from plasmapy.utils.exceptions import PhysicsWarning
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def two_fluid(  # noqa: PLR0912
+def two_fluid(  # noqa: PLR0912, PLR0915
     *,
     B: u.T,
     ion: Union[str, Particle],

--- a/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/plasmapy/dispersion/analytical/two_fluid_.py
@@ -25,7 +25,7 @@ from plasmapy.utils.exceptions import PhysicsWarning
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def two_fluid(
+def two_fluid(  # noqa: PLR0912
     *,
     B: u.T,
     ion: Union[str, Particle],

--- a/plasmapy/dispersion/numerical/hollweg_.py
+++ b/plasmapy/dispersion/numerical/hollweg_.py
@@ -27,7 +27,7 @@ c_si_unitless = c.value
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def hollweg(
+def hollweg(  # noqa: PLR0912
     *,
     B: u.T,
     ion: Union[str, Particle],

--- a/plasmapy/dispersion/numerical/hollweg_.py
+++ b/plasmapy/dispersion/numerical/hollweg_.py
@@ -27,7 +27,7 @@ c_si_unitless = c.value
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def hollweg(  # noqa: PLR0912
+def hollweg(  # noqa: PLR0912, PLR0915
     *,
     B: u.T,
     ion: Union[str, Particle],

--- a/plasmapy/dispersion/numerical/kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/kinetic_alfven_.py
@@ -28,7 +28,7 @@ c_si_unitless = c.value
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def kinetic_alfven(
+def kinetic_alfven(  # noqa: PLR0912
     *,
     B: u.T,
     ion: ParticleLike,

--- a/plasmapy/dispersion/numerical/kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/kinetic_alfven_.py
@@ -28,7 +28,7 @@ c_si_unitless = c.value
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def kinetic_alfven(  # noqa: PLR0912
+def kinetic_alfven(  # noqa: PLR0912, PLR0915
     *,
     B: u.T,
     ion: ParticleLike,

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -300,7 +300,7 @@ class ClassicalTransport:
         T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
         m_i={"can_be_negative": False},
     )
-    def __init__(  # noqa: PLR0912
+    def __init__(  # noqa: PLR0912, PLR0915
         self,
         T_e: u.K,
         n_e: u.m**-3,
@@ -1631,7 +1631,7 @@ def _nondim_tec_braginskii(hall, Z, field_orientation):
 #
 
 
-def _nondim_tc_e_ji_held(hall, Z, field_orientation):
+def _nondim_tc_e_ji_held(hall, Z, field_orientation):  # noqa: PLR0915
     """
     Dimensionless electron thermal conductivity — Ji-Held.
 

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -300,7 +300,7 @@ class ClassicalTransport:
         T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
         m_i={"can_be_negative": False},
     )
-    def __init__(
+    def __init__(  # noqa: PLR0912
         self,
         T_e: u.K,
         n_e: u.m**-3,

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -223,7 +223,7 @@ def extract_charge(arg: str):  # noqa: PLR0912
     return isotope_info, Z_from_arg
 
 
-def parse_and_check_atomic_input(  # noqa: PLR0912
+def parse_and_check_atomic_input(  # noqa: PLR0912, PLR0915
     argument: Union[str, Integral],
     mass_numb: Optional[Integral] = None,
     Z: Optional[Integral] = None,

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -149,7 +149,7 @@ def invalid_particle_errmsg(
     return errmsg
 
 
-def extract_charge(arg: str):
+def extract_charge(arg: str):  # noqa: PLR0912
     """
     Receive a `str` representing an element, isotope, or ion.
     Return a `tuple` containing a `str` that should represent an
@@ -223,7 +223,7 @@ def extract_charge(arg: str):
     return isotope_info, Z_from_arg
 
 
-def parse_and_check_atomic_input(
+def parse_and_check_atomic_input(  # noqa: PLR0912
     argument: Union[str, Integral],
     mass_numb: Optional[Integral] = None,
     Z: Optional[Integral] = None,

--- a/plasmapy/particles/_special_particles.py
+++ b/plasmapy/particles/_special_particles.py
@@ -136,7 +136,7 @@ An instance of `~plasmapy.particles._special_particles.ParticleZoo`.
 """
 
 
-def create_particles_dict() -> dict[str, dict]:
+def create_particles_dict() -> dict[str, dict]:  # noqa: PLR0912
     """
     Create a dictionary of dictionaries that contains physical
     information for particles and antiparticles that are not elements or

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -400,7 +400,10 @@ class IonizationStateCollection:
         return self._ionic_fractions
 
     @ionic_fractions.setter
-    def ionic_fractions(self, inputs: Union[dict, list, tuple]):  # noqa: PLR0912
+    def ionic_fractions(  # noqa: PLR0912, PLR0915
+        self,
+        inputs: Union[dict, list, tuple],
+    ):
         """
         Set the ionic fractions.
 

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -227,7 +227,7 @@ class IonizationStateCollection:
                 number_density=self.number_densities[particle][int_charge],
             )
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value):  # noqa: PLR0912
         errmsg = (
             f"Cannot set item for this IonizationStateCollection instance for "
             f"key = {key!r} and value = {value!r}"
@@ -400,7 +400,7 @@ class IonizationStateCollection:
         return self._ionic_fractions
 
     @ionic_fractions.setter
-    def ionic_fractions(self, inputs: Union[dict, list, tuple]):
+    def ionic_fractions(self, inputs: Union[dict, list, tuple]):  # noqa: PLR0912
         """
         Set the ionic fractions.
 

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -108,7 +108,7 @@ def mass_energy(particle: Particle, mass_numb: Optional[Integral] = None) -> u.J
     return particle.mass_energy
 
 
-def nuclear_reaction_energy(*args, **kwargs) -> u.J:
+def nuclear_reaction_energy(*args, **kwargs) -> u.J:  # noqa: PLR0915
     """
     Return the released energy from a nuclear reaction.
 

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -666,7 +666,7 @@ class AbstractGrid(ABC):
         """
         return list(self.ds.data_vars)
 
-    def _make_grid(
+    def _make_grid(  # noqa: PLR0912
         self,
         start: Union[int, float, u.Quantity],
         stop: Union[int, float, u.Quantity],

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -528,7 +528,7 @@ class CheckUnits(CheckBase):
 
         return wrapper
 
-    def _get_unit_checks(  # noqa: PLR0912
+    def _get_unit_checks(  # noqa: PLR0912, PLR0915
         self, bound_args: inspect.BoundArguments
     ) -> dict[str, dict[str, Any]]:
         """
@@ -786,7 +786,7 @@ class CheckUnits(CheckBase):
         if err is not None:
             raise err
 
-    def _check_unit_core(  # noqa: PLR0912
+    def _check_unit_core(  # noqa: PLR0912, PLR0915
         self, arg, arg_name: str, arg_checks: dict[str, Any]
     ) -> tuple[
         Optional[u.Quantity],

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -273,7 +273,12 @@ class CheckValues(CheckBase):
 
         return out_checks
 
-    def _check_value(self, arg, arg_name: str, arg_checks: dict[str, bool]):
+    def _check_value(  # noqa: PLR0912
+        self,
+        arg,
+        arg_name: str,
+        arg_checks: dict[str, bool],
+    ):
         """
         Perform checks ``arg_checks`` on function argument ``arg``.
 
@@ -523,7 +528,7 @@ class CheckUnits(CheckBase):
 
         return wrapper
 
-    def _get_unit_checks(
+    def _get_unit_checks(  # noqa: PLR0912
         self, bound_args: inspect.BoundArguments
     ) -> dict[str, dict[str, Any]]:
         """
@@ -781,7 +786,7 @@ class CheckUnits(CheckBase):
         if err is not None:
             raise err
 
-    def _check_unit_core(
+    def _check_unit_core(  # noqa: PLR0912
         self, arg, arg_name: str, arg_checks: dict[str, Any]
     ) -> tuple[
         Optional[u.Quantity],

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -287,7 +287,12 @@ class ValidateQuantities(CheckUnits, CheckValues):
 
         return validations
 
-    def _validate_quantity(self, arg, arg_name: str, arg_validations: dict[str, Any]):
+    def _validate_quantity(  # noqa: PLR0912
+        self,
+        arg,
+        arg_name: str,
+        arg_validations: dict[str, Any],
+    ):
         """
         Perform validations `arg_validations` on function argument `arg`
         named `arg_name`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,7 @@ extend-select = [
   "PLR0206",
   "PLR0402",
   "PLR0911",
-##  "PLR0912",
+#  "PLR0912",
 #  "PLR0913",
 #  "PLR0915",
   "PLR1701",
@@ -325,7 +325,7 @@ max-complexity = 20
 "plasmapy/formulary/braginskii.py" = ["C901"]
 "plasmapy/formulary/tests/test_distribution.py" = ["ARG005"]
 "plasmapy/particles/tests/test_decorators.py" = ["ARG001", "ARG002"]
-"plasmapy/utils/pytest_helpers/pytest_helpers.py" = ["BLE001", "PLR0911"]
+"plasmapy/utils/pytest_helpers/pytest_helpers.py" = ["BLE001", "PLR0911", "PLR0912"]
 "plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py" = ["BLE001", "TRY002"]
 
 [tool.ruff.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,6 @@ ignore = [
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
   "PLR0913", # too-many-arguments
-#  "PLR0915",
   "PLR2004", # magic-value-comparison
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,18 +236,7 @@ extend-select = [
   "PIE", # flake8-pie
   "PLC", # pylint convention
   "PLE", # pylint errors
-  "PLR0133",
-  "PLR0206",
-  "PLR0402",
-  "PLR0911",
-#  "PLR0912",
-#  "PLR0913",
-#  "PLR0915",
-  "PLR1701",
-  "PLR1711",
-  "PLR1722",
-##  "PLR2004",
-#  "PLR5501",
+  "PLR", # pylint refactorings
   "PTH", # flake8-use-pathlib
   "PYI", # flake8-pyi
   "RUF", # ruff specific rules
@@ -285,6 +274,11 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
+  "PLR0912",
+  "PLR0913",
+  "PLR0915",
+  "PLR2004",
+  "PLR5501",
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring
   "RUF003", # ambiguous-unicode-character-comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,18 @@ extend-select = [
   "PIE", # flake8-pie
   "PLC", # pylint convention
   "PLE", # pylint errors
+#  "PLR0133",
+#  "PLR0206",
+#  "PLR0402",
+#  "PLR0911",
+#  "PLR0912",
+#  "PLR0913",
+#  "PLR0915",
+#  "PLR1701",
+#  "PLR1711",
+#  "PLR1722",
+#  "PLR2004",
+#  "PLR5501",
   "PTH", # flake8-use-pathlib
   "PYI", # flake8-pyi
   "RUF", # ruff specific rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,9 +238,9 @@ extend-select = [
   "PLE", # pylint errors
   "PLR0133",
   "PLR0206",
-#  "PLR0402",
+  "PLR0402",
 #  "PLR0911",
-#  "PLR0912",
+##  "PLR0912",
 #  "PLR0913",
 #  "PLR0915",
   "PLR1701",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,8 +245,8 @@ extend-select = [
 #  "PLR0915",
   "PLR1701",
   "PLR1711",
-#  "PLR1722",
-#  "PLR2004",
+  "PLR1722",
+##  "PLR2004",
 #  "PLR5501",
   "PTH", # flake8-use-pathlib
   "PYI", # flake8-pyi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,9 +274,8 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
-#  "PLR0912",
-  "PLR0913",
-  "PLR0915",
+  "PLR0913", # too-many-arguments
+#  "PLR0915",
   "PLR2004", # magic-value-comparison
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring
@@ -318,7 +317,7 @@ max-complexity = 20
 "plasmapy/formulary/braginskii.py" = ["C901"]
 "plasmapy/formulary/tests/test_distribution.py" = ["ARG005"]
 "plasmapy/particles/tests/test_decorators.py" = ["ARG001", "ARG002"]
-"plasmapy/utils/pytest_helpers/pytest_helpers.py" = ["BLE001", "PLR0911", "PLR0912"]
+"plasmapy/utils/pytest_helpers/pytest_helpers.py" = ["BLE001", "PLR"]
 "plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py" = ["BLE001", "TRY002"]
 
 [tool.ruff.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,15 +236,15 @@ extend-select = [
   "PIE", # flake8-pie
   "PLC", # pylint convention
   "PLE", # pylint errors
-#  "PLR0133",
-#  "PLR0206",
+  "PLR0133",
+  "PLR0206",
 #  "PLR0402",
 #  "PLR0911",
 #  "PLR0912",
 #  "PLR0913",
 #  "PLR0915",
-#  "PLR1701",
-#  "PLR1711",
+  "PLR1701",
+  "PLR1711",
 #  "PLR1722",
 #  "PLR2004",
 #  "PLR5501",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,8 +277,8 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
-  "PLR2004",
-  "PLR5501",
+  "PLR2004", # magic-value-comparison
+#  "PLR5501",
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring
   "RUF003", # ambiguous-unicode-character-comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,11 +274,10 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
-  "PLR0912",
+#  "PLR0912",
   "PLR0913",
   "PLR0915",
   "PLR2004", # magic-value-comparison
-#  "PLR5501",
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring
   "RUF003", # ambiguous-unicode-character-comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,7 @@ extend-select = [
   "PLR0133",
   "PLR0206",
   "PLR0402",
-#  "PLR0911",
+  "PLR0911",
 ##  "PLR0912",
 #  "PLR0913",
 #  "PLR0915",
@@ -325,7 +325,7 @@ max-complexity = 20
 "plasmapy/formulary/braginskii.py" = ["C901"]
 "plasmapy/formulary/tests/test_distribution.py" = ["ARG005"]
 "plasmapy/particles/tests/test_decorators.py" = ["ARG001", "ARG002"]
-"plasmapy/utils/pytest_helpers/pytest_helpers.py" = ["BLE001"]
+"plasmapy/utils/pytest_helpers/pytest_helpers.py" = ["BLE001", "PLR0911"]
 "plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py" = ["BLE001", "TRY002"]
 
 [tool.ruff.pydocstyle]


### PR DESCRIPTION
This PR enables some ruff [rules](https://beta.ruff.rs/docs/rules/#refactor-plr) for pylint refactorings.  I added a bunch of `# noqa` comments for the functions that were flagged already.

There are some rules that we might want to revisit again in the future.

 - `PLR0912` limits the number of branches (i.e., conditionals) in a function to 12
 - `PLR0915` limits the number of statements in a function to 50

If we have a good reason to exceed these limits, we can add a comment like `# noqa: PLR0912" to turn off the rule for a function.