### PR TITLE
Add GitHub Action to remove labels when a PR is merged and update PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,43 +6,52 @@
 # If a label includes a space or a pattern begins with an asterisk or
 # special character, enclose it in quotes.
 
-Breaking:
+'changes existing API':
 - changelog/*.breaking*.rst
 
-Bug:
+bug:
 - changelog/*.bugfix*.rst
 
-'Continuous Integration':
+'CI':
 - .codecov.yaml
 - .github/workflows/*test*.yml
 - .pre-commit-config.yaml
+- .readthedocs.yml
 - CODEOWNERS
 - noxfile.py
 - tox.ini
 
-'Contributor Guide':
+'contributor guide':
 - changelog/README.rst
 - docs/contributing/**/*
 
 dependencies:
 - requirements.txt
 
-Documentation:
-- docs/**/*
-- changelog/*doc*.rst
-- README.md
+docs:
 - .readthedocs.yml
+- changelog/*doc*.rst
+- docs/**/*
+- README.md
 
 'GitHub Actions':
 - .github/**/*
 
-Notebooks:
+linters:
+- .sourcery.yaml
+- .pre-commit-config.yaml
+
+notebooks:
 - docs/notebooks/**/*
 
-Packaging:
+packaging:
 - .github/workflows/*publish*
 - .github/workflows/*release*
+- .zenodo*
+- CITATION.cff
+- LICENSE.md
 - MANIFEST.in
+- PATENT.md
 - pyproject.toml
 - setup.*
 
@@ -73,7 +82,7 @@ plasmapy.simulation:
 plasmapy.utils:
 - plasmapy/utils/**/*
 
-Testing:
+testing:
 - '**/test*.py'
 - '**/conftest.py'
 - .github/workflows/weekly.yml

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -21,9 +21,6 @@ jobs:
 
           const labelsToRemove = [
             'help wanted',
-            'needed for release',
-            'needs changelog entry',
-            'No changelog entry needed',
             'status: assigned',
             'status: in progress',
             'status: nearing completion',

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -20,15 +20,10 @@ jobs:
           if (!pull.data.merged) return;
 
           const labelsToRemove = [
-            'good first issue',
             'help wanted',
             'needed for release',
             'needs changelog entry',
             'No changelog entry needed',
-            'revisit in 2024',
-            'revisit in 2025',
-            'revisit in 2026',
-            'revisit in 2027',
             'status: assigned',
             'status: in progress',
             'status: nearing completion',

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -21,6 +21,7 @@ jobs:
 
           const labelsToRemove = [
             'help wanted',
+            'Stale',
             'status: assigned',
             'status: in progress',
             'status: nearing completion',

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -1,0 +1,45 @@
+name: Close PR
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  remove-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Remove specific labels
+      uses: actions/github-script@v4
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const { owner, repo, number } = context.issue;
+          const pull = await github.rest.pulls.get({ owner, repo, pull_number: number });
+
+          // If the pull request is not merged, do nothing
+          if (!pull.data.merged) return;
+
+          const labelsToRemove = [
+            'good first issue',
+            'help wanted',
+            'needed for release',
+            'needs changelog entry',
+            'No changelog entry needed',
+            'revisit in 2024',
+            'revisit in 2025',
+            'revisit in 2026',
+            'revisit in 2027',
+            'status: assigned',
+            'status: in progress',
+            'status: nearing completion',
+            'status: on hold',
+            'status: ready for review',
+            'status: ready to merge'
+          ];
+
+          const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: number });
+          for (let label of currentLabels) {
+            if (labelsToRemove.includes(label.name)) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name: label.name });
+            }
+          }

--- a/.github/workflows/new-pull-request.yml
+++ b/.github/workflows/new-pull-request.yml
@@ -1,4 +1,4 @@
-name: Comment on PR
+name: Open PR
 
 on:
   pull_request_target:


### PR DESCRIPTION
This PR adds a GitHub Action that will remove a set of labels from PRs when a PR is merged.  The labels to be removed are only relevant to open PRs (i.e., `status: in progress`).  Previously, I had been occasionally removing these labels manually, so this will automate a slightly tedious task.

I used ChatGPT 4.0 to create this GitHub Action.  It might be necessary to merge this to test whether or not it's working.
