### PR TITLE
Update `@angular_freq_to_hz` and implement `wrapt`

### DIFF
--- a/changelog/2175.trivial.rst
+++ b/changelog/2175.trivial.rst
@@ -1,0 +1,3 @@
+Expanded the variety of arguments that could be provided to a function
+decorated by `~plasmapy.utils.decorators.converters.angular_freq_to_hz`,
+and refactored this decorator to use ``wrapt``.

--- a/changelog/2175.trivial.rst
+++ b/changelog/2175.trivial.rst
@@ -1,3 +1,3 @@
 Expanded the variety of arguments that could be provided to a function
-decorated by `~plasmapy.utils.decorators.converters.angular_freq_to_hz`,
+decorated by `~plasmapy.utils.decorators.converter.angular_freq_to_hz`,
 and refactored this decorator to use ``wrapt``.

--- a/changelog/2176.doc.rst
+++ b/changelog/2176.doc.rst
@@ -1,0 +1,1 @@
+Changed the order of sections in newly built changelogs.

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -85,7 +85,7 @@ def angular_freq_to_hz(fn):
         <Quantity 0.07957747 Hz>
 
     """
-    # raise exception if fn uses the 'to_hz' kwarg
+
     sig = inspect.signature(fn)
     if "to_hz" in sig.parameters:
         raise ValueError(
@@ -94,18 +94,30 @@ def angular_freq_to_hz(fn):
         )
 
     # make new signature for fn
-    new_params = sig.parameters.copy()
-    new_params["to_hz"] = inspect.Parameter(
-        "to_hz", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=False
+    new_params = []
+    var_keyword_param = None
+    for param in sig.parameters.values():
+        if param.kind == param.VAR_KEYWORD:
+            var_keyword_param = param
+        else:
+            new_params.append(param)
+
+    new_params.append(
+        inspect.Parameter("to_hz", inspect.Parameter.KEYWORD_ONLY, default=False)
     )
+
+    if var_keyword_param:
+        new_params.append(var_keyword_param)
+
     new_sig = inspect.Signature(
-        parameters=new_params.values(), return_annotation=sig.return_annotation
+        parameters=new_params, return_annotation=sig.return_annotation
     )
     fn.__signature__ = new_sig
 
     @preserve_signature
     @functools.wraps(fn)
-    def wrapper(*args, to_hz=False, **kwargs):
+    def wrapper(*args, **kwargs):
+        to_hz = kwargs.pop("to_hz", False)
         _result = fn(*args, **kwargs)
         if to_hz:
             return _result.to(u.Hz, equivalencies=[(u.cy / u.s, u.Hz)])

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -3,10 +3,8 @@
 __all__ = ["angular_freq_to_hz"]
 
 import astropy.units as u
-import functools
 import inspect
-
-from plasmapy.utils.decorators.helpers import preserve_signature
+import wrapt
 
 
 def angular_freq_to_hz(fn):
@@ -85,7 +83,6 @@ def angular_freq_to_hz(fn):
         <Quantity 0.07957747 Hz>
 
     """
-
     sig = inspect.signature(fn)
     if "to_hz" in sig.parameters:
         raise ValueError(
@@ -114,24 +111,25 @@ def angular_freq_to_hz(fn):
     )
     fn.__signature__ = new_sig
 
-    @preserve_signature
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
+    @wrapt.decorator
+    def wrapper(fn, instance, args, kwargs):  # noqa: ARG001
         to_hz = kwargs.pop("to_hz", False)
         _result = fn(*args, **kwargs)
         if to_hz:
             return _result.to(u.Hz, equivalencies=[(u.cy / u.s, u.Hz)])
         return _result
 
+    fn = wrapper(fn)
+
     added_doc_bit = """
     Other Parameters
     ----------------
     to_hz: bool
-        Set `True` to to convert function output from angular frequency to Hz
+        Set `True` to convert function output from angular frequency to Hz
     """
-    if wrapper.__doc__ is not None:
-        wrapper.__doc__ += added_doc_bit
+    if fn.__doc__ is not None:
+        fn.__doc__ += added_doc_bit
     else:
-        wrapper.__doc__ = added_doc_bit
+        fn.__doc__ = added_doc_bit
 
-    return wrapper
+    return fn

--- a/plasmapy/utils/decorators/tests/test_converters.py
+++ b/plasmapy/utils/decorators/tests/test_converters.py
@@ -4,20 +4,41 @@ import numpy as np
 from plasmapy.utils.decorators.converter import angular_freq_to_hz
 
 
-def test_conversion():
+def test_to_hz():
     @angular_freq_to_hz
-    def test_function():
+    def func():
         return 2 * np.pi * u.rad / u.s
 
-    assert test_function().unit == (
+    assert func().unit == (
         u.rad / u.s
-    ), f"Unit expected is {(u.rad / u.s)} instead of {test_function().unit}"
+    ), f"Unit expected is {(u.rad / u.s)} instead of {func().unit}"
     assert (
-        test_function().value == 2 * np.pi
-    ), f"Value expected is {2 * np.pi} instead of {test_function().value}"
+        func().value == 2 * np.pi
+    ), f"Value expected is {2 * np.pi} instead of {func().value}"
     assert (
-        test_function(to_hz=True).unit == u.Hz
-    ), f"Unit expected is {u.Hz} instead of {test_function(to_hz=True).unit}"
+        func(to_hz=True).unit == u.Hz
+    ), f"Unit expected is {u.Hz} instead of {func(to_hz=True).unit}"
     assert (
-        test_function(to_hz=True).value == 1
-    ), f"Value expected is 1 instead of {test_function(to_hz=True).value}"
+        func(to_hz=True).value == 1
+    ), f"Value expected is 1 instead of {func(to_hz=True).value}"
+
+
+def test_to_hz_complicated_signature():
+    @angular_freq_to_hz
+    def func2(a, /, b, *args, c, d=2, **kwargs):  # noqa: ARG001
+        return 2 * np.pi * u.rad / u.s
+
+    result_rad_per_s = func2(1, 2, 3, 4, c=5, d=6, e=7)
+    result_hz = func2(1, 2, 3, 4, c=5, d=6, e=7, to_hz=True)
+
+    assert result_rad_per_s.unit == (
+        u.rad / u.s
+    ), f"Unit expected is {(u.rad / u.s)} instead of {result_rad_per_s.unit}"
+    assert (
+        result_rad_per_s.value == 2 * np.pi
+    ), f"Value expected is {2 * np.pi} instead of {result_rad_per_s.value}"
+
+    assert (
+        result_hz.unit == u.Hz
+    ), f"Unit expected is {u.Hz} instead of {result_hz.unit}"
+    assert result_hz.value == 1, f"Value expected is 1 instead of {result_hz.value}"

--- a/plasmapy/utils/decorators/tests/test_converters.py
+++ b/plasmapy/utils/decorators/tests/test_converters.py
@@ -1,6 +1,10 @@
 import astropy.units as u
 import numpy as np
 
+from typing import Optional
+
+from plasmapy.particles import particle_input, ParticleLike
+from plasmapy.utils.decorators import validate_quantities
 from plasmapy.utils.decorators.converter import angular_freq_to_hz
 
 
@@ -11,9 +15,9 @@ def test_to_hz():
 
     assert func().unit == (
         u.rad / u.s
-    ), f"Unit expected is {(u.rad / u.s)} instead of {func().unit}"
-    assert (
-        func().value == 2 * np.pi
+    ), f"Unit expected is {u.rad / u.s} instead of {func().unit}"
+    assert np.isclose(
+        func().value, 2 * np.pi
     ), f"Value expected is {2 * np.pi} instead of {func().value}"
     assert (
         func(to_hz=True).unit == u.Hz
@@ -26,7 +30,8 @@ def test_to_hz():
 def test_to_hz_complicated_signature():
     """
     Test that `angular_freq_to_hz` can decorate a function with
-    positional-only, postional, var-positional,
+    positional-only, postional, var-positional, keyword, keyword-only,
+    or var-keyword.
     """
 
     @angular_freq_to_hz
@@ -36,14 +41,27 @@ def test_to_hz_complicated_signature():
     result_rad_per_s = func2(1, 2, 3, 4, c=5, d=6, e=7)
     result_hz = func2(1, 2, 3, 4, c=5, d=6, e=7, to_hz=True)
 
-    assert result_rad_per_s.unit == (
-        u.rad / u.s
-    ), f"Unit expected is {(u.rad / u.s)} instead of {result_rad_per_s.unit}"
     assert (
-        result_rad_per_s.value == 2 * np.pi
+        result_rad_per_s.unit == u.rad / u.s
+    ), f"Unit expected is {(u.rad / u.s)} instead of {result_rad_per_s.unit}"
+    assert np.isclose(
+        result_rad_per_s.value, 2 * np.pi
     ), f"Value expected is {2 * np.pi} instead of {result_rad_per_s.value}"
 
     assert (
         result_hz.unit == u.Hz
     ), f"Unit expected is {u.Hz} instead of {result_hz.unit}"
     assert result_hz.value == 1, f"Value expected is 1 instead of {result_hz.value}"
+
+
+def test_to_hz_stacked_decorators():
+    """Test that @angular_freq_to_hz can be stacked with multiple decorators."""
+
+    @particle_input
+    @validate_quantities
+    @angular_freq_to_hz
+    def func(particle: Optional[ParticleLike] = None):  # noqa: ARG001
+        return 2 * np.pi * u.rad / u.s
+
+    assert u.isclose(func(), 2 * np.pi * u.rad / u.s)
+    assert u.isclose(func(to_hz=True), 1 * u.Hz)

--- a/plasmapy/utils/decorators/tests/test_converters.py
+++ b/plasmapy/utils/decorators/tests/test_converters.py
@@ -24,6 +24,11 @@ def test_to_hz():
 
 
 def test_to_hz_complicated_signature():
+    """
+    Test that `angular_freq_to_hz` can decorate a function with
+    positional-only, postional, var-positional,
+    """
+
     @angular_freq_to_hz
     def func2(a, /, b, *args, c, d=2, **kwargs):  # noqa: ARG001
         return 2 * np.pi * u.rad / u.s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,7 @@ max-complexity = 10
 "plasmapy/plasma/sources/*.py" = ["D102"]
 "plasmapy/utils/_pytest_helpers/pytest_helpers.py" = ["BLE001", "PLR"]
 "plasmapy/utils/_pytest_helpers/tests/test_pytest_helpers.py" = ["BLE001", "TRY002"]
+"plasmapy/utils/decorators/tests/test_converters.py" = ["ARG001", "ARG005"]
 "setup.py" = ["D100"]
 "test_*" = ["D100", "D101", "D102", "D103", "D104", "D209", "D400", "D401"]
 "*/*/tests/__init__.py" = ["D104"]


### PR DESCRIPTION
This PR is to address the problem described in #2171 about how `@angular_freq_to_hz` wasn't working with all types of arguments.  This PR also implements [`wrapt`](https://wrapt.readthedocs.io/en/latest/) as a replacement for `@preserve_signature`.

I should probably make ChatGPT-4 a co-author of this one as well...

Closes #2172.