### PR TITLE
Enable ruff rules for flake8-pytest-style

### DIFF
--- a/plasmapy/analysis/swept_langmuir/tests/test_floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_floating_potential.py
@@ -85,7 +85,7 @@ class TestFindFloatingPotential:
             assert mock_cs.call_args[1] == {"strip_units": True}
 
     @pytest.mark.parametrize(
-        "kwargs, _error",
+        ("kwargs", "_error"),
         [
             # errors on kwarg fit_type
             (
@@ -169,7 +169,7 @@ class TestFindFloatingPotential:
             find_floating_potential(**kwargs)
 
     @pytest.mark.parametrize(
-        "kwargs, expected, _warning",
+        ("kwargs", "expected", "_warning"),
         [
             # too many crossing islands
             (
@@ -229,7 +229,7 @@ class TestFindFloatingPotential:
                 assert rtn_val == val
 
     @pytest.mark.parametrize(
-        "min_points, fit_type, islands, indices",
+        ("min_points", "fit_type", "islands", "indices"),
         [
             (np.inf, "linear", [slice(29, 31)], slice(0, 70)),
             (1, "linear", [slice(29, 31)], slice(29, 31)),
@@ -263,7 +263,7 @@ class TestFindFloatingPotential:
         assert extras.fitted_indices == indices
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             # simple linear
             (
@@ -363,7 +363,7 @@ class TestFindFloatingPotential:
             else:
                 assert rtn_val == val
 
-    @pytest.mark.parametrize("m, b", [(2.0, 0.0), (1.33, -0.1), (0.5, -0.1)])
+    @pytest.mark.parametrize(("m", "b"), [(2.0, 0.0), (1.33, -0.1), (0.5, -0.1)])
     def test_perfect_linear(self, m, b):
         """Test calculated fit parameters on a few perfectly linear cases."""
         voltage = self._voltage
@@ -385,7 +385,7 @@ class TestFindFloatingPotential:
         assert np.allclose(extras.fitted_func.param_errors, (0.0, 0.0), atol=2e-8)
 
     @pytest.mark.parametrize(
-        "a, alpha, b",
+        ("a", "alpha", "b"),
         [(1.0, 0.2, -0.2), (2.7, 0.2, -10.0), (6.0, 0.6, -10.0)],
     )
     def test_perfect_exponential(self, a, alpha, b):

--- a/plasmapy/analysis/swept_langmuir/tests/test_helpers.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_helpers.py
@@ -10,7 +10,7 @@ from plasmapy.analysis.swept_langmuir.helpers import check_sweep
 
 
 @pytest.mark.parametrize(
-    "voltage, current, kwargs, with_context, expected",
+    ("voltage", "current", "kwargs", "with_context", "expected"),
     [
         # the one that works
         (

--- a/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
@@ -71,7 +71,7 @@ class TestFindIonSaturationCurrent:
         assert find_isat_ is find_ion_saturation_current
 
     @pytest.mark.parametrize(
-        "kwargs, _error",
+        ("kwargs", "_error"),
         [
             # errors on kwarg fit_type
             (
@@ -129,7 +129,7 @@ class TestFindIonSaturationCurrent:
             find_ion_saturation_current(**kwargs)
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             # linear fit to linear analytical data
             (

--- a/plasmapy/analysis/tests/test_fit_functions.py
+++ b/plasmapy/analysis/tests/test_fit_functions.py
@@ -29,7 +29,7 @@ class TestAbstractFitFunction:
         assert issubclass(self.ff_class, ABC)
 
     @pytest.mark.parametrize(
-        "name, isproperty",
+        ("name", "isproperty"),
         [
             ("__call__", False),
             ("curve_fit", False),
@@ -105,7 +105,7 @@ class BaseFFTests(ABC):
         assert ff_obj.__repr__() == f"{ff_obj.__str__()} {ff_obj.__class__}"
 
     @pytest.mark.parametrize(
-        "name, isproperty",
+        ("name", "isproperty"),
         [
             ("__call__", False),
             ("_param_names", False),
@@ -136,7 +136,7 @@ class BaseFFTests(ABC):
             )
 
     @pytest.mark.parametrize(
-        "name, value_ref_name",
+        ("name", "value_ref_name"),
         [
             ("param_names", "_test_param_names"),
             ("latex_str", "_test_latex_str"),
@@ -161,7 +161,7 @@ class BaseFFTests(ABC):
         assert value == exp_value
 
     @pytest.mark.parametrize(
-        "params, param_errors, with_condition",
+        ("params", "param_errors", "with_condition"),
         [
             (None, None, does_not_raise()),
             ("default", "default", does_not_raise()),
@@ -224,7 +224,7 @@ class BaseFFTests(ABC):
         assert all(isinstance(val, str) for val in ff_obj.param_names)
 
     @pytest.mark.parametrize(
-        "params, extra, with_condition",
+        ("params", "extra", "with_condition"),
         [
             ([2], None, does_not_raise()),
             (5, None, pytest.raises(ValueError)),
@@ -246,7 +246,7 @@ class BaseFFTests(ABC):
             assert ff_obj.params == ff_obj.FitParamTuple(*params)
 
     @pytest.mark.parametrize(
-        "param_errors, extra, with_condition",
+        ("param_errors", "extra", "with_condition"),
         [
             ([2], None, does_not_raise()),
             (5, None, pytest.raises(ValueError)),
@@ -268,7 +268,7 @@ class BaseFFTests(ABC):
             assert ff_obj.param_errors == ff_obj.FitParamTuple(*param_errors)
 
     @pytest.mark.parametrize(
-        "x, replace_a_param, with_condition",
+        ("x", "replace_a_param", "with_condition"),
         [
             (0, None, does_not_raise()),
             (1.0, None, does_not_raise()),
@@ -297,7 +297,7 @@ class BaseFFTests(ABC):
             assert np.allclose(y, y_expected)
 
     @pytest.mark.parametrize(
-        "x, kwargs, with_condition",
+        ("x", "kwargs", "with_condition"),
         [
             (0, {}, does_not_raise()),
             (1.0, {}, does_not_raise()),
@@ -333,7 +333,7 @@ class BaseFFTests(ABC):
                 assert np.allclose(y, self.func(x, *params))
 
     @pytest.mark.parametrize(
-        "x, kwargs, with_condition",
+        ("x", "kwargs", "with_condition"),
         [
             (0, {}, does_not_raise()),
             (0, {"reterr": True}, does_not_raise()),
@@ -572,7 +572,7 @@ class TestFFLinear(BaseFFTests):
         return err
 
     @pytest.mark.parametrize(
-        "params, param_errors, root, root_err, conditional",
+        ("params", "param_errors", "root", "root_err", "conditional"),
         [
             ((1, 1), (0, 0), -1, 0, does_not_raise()),
             (

--- a/plasmapy/analysis/tests/test_nullpoint.py
+++ b/plasmapy/analysis/tests/test_nullpoint.py
@@ -74,7 +74,7 @@ def test_trilinear_coeff_cal():
         )
     ]
 
-    @pytest.mark.parametrize("kwargs, expected", test_trilinear_coeff_cal_values)
+    @pytest.mark.parametrize(("kwargs", "expected"), test_trilinear_coeff_cal_values)
     def test_trilinear_coeff_cal_vals(kwargs, expected):
         r"""Test expected values."""
         assert _trilinear_coeff_cal(**kwargs) == expected
@@ -158,7 +158,7 @@ class Test_reduction:
         ({"vspace": vspace, "cell": [24, 25, 26]}, True),
     ]
 
-    @pytest.mark.parametrize("kwargs, expected", test_reduction_values)
+    @pytest.mark.parametrize(("kwargs", "expected"), test_reduction_values)
     def test_reduction_vals(self, kwargs, expected):
         r"""Test expected values."""
         assert _reduction(**kwargs) == expected
@@ -183,7 +183,7 @@ class Test_trilinear_analysis:
         ({"vspace": vspace, "cell": [24, 25, 26]}, False),
     ]
 
-    @pytest.mark.parametrize("kwargs, expected", test_trilinear_analysis_values)
+    @pytest.mark.parametrize(("kwargs", "expected"), test_trilinear_analysis_values)
     def test_trilinear_analysis_vals(self, kwargs, expected):
         r"""Test expected values."""
         assert _trilinear_analysis(**kwargs) == expected
@@ -199,7 +199,7 @@ class Test_bilinear_root:
         )
     ]
 
-    @pytest.mark.parametrize("kwargs, expected", test_bilinear_root_values)
+    @pytest.mark.parametrize(("kwargs", "expected"), test_bilinear_root_values)
     def test_bilinear_root_vals(self, kwargs, expected):
         r"""Test expected values."""
         x1, y1 = _bilinear_root(**kwargs)[0]
@@ -229,7 +229,7 @@ class Test_locate_null_point:
         )
     ]
 
-    @pytest.mark.parametrize("kwargs, expected", test_locate_null_point_values)
+    @pytest.mark.parametrize(("kwargs", "expected"), test_locate_null_point_values)
     def test_locate_null_point_vals(self, kwargs, expected):
         r"""Test expected values."""
         assert np.isclose(
@@ -456,7 +456,7 @@ class Test_classify_null_point:
         ),
     ]
 
-    @pytest.mark.parametrize("kwargs, expected", test_classify_null_point_values)
+    @pytest.mark.parametrize(("kwargs", "expected"), test_classify_null_point_values)
     def test_classify_null_point_vals(self, kwargs, expected):
         r"""Test expected values."""
         assert uniform_null_point_find(**kwargs)[0].classification == expected

--- a/plasmapy/analysis/tests/test_nullpoint.py
+++ b/plasmapy/analysis/tests/test_nullpoint.py
@@ -237,7 +237,7 @@ class Test_locate_null_point:
         ).all()
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_null_point_find1():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Uniform grid
@@ -254,7 +254,7 @@ def test_null_point_find1():
     assert np.isclose(loc, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_null_point_find2():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Non-uniform grid
@@ -288,7 +288,7 @@ def test_null_point_find3():
     assert np.isclose(loc3, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 @pytest.mark.xfail(np.__version__ >= "1.24.0", reason="See issue #2101.")
 def test_null_point_find4():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
@@ -308,7 +308,7 @@ def test_null_point_find4():
     assert np.isclose(second_loc4, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_null_point_find5():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Many null points because a y vector dimension is zero
@@ -338,7 +338,7 @@ def test_null_point_find5():
             )
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_null_point_find6():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Many null points; All vector dimensions zero
@@ -353,7 +353,7 @@ def test_null_point_find6():
     assert len(npoints6) == 0
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_null_point_find7():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # No null points, discriminant less than zero
@@ -368,7 +368,7 @@ def test_null_point_find7():
     assert len(npoints7) == 0
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 @pytest.mark.xfail(np.__version__ >= "1.24.0", reason="See issue #2101.")
 def test_null_point_find8():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
@@ -388,7 +388,7 @@ def test_null_point_find8():
     assert np.allclose(loc2, [5.5, 5.5, 5.5], atol=_TESTING_ATOL)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class Test_classify_null_point:
     r"""Test `~plasmapy.analysis.nullpoint._classify_null_point`."""
 
@@ -476,7 +476,7 @@ def test_null_point_find9():
 
 
 # Tests that capture the degenerate nulls/2D nulls
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_null_point_find10():
     nullpoint10_args = {
         "x_range": [-0.1, 0.1],
@@ -498,7 +498,7 @@ def test_null_point_find10():
             assert p.classification == "Continuous concentric ellipses"
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_null_point_find11():
     nullpoint10_args = {
         "x_range": [-0.1, 0.1],

--- a/plasmapy/analysis/time_series/tests/test_excess_statistics.py
+++ b/plasmapy/analysis/time_series/tests/test_excess_statistics.py
@@ -8,7 +8,7 @@ from plasmapy.analysis.time_series.excess_statistics import ExcessStatistics
 
 
 @pytest.mark.parametrize(
-    "signal, thresholds, time_step, pdf, bins, expected",
+    ("signal", "thresholds", "time_step", "pdf", "bins", "expected"),
     [
         (
             [0, 2, 0],
@@ -89,7 +89,7 @@ def test_ExcessStatistics(signal, thresholds, time_step, pdf, bins, expected):
 
 
 @pytest.mark.parametrize(
-    "signal, thresholds, time_step, bins, exception",
+    ("signal", "thresholds", "time_step", "bins", "exception"),
     [([1, 2], 1, -1, 32, ValueError), ([1, 2], 1, 1, 1.5, TypeError)],
 )
 def test_ExcessStatistics_exception(signal, thresholds, time_step, bins, exception):

--- a/plasmapy/analysis/time_series/tests/test_running_moments.py
+++ b/plasmapy/analysis/time_series/tests/test_running_moments.py
@@ -8,7 +8,7 @@ from plasmapy.analysis.time_series.running_moments import running_mean, running_
 
 
 @pytest.mark.parametrize(
-    "signal, radius, expected",
+    ("signal", "radius", "expected"),
     [
         ([1, 2, 3], 1, [2]),
         ([1, 2, 3, 4], 1, [2, 3]),
@@ -22,7 +22,7 @@ def test_running_mean(signal, radius, expected):
     assert np.allclose(result, expected)
 
 
-@pytest.mark.parametrize("signal, radius", [([1, 2], 1), ([1, 2, 3, 4], 1.2)])
+@pytest.mark.parametrize(("signal", "radius"), [([1, 2], 1), ([1, 2, 3, 4], 1.2)])
 def test_running_mean_exception(signal, radius):
     """Test whether exception is risen"""
     with pytest.raises((ValueError, TypeError)):
@@ -30,7 +30,7 @@ def test_running_mean_exception(signal, radius):
 
 
 @pytest.mark.parametrize(
-    "signal, radius, moment, time, expected",
+    ("signal", "radius", "moment", "time", "expected"),
     [
         ([1, 2, 3], 1, 1, [1, 2, 3], ([2], [2])),
         ([1, 2, 3] * u.eV, 1, 1, [1, 2, 3], ([2] * u.eV, [2])),
@@ -53,7 +53,7 @@ def test_running_moment(signal, radius, moment, time, expected):
 
 
 @pytest.mark.parametrize(
-    "signal, radius, moment, time",
+    ("signal", "radius", "moment", "time"),
     [
         ([1, 2, 3, 4, 5], 1, 0, None),
         ([1, 2, 3, 4, 5], 1, 6, None),

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_detector_stacks.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_detector_stacks.py
@@ -13,7 +13,7 @@ from plasmapy.diagnostics.charged_particle_radiography.detector_stacks import (
 from plasmapy.utils.data.downloader import get_file
 
 
-@pytest.fixture
+@pytest.fixture()
 def hdv2_stack(tmp_path):
     # Fetch stopping power data files from data module
     tissue_path = get_file("NIST_PSTAR_tissue_equivalent.txt", directory=tmp_path)

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -232,7 +232,7 @@ def run_mesh_example(
     return sim
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_1D_deflections():
     # Check B-deflection
     hax, lineout = run_1D_example("constant_bz")
@@ -245,7 +245,7 @@ def test_1D_deflections():
     assert np.isclose(loc.si.value, 0.0335, 0.005)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_coordinate_systems():
     """
     Check that specifying the same point in different coordinate systems
@@ -275,7 +275,7 @@ def test_coordinate_systems():
     assert np.allclose(sim2.detector, sim3.detector, atol=1e-2)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_input_validation():
     """
     Intentionally raise a number of errors.
@@ -356,7 +356,7 @@ def test_input_validation():
         hax, vax, values = cpr.synthetic_radiograph(sim, size=size)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_init():
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
@@ -383,7 +383,7 @@ def test_init():
     assert all(sim.det_hdir == np.array([1, 0, 0]))
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_create_particles():
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
@@ -403,7 +403,7 @@ def test_create_particles():
     sim.create_particles(1e3, 15 * u.MeV, particle="e")
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_load_particles():
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
@@ -435,7 +435,7 @@ def test_load_particles():
     sim.run(field_weighting="nearest neighbor")
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_run_options():
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
@@ -504,7 +504,7 @@ def create_tracker_obj():
 tracker_obj_simulated = create_tracker_obj().run(field_weighting="nearest neighbor")
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class TestSyntheticRadiograph:
     """
     Tests for
@@ -631,7 +631,7 @@ class TestSyntheticRadiograph:
         assert np.all(np.isposinf(od_results[2][zero_mask]))
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_saving_output(tmp_path):
     """Test behavior of Tracker.save_results."""
 
@@ -657,7 +657,7 @@ def test_saving_output(tmp_path):
         assert np.allclose(results_1[key], results_2[key])
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     "case",
     ["creating particles", "loading particles", "adding a wire mesh"],
@@ -688,7 +688,7 @@ def test_cannot_modify_simulation_after_running(case):
             pytest.fail(f"Unrecognized test case '{case}'.")
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_gaussian_sphere_analytical_comparison():
     """
     This test runs a known example problem and compares to a theoretical
@@ -784,7 +784,7 @@ def test_gaussian_sphere_analytical_comparison():
     assert np.isclose(max_deflection, sim.max_deflection.to(u.rad).value, atol=1e-3)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_add_wire_mesh():
     # ************************************************************
     # Test various input configurations

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -517,7 +517,7 @@ class TestSyntheticRadiograph:
     sim_results = tracker_obj_simulated.results_dict.copy()
 
     @pytest.mark.parametrize(
-        "args, kwargs, _raises",
+        ("args", "kwargs", "_raises"),
         [
             # obj wrong type
             ((5,), {}, TypeError),
@@ -546,7 +546,7 @@ class TestSyntheticRadiograph:
             cpr.synthetic_radiograph(sim_results)
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected",
+        ("args", "kwargs", "expected"),
         [
             (
                 # From a Tracker object

--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -263,7 +263,7 @@ class Test__Characteristic_inherited_methods:
         assert np.allclose(log_limits.to(u.A).value, np.array((0.014003, 1.42577333)))
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class Test__swept_probe_analysis:
     r"""Test the swept_probe_analysis function in langmuir.py"""
 

--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -140,7 +140,7 @@ class Test__characteristic_errors:
         assert (a.current - b.current == ab_sub.current).all(), errStr
 
 
-@pytest.fixture
+@pytest.fixture()
 def characteristic():
     r"""Create a dummy characteristic with random values"""
 
@@ -148,7 +148,7 @@ def characteristic():
         return langmuir.Characteristic(bias_arr, current_arr)
 
 
-@pytest.fixture
+@pytest.fixture()
 def characteristic_simulated():
     r"""Create a simulated probe characteristic (provisional)"""
 

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -187,7 +187,7 @@ def single_species_collective_spectrum(single_species_collective_args):
     return (alpha, wavelengths, Skw)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_single_species_collective_spectrum(single_species_collective_spectrum):
     """
     Compares the generated spectrum to previously determined values
@@ -216,7 +216,7 @@ def test_single_species_collective_spectrum(single_species_collective_spectrum):
     )
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_spectral_density_minimal_arguments(single_species_collective_args):
     """
     Check that spectral density runs with minimal arguments
@@ -409,7 +409,7 @@ def single_species_non_collective_spectrum(single_species_non_collective_args):
     return (alpha, wavelengths, Skw)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_single_species_non_collective_spectrum(single_species_non_collective_spectrum):
     """
     Compares the generated spectrum to previously determined values
@@ -544,7 +544,7 @@ def test_spectral_density_input_errors(
                 assert msg in str(excinfo.value)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_split_populations():
     """
     This test makes sure that splitting a single population of ions or electrons
@@ -1034,7 +1034,7 @@ def noncollective_single_species_settings_params():
     return kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fit_epw_single_species(epw_single_species_settings_params):
     wavelengths, params, settings = spectral_density_model_settings_params(
         epw_single_species_settings_params
@@ -1043,7 +1043,7 @@ def test_fit_epw_single_species(epw_single_species_settings_params):
     run_fit(wavelengths, params, settings, notch=(531, 533))
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fit_epw_multi_species(epw_multi_species_settings_params):
     wavelengths, params, settings = spectral_density_model_settings_params(
         epw_multi_species_settings_params
@@ -1052,7 +1052,7 @@ def test_fit_epw_multi_species(epw_multi_species_settings_params):
     run_fit(wavelengths, params, settings, notch=(531, 533))
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fit_iaw_single_species(iaw_single_species_settings_params):
     wavelengths, params, settings = spectral_density_model_settings_params(
         iaw_single_species_settings_params
@@ -1061,7 +1061,7 @@ def test_fit_iaw_single_species(iaw_single_species_settings_params):
     run_fit(wavelengths, params, settings)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fit_iaw_instr_func(iaw_single_species_settings_params):
     """
     Tests fitting with an instrument function
@@ -1076,7 +1076,7 @@ def test_fit_iaw_instr_func(iaw_single_species_settings_params):
     run_fit(wavelengths, params, settings)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fit_iaw_multi_species(iaw_multi_species_settings_params):
     wavelengths, params, settings = spectral_density_model_settings_params(
         iaw_multi_species_settings_params
@@ -1085,7 +1085,7 @@ def test_fit_iaw_multi_species(iaw_multi_species_settings_params):
     run_fit(wavelengths, params, settings)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fit_noncollective_single_species(noncollective_single_species_settings_params):
     wavelengths, params, settings = spectral_density_model_settings_params(
         noncollective_single_species_settings_params
@@ -1094,7 +1094,7 @@ def test_fit_noncollective_single_species(noncollective_single_species_settings_
     run_fit(wavelengths, params, settings)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fit_with_instr_func(epw_single_species_settings_params):
     """
 
@@ -1143,7 +1143,7 @@ def test_fit_with_invalid_instr_func(instr_func, iaw_single_species_settings_par
         run_fit(wavelengths, params, settings)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fit_with_minimal_parameters():
     # Create example data for fitting
     probe_wavelength = 532 * u.nm

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -432,7 +432,7 @@ def test_single_species_non_collective_spectrum(single_species_non_collective_sp
 
 
 @pytest.mark.parametrize(
-    "kwargs,error,msg",
+    ("kwargs", "error", "msg"),
     [
         # Ion species provided but empty
         (
@@ -1210,7 +1210,7 @@ def test_fit_with_minimal_parameters():
 
 
 @pytest.mark.parametrize(
-    "control,error,msg",
+    ("control", "error", "msg"),
     [
         # Required settings
         (

--- a/plasmapy/dispersion/analytical/tests/test_stix_.py
+++ b/plasmapy/dispersion/analytical/tests/test_stix_.py
@@ -51,7 +51,7 @@ class TestStix:
         return S, P, D
 
     @pytest.mark.parametrize(
-        "kwargs, _error",
+        ("kwargs", "_error"),
         [
             ({**_kwargs_single_valued, "B": "wrong type"}, TypeError),
             ({**_kwargs_single_valued, "B": [8e-9, 8.5e-9] * u.T}, ValueError),
@@ -85,7 +85,7 @@ class TestStix:
             stix(**kwargs)
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             ({**_kwargs_single_valued, "w": 2 * u.rad / u.s}, {"shape": (4,)}),
             (
@@ -141,7 +141,7 @@ class TestStix:
         assert k.unit == u.rad / u.m
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             # case taken from Stix figure 1-1
             # Note: ns = [n = k * c / w, ]

--- a/plasmapy/dispersion/analytical/tests/test_two_fluid_.py
+++ b/plasmapy/dispersion/analytical/tests/test_two_fluid_.py
@@ -32,7 +32,7 @@ class TestTwoFluid:
     }
 
     @pytest.mark.parametrize(
-        "kwargs, _error",
+        ("kwargs", "_error"),
         [
             ({**_kwargs_single_valued, "B": "wrong type"}, TypeError),
             ({**_kwargs_single_valued, "B": [8e-9, 8.5e-9] * u.T}, ValueError),
@@ -69,7 +69,7 @@ class TestTwoFluid:
             two_fluid(**kwargs)
 
     @pytest.mark.parametrize(
-        "kwargs, _warning",
+        ("kwargs", "_warning"),
         [
             # violates the low-frequency assumption (w/kc << 1)
             (
@@ -92,7 +92,7 @@ class TestTwoFluid:
             two_fluid(**kwargs)
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             (
                 {**_kwargs_bellan2012, "theta": 0 * u.deg},
@@ -140,7 +140,7 @@ class TestTwoFluid:
             assert np.isclose(norm, expected[mode])
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             (
                 {
@@ -168,7 +168,7 @@ class TestTwoFluid:
             assert np.isclose(ws[mode], ws_expected[mode], atol=0, rtol=1.7e-4)
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             ({**_kwargs_bellan2012, "theta": 0 * u.deg}, {"shape": ()}),
             (

--- a/plasmapy/dispersion/numerical/tests/test_hollweg_.py
+++ b/plasmapy/dispersion/numerical/tests/test_hollweg_.py
@@ -31,7 +31,7 @@ class TestHollweg:
     }
 
     @pytest.mark.parametrize(
-        "kwargs, _error",
+        ("kwargs", "_error"),
         [
             ({**_kwargs_single_valued, "B": "wrong type"}, TypeError),
             ({**_kwargs_single_valued, "B": [8e-9, 8.5e-9] * u.T}, ValueError),
@@ -68,7 +68,7 @@ class TestHollweg:
             hollweg(**kwargs)
 
     @pytest.mark.parametrize(
-        "kwargs, _warning",
+        ("kwargs", "_warning"),
         [
             # w/w_ci << 1 PhysicsWarning
             (
@@ -117,7 +117,7 @@ class TestHollweg:
             hollweg(**kwargs)
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             # k is an array, theta is single valued
             (
@@ -195,7 +195,7 @@ class TestHollweg:
             assert np.allclose(val.value, expected[mode])
 
     @pytest.mark.parametrize(
-        "kwargs, expected, desired_beta",
+        ("kwargs", "expected", "desired_beta"),
         [
             (  # beta = 1/20 for kx*L = 0
                 {**_kwargs_hollweg1999, "k": 1e-14 * u.rad / u.m, "B": 6.971e-8 * u.T},
@@ -305,7 +305,7 @@ class TestHollweg:
         )
     )
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             (
                 {
@@ -332,7 +332,7 @@ class TestHollweg:
             assert np.isclose(ws[mode], ws_expected[mode], atol=1e-5, rtol=1.7e-4)
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             ({**_kwargs_single_valued}, {"shape": ()}),
             (

--- a/plasmapy/dispersion/numerical/tests/test_kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/tests/test_kinetic_alfven_.py
@@ -28,7 +28,7 @@ class TestKinetic_Alfven:
     }
 
     @pytest.mark.parametrize(
-        "kwargs, _error",
+        ("kwargs", "_error"),
         [
             ({**_kwargs_single_valued, "B": "wrong type"}, TypeError),
             ({**_kwargs_single_valued, "B": [1e-9, 2e-9, 3e-9] * u.T}, ValueError),
@@ -73,7 +73,7 @@ class TestKinetic_Alfven:
         )
     )
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             (
                 {
@@ -102,7 +102,7 @@ class TestKinetic_Alfven:
             assert np.allclose(ws[theta], ws_expected[theta], atol=0, rtol=1e-2)
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             ({**_kwargs_single_valued, "theta": 0 * u.deg}, {"shape": (2,)}),
             (
@@ -139,7 +139,7 @@ class TestKinetic_Alfven:
             assert val.shape == expected["shape"]
 
     @pytest.mark.parametrize(
-        "kwargs, _warning",
+        ("kwargs", "_warning"),
         [
             # w/vT min PhysicsWarning
             (

--- a/plasmapy/dispersion/tests/test_dispersion.py
+++ b/plasmapy/dispersion/tests/test_dispersion.py
@@ -52,7 +52,7 @@ class TestPlasmaDispersionFunction:
     """
 
     @pytest.mark.parametrize(
-        "bound_name, bound_attr",
+        ("bound_name", "bound_attr"),
         [("lite", plasma_dispersion_func_lite)],
     )
     def test_lite_function_binding(self, bound_name, bound_attr):
@@ -77,7 +77,7 @@ class TestPlasmaDispersionFunction:
             origin = f"{attr.__module__}.{attr.__name__}"
             assert origin == bound_origin
 
-    @pytest.mark.parametrize("w, expected", plasma_dispersion_func_table)
+    @pytest.mark.parametrize(("w", "expected"), plasma_dispersion_func_table)
     def test_plasma_dispersion_func(self, w, expected):
         r"""Test plasma_dispersion_func against tabulated results and
         known symmetry properties."""
@@ -202,7 +202,7 @@ class TestPlasmaDispersionFunction:
                 f"equal to {Z_at_root} instead of 0j."
             )
 
-    @pytest.mark.parametrize("w, expected_error", plasma_disp_func_errors_table)
+    @pytest.mark.parametrize(("w", "expected_error"), plasma_disp_func_errors_table)
     def test_plasma_dispersion_func_errors(self, w, expected_error):
         """Test errors that should be raised by plasma_dispersion_func."""
 
@@ -217,7 +217,7 @@ class TestPlasmaDispersionFunction:
 class TestPlasmaDispersionFunctionLite:
     """Test class for `plasma_dispersion_func_lite`."""
 
-    @pytest.mark.parametrize("w, expected", plasma_dispersion_func_table)
+    @pytest.mark.parametrize(("w", "expected"), plasma_dispersion_func_table)
     def test_normal_vs_lite(self, w, expected):  # noqa: ARG002
         r"""Test that plasma_dispersion_func and plasma_dispersion_func_lite
         calculate the same values."""
@@ -259,7 +259,7 @@ class TestPlasmaDispersionFunctionDeriv:
     """
 
     @pytest.mark.parametrize(
-        "bound_name, bound_attr",
+        ("bound_name", "bound_attr"),
         [("lite", plasma_dispersion_func_deriv_lite)],
     )
     def test_lite_function_binding(self, bound_name, bound_attr):
@@ -284,7 +284,7 @@ class TestPlasmaDispersionFunctionDeriv:
             origin = f"{attr.__module__}.{attr.__name__}"
             assert origin == bound_origin
 
-    @pytest.mark.parametrize("w, expected", plasma_disp_deriv_table)
+    @pytest.mark.parametrize(("w", "expected"), plasma_disp_deriv_table)
     def test_plasma_dispersion_func_deriv(self, w, expected):
         r"""Test plasma_dispersion_func_deriv against tabulated results"""
 
@@ -317,7 +317,7 @@ class TestPlasmaDispersionFunctionDeriv:
             f"-2 * [1 + w * Z(w)] = {Z_deriv_characterization}."
         )
 
-    @pytest.mark.parametrize("w, expected_error", plasma_disp_func_errors_table)
+    @pytest.mark.parametrize(("w", "expected_error"), plasma_disp_func_errors_table)
     def test_plasma_dispersion_deriv_errors(self, w, expected_error):
         """Test errors that should be raised by plasma_dispersion_func_deriv."""
 
@@ -332,7 +332,7 @@ class TestPlasmaDispersionFunctionDeriv:
 class TestPlasmaDispersionFunctionDerivLite:
     """Test class for `plasma_dispersion_func_deriv_lite`."""
 
-    @pytest.mark.parametrize("w, expected", plasma_disp_deriv_table)
+    @pytest.mark.parametrize(("w", "expected"), plasma_disp_deriv_table)
     def test_normal_vs_lite(self, w, expected):  # noqa: ARG002
         r"""Test that plasma_dispersion_func_deriv and
         plasma_dispersion_func_deriv_lite

--- a/plasmapy/formulary/collisions/tests/test_frequencies.py
+++ b/plasmapy/formulary/collisions/tests/test_frequencies.py
@@ -67,7 +67,7 @@ class TestSingleParticleCollisionFrequencies:
     ones_array2d = np.ones([5, 5])
 
     @pytest.mark.parametrize(
-        "attribute_to_test, expected_attribute_units",
+        ("attribute_to_test", "expected_attribute_units"),
         [
             ("momentum_loss", u.Hz),
             ("transverse_diffusion", u.Hz),
@@ -211,8 +211,12 @@ class TestSingleParticleCollisionFrequencies:
         return limit_values
 
     @pytest.mark.parametrize(
-        "interaction_type, limit_type, constructor_arguments, "
-        "constructor_keyword_arguments",
+        (
+            "interaction_type",
+            "limit_type",
+            "constructor_arguments",
+            "constructor_keyword_arguments",
+        ),
         [
             # Slow limit (x << 1)
             (
@@ -422,7 +426,7 @@ class TestSingleParticleCollisionFrequencies:
             )
 
     @pytest.mark.parametrize(
-        "expected_error, constructor_arguments, constructor_keyword_arguments",
+        ("expected_error", "constructor_arguments", "constructor_keyword_arguments"),
         [
             # Arrays of unequal shape error
             (
@@ -499,7 +503,7 @@ class TestMaxwellianCollisionFrequencies:
             return (4.8e-8 * n * Coulomb_log * T_a**-1.5 * mu**-0.5) * u.Hz
 
     @pytest.mark.parametrize(
-        "expected_error, constructor_arguments, constructor_keyword_arguments",
+        ("expected_error", "constructor_arguments", "constructor_keyword_arguments"),
         [
             # Arrays of unequal shape error
             (
@@ -527,8 +531,12 @@ class TestMaxwellianCollisionFrequencies:
             )
 
     @pytest.mark.parametrize(
-        "expected_error, constructor_arguments, "
-        "constructor_keyword_arguments, attribute_name",
+        (
+            "expected_error",
+            "constructor_arguments",
+            "constructor_keyword_arguments",
+            "attribute_name",
+        ),
         [
             # Specified interaction isn't electron-ion
             (
@@ -605,7 +613,7 @@ class TestMaxwellianCollisionFrequencies:
             getattr(test_case, attribute_name)
 
     @pytest.mark.parametrize(
-        "frequency_to_test, constructor_keyword_arguments",
+        ("frequency_to_test", "constructor_keyword_arguments"),
         [
             (
                 "Maxwellian_avg_ei_collision_freq",

--- a/plasmapy/formulary/collisions/tests/test_lengths.py
+++ b/plasmapy/formulary/collisions/tests/test_lengths.py
@@ -160,7 +160,7 @@ class Test_impact_parameter:
         )
 
     @pytest.mark.parametrize(
-        "n_e_shape,T_shape",
+        ("n_e_shape", "T_shape"),
         # Scalar T
         [
             ((2, 3, 5), (1,)),

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -137,7 +137,7 @@ class Test_permittivity_1D_Maxwellian:
     ]
 
     @pytest.mark.parametrize(
-        "bound_name, bound_attr",
+        ("bound_name", "bound_attr"),
         [("lite", permittivity_1D_Maxwellian_lite)],
     )
     def test_lite_function_binding(self, bound_name, bound_attr):
@@ -162,7 +162,7 @@ class Test_permittivity_1D_Maxwellian:
             origin = f"{attr.__module__}.{attr.__name__}"
             assert origin == bound_origin
 
-    @pytest.mark.parametrize("kwargs, expected", cases)
+    @pytest.mark.parametrize(("kwargs", "expected"), cases)
     def test_known(self, kwargs, expected):
         """
         Tests permittivity_1D_Maxwellian for expected value.
@@ -176,7 +176,7 @@ class Test_permittivity_1D_Maxwellian:
             f"Permittivity value should be {expected} and not {val}.",
         )
 
-    @pytest.mark.parametrize("kwargs, expected", cases)
+    @pytest.mark.parametrize(("kwargs", "expected"), cases)
     def test_fail(self, kwargs, expected):
         """
         Tests if `test_known` would fail if we slightly adjusted the
@@ -197,7 +197,9 @@ class Test_permittivity_1D_Maxwellian:
 class Test_permittivity_1D_Maxwellian_lite:
     """Test class for `permittivity_1D_Maxwellian_lite`."""
 
-    @pytest.mark.parametrize("kwargs, expected", Test_permittivity_1D_Maxwellian.cases)
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"), Test_permittivity_1D_Maxwellian.cases
+    )
     def test_normal_vs_lite_values(self, kwargs, expected):  # noqa: ARG002
         """
         Test that `permittivity_1D_Maxwellian_lite` and

--- a/plasmapy/formulary/tests/test_dimensionless.py
+++ b/plasmapy/formulary/tests/test_dimensionless.py
@@ -32,7 +32,7 @@ T_e = 1e6 * u.K
 
 
 @pytest.mark.parametrize(
-    "alias, parent",
+    ("alias", "parent"),
     [
         (nD_, Debye_number),
         (betaH_, Hall_parameter),

--- a/plasmapy/formulary/tests/test_distribution.py
+++ b/plasmapy/formulary/tests/test_distribution.py
@@ -481,7 +481,7 @@ class Test_Maxwellian_velocity_2D:
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class Test_Maxwellian_speed_2D:
     @classmethod
     def setup_class(cls):
@@ -607,7 +607,7 @@ class Test_Maxwellian_speed_2D:
             )
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class Test_Maxwellian_velocity_3D:
     @classmethod
     def setup_class(cls):
@@ -1127,7 +1127,7 @@ class Test_kappa_velocity_1D:
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class Test_kappa_velocity_3D:
     @classmethod
     def setup_class(cls):

--- a/plasmapy/formulary/tests/test_frequencies.py
+++ b/plasmapy/formulary/tests/test_frequencies.py
@@ -26,7 +26,7 @@ B_nanarr = np.array([0.001, np.nan]) * u.T
 
 
 @pytest.mark.parametrize(
-    "alias, parent",
+    ("alias", "parent"),
     [
         (oc_, gyrofrequency),
         (wc_, gyrofrequency),

--- a/plasmapy/formulary/tests/test_lengths.py
+++ b/plasmapy/formulary/tests/test_lengths.py
@@ -76,7 +76,7 @@ class TestGyroradius:
     """Tests for `plasmapy.formulary.lengths.gyroradius`."""
 
     @pytest.mark.parametrize(
-        "args, kwargs, _error",
+        ("args", "kwargs", "_error"),
         [
             ((u.T, "e-"), {}, TypeError),
             ((5 * u.A, "e-"), {"Vperp": 8 * u.m / u.s}, u.UnitTypeError),
@@ -133,7 +133,7 @@ class TestGyroradius:
             gyroradius(*args, **kwargs)
 
     @pytest.mark.parametrize(
-        "args, kwargs, nan_mask",
+        ("args", "kwargs", "nan_mask"),
         [
             ((np.nan * u.T,), {"particle": "e-", "T": 1 * u.K}, None),
             ((np.nan * u.T,), {"particle": "e-", "Vperp": 1 * u.m / u.s}, None),
@@ -165,7 +165,7 @@ class TestGyroradius:
             assert np.all(np.logical_not(rc_isnans[np.logical_not(nan_mask)]))
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected, atol",
+        ("args", "kwargs", "expected", "atol"),
         [
             (
                 (1 * u.T,),
@@ -294,7 +294,7 @@ class TestGyroradius:
         assert rc.unit == u.m
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected, _warns",
+        ("args", "kwargs", "expected", "_warns"),
         [
             ((1.0, "e-"), {"Vperp": 1.0}, 5.6856301e-12 * u.m, u.UnitsWarning),
             ((1.0 * u.T, "e-"), {"Vperp": 1.0}, 5.6856301e-12 * u.m, u.UnitsWarning),
@@ -396,7 +396,7 @@ def test_inertial_length():
 
 
 @pytest.mark.parametrize(
-    "alias, parent",
+    ("alias", "parent"),
     [
         (cwp_, inertial_length),
         (lambdaD_, Debye_length),

--- a/plasmapy/formulary/tests/test_mathematics.py
+++ b/plasmapy/formulary/tests/test_mathematics.py
@@ -10,7 +10,7 @@ from plasmapy.formulary import mathematics
 
 
 @pytest.mark.parametrize(
-    "a, b, correct",
+    ("a", "b", "correct"),
     [
         # Test one rotation
         (
@@ -30,7 +30,7 @@ def test_rot_a_to_b(a, b, correct):
 
 
 @pytest.mark.parametrize(
-    "a, b, _raises",
+    ("a", "b", "_raises"),
     [
         # a is the wrong length
         (np.array([1, 0]), np.array([1, 0, 0]), ValueError),

--- a/plasmapy/formulary/tests/test_misc.py
+++ b/plasmapy/formulary/tests/test_misc.py
@@ -31,7 +31,7 @@ T_e = 1e6 * u.K
 
 
 @pytest.mark.parametrize(
-    "alias, parent",
+    ("alias", "parent"),
     [
         (DB_, Bohm_diffusion),
         (ub_, magnetic_energy_density),
@@ -49,7 +49,7 @@ class Test_mass_density:
     r"""Test the mass_density function in misc.py."""
 
     @pytest.mark.parametrize(
-        "args, kwargs, conditional",
+        ("args", "kwargs", "conditional"),
         [
             ((-1 * u.kg * u.m**-3, "He"), {}, pytest.raises(ValueError)),
             ((-1 * u.m**-3, "He"), {}, pytest.raises(ValueError)),
@@ -69,7 +69,7 @@ class Test_mass_density:
             mass_density(*args, **kwargs)
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected",
+        ("args", "kwargs", "expected"),
         [
             ((1.0 * u.g * u.m**-3, ""), {}, 1.0e-3 * u.kg * u.m**-3),
             ((5.0e12 * u.cm**-3, "He"), {}, 3.32323849e-8 * u.kg * u.m**-3),

--- a/plasmapy/formulary/tests/test_plasma_frequency.py
+++ b/plasmapy/formulary/tests/test_plasma_frequency.py
@@ -19,7 +19,7 @@ from plasmapy.utils.pytest_helpers import assert_can_handle_nparray
 
 
 @pytest.mark.parametrize(
-    "alias, parent",
+    ("alias", "parent"),
     [(wp_, plasma_frequency)],
 )
 def test_aliases(alias, parent):
@@ -35,7 +35,7 @@ class TestPlasmaFrequency:
     """
 
     @pytest.mark.parametrize(
-        "bound_name, bound_attr",
+        ("bound_name", "bound_attr"),
         [("lite", plasma_frequency_lite)],
     )
     def test_lite_function_binding(self, bound_name, bound_attr):
@@ -58,7 +58,7 @@ class TestPlasmaFrequency:
             assert origin == bound_origin
 
     @pytest.mark.parametrize(
-        "args, kwargs, _error",
+        ("args", "kwargs", "_error"),
         [
             ((u.m**-3, "e-"), {}, TypeError),
             (("not a density", "e-"), {}, TypeError),
@@ -76,7 +76,7 @@ class TestPlasmaFrequency:
             plasma_frequency(*args, **kwargs)
 
     @pytest.mark.parametrize(
-        "args, kwargs, _warning, expected",
+        ("args", "kwargs", "_warning", "expected"),
         [
             (
                 (1e19, "e-"),
@@ -100,7 +100,7 @@ class TestPlasmaFrequency:
             assert np.allclose(wp, expected)
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected, rtol",
+        ("args", "kwargs", "expected", "rtol"),
         [
             ((1 * u.cm**-3, "e-"), {}, 5.64e4, 1e-2),
             ((1 * u.cm**-3, "N"), {}, 3.53e2, 1e-1),
@@ -123,7 +123,7 @@ class TestPlasmaFrequency:
         assert np.allclose(wp.value, expected, rtol=rtol)
 
     @pytest.mark.parametrize(
-        "args, kwargs",
+        ("args", "kwargs"),
         [((1 * u.cm**-3, "N"), {}), ((1e12 * u.cm**-3,), {"particle": "p"})],
     )
     def test_to_hz(self, args, kwargs):

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -155,7 +155,7 @@ def test_Wigner_Seitz_radius():
     assert testTrue, errStr
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class TestChemicalPotential:
     value_test_parameters = (
         "n_e, T, expected_value",

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -57,7 +57,7 @@ def test_deBroglie_wavelength():
 
 
 @pytest.mark.parametrize(
-    "kwargs, exception",
+    ("kwargs", "exception"),
     [
         ({"V": c * 1.00000001, "particle": "e-"}, RelativityError),
         ({"V": 8 * u.m / u.s, "particle": 5 * u.m}, InvalidParticleError),
@@ -249,7 +249,7 @@ class TestQuantumTheta:
         assert theta.unit.is_equivalent(u.dimensionless_unscaled)
 
     @pytest.mark.parametrize(
-        "T, n_e, expected_theta",
+        ("T", "n_e", "expected_theta"),
         [
             (1 * u.eV, 1e26 * u.m**-3, 12.72906),  # Both regimes are present
             (2 / 3 * u.eV, 1e40 * u.m**-3, 3.93887e-9),  # Fermi regime

--- a/plasmapy/formulary/tests/test_relativity.py
+++ b/plasmapy/formulary/tests/test_relativity.py
@@ -18,7 +18,7 @@ from plasmapy.utils.exceptions import RelativityError
 
 
 @pytest.mark.parametrize(
-    "speed, expected",
+    ("speed", "expected"),
     [
         (0 * u.m / u.s, 1),
         (np.nan * u.m / u.s, np.nan),
@@ -37,7 +37,7 @@ def test_Lorentz_factor(speed, expected):
 
 
 @pytest.mark.parametrize(
-    "speed, exception",
+    ("speed", "exception"),
     [
         (np.inf * u.m / u.s, RelativityError),
         (-np.inf * u.m / u.s, RelativityError),
@@ -52,7 +52,7 @@ def test_Lorentz_factor_exceptions(speed, exception):
 
 
 @pytest.mark.parametrize(
-    "speed, warning", [(2.2, u.UnitsWarning), (np.nan, u.UnitsWarning)]
+    ("speed", "warning"), [(2.2, u.UnitsWarning), (np.nan, u.UnitsWarning)]
 )
 def test_Lorentz_factor_warnings(speed, warning):
     with pytest.warns(warning):
@@ -60,7 +60,7 @@ def test_Lorentz_factor_warnings(speed, warning):
 
 
 @pytest.mark.parametrize(
-    "velocity, mass, expected",
+    ("velocity", "mass", "expected"),
     [
         (123456789 * u.m / u.s, 1 * u.kg, 9.86265694e16 * u.J),
         (-123456789 * u.m / u.s, 1 * u.kg, 9.86265694e16 * u.J),
@@ -81,7 +81,7 @@ def test_relativistic_energy(velocity, mass, expected):
 
 
 @pytest.mark.parametrize(
-    "velocity, mass, exception",
+    ("velocity", "mass", "exception"),
     [
         (1.00000001 * c, 1 * u.kg, RelativityError),
         (-1.00000001 * c, 1 * u.kg, RelativityError),
@@ -94,7 +94,7 @@ def test_relativistic_energy_exceptions(velocity, mass, exception):
 
 
 @pytest.mark.parametrize(
-    "velocity, mass, warning",
+    ("velocity", "mass", "warning"),
     [
         (2.2, 5 * u.kg, u.UnitsWarning),
     ],
@@ -114,8 +114,8 @@ proton_at_half_c_inputs = [
 ]
 
 
-@pytest.mark.parametrize("attribute, expected", proton_at_half_c_inputs)
-@pytest.mark.parametrize("parameter, argument", proton_at_half_c_inputs)
+@pytest.mark.parametrize(("attribute", "expected"), proton_at_half_c_inputs)
+@pytest.mark.parametrize(("parameter", "argument"), proton_at_half_c_inputs)
 def test_relativistic_body(parameter, argument, attribute, expected):
     """
     Test that when we create `RelativisticBody` instances for each of
@@ -134,8 +134,8 @@ def test_relativistic_body(parameter, argument, attribute, expected):
     assert_quantity_allclose(actual, expected, rtol=1e-9)
 
 
-@pytest.mark.parametrize("attr_to_set, set_value", proton_at_half_c_inputs)
-@pytest.mark.parametrize("attr_to_test, expected", proton_at_half_c_inputs)
+@pytest.mark.parametrize(("attr_to_set", "set_value"), proton_at_half_c_inputs)
+@pytest.mark.parametrize(("attr_to_test", "expected"), proton_at_half_c_inputs)
 def test_relativistic_body_setters(attr_to_set, set_value, attr_to_test, expected):
     """Test setting RelativisticBody attributes."""
     relativistic_body = RelativisticBody(proton, v_over_c=0.1)
@@ -162,7 +162,7 @@ def test_relativistic_body_mass_energy(particle):
 
 
 @pytest.mark.parametrize(
-    "kwargs, exception",
+    ("kwargs", "exception"),
     [
         ({"V": 299792459 * (u.m / u.s)}, RelativityError),
         ({"v_over_c": 1.00001}, RelativityError),
@@ -195,7 +195,7 @@ def test_relativistic_body_equality():
 
 
 @pytest.mark.parametrize(
-    "this, that",
+    ("this", "that"),
     [
         (RelativisticBody("p+", v_over_c=0.2), RelativisticBody("p+", v_over_c=0.5)),
         (RelativisticBody("p+", v_over_c=0.2), RelativisticBody("e-", v_over_c=0.2)),

--- a/plasmapy/formulary/tests/test_speeds.py
+++ b/plasmapy/formulary/tests/test_speeds.py
@@ -29,7 +29,7 @@ T_negarr = np.array([1e6, -5151.0]) * u.K
 
 
 @pytest.mark.parametrize(
-    "alias, parent",
+    ("alias", "parent"),
     [
         (va_, Alfven_speed),
         (cs_, ion_sound_speed),
@@ -44,7 +44,7 @@ class TestAlfvenSpeed:
     """Test `~plasmapy.formulary.speeds.Alfven_speed`."""
 
     @pytest.mark.parametrize(
-        "args, kwargs, _error",
+        ("args", "kwargs", "_error"),
         [
             # scenarios that raise RelativityError
             ((10 * u.T, 1.0e-10 * u.kg * u.m**-3), {}, RelativityError),
@@ -87,7 +87,7 @@ class TestAlfvenSpeed:
             Alfven_speed(*args, **kwargs)
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected, isclose_kw, _warning",
+        ("args", "kwargs", "expected", "isclose_kw", "_warning"),
         [
             # scenarios that issue RelativityWarning
             (
@@ -125,7 +125,7 @@ class TestAlfvenSpeed:
             assert np.isclose(val.value, expected, **isclose_kw)
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected, isclose_kw",
+        ("args", "kwargs", "expected", "isclose_kw"),
         [
             (
                 (1 * u.T, 1e-8 * u.kg * u.m**-3),
@@ -200,7 +200,7 @@ class TestAlfvenSpeed:
         assert np.allclose(Alfven_speed(*args, **kwargs), expected, **isclose_kw)
 
     @pytest.mark.parametrize(
-        "args, kwargs, nan_mask",
+        ("args", "kwargs", "nan_mask"),
         [
             ((np.nan * u.T, 1 * u.kg * u.m**-3), {}, []),
             ((0.001 * u.T, np.nan * u.kg * u.m**-3), {}, []),
@@ -237,7 +237,7 @@ class Test_Ion_Sound_Speed:
     r"""Test the ion_sound_speed function in speeds.py."""
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected, isclose_kw",
+        ("args", "kwargs", "expected", "isclose_kw"),
         [
             (
                 (),
@@ -329,7 +329,7 @@ class Test_Ion_Sound_Speed:
     # ion='H-1')
 
     @pytest.mark.parametrize(
-        "kwargs1, kwargs2, _warning",
+        ("kwargs1", "kwargs2", "_warning"),
         [
             ({"T_i": T_i, "T_e": T_e, "n_e": n_e, "ion": "p"}, {}, PhysicsWarning),
             ({"T_i": T_i, "T_e": T_e, "k": k_1, "ion": "p"}, {}, PhysicsWarning),
@@ -353,7 +353,7 @@ class Test_Ion_Sound_Speed:
                 val == ion_sound_speed(**kwargs2)  # noqa: B015
 
     @pytest.mark.parametrize(
-        "args, kwargs, _error",
+        ("args", "kwargs", "_error"),
         [
             (
                 (),

--- a/plasmapy/formulary/tests/test_thermal_speed.py
+++ b/plasmapy/formulary/tests/test_thermal_speed.py
@@ -31,7 +31,7 @@ from plasmapy.utils.pytest_helpers import assert_can_handle_nparray
 
 
 @pytest.mark.parametrize(
-    "alias, parent",
+    ("alias", "parent"),
     [(vth_, thermal_speed), (vth_kappa_, kappa_thermal_speed)],
 )
 def test_aliases(alias, parent):
@@ -45,7 +45,7 @@ class TestThermalSpeedCoefficients:
     """
 
     @pytest.mark.parametrize(
-        "ndim, method, _error",
+        ("ndim", "method", "_error"),
         [
             (0, "most_probable", ValueError),
             (4, "most_probable", ValueError),
@@ -60,7 +60,7 @@ class TestThermalSpeedCoefficients:
             thermal_speed_coefficients(ndim=ndim, method=method)
 
     @pytest.mark.parametrize(
-        "ndim, method, expected",
+        ("ndim", "method", "expected"),
         [
             (1, "most_probable", 0),
             (2, "most_probable", 1),
@@ -97,7 +97,7 @@ class TestThermalSpeed:
     """
 
     @pytest.mark.parametrize(
-        "bound_name, bound_attr",
+        ("bound_name", "bound_attr"),
         [
             ("lite", thermal_speed_lite),
             ("coefficients", thermal_speed_coefficients),
@@ -123,7 +123,7 @@ class TestThermalSpeed:
             assert origin == bound_origin
 
     @pytest.mark.parametrize(
-        "args, kwargs, expected",
+        ("args", "kwargs", "expected"),
         [
             # Parameters that should return the value of the thermal
             # speed coefficient.
@@ -239,7 +239,7 @@ class TestThermalSpeed:
         assert vth.unit == u.m / u.s
 
     @pytest.mark.parametrize(
-        "args, kwargs, _error",
+        ("args", "kwargs", "_error"),
         [
             ((5 * u.m, "e-"), {}, u.UnitTypeError),
             ((5 * u.m, "He+"), {}, u.UnitTypeError),
@@ -257,7 +257,7 @@ class TestThermalSpeed:
             thermal_speed(*args, **kwargs)
 
     @pytest.mark.parametrize(
-        "args, kwargs, _warning, expected",
+        ("args", "kwargs", "_warning", "expected"),
         [
             ((), {"T": 1e9 * u.K, "particle": "e-"}, RelativityWarning, None),
             (

--- a/plasmapy/formulary/tests/test_transport.py
+++ b/plasmapy/formulary/tests/test_transport.py
@@ -49,7 +49,7 @@ def count_decimal_places(digits):
     return len(fractional)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class Test_classical_transport:
     @classmethod
     def setup_class(cls):

--- a/plasmapy/formulary/tests/test_transport.py
+++ b/plasmapy/formulary/tests/test_transport.py
@@ -370,7 +370,7 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize(
-        "model, attr_name, field_orientation, expected",
+        ("model", "attr_name", "field_orientation", "expected"),
         [
             ("ji-held", "resistivity", "all", 3),
             ("ji-held", "thermoelectric_conductivity", "all", 3),
@@ -400,7 +400,7 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize(
-        "model, expected",
+        ("model", "expected"),
         [
             ("ji-held", 2.77028546e-8 * u.Ohm * u.m),
             ("spitzer", 2.78349687e-8 * u.Ohm * u.m),
@@ -425,7 +425,7 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize(
-        "model, expected",
+        ("model", "expected"),
         [
             ("ji-held", 0.702 * u.s / u.s),
             ("spitzer", 0.69944979 * u.s / u.s),
@@ -453,7 +453,7 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize(
-        "model, expected",
+        ("model", "expected"),
         [
             (
                 "ji-held",
@@ -485,7 +485,7 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize(
-        "model, expected",
+        ("model", "expected"),
         [
             (
                 "ji-held",
@@ -515,7 +515,7 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize(
-        "model, expected",
+        ("model", "expected"),
         [
             ("ji-held", 5084253.556001088 * u.W / (u.K * u.m)),
             ("spitzer", 5082147.824377487 * u.W / (u.K * u.m)),
@@ -545,7 +545,7 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize(
-        "model, expected",
+        ("model", "expected"),
         [
             ("ji-held", 134547.55528106514 * u.W / (u.K * u.m)),
             ("braginskii", 133052.21732349042 * u.W / (u.K * u.m)),
@@ -572,7 +572,7 @@ class Test_classical_transport:
         assert testTrue, errStr
 
     @pytest.mark.parametrize(
-        "key, expected",
+        ("key", "expected"),
         {
             "resistivity": [2.84304305e-08, 5.54447070e-08, 1.67853407e-12],
             "thermoelectric conductivity": [
@@ -722,7 +722,7 @@ class Test_classical_transport:
             )
 
 
-@pytest.mark.parametrize(["particle"], ["e", "p"])
+@pytest.mark.parametrize("particle", ["e", "p"])
 def test_nondim_thermal_conductivity_unrecognized_model(particle):
     with pytest.raises(ValueError):
         _nondim_thermal_conductivity(
@@ -740,7 +740,7 @@ def test_nondim_te_conductivity_unrecognized_model():
         _nondim_te_conductivity(1, 1, "e", "this is not a model", "parallel")
 
 
-@pytest.mark.parametrize(["particle"], ["e", "p"])
+@pytest.mark.parametrize("particle", ["e", "p"])
 def test_nondim_viscosity_unrecognized_model(particle):
     with pytest.raises(ValueError):
         _nondim_viscosity(1, 1, particle, "not a model", "parallel")
@@ -756,7 +756,7 @@ class Test__nondim_tc_e_braginskii:
 
     # values from Braginskii '65
     @pytest.mark.parametrize(
-        "Z, field_orientation, expected",
+        ("Z", "field_orientation", "expected"),
         [
             (1, "par", 3.16),  # eq (2.12), table 1
             (2, "par", 4.9),  # eq (2.12), table 1
@@ -772,7 +772,7 @@ class Test__nondim_tc_e_braginskii:
 
     # values from Braginskii '65
     @pytest.mark.parametrize(
-        "Z, field_orientation, expected",
+        ("Z", "field_orientation", "expected"),
         [
             (1, "perp", 4.66),  # eq (2.13), table 1
             (2, "perp", 4.0),  # eq (2.13), table 1
@@ -849,7 +849,7 @@ class Test__nondim_tec_braginskii:
 
     # values from Braginskii '65
     @pytest.mark.parametrize(
-        "Z, field_orientation, expected",
+        ("Z", "field_orientation", "expected"),
         [
             (1, "par", 0.71),  # eq (2.9), table 1
             (2, "par", 0.9),  # eq (2.9), table 1
@@ -888,7 +888,7 @@ class Test__nondim_resist_braginskii:
 
     # values from Braginskii '65
     @pytest.mark.parametrize(
-        "Z, field_orientation, expected",
+        ("Z", "field_orientation", "expected"),
         [
             (1, "par", 0.51),  # eq (2.8), table 1
             (2, "par", 0.44),  # table 1
@@ -927,7 +927,7 @@ class Test__nondim_visc_i_braginskii:
 
     # values from Braginskii '65, eqs. 2.22 to 2.24
     @pytest.mark.parametrize(
-        "expected, power",
+        ("expected", "power"),
         [(np.array((0.96, 0.3, 1.2, 0.5, 1.0)), np.array((0, 2, 2, 1, 1)))],
     )
     def test_known_values(self, expected, power):
@@ -954,7 +954,7 @@ class Test__nondim_visc_e_braginskii:
 
     # values from Braginskii '65
     @pytest.mark.parametrize(
-        "Z, expected, idx",
+        ("Z", "expected", "idx"),
         [
             (1, 0.73, 0),  # eq (2.25)
             (1, 0.51, 1),  # eq (2.26)
@@ -1032,7 +1032,7 @@ def test__nondim_tec_spitzer(Z):
 
 # approximated from Ji-Held '13 figures 1 and 2 (black circles)
 @pytest.mark.parametrize(
-    "hall, Z, field_orientation, expected",
+    ("hall", "Z", "field_orientation", "expected"),
     [
         (0.0501, 1, "perp", 3.187),
         (0.2522, 1, "perp", 2.597),
@@ -1083,7 +1083,7 @@ def test__nondim_tc_e_ji_held(hall, Z, field_orientation, expected):
 
 # approximated from Ji-Held '13 figures 1 and 2 (black circles)
 @pytest.mark.parametrize(
-    "hall, Z, field_orientation, expected",
+    ("hall", "Z", "field_orientation", "expected"),
     [
         (0.03939, 1, "perp", 0.6959),
         (0.2498, 1, "perp", 0.6216),
@@ -1137,7 +1137,7 @@ def test__nondim_tec_ji_held(hall, Z, field_orientation, expected):
 
 # approximated from Ji-Held '13 figures 1 and 2 (black circles)
 @pytest.mark.parametrize(
-    "hall, Z, field_orientation, expected",
+    ("hall", "Z", "field_orientation", "expected"),
     [
         (0.06317, 1, "perp", 0.5064),
         (0.3966, 1, "perp", 0.5316),
@@ -1188,7 +1188,7 @@ def test__nondim_resist_ji_held(hall, Z, field_orientation, expected):
 
 # approximated from Ji-Held '13 figure 3 (K = 80)
 @pytest.mark.parametrize(
-    "hall, Z, index, expected",
+    ("hall", "Z", "index", "expected"),
     [
         (0.01968, 1, 2, 0.7368),
         (0.1338, 1, 2, 0.7171),
@@ -1221,7 +1221,7 @@ def test__nondim_visc_e_ji_held(hall, Z, index, expected):
 # note r = sqrt(2) * x
 # note kappa from figure = kappa_hat / sqrt(2)
 @pytest.mark.parametrize(
-    "hall, Z, mu, theta, field_orientation, expected",
+    ("hall", "Z", "mu", "theta", "field_orientation", "expected"),
     [
         (0.01529, 1, 0, 100, "perp", 3.99586042),
         (0.0589, 1, 0, 100, "perp", 3.96828326),
@@ -1253,7 +1253,7 @@ def test__nondim_tc_i_ji_held(hall, Z, mu, theta, field_orientation, expected):
 # note r = sqrt(2) * x
 # note eta from figure = eta_hat / sqrt(2)
 @pytest.mark.parametrize(
-    "hall, Z, mu, theta, index, expected",
+    ("hall", "Z", "mu", "theta", "index", "expected"),
     [
         (0.01981, 1, 0, 100, 2, 0.96166522),
         (0.17423, 1, 0, 100, 2, 0.92206724),

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -336,7 +336,9 @@ def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected):
     )
 
     if expected is not None:
-        assert u.isclose(result1, result2) and u.isclose(result2, expected), (
+        assert u.isclose(result1, result2) and u.isclose(  # noqa: PT018
+            result2, expected
+        ), (
             f"particle_mass({arg1!r}, **{kwargs1}) = {result1!r} and "
             f"particle_mass({arg2!r}, **{kwargs2}) = {result2!r}, but "
             f"these results are not equal to {expected!r} as expected."

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -238,7 +238,7 @@ table_functions_args_kwargs_output = [
 
 
 @pytest.mark.parametrize(
-    "tested_function, args, kwargs, expected_output",
+    ("tested_function", "args", "kwargs", "expected_output"),
     table_functions_args_kwargs_output,
 )
 def test_functions_and_values(tested_function, args, kwargs, expected_output):
@@ -320,7 +320,7 @@ equivalent_particle_mass_args = [
 
 
 @pytest.mark.parametrize(
-    "arg1, kwargs1, arg2, kwargs2, expected", equivalent_particle_mass_args
+    ("arg1", "kwargs1", "arg2", "kwargs2", "expected"), equivalent_particle_mass_args
 )
 def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected):
     """Test that `particle_mass` returns equivalent results for
@@ -499,7 +499,7 @@ isotopic_abundance_sum_table = (
 )
 
 
-@pytest.mark.parametrize("element, isotopes", isotopic_abundance_sum_table)
+@pytest.mark.parametrize(("element", "isotopes"), isotopic_abundance_sum_table)
 def test_isotopic_abundances_sum(element, isotopes):
     """Test that the sum of isotopic abundances for each element with
     isotopic abundances is one."""
@@ -525,7 +525,7 @@ def test_ion_list_example():
 
 
 @pytest.mark.parametrize(
-    "particle, min_charge, max_charge, expected_charge_numbers",
+    ("particle", "min_charge", "max_charge", "expected_charge_numbers"),
     [
         ("H-1", 0, 1, [0, 1]),
         ("p+", 1, 1, [1]),
@@ -544,7 +544,7 @@ def test_ion_list(particle, min_charge, max_charge, expected_charge_numbers):
 
 
 @pytest.mark.parametrize(
-    "element, min_charge, max_charge", [("Li", 0, 4), ("Li", 3, 2)]
+    ("element", "min_charge", "max_charge"), [("Li", 0, 4), ("Li", 3, 2)]
 )
 def test_invalid_inputs_to_ion_list(element, min_charge, max_charge):
     with pytest.raises(ChargeError):
@@ -566,7 +566,7 @@ str_electron_table = [
 ]
 
 
-@pytest.mark.parametrize("particle, electron", str_electron_table)
+@pytest.mark.parametrize(("particle", "electron"), str_electron_table)
 def test_is_electron(particle, electron):
     assert _is_electron(particle) == electron
 
@@ -582,7 +582,7 @@ def test_ionic_levels_example():
 
 
 @pytest.mark.parametrize(
-    "particle, min_charge, max_charge, expected_charge_numbers",
+    ("particle", "min_charge", "max_charge", "expected_charge_numbers"),
     [
         ("H-1", 0, 1, [0, 1]),
         ("p+", 1, 1, [1]),
@@ -601,7 +601,7 @@ def test_ion_list2(particle, min_charge, max_charge, expected_charge_numbers):
 
 
 @pytest.mark.parametrize(
-    "element, min_charge, max_charge", [("Li", 0, 4), ("Li", 3, 2)]
+    ("element", "min_charge", "max_charge"), [("Li", 0, 4), ("Li", 3, 2)]
 )
 def test_invalid_inputs_to_ion_list2(element, min_charge, max_charge):
     with pytest.raises(ChargeError):

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -345,7 +345,7 @@ def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected):
         )
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_known_common_stable_isotopes():
     """Test that `known_isotopes`, `common_isotopes`, and
     `stable_isotopes` return the correct values for hydrogen."""
@@ -423,7 +423,7 @@ def test_known_common_stable_isotopes_cases():
     assert "He-4" in common_isotopes("He", most_common_only=True)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_known_common_stable_isotopes_len():
     """Test that `known_isotopes`, `common_isotopes`, and
     `stable_isotopes` each return a `list` of the expected length.

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -78,7 +78,7 @@ particle_input_simple_table = [
         function_decorated_with_particle_input,
     ],
 )
-@pytest.mark.parametrize("args, kwargs, symbol", particle_input_simple_table)
+@pytest.mark.parametrize(("args", "kwargs", "symbol"), particle_input_simple_table)
 def test_particle_input_simple(func, args, kwargs, symbol):
     """
     Test that simple functions decorated by particle_input correctly
@@ -117,7 +117,9 @@ particle_input_error_table = [
 ]
 
 
-@pytest.mark.parametrize("func, kwargs, expected_error", particle_input_error_table)
+@pytest.mark.parametrize(
+    ("func", "kwargs", "expected_error"), particle_input_error_table
+)
 def test_particle_input_errors(func, kwargs, expected_error):
     """
     Test that functions decorated with `@particle_input` raise the
@@ -187,7 +189,7 @@ ambiguous_arguments = [
 ]
 
 
-@pytest.mark.parametrize("args, kwargs", ambiguous_arguments)
+@pytest.mark.parametrize(("args", "kwargs"), ambiguous_arguments)
 def test_function_with_ambiguity(args, kwargs):
     """
     Test that a function decorated with particle_input that has two
@@ -251,7 +253,7 @@ categorization_particle_exception = [
 
 
 @pytest.mark.parametrize(
-    "categorization, particle, exception", categorization_particle_exception
+    ("categorization", "particle", "exception"), categorization_particle_exception
 )
 def test_decorator_categories(categorization, particle, exception):
     """
@@ -306,7 +308,7 @@ decorator_pairs = [
 ]
 
 
-@pytest.mark.parametrize("decorator1, decorator2", decorator_pairs)
+@pytest.mark.parametrize(("decorator1", "decorator2"), decorator_pairs)
 def test_stacking_decorators(decorator1, decorator2):
     """
     Test that particle_input and validate_quantities can be stacked in
@@ -326,7 +328,7 @@ def test_stacking_decorators(decorator1, decorator2):
     assert distance_1_2 == distance_2_1 == 3 * u.cm
 
 
-@pytest.mark.parametrize("decorator1, decorator2", decorator_pairs)
+@pytest.mark.parametrize(("decorator1", "decorator2"), decorator_pairs)
 def test_preserving_signature_with_stacked_decorators(decorator1, decorator2):
     """
     Test that |particle_input| & |validate_quantities| preserve the
@@ -414,7 +416,7 @@ def test_annotated_init():
 
 
 @pytest.mark.parametrize(
-    "outer_decorator, inner_decorator",
+    ("outer_decorator", "inner_decorator"),
     [
         (particle_input, validate_quantities_),
         (particle_input(), validate_quantities_),
@@ -468,7 +470,9 @@ kwargs_to_decorator_and_args = [
 ]
 
 
-@pytest.mark.parametrize("kwargs_to_particle_input, arg", kwargs_to_decorator_and_args)
+@pytest.mark.parametrize(
+    ("kwargs_to_particle_input", "arg"), kwargs_to_decorator_and_args
+)
 def test_particle_input_verification(kwargs_to_particle_input, arg):
     """Test the allow_custom_particles keyword argument to particle_input."""
 

--- a/plasmapy/particles/tests/test_exceptions.py
+++ b/plasmapy/particles/tests/test_exceptions.py
@@ -198,7 +198,7 @@ tests_for_exceptions = {
 
 
 @pytest.mark.parametrize(
-    ["tested_object", "args", "kwargs", "expected_exception"],
+    ("tested_object", "args", "kwargs", "expected_exception"),
     list(tests_for_exceptions.values()),
     ids=list(tests_for_exceptions.keys()),
 )
@@ -1023,7 +1023,7 @@ type_error_tests = [
 
 
 @pytest.mark.parametrize(
-    ["tested_object", "args", "kwargs", "expected"],
+    ("tested_object", "args", "kwargs", "expected"),
     tests_from_nuclear + tests_from_atomic + particle_error_tests + type_error_tests,
 )
 def test_unnamed_tests_exceptions(tested_object, args, kwargs, expected):

--- a/plasmapy/particles/tests/test_factory.py
+++ b/plasmapy/particles/tests/test_factory.py
@@ -48,7 +48,7 @@ test_cases = [
 ]
 
 
-@pytest.mark.parametrize("args, kwargs, expected", test_cases)
+@pytest.mark.parametrize(("args", "kwargs", "expected"), test_cases)
 def test_physical_particle_factory(args, kwargs, expected):
     result = _physical_particle_factory(*args, **kwargs)
     assert result == expected
@@ -65,7 +65,7 @@ test_cases_for_exceptions = [
 ]
 
 
-@pytest.mark.parametrize("args, kwargs, expected", test_cases_for_exceptions)
+@pytest.mark.parametrize(("args", "kwargs", "expected"), test_cases_for_exceptions)
 def test_particle_factory_exceptions(args, kwargs, expected):
     with pytest.raises(expected):
         _physical_particle_factory(*args, **kwargs)

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -362,7 +362,7 @@ class TestIonizationStateCollectionItemAssignment:
         )
 
     @pytest.mark.parametrize(
-        "element, new_states",
+        ("element", "new_states"),
         [
             ("H", [np.nan, np.nan]),
             ("He", [np.nan, np.nan, np.nan]),
@@ -388,7 +388,7 @@ class TestIonizationStateCollectionItemAssignment:
         )
 
     @pytest.mark.parametrize(
-        "base_particle, new_states, expected_exception",
+        ("base_particle", "new_states", "expected_exception"),
         [
             ("H", (0, 0.9), ValueError),
             ("H", (-0.1, 1.1), ValueError),
@@ -493,7 +493,7 @@ class TestIonizationStateCollectionAttributes:
             assert np.isnan(default_value[element])
 
     @pytest.mark.parametrize(
-        "attribute, invalid_value, expected_exception",
+        ("attribute", "invalid_value", "expected_exception"),
         [
             ("T_e", "5 * u.m", u.UnitsError),
             ("T_e", "-1 * u.K", ParticleError),
@@ -547,7 +547,7 @@ class TestIonizationStateCollectionAttributes:
         )
 
     @pytest.mark.parametrize(
-        "key, invalid_fracs, expected_exception",
+        ("key", "invalid_fracs", "expected_exception"),
         [
             ("H", [-0.01, 1.01], ValueError),
             ("H", [0.4, 0.5], ValueError),
@@ -791,7 +791,7 @@ class TestIonizationStateCollectionDensityEqualities:
             )
 
     @pytest.mark.parametrize(
-        "this, that",
+        ("this", "that"),
         itertools.product(
             ["ndens1", "ndens2", "no_ndens3", "no_ndens4", "no_ndens5"], repeat=2
         ),
@@ -858,7 +858,7 @@ physical_properties = ["charge", "mass"]
 @pytest.mark.parametrize("include_neutrals", [True, False])
 @pytest.mark.parametrize("use_rms_mass", [False, True])
 @pytest.mark.parametrize("use_rms_charge", [False, True])
-@pytest.mark.parametrize("base_particle, ionic_fractions", example_ionic_fractions)
+@pytest.mark.parametrize(("base_particle", "ionic_fractions"), example_ionic_fractions)
 @pytest.mark.parametrize("physical_type", physical_properties)
 def test_average_ion_consistency(
     base_particle,

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -107,7 +107,7 @@ tests = {
 test_names = tests.keys()
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class TestIonizationStateCollection:
     @classmethod
     def setup_class(cls):

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -26,7 +26,9 @@ ionic_fraction_table = [
 ]
 
 
-@pytest.mark.parametrize("ion, ionic_fraction, number_density", ionic_fraction_table)
+@pytest.mark.parametrize(
+    ("ion", "ionic_fraction", "number_density"), ionic_fraction_table
+)
 def test_ionic_level_attributes(ion, ionic_fraction, number_density):
     instance = IonicLevel(
         ion=ion, ionic_fraction=ionic_fraction, number_density=number_density
@@ -46,7 +48,7 @@ def test_ionic_level_attributes(ion, ionic_fraction, number_density):
 
 
 @pytest.mark.parametrize(
-    "invalid_fraction, expected_exception",
+    ("invalid_fraction", "expected_exception"),
     [(-1e-9, ParticleError), (1.00000000001, ParticleError), ("...", ParticleError)],
 )
 def test_ionic_level_invalid_inputs(invalid_fraction, expected_exception):
@@ -68,7 +70,7 @@ def test_ionic_level_invalid_particles(invalid_particle):
         IonicLevel(invalid_particle, ionic_fraction=0)
 
 
-@pytest.mark.parametrize("ion1, ion2", [("Fe-56 6+", "Fe-56 5+"), ("H 1+", "D 1+")])
+@pytest.mark.parametrize(("ion1", "ion2"), [("Fe-56 6+", "Fe-56 5+"), ("H 1+", "D 1+")])
 def test_ionic_level_comparison_with_different_ions(ion1, ion2):
     """
     Test that a `TypeError` is raised when an `IonicLevel` object
@@ -158,7 +160,7 @@ def test_equal_to_itself(He_ionization_state):
     assert He_ionization_state == He_ionization_state
 
 
-@pytest.mark.parametrize("tolerance, output", [(1e-8, True), (1e-9001, False)])
+@pytest.mark.parametrize(("tolerance", "output"), [(1e-8, True), (1e-9001, False)])
 def test_equal_to_within_tolerance(tolerance, output):
     """
     Test that `IonizationState.__eq__` returns `True` for two
@@ -507,7 +509,7 @@ def test_default_T_i_is_T_e(instance):
 
 
 @pytest.mark.parametrize(
-    ["T_i", "expectation"],
+    ("T_i", "expectation"),
     [
         (10 * u.m, pytest.raises(u.UnitTypeError)),
         (
@@ -664,7 +666,7 @@ particles_and_ionfracs = [
 
 
 @pytest.mark.parametrize("physical_property", physical_properties)
-@pytest.mark.parametrize("base_particle, ionic_fractions", particles_and_ionfracs)
+@pytest.mark.parametrize(("base_particle", "ionic_fractions"), particles_and_ionfracs)
 def test_weighted_mean_ion(base_particle, ionic_fractions, physical_property):
     """
     Test that `IonizationState.average_ion` gives a |CustomParticle|
@@ -681,7 +683,7 @@ def test_weighted_mean_ion(base_particle, ionic_fractions, physical_property):
 
 
 @pytest.mark.parametrize("physical_property", physical_properties)
-@pytest.mark.parametrize("base_particle, ionic_fractions", particles_and_ionfracs)
+@pytest.mark.parametrize(("base_particle", "ionic_fractions"), particles_and_ionfracs)
 def test_weighted_rms_ion(base_particle, ionic_fractions, physical_property):
     """
     Test that `IonizationState.average_ion` gives a |CustomParticle|

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -336,7 +336,7 @@ def test_getitem(test_ionization_state):
         pytest.fail(str.join("", errors))
 
 
-@pytest.fixture
+@pytest.fixture()
 def He_ionization_state():
     return IonizationState(  # noqa: PIE804
         **{
@@ -434,7 +434,7 @@ expected_properties = {
 }
 
 
-@pytest.fixture
+@pytest.fixture()
 def instance():
     kwargs = {
         "particle": "He-4",

--- a/plasmapy/particles/tests/test_nuclear.py
+++ b/plasmapy/particles/tests/test_nuclear.py
@@ -88,7 +88,8 @@ nuclear_reaction_energy_kwargs_table = [
 
 
 @pytest.mark.parametrize(
-    "reactants, products, expectedMeV, tol", nuclear_reaction_energy_kwargs_table
+    ("reactants", "products", "expectedMeV", "tol"),
+    nuclear_reaction_energy_kwargs_table,
 )
 def test_nuclear_reaction_energy_kwargs(reactants, products, expectedMeV, tol):
     energy = nuclear_reaction_energy(reactants=reactants, products=products).si
@@ -117,7 +118,7 @@ table_of_nuclear_tests = [
 
 
 @pytest.mark.parametrize(
-    ["tested_object", "args", "kwargs", "expected_value"], table_of_nuclear_tests
+    ("tested_object", "args", "kwargs", "expected_value"), table_of_nuclear_tests
 )
 def test_nuclear_table(tested_object, args, kwargs, expected_value):
     run_test(tested_object, args, kwargs, expected_value, rtol=1e-3)

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -48,7 +48,7 @@ aliases_and_symbols = [
 ]
 
 
-@pytest.mark.parametrize("alias, symbol", aliases_and_symbols)
+@pytest.mark.parametrize(("alias", "symbol"), aliases_and_symbols)
 def test_dealias_particle_aliases(alias, symbol):
     """Test that _dealias_particle_aliases correctly takes in aliases and
     returns the corresponding symbols, and returns the original argument
@@ -267,7 +267,7 @@ parse_check_table = [
 ]
 
 
-@pytest.mark.parametrize("arg, kwargs, expected", parse_check_table)
+@pytest.mark.parametrize(("arg", "kwargs", "expected"), parse_check_table)
 def test_parse_and_check_atomic_input(arg, kwargs, expected):
     result = parse_and_check_atomic_input(arg, **kwargs)
     assert result == expected, (
@@ -316,7 +316,7 @@ invalid_particles_table = [
 ]
 
 
-@pytest.mark.parametrize("arg, kwargs", invalid_particles_table)
+@pytest.mark.parametrize(("arg", "kwargs"), invalid_particles_table)
 def test_parse_InvalidParticleErrors(arg, kwargs):
     r"""Tests that _parse_and_check_atomic_input raises an
     InvalidParticleError when the input does not correspond
@@ -355,7 +355,7 @@ atomic_warnings_table = [
 ]
 
 
-@pytest.mark.parametrize("arg, kwargs, num_warnings", atomic_warnings_table)
+@pytest.mark.parametrize(("arg", "kwargs", "num_warnings"), atomic_warnings_table)
 def test_parse_AtomicWarnings(arg, kwargs, num_warnings):
     r"""Tests that _parse_and_check_atomic_input issues an AtomicWarning
     under the required conditions."""

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -504,7 +504,7 @@ test_Particle_table = [
 ]
 
 
-@pytest.mark.parametrize("arg, kwargs, expected_dict", test_Particle_table)
+@pytest.mark.parametrize(("arg", "kwargs", "expected_dict"), test_Particle_table)
 def test_Particle_class(arg, kwargs, expected_dict):
     """
     Test that `~plasmapy.particles.Particle` objects for different
@@ -622,7 +622,7 @@ test_Particle_error_table = [
 
 
 @pytest.mark.parametrize(
-    "args, kwargs, attribute, exception", test_Particle_error_table
+    ("args", "kwargs", "attribute", "exception"), test_Particle_error_table
 )
 def test_Particle_errors(args, kwargs, attribute, exception):
     """
@@ -646,7 +646,9 @@ test_Particle_warning_table = [
 ]
 
 
-@pytest.mark.parametrize("arg, kwargs, attribute, warning", test_Particle_warning_table)
+@pytest.mark.parametrize(
+    ("arg", "kwargs", "attribute", "warning"), test_Particle_warning_table
+)
 def test_Particle_warnings(arg, kwargs, attribute, warning):
     """
     Test that the appropriate warnings are issued during the creation
@@ -700,7 +702,7 @@ nuclide_mass_and_mass_equiv_table = [
 ]
 
 
-@pytest.mark.parametrize("isotope, ion", nuclide_mass_and_mass_equiv_table)
+@pytest.mark.parametrize(("isotope", "ion"), nuclide_mass_and_mass_equiv_table)
 def test_particle_class_mass_nuclide_mass(isotope: str, ion: str):
     """
     Test that the ``mass`` and ``nuclide_mass`` attributes return
@@ -767,7 +769,9 @@ def test_particle_half_life_string():
         assert isinstance(Particle(isotope).half_life, str)
 
 
-@pytest.mark.parametrize("p, is_one", [(Particle("e-"), True), (Particle("p+"), False)])
+@pytest.mark.parametrize(
+    ("p", "is_one"), [(Particle("e-"), True), (Particle("p+"), False)]
+)
 def test_particle_is_electron(p, is_one):
     assert p.is_electron == is_one
 
@@ -936,7 +940,9 @@ customized_particle_tests = [
 ]
 
 
-@pytest.mark.parametrize("cls, kwargs, attr, expected", customized_particle_tests)
+@pytest.mark.parametrize(
+    ("cls", "kwargs", "attr", "expected"), customized_particle_tests
+)
 def test_custom_particles(cls, kwargs, attr, expected):
     """Test the attributes of dimensionless and custom particles."""
     instance = cls(**kwargs)
@@ -949,7 +955,7 @@ def test_custom_particles(cls, kwargs, attr, expected):
 
 
 @pytest.mark.parametrize(
-    "cls, symbol, expected",
+    ("cls", "symbol", "expected"),
     [
         (CustomParticle, None, "CustomParticle(mass=nan kg, charge=nan C)"),
         (CustomParticle, "η", "η"),
@@ -969,7 +975,7 @@ custom_particle_categories_table = [
 ]
 
 
-@pytest.mark.parametrize("kwargs, expected", custom_particle_categories_table)
+@pytest.mark.parametrize(("kwargs", "expected"), custom_particle_categories_table)
 def test_custom_particle_categories(kwargs, expected):
     """Test that CustomParticle.categories behaves as expected."""
     custom_particle = CustomParticle(**kwargs)
@@ -990,7 +996,7 @@ custom_particle_is_category_table = [
 
 
 @pytest.mark.parametrize(
-    "kwargs_to_custom_particle, kwargs_to_is_category, expected",
+    ("kwargs_to_custom_particle", "kwargs_to_is_category", "expected"),
     custom_particle_is_category_table,
 )
 def test_custom_particle_is_category(
@@ -1043,7 +1049,7 @@ custom_particle_errors = [
 ]
 
 
-@pytest.mark.parametrize("cls, kwargs, exception", custom_particle_errors)
+@pytest.mark.parametrize(("cls", "kwargs", "exception"), custom_particle_errors)
 def test_customized_particles_errors(cls, kwargs, exception):
     """
     Test that attempting to create invalid dimensionless or custom particles
@@ -1072,7 +1078,9 @@ customized_particle_repr_table = [
 ]
 
 
-@pytest.mark.parametrize("cls, kwargs, expected_repr", customized_particle_repr_table)
+@pytest.mark.parametrize(
+    ("cls", "kwargs", "expected_repr"), customized_particle_repr_table
+)
 def test_customized_particle_repr(cls, kwargs, expected_repr):
     """Test the string representations of dimensionless and custom particles."""
     instance = cls(**kwargs)
@@ -1183,7 +1191,8 @@ custom_particles_from_json_tests = [
 
 
 @pytest.mark.parametrize(
-    "cls, kwargs, json_string, expected_exception", custom_particles_from_json_tests
+    ("cls", "kwargs", "json_string", "expected_exception"),
+    custom_particles_from_json_tests,
 )
 def test_custom_particles_from_json_string(
     cls, kwargs, json_string, expected_exception
@@ -1215,7 +1224,8 @@ def test_custom_particles_from_json_string(
 
 
 @pytest.mark.parametrize(
-    "cls, kwargs, json_string, expected_exception", custom_particles_from_json_tests
+    ("cls", "kwargs", "json_string", "expected_exception"),
+    custom_particles_from_json_tests,
 )
 def test_custom_particles_from_json_file(cls, kwargs, json_string, expected_exception):
     """Test the attributes of dimensionless and custom particles generated from
@@ -1283,7 +1293,7 @@ particles_from_json_tests = [
 
 
 @pytest.mark.parametrize(
-    "cls, kwargs, json_string, expected_exception", particles_from_json_tests
+    ("cls", "kwargs", "json_string", "expected_exception"), particles_from_json_tests
 )
 def test_particles_from_json_string(cls, kwargs, json_string, expected_exception):
     """Test the attributes of Particle objects created from JSON representation."""
@@ -1305,7 +1315,7 @@ def test_particles_from_json_string(cls, kwargs, json_string, expected_exception
 
 
 @pytest.mark.parametrize(
-    "cls, kwargs, json_string, expected_exception", particles_from_json_tests
+    ("cls", "kwargs", "json_string", "expected_exception"), particles_from_json_tests
 )
 def test_particles_from_json_file(cls, kwargs, json_string, expected_exception):
     """Test the attributes of Particle objects created from JSON representation."""
@@ -1367,7 +1377,7 @@ particle_json_repr_table = [
 ]
 
 
-@pytest.mark.parametrize("cls, kwargs, expected_repr", particle_json_repr_table)
+@pytest.mark.parametrize(("cls", "kwargs", "expected_repr"), particle_json_repr_table)
 def test_particle_to_json_string(cls, kwargs, expected_repr):
     """Test the JSON representations of normal, dimensionless and custom particles."""
     instance = cls(**kwargs)
@@ -1388,7 +1398,7 @@ def test_particle_to_json_string(cls, kwargs, expected_repr):
     )
 
 
-@pytest.mark.parametrize("cls, kwargs, expected_repr", particle_json_repr_table)
+@pytest.mark.parametrize(("cls", "kwargs", "expected_repr"), particle_json_repr_table)
 def test_particle_to_json_file(cls, kwargs, expected_repr):
     """Test the JSON representations of normal, dimensionless and custom particles."""
     instance = cls(**kwargs)
@@ -1444,7 +1454,7 @@ def test_CustomParticle_cmp():
 
 
 @pytest.mark.parametrize(
-    "attr, arg",
+    ("attr", "arg"),
     [
         ("charge", 2 * u.C),
         ("mass", 2 * u.kg),
@@ -1468,7 +1478,7 @@ test_molecule_table = [
 
 
 @pytest.mark.parametrize(
-    "args, kwargs, expected",
+    ("args", "kwargs", "expected"),
     [
         ([], {}, CustomParticle()),
         ([1 * u.kg], {}, CustomParticle(mass=1 * u.kg)),
@@ -1485,7 +1495,7 @@ def test_CustomParticle_from_quantities(args, kwargs, expected):
 
 
 @pytest.mark.parametrize(
-    "args, kwargs, exception",
+    ("args", "kwargs", "exception"),
     [
         ([1 * u.C], {"Z": 2}, InvalidParticleError),
         ([3 * u.m], {}, InvalidParticleError),
@@ -1497,7 +1507,7 @@ def test_CustomParticle_from_quantities_errors(args, kwargs, exception):
         CustomParticle._from_quantities(*args, **kwargs)
 
 
-@pytest.mark.parametrize("m, Z, symbol, m_symbol, m_Z", test_molecule_table)
+@pytest.mark.parametrize(("m", "Z", "symbol", "m_symbol", "m_Z"), test_molecule_table)
 def test_molecule(m, Z, symbol, m_symbol, m_Z):
     """Test ``molecule`` function."""
     assert CustomParticle(m, Z, symbol) == molecule(m_symbol, m_Z)
@@ -1512,7 +1522,7 @@ test_molecule_error_table = [
 ]
 
 
-@pytest.mark.parametrize("symbol, Z", test_molecule_error_table)
+@pytest.mark.parametrize(("symbol", "Z"), test_molecule_error_table)
 def test_molecule_error(symbol, Z):
     """Test the error raised in case of a bad molecule symbol."""
     with pytest.raises(InvalidParticleError):

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -737,7 +737,7 @@ def test_particle_class_mass_nuclide_mass(isotope: str, ion: str):
             f"of the ion."
         )
 
-        assert Isotope.isotope and not Isotope.ion, inputerrmsg
+        assert Isotope.isotope and not Isotope.ion, inputerrmsg  # noqa: PT018
         assert Isotope.isotope == Ion.isotope, inputerrmsg
         assert Ion.charge_number == Ion.atomic_number, inputerrmsg
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -751,7 +751,7 @@ def test_particle_class_mass_nuclide_mass(isotope: str, ion: str):
         )
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_particle_half_life_string():
     """
     Find the first isotope where the half-life is stored as a string

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -328,7 +328,7 @@ def test_particle_multiplication(method, particle):
 
 
 @pytest.mark.parametrize(
-    "particles, args, kwargs, expected",
+    ("particles", "args", "kwargs", "expected"),
     [
         [
             ["electron", "proton", "neutron"],
@@ -396,7 +396,7 @@ def test_weighted_mean_particle():
 boolean_pairs = [(False, False), (True, False), (False, True), (True, True)]
 
 
-@pytest.mark.parametrize("use_rms_charge, use_rms_mass", boolean_pairs)
+@pytest.mark.parametrize(("use_rms_charge", "use_rms_mass"), boolean_pairs)
 def test_root_mean_square_particle(use_rms_charge, use_rms_mass):
     """
     Test that ``ParticleList.average_particle`` returns the mean or root
@@ -430,7 +430,7 @@ particle_multiplicities = [
 
 
 @pytest.mark.parametrize("particle_multiplicities", particle_multiplicities)
-@pytest.mark.parametrize("use_rms_charge, use_rms_mass", boolean_pairs)
+@pytest.mark.parametrize(("use_rms_charge", "use_rms_mass"), boolean_pairs)
 def test_weighted_averages_of_particles(
     particle_multiplicities: dict[ParticleLike, int],
     use_rms_charge,
@@ -495,7 +495,7 @@ def test_particle_list_with_no_arguments():
 
 
 @pytest.mark.parametrize(
-    "quantities, expected",
+    ("quantities", "expected"),
     (
         ((1, 2) * u.kg, (CustomParticle(mass=1 * u.kg), CustomParticle(mass=2 * u.kg))),
         (

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -28,7 +28,7 @@ attributes = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def various_particles():
     """A sample `ParticleList` with several different valid particles."""
     return ParticleList(

--- a/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
@@ -132,7 +132,7 @@ units_test_table = [
 ]
 
 
-@pytest.mark.parametrize("openPMD_dims, expected", units_test_table)
+@pytest.mark.parametrize(("openPMD_dims", "expected"), units_test_table)
 @pytest.mark.slow
 def test_fetch_units(openPMD_dims, expected: Union[tuple, list]):
     units = openpmd_hdf5._fetch_units(openPMD_dims)

--- a/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
@@ -31,7 +31,7 @@ def h5_theta(request):
     h5.close()
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class TestOpenPMD2D:
     """Test 2D HDF5 dataset based on OpenPMD."""
 
@@ -89,7 +89,7 @@ class TestOpenPMD3D:
             h5_3d.electric_current  # noqa: B018
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class TestOpenPMDThetaMode:
     """Test thetaMode HDF5 dataset based on OpenPMD."""
 
@@ -133,7 +133,7 @@ units_test_table = [
 
 
 @pytest.mark.parametrize(("openPMD_dims", "expected"), units_test_table)
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_fetch_units(openPMD_dims, expected: Union[tuple, list]):
     units = openpmd_hdf5._fetch_units(openPMD_dims)
     assert units == expected

--- a/plasmapy/plasma/sources/tests/test_plasma3d.py
+++ b/plasmapy/plasma/sources/tests/test_plasma3d.py
@@ -60,7 +60,7 @@ def test_Plasma3D_setup(grid_dimensions, expected_size):
     assert test_plasma.electric_field.si.unit == u.V / u.m
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_Plasma3D_derived_vars():
     r"""Function to test derived variables of the Plasma3D class.
 

--- a/plasmapy/plasma/sources/tests/test_plasma3d.py
+++ b/plasmapy/plasma/sources/tests/test_plasma3d.py
@@ -6,7 +6,7 @@ from plasmapy.plasma.sources import plasma3d
 
 
 @pytest.mark.parametrize(
-    "grid_dimensions, expected_size",
+    ("grid_dimensions", "expected_size"),
     [
         pytest.param((100, 1, 1), 100, marks=pytest.mark.slow),  # Test 1D setup
         pytest.param((128, 128, 1), 16384, marks=pytest.mark.slow),  # 2D

--- a/plasmapy/plasma/sources/tests/test_plasmablob.py
+++ b/plasmapy/plasma/sources/tests/test_plasmablob.py
@@ -63,7 +63,7 @@ def test_Plasma3D_setup(grid_dimensions, expected_size):
     assert test_plasma.electric_field.si.unit == u.V / u.m
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_Plasma3D_derived_vars():
     r"""Function to test derived variables of the Plasma3D class.
 
@@ -106,7 +106,7 @@ def test_Plasma3D_derived_vars():
     assert np.allclose(test_plasma.alfven_speed.value, 10.92548431)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_Plasma3D_add_magnetostatics():
     r"""Function to test add_magnetostatic function"""
     dipole = magnetostatics.MagneticDipole(

--- a/plasmapy/plasma/sources/tests/test_plasmablob.py
+++ b/plasmapy/plasma/sources/tests/test_plasmablob.py
@@ -9,7 +9,7 @@ from plasmapy.utils.exceptions import CouplingWarning
 
 
 @pytest.mark.parametrize(
-    "grid_dimensions, expected_size",
+    ("grid_dimensions", "expected_size"),
     [
         pytest.param((100, 1, 1), 100, marks=pytest.mark.slow),  # Test 1D setup
         pytest.param((128, 128, 1), 16384, marks=pytest.mark.slow),  # 2D

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -690,7 +690,7 @@ def test_nonuniform_cartesian_NN_interp(
     assert np.allclose(pout, expected, atol=dx_max, equal_nan=True)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_nonuniform_cartesian_nearest_neighbor_interpolator():
     """
     Note that this test is running on a very small grid, because otherwise it is

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -11,7 +11,7 @@ from plasmapy.plasma import grids
 rs = np.random.RandomState(120921)
 
 
-@pytest.fixture
+@pytest.fixture()
 def abstract_grid_uniform():
     """
     A `pytest` fixture that generates an abstract grid that spans
@@ -37,7 +37,7 @@ def abstract_grid_uniform():
     return grid
 
 
-@pytest.fixture
+@pytest.fixture()
 def abstract_grid_nonuniform():
     """
     A `pytest` fixture that generates an abstract grid that spans
@@ -456,7 +456,7 @@ def test_AbstractGrid_vector_intersects(
 # **********************************************************************
 
 
-@pytest.fixture
+@pytest.fixture()
 def uniform_cartesian_grid():
     """
     A `pytest` fixture that generates a CartesianGrid that spans
@@ -587,7 +587,7 @@ def test_uniform_cartesian_NN_interp_persistence(uniform_cartesian_grid):
 # **********************************************************************
 
 
-@pytest.fixture
+@pytest.fixture()
 def nonuniform_cartesian_grid():
     """
     A `pytest` fixture that generates a NonUniformCartesianGrid that spans

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -151,7 +151,7 @@ create_args = [
 ]
 
 
-@pytest.mark.parametrize("args,kwargs,shape,error", create_args)
+@pytest.mark.parametrize(("args", "kwargs", "shape", "error"), create_args)
 def test_AbstractGrid_creation(args, kwargs, shape, error):
     """
     Test the creation of AbstractGrids
@@ -225,7 +225,7 @@ abstract_attrs = [
 ]
 
 
-@pytest.mark.parametrize("attr,type_,type_in_iter,value", abstract_attrs)
+@pytest.mark.parametrize(("attr", "type_", "type_in_iter", "value"), abstract_attrs)
 def test_AbstractGrid_uniform_attributes(
     attr,
     type_,
@@ -261,7 +261,7 @@ abstract_attrs = [
 ]
 
 
-@pytest.mark.parametrize("attr,type_,type_in_iter,value", abstract_attrs)
+@pytest.mark.parametrize(("attr", "type_", "type_in_iter", "value"), abstract_attrs)
 def test_AbstractGrid_nonuniform_attributes(
     attr,
     type_,
@@ -319,7 +319,7 @@ def test_unit_attribute_error_case():
         grid.unit  # noqa: B018
 
 
-@pytest.mark.parametrize("key,value,error,warning,match", quantities)
+@pytest.mark.parametrize(("key", "value", "error", "warning", "match"), quantities)
 def test_AbstractGrid_add_quantities(
     abstract_grid_uniform, key, value, error, warning, match
 ):
@@ -364,7 +364,9 @@ req_q = [
 ]
 
 
-@pytest.mark.parametrize("required,replace_with_zeros,error,warning,match", req_q)
+@pytest.mark.parametrize(
+    ("required", "replace_with_zeros", "error", "warning", "match"), req_q
+)
 def test_AbstractGrid_require_quantities(
     abstract_grid_uniform, required, replace_with_zeros, error, warning, match
 ):
@@ -416,7 +418,7 @@ on_grid = [
 ]
 
 
-@pytest.mark.parametrize("fixture,pos,result", on_grid)
+@pytest.mark.parametrize(("fixture", "pos", "result"), on_grid)
 def test_AbstractGrid_on_grid(
     abstract_grid_uniform, abstract_grid_nonuniform, fixture, pos, result
 ):
@@ -439,7 +441,7 @@ vector_intersect = [
 ]
 
 
-@pytest.mark.parametrize("fixture,p1,p2,result", vector_intersect)
+@pytest.mark.parametrize(("fixture", "p1", "p2", "result"), vector_intersect)
 def test_AbstractGrid_vector_intersects(
     abstract_grid_uniform, abstract_grid_nonuniform, fixture, p1, p2, result
 ):
@@ -495,7 +497,9 @@ create_args_uniform_cartesian = [
 ]
 
 
-@pytest.mark.parametrize("args,kwargs,shape,error", create_args_uniform_cartesian)
+@pytest.mark.parametrize(
+    ("args", "kwargs", "shape", "error"), create_args_uniform_cartesian
+)
 def test_CartesianGrid_creation(args, kwargs, shape, error):
     # If no exception is expected, create the grid and check its shape
     if error is None:
@@ -508,7 +512,7 @@ def test_CartesianGrid_creation(args, kwargs, shape, error):
 
 
 @pytest.mark.parametrize(
-    "pos,quantities,expected",
+    ("pos", "quantities", "expected"),
     [  # Test one point
         (np.array([0.1, -0.3, 0]) * u.cm, ["x"], np.array([0.1]) * u.cm),
         # Test two points and two quantities
@@ -536,7 +540,7 @@ def test_uniform_cartesian_NN_interp(pos, quantities, expected, uniform_cartesia
 
 
 @pytest.mark.parametrize(
-    "pos,quantities,error",
+    ("pos", "quantities", "error"),
     [  # Quantity not in
         (np.array([0.1, -0.3, 0]) * u.cm, ["not_a_quantity"], KeyError),
     ],
@@ -641,7 +645,9 @@ create_args_nonuniform_cartesian = [
 ]
 
 
-@pytest.mark.parametrize("args,kwargs,shape,error", create_args_nonuniform_cartesian)
+@pytest.mark.parametrize(
+    ("args", "kwargs", "shape", "error"), create_args_nonuniform_cartesian
+)
 def test_NonUniformCartesianGrid_creation(args, kwargs, shape, error):
     # If no exception is expected, create the grid and check its shape
     if error is None:
@@ -654,7 +660,7 @@ def test_NonUniformCartesianGrid_creation(args, kwargs, shape, error):
 
 
 @pytest.mark.parametrize(
-    "pos,quantities,expected",
+    ("pos", "quantities", "expected"),
     [  # Test one point
         (np.array([0.1, -0.3, 0]) * u.cm, ["x"], np.array([0.1]) * u.cm),
         # Test two points and two quantities
@@ -714,7 +720,7 @@ def test_nonuniform_cartesian_nearest_neighbor_interpolator():
 
 
 @pytest.mark.parametrize(
-    "pos, what, expected",
+    ("pos", "what", "expected"),
     [
         (np.array([0.1, -0.3, 0.2]) * u.cm, ("x",), np.array([0.1]) * u.cm),
         (np.array([0.1, 0.25, 0.2]) * u.cm, ("x",), np.array([0.1]) * u.cm),
@@ -770,7 +776,7 @@ def test_volume_averaged_interpolator_missing_key(uniform_cartesian_grid):
 
 
 @pytest.mark.parametrize(
-    "pos, nan_mask",
+    ("pos", "nan_mask"),
     [
         (np.array([-5.0, 0.0, 0.0]) * u.cm, None),
         (np.array([5.0, 0.0, 0.0]) * u.cm, None),

--- a/plasmapy/simulation/tests/test_particletracker.py
+++ b/plasmapy/simulation/tests/test_particletracker.py
@@ -100,7 +100,7 @@ def fit_sine_curve(position, t, expected_gyrofrequency, phase=0):
 #     # s.plot_trajectories()
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_particle_exb_drift(uniform_magnetic_field):
     r"""
     Tests the particle stepper for a field with magnetic field in the Z

--- a/plasmapy/utils/data/tests/test_downloader.py
+++ b/plasmapy/utils/data/tests/test_downloader.py
@@ -18,7 +18,7 @@ test_files = [
 ]
 
 
-@pytest.mark.parametrize("filename,expected", test_files)
+@pytest.mark.parametrize(("filename", "expected"), test_files)
 def test_get_file(filename, expected, tmp_path):
     """
     Test the get_file function

--- a/plasmapy/utils/decorators/tests/test_checks.py
+++ b/plasmapy/utils/decorators/tests/test_checks.py
@@ -1249,25 +1249,25 @@ relativistic_warning_examples = [
 
 
 # Tests for _check_relativistic
-@pytest.mark.parametrize("speed, betafrac", non_relativistic_speed_examples)
+@pytest.mark.parametrize(("speed", "betafrac"), non_relativistic_speed_examples)
 def test__check_relativisitc_valid(speed, betafrac):
     _check_relativistic(speed, "f", betafrac=betafrac)
 
 
-@pytest.mark.parametrize("speed, betafrac, error", relativistic_error_examples)
+@pytest.mark.parametrize(("speed", "betafrac", "error"), relativistic_error_examples)
 def test__check_relativistic_errors(speed, betafrac, error):
     with pytest.raises(error):
         _check_relativistic(speed, "f", betafrac=betafrac)
 
 
-@pytest.mark.parametrize("speed, betafrac", relativistic_warning_examples)
+@pytest.mark.parametrize(("speed", "betafrac"), relativistic_warning_examples)
 def test__check_relativistic_warnings(speed, betafrac):
     with pytest.warns(RelativityWarning):
         _check_relativistic(speed, "f", betafrac=betafrac)
 
 
 # Tests for check_relativistic decorator
-@pytest.mark.parametrize("speed, betafrac", non_relativistic_speed_examples)
+@pytest.mark.parametrize(("speed", "betafrac"), non_relativistic_speed_examples)
 def test_check_relativistic_decorator(speed, betafrac):
     @check_relativistic(betafrac=betafrac)
     def speed_func():
@@ -1294,7 +1294,7 @@ def test_check_relativistic_decorator_no_args_parentheses(speed):
     speed_func()
 
 
-@pytest.mark.parametrize("speed, betafrac, error", relativistic_error_examples)
+@pytest.mark.parametrize(("speed", "betafrac", "error"), relativistic_error_examples)
 def test_check_relativistic_decorator_errors(speed, betafrac, error):
     @check_relativistic(betafrac=betafrac)
     def speed_func():

--- a/plasmapy/utils/decorators/tests/test_helpers.py
+++ b/plasmapy/utils/decorators/tests/test_helpers.py
@@ -49,7 +49,7 @@ class TestModifyDocstring:
         assert wfoo.__original_doc__ == original_doc
 
     @pytest.mark.parametrize(
-        "prepend, append, expected",
+        ("prepend", "append", "expected"),
         [(5, None, TypeError), (None, 5, TypeError)],
     )
     def test_raises(self, prepend, append, expected):
@@ -64,7 +64,7 @@ class TestModifyDocstring:
         assert wfoo.__signature__ == inspect.signature(self.func_simple_docstring)
 
     @pytest.mark.parametrize(
-        "prepend, append, func_name, additions",
+        ("prepend", "append", "func_name", "additions"),
         [
             (
                 "Hello",

--- a/plasmapy/utils/decorators/tests/test_lite_func.py
+++ b/plasmapy/utils/decorators/tests/test_lite_func.py
@@ -29,7 +29,7 @@ def bar():
 
 
 @pytest.mark.parametrize(
-    "lite_func, attrs, _error",
+    ("lite_func", "attrs", "_error"),
     [
         # conditions on attrs kwarg
         (foo_lite, "not a dictionary", TypeError),
@@ -48,7 +48,7 @@ def test_raises(lite_func, attrs, _error):
 
 
 @pytest.mark.parametrize(
-    "lite_func, attrs",
+    ("lite_func", "attrs"),
     [
         (foo_lite, None),
         (jit(foo_lite), None),
@@ -79,7 +79,7 @@ def test_binding(lite_func, attrs):
 
 
 @pytest.mark.parametrize(
-    "lite_func, attrs",
+    ("lite_func", "attrs"),
     [
         (foo_lite, None),
         (foo_lite, {"bar": bar}),

--- a/plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py
+++ b/plasmapy/utils/pytest_helpers/tests/test_pytest_helpers.py
@@ -96,7 +96,7 @@ f_args_kwargs_expected_whaterror = [
 
 
 @pytest.mark.parametrize(
-    "f, args, kwargs, expected, whaterror", f_args_kwargs_expected_whaterror
+    ("f", "args", "kwargs", "expected", "whaterror"), f_args_kwargs_expected_whaterror
 )
 def test_run_test(f, args, kwargs, expected, whaterror):
     """
@@ -242,7 +242,7 @@ run_test_equivalent_calls_table = [
 ]
 
 
-@pytest.mark.parametrize("inputs, error", run_test_equivalent_calls_table)
+@pytest.mark.parametrize(("inputs", "error"), run_test_equivalent_calls_table)
 def test_run_test_equivalent_calls(inputs, error):
     if error is None:
         try:

--- a/plasmapy/utils/tests/test_code_repr.py
+++ b/plasmapy/utils/tests/test_code_repr.py
@@ -32,7 +32,7 @@ function_case = namedtuple("function_case", ("func", "args", "kwargs", "expected
 
 
 @pytest.mark.parametrize(
-    "func, args, kwargs, expected",
+    ("func", "args", "kwargs", "expected"),
     [
         function_case(
             func=generic_function, args=(), kwargs={}, expected="generic_function()"
@@ -159,7 +159,7 @@ method_case = namedtuple(
 
 
 @pytest.mark.parametrize(
-    "args_to_cls, kwargs_to_cls, args_to_method, kwargs_to_method, expected",
+    ("args_to_cls", "kwargs_to_cls", "args_to_method", "kwargs_to_method", "expected"),
     [
         method_case(
             args_to_cls=(),
@@ -228,7 +228,7 @@ attribute_case = namedtuple(
 
 
 @pytest.mark.parametrize(
-    "args_to_cls, kwargs_to_cls, expected",
+    ("args_to_cls", "kwargs_to_cls", "expected"),
     [
         attribute_case(args_to_cls=(), kwargs_to_cls={}, expected="SampleClass().attr"),
         attribute_case(
@@ -263,7 +263,7 @@ ndarray_case = namedtuple("ndarray_case", ("array_inputs", "max_items", "expecte
 
 
 @pytest.mark.parametrize(
-    "array_inputs, max_items, expected",
+    ("array_inputs", "max_items", "expected"),
     [
         ndarray_case(array_inputs=[0], max_items=np.inf, expected="np.array([0])"),
         ndarray_case(
@@ -338,7 +338,7 @@ quantity_case = namedtuple("QuantityTestCases", ("quantity", "expected"))
 
 
 @pytest.mark.parametrize(
-    "quantity, expected",
+    ("quantity", "expected"),
     [
         quantity_case(quantity=5.3 * u.m, expected="5.3*u.m"),
         quantity_case(quantity=5.4 / u.m, expected="5.4/u.m"),
@@ -381,7 +381,7 @@ def test__string_together_warnings_for_printing():
 
 
 @pytest.mark.parametrize(
-    "arg, expected",
+    ("arg", "expected"),
     [
         (1, "1"),
         ("asdf", "'asdf'"),
@@ -408,7 +408,7 @@ def test__code_repr_of_arg(arg, expected):
 
 
 @pytest.mark.parametrize(
-    "args, kwargs, expected",
+    ("args", "kwargs", "expected"),
     [
         ((), {}, ""),
         (1, {"a": "b"}, "1, a='b'"),
@@ -434,7 +434,7 @@ def test__code_repr_of_args_and_kwargs(args, kwargs, expected):
 
 
 @pytest.mark.parametrize(
-    "obj, expected",
+    ("obj", "expected"),
     [
         (ArithmeticError, "an ArithmeticError"),
         (EOFError, "an EOFError"),
@@ -459,7 +459,7 @@ def test__name_with_article(obj, expected):
 
 
 @pytest.mark.parametrize(
-    "obj, showmodule, expected_name",
+    ("obj", "showmodule", "expected_name"),
     [
         (ValueError, False, "ValueError"),
         (TypeError, True, "TypeError"),

--- a/plasmapy/utils/tests/test_roman.py
+++ b/plasmapy/utils/tests/test_roman.py
@@ -151,7 +151,7 @@ exceptions_table = [
 ]
 
 
-@pytest.mark.parametrize("integer, roman_numeral", ints_and_roman_numerals)
+@pytest.mark.parametrize(("integer", "roman_numeral"), ints_and_roman_numerals)
 def test_to_roman(integer, roman_numeral):
     """
     Test that `~plasmapy.utils.roman.to_roman` correctly converts
@@ -161,7 +161,9 @@ def test_to_roman(integer, roman_numeral):
     run_test(func=roman.from_roman, args=roman_numeral, expected_outcome=int(integer))
 
 
-@pytest.mark.parametrize("function, argument, expected_exception", exceptions_table)
+@pytest.mark.parametrize(
+    ("function", "argument", "expected_exception"), exceptions_table
+)
 def test_to_roman_exceptions(function, argument, expected_exception):
     """
     Test that `~plasmapy.utils.roman` functions raise the correct
@@ -180,6 +182,6 @@ test_is_roman_numeral_table = [
 ]
 
 
-@pytest.mark.parametrize("argument, expected", test_is_roman_numeral_table)
+@pytest.mark.parametrize(("argument", "expected"), test_is_roman_numeral_table)
 def test_is_roman_numeral(argument, expected):
     run_test(func=roman.is_roman_numeral, args=argument, expected_outcome=expected)

--- a/plasmapy/utils/tests/test_units_helpers.py
+++ b/plasmapy/utils/tests/test_units_helpers.py
@@ -58,7 +58,7 @@ test_cases = [
 ]
 
 
-@pytest.mark.parametrize("collection, kwargs, expected", test_cases)
+@pytest.mark.parametrize(("collection", "kwargs", "expected"), test_cases)
 def test_get_physical_type_dict(collection, kwargs, expected):
     physical_type_dict = _get_physical_type_dict(collection, **kwargs)
     assert physical_type_dict == expected
@@ -88,7 +88,7 @@ test_cases_exceptions = [
 ]
 
 
-@pytest.mark.parametrize("collection, kwargs, expected", test_cases_exceptions)
+@pytest.mark.parametrize(("collection", "kwargs", "expected"), test_cases_exceptions)
 def test_get_physical_type_dict_exceptions(collection, kwargs, expected):
     with pytest.raises(expected):
         _get_physical_type_dict(collection, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,6 @@ ignore = [
   "PT011", # pytest-raises-too-broad
   "PT012", # pytest-raises-multiple-statements
   "PT019", # pytest-fixture-param-without-value
-  "PT021",
   "PT022",
   "PT023",
   "PT024",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,6 @@ ignore = [
   "PT011", # pytest-raises-too-broad
   "PT012", # pytest-raises-multiple-statements
   "PT019", # pytest-fixture-param-without-value
-  "PT022",
   "PT023",
   "PT024",
   "PT025",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,8 +277,7 @@ ignore = [
   "PT007", # pytest-parametrize-values-wrong-type
   "PT011", # pytest-raises-too-broad
   "PT012", # pytest-raises-multiple-statements
-  "PT019", # pytest-fixture-param-without-value
-  "PT023", # pytest-incorrect-mark-parentheses-style
+  "PT019", # pytest-fixture-param-without-value (enable later?)
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring
   "RUF003", # ambiguous-unicode-character-comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,8 +277,6 @@ ignore = [
   "PT007", # pytest-parametrize-values-wrong-type
   "PT011", # pytest-raises-too-broad
   "PT012", # pytest-raises-multiple-statements
-  "PT015",
-  "PT016",
   "PT017",
   "PT018",
   "PT019",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,6 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
-  "PT003",
   "PT004",
   "PT005",
   "PT006",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,7 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
-  "PT001",
+#  "PT001",
   "PT002",
   "PT003",
   "PT004",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,8 +274,6 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
-#  "PT001",
-  "PT002",
   "PT003",
   "PT004",
   "PT005",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,6 @@ ignore = [
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
   "PT007", # pytest-parametrize-values-wrong-type
-  "PT010",
   "PT011",
   "PT012",
   "PT013",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,6 @@ ignore = [
   "PT012", # pytest-raises-multiple-statements
   "PT019", # pytest-fixture-param-without-value
   "PT023", # pytest-incorrect-mark-parentheses-style
-  "PT026",
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring
   "RUF003", # ambiguous-unicode-character-comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,6 @@ ignore = [
   "PT012", # pytest-raises-multiple-statements
   "PT019", # pytest-fixture-param-without-value
   "PT023", # pytest-incorrect-mark-parentheses-style
-  "PT025",
   "PT026",
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,6 @@ ignore = [
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
   "PT007", # pytest-parametrize-values-wrong-type
-  "PT009",
   "PT010",
   "PT011",
   "PT012",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,6 @@ ignore = [
   "PT011", # pytest-raises-too-broad
   "PT012", # pytest-raises-multiple-statements
   "PT019", # pytest-fixture-param-without-value
-  "PT020",
   "PT021",
   "PT022",
   "PT023",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,8 +277,6 @@ ignore = [
   "PT007", # pytest-parametrize-values-wrong-type
   "PT011", # pytest-raises-too-broad
   "PT012", # pytest-raises-multiple-statements
-  "PT017",
-  "PT018",
   "PT019",
   "PT020",
   "PT021",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,8 +274,6 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
-  "PT004",
-  "PT005",
   "PT006",
   "PT007",
   "PT008",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,7 @@ ignore = [
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
   "PT007", # pytest-parametrize-values-wrong-type
-  "PT011",
+  "PT011", # pytest-raises-too-broad
   "PT012",
   "PT013",
   "PT015",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ extend-select = [
   "PIE", # flake8-pie
   "PLC", # pylint convention
   "PLE", # pylint errors
+  "PT", # flake8-pytest-style
   "PTH", # flake8-use-pathlib
   "PYI", # flake8-pyi
   "RUF", # ruff specific rules
@@ -273,6 +274,31 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
+  "PT001",
+  "PT002",
+  "PT003",
+  "PT004",
+  "PT005",
+  "PT006",
+  "PT007",
+  "PT008",
+  "PT009",
+  "PT010",
+  "PT011",
+  "PT012",
+  "PT013",
+  "PT015",
+  "PT016",
+  "PT017",
+  "PT018",
+  "PT019",
+  "PT020",
+  "PT021",
+  "PT022",
+  "PT023",
+  "PT024",
+  "PT025",
+  "PT026",
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring
   "RUF003", # ambiguous-unicode-character-comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,6 @@ ignore = [
   "PT012", # pytest-raises-multiple-statements
   "PT019", # pytest-fixture-param-without-value
   "PT023", # pytest-incorrect-mark-parentheses-style
-  "PT024",
   "PT025",
   "PT026",
   "RUF001", # ambiguous-unicode-character-string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,7 @@ ignore = [
   "PT011", # pytest-raises-too-broad
   "PT012", # pytest-raises-multiple-statements
   "PT019", # pytest-fixture-param-without-value
-  "PT023",
+  "PT023", # pytest-incorrect-mark-parentheses-style
   "PT024",
   "PT025",
   "PT026",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,8 +276,7 @@ ignore = [
   "PLE0605", # invalid-all-format
   "PT007", # pytest-parametrize-values-wrong-type
   "PT011", # pytest-raises-too-broad
-  "PT012",
-  "PT013",
+  "PT012", # pytest-raises-multiple-statements
   "PT015",
   "PT016",
   "PT017",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,6 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
-  "PT006",
   "PT007",
   "PT008",
   "PT009",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,7 @@ ignore = [
   "N806", # non-lowercase-variable-in-function
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
-  "PT007",
+  "PT007", # pytest-parametrize-values-wrong-type
   "PT008",
   "PT009",
   "PT010",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,7 +277,7 @@ ignore = [
   "PT007", # pytest-parametrize-values-wrong-type
   "PT011", # pytest-raises-too-broad
   "PT012", # pytest-raises-multiple-statements
-  "PT019",
+  "PT019", # pytest-fixture-param-without-value
   "PT020",
   "PT021",
   "PT022",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,6 @@ ignore = [
   "N816", # mixed-case-variable-in-global-scope
   "PLE0605", # invalid-all-format
   "PT007", # pytest-parametrize-values-wrong-type
-  "PT008",
   "PT009",
   "PT010",
   "PT011",


### PR DESCRIPTION
This PR enables the [`PT`](https://beta.ruff.rs/docs/rules/#flake8-pytest-style-pt) rule set for ruff for flake8-pytest-style.

All of the changes to `.py` files are either autofixes or adding `# noqa` comments to turn off a ruff rule.

