### PR TITLE
Fix tests in `test_nullpoint`

### DIFF
--- a/changelog/2133.bugfix.rst
+++ b/changelog/2133.bugfix.rst
@@ -1,0 +1,2 @@
+The `~plasmapy.analysis.nullpoint._vector_space` function now returns a
+list for its delta values instead of an array.

--- a/changelog/2133.bugfix.rst
+++ b/changelog/2133.bugfix.rst
@@ -1,2 +1,2 @@
-The `~plasmapy.analysis.nullpoint._vector_space` function now returns a
+The ``plasmapy.analysis.nullpoint._vector_space`` function now returns a
 list for its delta values instead of an array.

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -251,7 +251,7 @@ def _vector_space(
         w = w_arr
     else:
         u, v, w = func(x, y, z)
-    return np.array([x, y, z]), np.array([u, v, w]), np.array([dx, dy, dz])
+    return np.array([x, y, z]), np.array([u, v, w]), [dx, dy, dz]
 
 
 def _trilinear_coeff_cal(vspace, cell):

--- a/plasmapy/analysis/tests/test_nullpoint.py
+++ b/plasmapy/analysis/tests/test_nullpoint.py
@@ -289,7 +289,6 @@ def test_null_point_find3():
 
 
 @pytest.mark.slow()
-@pytest.mark.xfail(np.__version__ >= "1.24.0", reason="See issue #2101.")
 def test_null_point_find4():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Two null points
@@ -369,7 +368,6 @@ def test_null_point_find7():
 
 
 @pytest.mark.slow()
-@pytest.mark.xfail(np.__version__ >= "1.24.0", reason="See issue #2101.")
 def test_null_point_find8():
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Non-linear field
@@ -426,9 +424,6 @@ class Test_classify_null_point:
                 "func": lambda x, y, z: [(y - 5.5) * (y + 5.5), (z - 5.5), (x - 5.5)],
             },
             "Spiral null",
-            marks=pytest.mark.xfail(
-                np.__version__ >= "1.24.0", reason="See issue #2101."
-            ),
         ),
         (
             {


### PR DESCRIPTION
Resolves #2101 

The `_vector_space` function in the `nullpoint` module returns an array for its delta values in each dimension. This is problematic because each dimension can have a different precision, meaning a different size for the delta array. The solution is to instead simply return a list.