### PR TITLE
Change `whatsnew` to `changelog` in `release` GitHub Action 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,14 @@ jobs:
 
     - name: Update CITATION.cff, docs/about/citation.rst with the DOI for the new version.
       run: |
-        python .github/scripts/citation_updater.py CITATION.cff docs/about/citation.rst docs/whatsnew/index.rst --version=${{ github.event.inputs.tag}} --doi=${{ github.event.inputs.doi}}
+        python .github/scripts/citation_updater.py CITATION.cff docs/about/citation.rst docs/changelog/index.rst --version=${{ github.event.inputs.tag}} --doi=${{ github.event.inputs.doi}}
         git add .
-        git commit -m "Update citation and whatsnew index entry"
+        git commit -m "Update citation and changelog index entry"
 
     - name: Create changelog
       run: |
-        towncrier build --yes --version ${{ github.event.inputs.tag }} --draft | tee docs/whatsnew/${{ github.event.inputs.tag }}.rst
-        sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' docs/whatsnew/${{ github.event.inputs.tag }}.rst   # strip empty lines
+        towncrier build --yes --version ${{ github.event.inputs.tag }} --draft | tee docs/changelog/${{ github.event.inputs.tag }}.rst
+        sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' docs/changelog/${{ github.event.inputs.tag }}.rst   # strip empty lines
         git add .
         towncrier build --yes --version ${{ github.event.inputs.tag }}
         git commit --allow-empty -nm "Add changelog entries for v${{ github.event.inputs.tag }}"


### PR DESCRIPTION
We renamed `whatsnew` → `changelog` in the docs, but didn't update it in this GitHub Action. This PR fixes that oversight.