### PR TITLE
Update configuration for GitHub Action that marks issues & PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,12 @@
-name: Close stale issues and PR
+name: Close stale issues and PRs
+
 on:
   schedule:
-  - cron: 30 1 * * *
+  - cron: 42 4 * * 6
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:
@@ -10,9 +15,16 @@ jobs:
     - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: This pull request will be closed in 14 days due to a year of inactivity unless the stale label or comment is removed.
+        stale-issue-message: This issue will be closed in 90 days due to five years of inactivity unless the stale label or comment is removed.
+        close-issue-message: This issue was closed because it has had no activity for five years.
+        stale-pr-message: This pull request will be closed in 60 days due to a year of inactivity unless the stale label or comment is removed.
         close-pr-message: This pull request was closed because it has had no activity for the past year.
-        days-before-pr-stale: 365
-        days-before-pr-close: 15
-          # never close issues
-        days-before-close: -1
+        days-before-issue-stale: 1826
+        days-before-issue-close: 90
+        days-before-pr-stale: 366
+        days-before-pr-close: 60
+        exempt-issue-labels:
+        - Bug
+        - 'Bug: needs more info'
+        - 'Priority: high'
+        - 'Priority: critical'


### PR DESCRIPTION
This PR makes some updates to the GitHub Action that marks PRs and issues as stale. I noticed that a lot of recent issues got labeled as stale, and I suspect that default settings may have changed.

I made it so that issues get marked as stale after five years of inactivity.  Issues have the potential to remain relevant for several years, so I want to err on the side of letting them stay open for longer.

PRs still get marked as stale after a year of inactivity, which seems reasonable.