### PR TITLE
Change section order within changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,18 +340,13 @@ issue_format = ":pr:`{issue}`" # Despite the name mismatch, we use this for link
 wrap = true
 
 [[tool.towncrier.type]]
-directory = "breaking"
-name = "Backwards Incompatible Changes"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "removal"
-name = "Deprecations and Removals"
-showcontent = true
-
-[[tool.towncrier.type]]
 directory = "feature"
 name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Improved Documentation"
 showcontent = true
 
 [[tool.towncrier.type]]
@@ -360,8 +355,13 @@ name = "Bug Fixes"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "doc"
-name = "Improved Documentation"
+directory = "breaking"
+name = "Backwards Incompatible Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removal"
+name = "Deprecations and Removals"
 showcontent = true
 
 [[tool.towncrier.type]]


### PR DESCRIPTION
This PR follows the advice of a [recent episode](https://testandcode.com/200) of the test & code podcast, which suggested a certain order for changelog entries.  This PR puts the most exciting stuff (features!) first.