### PR TITLE
Refine GitHub Action for updating pinned requirements

### DIFF
--- a/.github/workflows/update-pinned-reqs.yml
+++ b/.github/workflows/update-pinned-reqs.yml
@@ -2,7 +2,7 @@ name: Update pinned requirements
 
 on:
   schedule:
-  - cron: 27 6 * * 0
+  - cron: 0 6 * * 1
   workflow_dispatch:
 
 jobs:
@@ -32,10 +32,33 @@ jobs:
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
       with:
         commit-message: Regenerate requirements.txt
         title: Update pinned requirements
-        body: This PR updates the pinned requirements based on the current state of the main branch.
+        body: >
+          This PR
+          [regenerates](https://www.youtube.com/watch?v=qWM7l9SAipg&themeRefresh=1)
+          the pinned requirements contained in
+          [\`requirements.txt\`](https://github.com/PlasmaPy/PlasmaPy/blob/main/requirements.txt).
+          This file defines the Python environment used by certain
+          GitHub Actions checks, as well as by IDEs like PyCharm and VS
+          Code.
+
+          If all tests pass, please merge this PR. If any checks fail
+          due to changes in the packages that we depend on, this PR may
+          be used to perform the fixes that are necessary to get the
+          checks to pass again.
+
+          The pinned requirements are created by the command
+
+          \`\`\`console
+          pip-compile --all-extras --output-file=requirements.txt --resolver=backtracking -r -U
+          \`\`\`
+
+          which uses \`pip-compile\` from
+          [\`pip-tools\`](https://pip-tools.readthedocs.io/).
         labels: No changelog entry needed, dependencies
         delete-branch: true
         base: main


### PR DESCRIPTION
This PR updates the message posted by this GitHub Action, and also changes a token so that CI checks will actually be run by this automatically generated PR.