### PR TITLE
Add `# noqa` comment for cognitive complexity rule

### DIFF
--- a/plasmapy/formulary/collisions/helio/collisional_analysis.py
+++ b/plasmapy/formulary/collisions/helio/collisional_analysis.py
@@ -16,7 +16,7 @@ from plasmapy.utils.decorators import validate_quantities
     T_1={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_2={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def temp_ratio(  # noqa: PLR0912, PLR0915
+def temp_ratio(  # noqa: C901, PLR0912, PLR0915
     *,
     r_0: u.au,
     r_n: u.au,


### PR DESCRIPTION
I just merged #2119 without pulling in the changes from `main` after #1986 was merged, and noticed that another `# noqa` comment was needed which this PR adds.