### PR TITLE
Fix failing weekly numpy test

### DIFF
--- a/changelog/2138.trivial.rst
+++ b/changelog/2138.trivial.rst
@@ -1,0 +1,1 @@
+Change from ``indexserver`` to ``PIP_INDEX_URL`` to index nightly numpy builds

--- a/changelog/2138.trivial.rst
+++ b/changelog/2138.trivial.rst
@@ -1,1 +1,1 @@
-Change from ``indexserver`` to ``PIP_INDEX_URL`` to index nightly numpy builds
+Changed from ``indexserver`` to ``PIP_INDEX_URL`` to index nightly numpy builds

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ allowlist_externals =
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    set_env =
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
     PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals -n=auto --dist=loadfile

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 envlist = clean,py311,build_docs
 
 isolated_build = True
-indexserver =
-    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
 allowlist_externals =
@@ -13,12 +11,15 @@ allowlist_externals =
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
+    set_env =
+    PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
+    PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
     PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals -n=auto --dist=loadfile
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
     matplotlibdev: git+https://github.com/matplotlib/matplotlib
-    numpydev: :NIGHTLY:numpy
+    numpydev: numpy
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
     cov: pytest-cov


### PR DESCRIPTION
Resolves #2100 

Tox has removed their `indexserver` configuration in favor of using environment variables.

See https://tox.wiki/en/4.5.1/faq.html#using-two-pypi-servers