### PR TITLE
Rename parameter in `thermal_bremsstrahlung`

### DIFF
--- a/plasmapy/formulary/radiation.py
+++ b/plasmapy/formulary/radiation.py
@@ -31,7 +31,7 @@ def thermal_bremsstrahlung(
     n_e: u.m**-3,
     T_e: u.K,
     n_i: u.m**-3 = None,
-    ion_species: ParticleLike = "H+",
+    ion: ParticleLike = "p+",
     kmax: u.m = None,
 ) -> np.ndarray:
     r"""
@@ -76,9 +76,9 @@ def thermal_bremsstrahlung(
         Ion number density in the plasma (convertible to m\ :sup:`-3`\ ). Defaults
         to the quasi-neutral condition :math:`n_i = n_e / Z`\ .
 
-    ion_species : `str` or `~plasmapy.particles.particle_class.Particle`, optional
-        An instance of `~plasmapy.particles.particle_class.Particle`, or a string
-        convertible to `~plasmapy.particles.particle_class.Particle`.
+    ion : |particle-like|, optional
+        An instance of `~plasmapy.particles.particle_class.Particle`, or
+        a string convertible to |Particle|.
 
     kmax :  `~astropy.units.Quantity`
         Cutoff wavenumber (convertible to radians per meter). Defaults
@@ -96,7 +96,7 @@ def thermal_bremsstrahlung(
 
     # Default n_i is n_e/Z:
     if n_i is None:
-        n_i = n_e / ion_species.charge_number
+        n_i = n_e / ion.charge_number
 
     # Default value of kmax is the electrom thermal de Broglie wavelength
     if kmax is None:
@@ -136,7 +136,7 @@ def thermal_bremsstrahlung(
         / (const.m_e.si * const.c.si**2) ** 1.5
     )
 
-    Zi = ion_species.charge_number
+    Zi = ion.charge_number
     c2 = (
         np.sqrt(1 - ω_pe**2 / ω**2)
         * Zi**2

--- a/plasmapy/formulary/tests/test_radiation.py
+++ b/plasmapy/formulary/tests/test_radiation.py
@@ -12,7 +12,7 @@ def test_thermal_bremsstrahlung():
     ne, Te = 1e22 * u.cm**-3, 1e2 * u.eV
     ion_species = "H+"
 
-    spectrum = thermal_bremsstrahlung(frequencies, ne, Te, ion_species=ion_species)
+    spectrum = thermal_bremsstrahlung(frequencies, ne, Te, ion=ion_species)
 
     assert np.isclose(np.max(spectrum).value, 128.4, 1), (
         f"Spectrum maximum is {np.max(spectrum).value} "
@@ -22,13 +22,9 @@ def test_thermal_bremsstrahlung():
     # Test violates w > wpe limit
     small_frequencies = (10 ** np.arange(12, 16, 0.01)) / u.s
     with pytest.raises(PhysicsError):
-        spectrum = thermal_bremsstrahlung(
-            small_frequencies, ne, Te, ion_species=ion_species
-        )
+        spectrum = thermal_bremsstrahlung(small_frequencies, ne, Te, ion=ion_species)
 
     # Test violates Rayleigh-Jeans limit
     small_Te = 1 * u.eV
     with pytest.raises(PhysicsError):
-        spectrum = thermal_bremsstrahlung(
-            frequencies, ne, small_Te, ion_species=ion_species
-        )
+        spectrum = thermal_bremsstrahlung(frequencies, ne, small_Te, ion=ion_species)


### PR DESCRIPTION
This PR renamed the `ion_species` parameter in `thermal_bremsstrahlung` to `ion`. The purpose is so that the API of `thermal_bremsstrahlung` better matches the API of other functions that accept ions as inputs.