### PR TITLE
Add `mass_numb` and `Z` as parameters to functions decorated with `@particle_input`

### DIFF
--- a/changelog/2140.feature.rst
+++ b/changelog/2140.feature.rst
@@ -1,0 +1,3 @@
+Added ``mass_numb`` and ``Z`` as parameters to functions decorated
+with |particle_input| in `plasmapy.formulary.lengths`
+and `plasmapy.formulary.distribution`.

--- a/plasmapy/formulary/distribution.py
+++ b/plasmapy/formulary/distribution.py
@@ -38,7 +38,15 @@ def _v_drift_conversion(v_drift):
 
 @particle_input
 def Maxwellian_1D(
-    v, T, particle: ParticleLike = "e", v_drift=0, vTh=np.nan, units="units"
+    v,
+    T,
+    particle: ParticleLike = "e",
+    v_drift=0,
+    vTh=np.nan,
+    units="units",
+    *,
+    mass_numb=None,
+    Z=None,
 ):
     r"""
     Probability distribution function of velocity for a Maxwellian
@@ -74,6 +82,12 @@ def Maxwellian_1D(
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
         computations.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -156,6 +170,9 @@ def Maxwellian_velocity_2D(
     vy_drift=0,
     vTh=np.nan,
     units="units",
+    *,
+    mass_numb=None,
+    Z=None,
 ):
     r"""
     Probability distribution function of velocity for a Maxwellian
@@ -198,6 +215,12 @@ def Maxwellian_velocity_2D(
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
         computations.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -246,8 +269,6 @@ def Maxwellian_velocity_2D(
     ... vx_drift=0 * u.m / u.s,
     ... vy_drift=0 * u.m / u.s)
     <Quantity 3.5002...e-13 s2 / m2>
-
-
     """
     if units == "units":
         # unit checks and conversions
@@ -297,6 +318,9 @@ def Maxwellian_velocity_3D(
     vz_drift=0,
     vTh=np.nan,
     units="units",
+    *,
+    mass_numb=None,
+    Z=None,
 ):
     r"""
     Probability distribution function of velocity for a Maxwellian
@@ -345,6 +369,12 @@ def Maxwellian_velocity_3D(
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
         computations.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -395,8 +425,6 @@ def Maxwellian_velocity_3D(
     ... vy_drift=0 * u.m / u.s,
     ... vz_drift=0 * u.m / u.s)
     <Quantity 2.0708...e-19 s3 / m3>
-
-
     """
     if units == "units":
         # unit checks and conversions
@@ -437,7 +465,15 @@ def Maxwellian_velocity_3D(
 
 @particle_input
 def Maxwellian_speed_1D(
-    v, T, particle: ParticleLike = "e", v_drift=0, vTh=np.nan, units="units"
+    v,
+    T,
+    particle: ParticleLike = "e",
+    v_drift=0,
+    vTh=np.nan,
+    units="units",
+    *,
+    mass_numb=None,
+    Z=None,
 ):
     r"""
     Probability distribution function of speed for a Maxwellian distribution
@@ -473,6 +509,12 @@ def Maxwellian_speed_1D(
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
         computations.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -548,7 +590,15 @@ def Maxwellian_speed_1D(
 
 @particle_input
 def Maxwellian_speed_2D(
-    v, T, particle: ParticleLike = "e", v_drift=0, vTh=np.nan, units="units"
+    v,
+    T,
+    particle: ParticleLike = "e",
+    v_drift=0,
+    vTh=np.nan,
+    units="units",
+    *,
+    mass_numb=None,
+    Z=None,
 ):
     r"""
     Probability distribution function of speed for a Maxwellian
@@ -585,6 +635,12 @@ def Maxwellian_speed_2D(
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
         computations.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -667,7 +723,15 @@ def Maxwellian_speed_2D(
 
 @particle_input
 def Maxwellian_speed_3D(
-    v, T, particle: ParticleLike = "e", v_drift=0, vTh=np.nan, units="units"
+    v,
+    T,
+    particle: ParticleLike = "e",
+    v_drift=0,
+    vTh=np.nan,
+    units="units",
+    *,
+    mass_numb=None,
+    Z=None,
 ):
     r"""
     Probability distribution function of speed for a Maxwellian
@@ -704,6 +768,12 @@ def Maxwellian_speed_3D(
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
         computations.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -746,7 +816,6 @@ def Maxwellian_speed_3D(
     >>> v=1 * u.m / u.s
     >>> Maxwellian_speed_3D(v=v, T=30000*u.K, particle='e', v_drift=0 * u.m / u.s)
     <Quantity 2.60235...e-18 s / m>
-
     """
     if v_drift != 0:
         raise NotImplementedError("Non-zero drift speed is work in progress.")
@@ -786,7 +855,16 @@ def Maxwellian_speed_3D(
 
 @particle_input
 def kappa_velocity_1D(
-    v, T, kappa, particle: ParticleLike = "e", v_drift=0, vTh=np.nan, units="units"
+    v,
+    T,
+    kappa,
+    particle: ParticleLike = "e",
+    v_drift=0,
+    vTh=np.nan,
+    units="units",
+    *,
+    mass_numb=None,
+    Z=None,
 ):
     r"""
     Return the probability density at the velocity ``v`` in m/s
@@ -827,6 +905,12 @@ def kappa_velocity_1D(
         equal to ``"units"``) or to run as unitless (when equal to
         ``"unitless"``). The unitless version is substantially faster for
         intensive computations.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -935,6 +1019,9 @@ def kappa_velocity_3D(
     vz_drift=0,
     vTh=np.nan,
     units="units",
+    *,
+    mass_numb=None,
+    Z=None,
 ):
     r"""
     Return the probability density function for finding a particle with
@@ -987,6 +1074,12 @@ def kappa_velocity_3D(
         equal to "units") or to run as unitless (when equal to "unitless").
         The unitless version is substantially faster for intensive
         computations.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -108,6 +108,8 @@ def gyroradius(  # noqa: C901
     T: u.K = None,
     lorentzfactor=np.nan,
     relativistic: bool = True,
+    mass_numb=None,
+    Z=None,
 ) -> u.m:
     r"""
     Return the particle gyroradius.
@@ -138,6 +140,12 @@ def gyroradius(  # noqa: C901
     relativistic : `bool`, optional, |keyword-only|
         Whether or not you want to use a relativistic approximation.
         `True` by default.
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -355,7 +363,9 @@ rhoc_ = gyroradius
     validations_on_return={"equivalencies": u.dimensionless_angles()},
 )
 @particle_input(require="charged")
-def inertial_length(n: u.m**-3, particle: ParticleLike) -> u.m:
+def inertial_length(
+    n: u.m**-3, particle: ParticleLike, *, mass_numb=None, Z=None
+) -> u.m:
     r"""
     Calculate a charged particle's inertial length.
 
@@ -369,6 +379,12 @@ def inertial_length(n: u.m**-3, particle: ParticleLike) -> u.m:
     particle : `~plasmapy.particles.particle_class.Particle`
         Representation of the particle species (e.g., 'p+' for protons,
         'D+' for deuterium, or 'He-4 +1' for singly ionized helium-4).
+
+    mass_numb : integer, |keyword-only|, optional
+        The mass number associated with ``particle``.
+
+    Z : real number, |keyword-only|, optional
+        The charge number associated with ``particle``.
 
     Returns
     -------
@@ -397,6 +413,7 @@ def inertial_length(n: u.m**-3, particle: ParticleLike) -> u.m:
     The inertial length of a particle of species :math:`s` is given by
 
     .. math::
+
         d = \frac{c}{ω_{ps}}
 
     The inertial length is the characteristic length scale for a


### PR DESCRIPTION
If a function is decorated with `@particle_input` and also has `mass_numb` and `Z` as parameters to the function, then we can specify the mass number via `mass_numb` and charge number via `Z`.  This PR adds `mass_numb` and `Z` to a few functions in `plasampy.formulary.lengths` and `plasmapy.formulary.distribition` since I forgot to add it before.

Follows up on #1732.  Related to #341.