### PR TITLE
Add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.py]
+profile = black
+
+[*.rst]
+indent_size = 3
+max_line_length = 72
+
+[*.md]
+max_line_length = 72
+
+[*.{yml,yaml,toml,cff}]
+indent_size = 2


### PR DESCRIPTION
An [`.editorconfig`](https://editorconfig.org/) file "helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs."  Essentially, IDEs can use it to determine things like tab sizes.

We use autoformatters for most of our files, but that can add an extra step to the process (i.e. requiring someone to run pre-commit).  Having an `.editorconfig` file consistent with autoformatters will make it a little more likely that contributors can skip autoformatting steps.