### PR TITLE
Enable PLW rule set for ruff

### DIFF
--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -1138,7 +1138,7 @@ def _locate_null_point(vspace, cell, n, err):
         If the maximum number of iteration has been reached, but
         convergence has not occurred.
     """
-    global _recursion_level
+    global _recursion_level  # noqa: PLW0602
     # Calculating the Jacobian and trilinear approximation functions for the cell
     tlApprox = trilinear_approx(vspace, cell)
     jcb = _trilinear_jacobian(vspace, cell)
@@ -1216,8 +1216,8 @@ def _locate_null_point(vspace, cell, n, err):
     )
     # Newton Iteration
     for x0 in starting_pos:
-        x0 = np.array(x0)
-        x0 = x0.reshape(3, 1)
+        x0 = np.array(x0)  # noqa: PLW2901
+        x0 = x0.reshape(3, 1)  # noqa: PLW2901
         for _i in range(n):  # noqa: B007
             locx = tlApprox(x0[0], x0[1], x0[2])[0]
             locy = tlApprox(x0[0], x0[1], x0[2])[1]
@@ -1242,7 +1242,7 @@ def _locate_null_point(vspace, cell, n, err):
                 else:
                     break
             # Adjust position
-            x0 = np.subtract(
+            x0 = np.subtract(  # noqa: PLW2901
                 x0, np.matmul(np.linalg.inv(jcb(x0[0], x0[1], x0[2])), Bx0)
             )
             norm = np.linalg.norm(x0)

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -136,7 +136,7 @@ def args_to_lite_args(kwargs):
     ion_mass = np.zeros(len(kwargs["ions"]))
     for i, particle in enumerate(kwargs["ions"]):
         if not isinstance(particle, Particle):
-            particle = Particle(particle)
+            particle = Particle(particle)  # noqa: PLW2901
         ion_z[i] = particle.charge_number
         ion_mass[i] = particle_mass(particle).to(u.kg).value
     kwargs["ion_z"] = ion_z

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -643,7 +643,7 @@ class AbstractGrid(ABC):
                 }
             # If grid is non-uniform, flatten quantity
             else:
-                quantity = quantity.flatten()
+                quantity = quantity.flatten()  # noqa: PLW2901
                 dims = ["ax"]
                 coords = {"ax": self.ds.coords["ax"]}
 

--- a/plasmapy/utils/_units_helpers.py
+++ b/plasmapy/utils/_units_helpers.py
@@ -71,7 +71,7 @@ def _get_physical_type_dict(
 
     for obj in iterable:
         if isinstance(obj, Number) and numbers_become_quantities:
-            obj = u.Quantity(obj, u.dimensionless_unscaled)
+            obj = u.Quantity(obj, u.dimensionless_unscaled)  # noqa: PLW2901
 
         if only_quantities and not isinstance(obj, u.Quantity):
             if strict:

--- a/plasmapy/utils/decorators/tests/test_checks.py
+++ b/plasmapy/utils/decorators/tests/test_checks.py
@@ -426,7 +426,7 @@ class TestCheckUnits:
 
                 for key, val in default_checks.items():
                     if key in case["output"][arg_name]:
-                        val = case["output"][arg_name][key]
+                        val = case["output"][arg_name][key]  # noqa: PLW2901
                     assert arg_checks[key] == val
 
     def test_cu_method__check_unit(self):

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -195,7 +195,7 @@ class TestValidateQuantities:
 
                 for key, val in default_validations.items():
                     if key in case["output"][arg_name]:
-                        val = case["output"][arg_name][key]
+                        val = case["output"][arg_name][key]  # noqa: PLW2901
                     assert arg_validations[key] == val
 
         # method calls `_get_unit_checks` and `_get_value_checks`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ extend-select = [
   "PIE", # flake8-pie
   "PLC", # pylint convention
   "PLE", # pylint errors
+  "PLW", # pylint warnings
   "PTH", # flake8-use-pathlib
   "PYI", # flake8-pyi
   "RUF", # ruff specific rules


### PR DESCRIPTION
This PR enables the [PLW](https://beta.ruff.rs/docs/rules/#warning-plw) rule set for ruff, and adds `noqa` comments for lines that ruff flagged.