### PR TITLE
Add basic caching to GitHub Actions CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -55,6 +55,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
+        cache: pip
 
     - name: Install Python dependencies
       run: python -m pip install --progress-bar off --upgrade tox
@@ -88,6 +89,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
+        cache: pip
 
     - name: Install tox
       run: python -m pip install --progress-bar off --upgrade tox
@@ -112,6 +114,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
+        cache: pip
 
     - name: Install Python dependencies
       run: python -m pip install --progress-bar off --upgrade tox
@@ -135,6 +138,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
+        cache: pip
 
     - name: Install requirements
       run: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -81,6 +81,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
+        cache: pip
 
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
   hooks:
   - id: nbqa-black
     additional_dependencies:
-    - black==23.1.0
+    - black==23.3.0
     args:
     - --nbqa-mutate
   - id: nbqa-isort


### PR DESCRIPTION
The GitHub Action for setting up Python has an option for caching dependencies. This PR attempts to enable it for our CI in several places.