### PR TITLE
Mark tests as slow

### DIFF
--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -131,6 +131,7 @@ def _test_grid(  # noqa: C901, PLR0912
     return grid
 
 
+@pytest.mark.slow()
 def test_multiple_grids():
     """
     Test that a case with two grids runs.
@@ -896,6 +897,7 @@ def test_add_wire_mesh():
     assert np.isclose(measured_spacing, true_spacing, 0.5)
 
 
+@pytest.mark.slow()
 def test_multiple_grids2():
     """
     Test that a case with two grids runs.

--- a/plasmapy/formulary/collisions/helio/tests/test_collisional_analysis.py
+++ b/plasmapy/formulary/collisions/helio/tests/test_collisional_analysis.py
@@ -108,6 +108,7 @@ class Testcollisional_thermalizastion:
             ({**_kwargs_scalar_value, "temperature_scale": "wrong type"}, TypeError),
         ],
     )
+    @pytest.mark.slow()
     def test_raises(self, kwargs, _error):
         with pytest.raises(_error):
             temp_ratio(**kwargs)

--- a/plasmapy/formulary/collisions/tests/test_dimensionless.py
+++ b/plasmapy/formulary/collisions/tests/test_dimensionless.py
@@ -83,6 +83,7 @@ class Test_coupling_parameter:
         assert testTrue, errStr
 
     # TODO vector z_mean
+    @pytest.mark.slow()
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
     @pytest.mark.parametrize(


### PR DESCRIPTION
I did `pytest -m "not slow" --durations=50` to find the 50 tests that were taking the longest to run.  I'm decorating them with `@pytest.mark.slow()` so that we can run `pytest -m "not slow"` to skip tests that take a relatively long time to run.  

I usually define tests as "slow" if they take longer than half a second to run, with a couple of exceptions for functionality that takes significantly longer the first time it is run (i.e., something decorated with `@numba.jit`).