### PR TITLE
Add a weekly test for conda-forge installation

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -7,15 +7,14 @@ on:
 
 jobs:
   conda_installs:
-    name: ${{ matrix.name }}
+    name: Install PlasmaPy from ${{ matrix.channel }} channel
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         include:
 
-        - name: Conda-forge
-          channel: conda-forge
+        - channel: conda-forge
 
     steps:
     - name: Set up conda

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -6,6 +6,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  conda_installs:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+
+        - name: Conda (default)
+          channel: default
+
+        - name: Conda-forge
+          channel: conda-forge
+
+    steps:
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: 3.9
+
+    - name: Install PlasmaPy with conda
+      run: conda install -c --yes ${{ matrix.channel }} plasmapy
+
+
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         include:
 
-        - name: Conda (default)
-          channel: default
-
         - name: Conda-forge
           channel: conda-forge
 
@@ -27,7 +24,7 @@ jobs:
         auto-update-conda: true
         python-version: 3.9
 
-    - name: Install PlasmaPy with conda
+    - name: Install PlasmaPy from ${{ matrix.channel }} channel
       run: conda install -c ${{ matrix.channel }} --yes plasmapy
 
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: 3.9
 
     - name: Install PlasmaPy with conda
-      run: conda install -c --yes ${{ matrix.channel }} plasmapy
+      run: conda install -c ${{ matrix.channel }} --yes plasmapy
 
 
   tests:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -23,7 +23,7 @@ jobs:
         auto-update-conda: true
         python-version: 3.9
 
-    - name: Install PlasmaPy from ${{ matrix.channel }} channel
+    - name: Install PlasmaPy
       run: conda install -c ${{ matrix.channel }} --yes plasmapy
 
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   conda_installs:
-    name: Install PlasmaPy from ${{ matrix.channel }} channel
+    name: Install from ${{ matrix.channel }} channel
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Resolves #1638

Adds a weekly test to the workflow to ensure that PlasmaPy can be installed via the conda-forge channel.