### PR TITLE
Fix failing astropy weekly tests

### DIFF
--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -280,7 +280,7 @@ class ClassicalTransport:
     >>> t = ClassicalTransport(1*u.eV, 1e20/u.m**3,
     ...                         1*u.eV, 1e20/u.m**3, 'p')
     >>> t.resistivity
-    <Quantity 0.0003670... m Ohm>
+    <Quantity 0.0003670... Ohm m>
     >>> t.thermoelectric_conductivity
     <Quantity 0.71108...>
     >>> t.ion_thermal_conductivity

--- a/plasmapy/formulary/tests/test_magnetostatics.py
+++ b/plasmapy/formulary/tests/test_magnetostatics.py
@@ -39,7 +39,7 @@ class Test_MagneticDipole:
     def test_repr(self):
         """Test __repr__ function"""
         B1 = MagneticDipole(self.moment, self.p0)
-        assert repr(B1) == r"MagneticDipole(moment=[0. 0. 1.]A m2, p0=[0. 0. 0.]m)"
+        assert repr(B1) == r"MagneticDipole(moment=[0. 0. 1.]m2 A, p0=[0. 0. 0.]m)"
 
 
 class Test_GeneralWire:


### PR DESCRIPTION
Numpy has made some updates to unit ordering (still trying to find which specific commit, or even if this was intended), causing tests dependent on string representation of quantities to fail.