### PR TITLE
Use `bibtex-tidy` on `bibliography.bib`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,8 @@ repos:
   rev: v1.11.0
   hooks:
   - id: bibtex-tidy
-    files: examples/references.bib
-    args: [--sort=key, --quiet]
+    files: docs/bibliography.bib
+    args: [--sort=key, --wrap=88, --enclosing-braces=title, journal, --strip-comments, --sort-fields, --no-escape, --drop-all-caps, --sort, --no-align, --omit=month, --modify]
 
 - repo: https://github.com/pre-commit/mirrors-csslint
   rev: v1.0.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,13 @@ repos:
     # run this hook on `labeler.yml`.
     exclude: .github/labeler.yml
 
+- repo: https://github.com/FlamingTempura/bibtex-tidy
+  rev: v1.11.0
+  hooks:
+  - id: bibtex-tidy
+    files: examples/references.bib
+    args: [--sort=key, --quiet]
+
 - repo: https://github.com/pre-commit/mirrors-csslint
   rev: v1.0.5
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,6 @@ repos:
     # run this hook on `labeler.yml`.
     exclude: .github/labeler.yml
 
-- repo: https://github.com/FlamingTempura/bibtex-tidy
-  rev: v1.11.0
-  hooks:
-  - id: bibtex-tidy
-    files: docs/bibliography.bib
-    args: [--sort=key, --wrap=88, --enclosing-braces=title, journal, --strip-comments, --sort-fields, --no-escape, --drop-all-caps, --sort, --no-align, --omit=month, --modify]
-
 - repo: https://github.com/pre-commit/mirrors-csslint
   rev: v1.0.5
   hooks:

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -1,6 +1,6 @@
 @article{alfven:1942,
    author = {H. Alfvén},
-   title = "{Existence of Electromagnetic-Hydrodynamic Waves}",
+   title = {{Existence of Electromagnetic-Hydrodynamic Waves}},
    year = 1942,
    journal = {Nature},
    volume = 150,
@@ -8,28 +8,35 @@
    pages = {405–406},
    doi = {10.1038/150405d0}
 }
+@book{baumjohann:1997,
+   author = {W. Baumjohann and R. A. Treumann},
+   title = {{Basic Space Plasma Physics}},
+   year = 1997,
+   publisher = {Imperial College Press},
+   place = {London}
+}
 @book{bekefi:1966,
    author = {G. Bekefi},
-   title = "{Radiation Processes in Plasmas}",
-   year = {1966},
+   title = {{Radiation Processes in Plasmas}},
+   year = 1966,
    publisher = {Wiley},
-   isbn = {9780471063506},
+   isbn = 9780471063506
 }
 @article{bellan:2012,
    author = {P. M. Bellan},
-   title = "{Improved basis set for low frequency plasma waves}",
+   title = {{Improved basis set for low frequency plasma waves}},
    year = 2012,
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 117,
    number = {A12},
-   doi = {10.1029/2012JA017856},
+   doi = {10.1029/2012ja017856}
 }
 @book{bernstein:2015,
    author = {D. S. Bernstein},
-   title = "{
-      Beyond Legacy Code: Nine Practices to Extend the Life (and Value) of Your
-      Software
-   }",
+   title = {
+      {   Beyond Legacy Code: Nine Practices to Extend the Life (and Value) of Your
+      Software   }
+   },
    year = 2015,
    publisher = {Pragmatic Bookshelf},
    isbn = 9781680500790,
@@ -38,28 +45,28 @@
 }
 @book{birdsall:2004,
    author = {C. K. Birdsall and A. B. Langdon},
-   title = "{Plasma Physics via Computer Simulation}",
+   title = {{Plasma Physics via Computer Simulation}},
    year = 2004,
    publisher = {{CRC} Press},
    doi = {10.1201/9781315275048}
 }
 @book{bohm:1949,
-   title = "{The Characteristics of Electrical Discharges in Magnetic Fields}",
    author = {D. Bohm},
+   title = {{The Characteristics of Electrical Discharges in Magnetic Fields}},
    year = 1949,
    publisher = {McGraw-Hill},
    editor = {A. Guthrie and R. K. Wakerling}
 }
 @book{bonitz:1998,
    author = {M. Bonitz},
-   title = "{Quantum Kinetic Theory}",
+   title = {{Quantum Kinetic Theory}},
    year = 1998,
    publisher = {Springer},
    doi = {10.1007/978-3-319-24121-0}
 }
 @inproceedings{boris:1970,
    author = {J. P. Boris},
-   title = "{Relativistic plasma simulation—Optimization of a hybrid code}",
+   title = {{Relativistic plasma simulation—Optimization of a hybrid code}},
    year = 1970,
    booktitle = {Proceedings of Fourth Conference on Numerical Simulation of Plasmas},
    publisher = {Naval Research Laboratory},
@@ -69,43 +76,45 @@
 }
 @article{braginskii:1965,
    author = {S. I. Braginskii},
-   title = "{Transport Processes in a Plasma}",
+   title = {{Transport Processes in a Plasma}},
    year = 1965,
    journal = {Reviews of Plasma Physics},
    volume = 1,
    pages = 205
 }
 @article{buchsbaum:1960,
-author = {Buchsbaum, S. J. },
-title = {Resonance in a Plasma with Two Ion Species},
-journal = {The Physics of Fluids},
-volume = {3},
-number = {3},
-pages = {418-420},
-year = {1960},
-doi = {10.1063/1.1706052},
-URL = {https://aip.scitation.org/doi/abs/10.1063/1.1706052},
+   author = {S. J. Buchsbaum},
+   title = {{Resonance in a Plasma with Two Ion Species}},
+   year = 1960,
+   journal = {The Physics of Fluids},
+   volume = 3,
+   number = 3,
+   pages = {418--420},
+   doi = {10.1063/1.1706052},
+   url = {https://aip.scitation.org/doi/abs/10.1063/1.1706052}
 }
 @unpublished{callen:unpublished,
    author = {J. Callen},
    title = {{Draft Material For "Fundamentals of Plasma Physics" Book}},
-   note = {Unpublished},
-   url = {https://docs.google.com/document/d/e/2PACX-1vQmvQ_b8p0P2cYsWGMQYVd92OBLX9Sm6XGiCMRBidoVSoJffj2MBvWiwpix46mqlq_HQvHD5ofpfrNF/pub}
+   url = {
+      https://docs.google.com/document/d/e/2PACX-1vQmvQ\%5Fb8p0P2cYsWGMQYVd92OBLX9Sm6XGiCMRBidoVSoJffj2MBvWiwpix46mqlq\%5FHQvHD5ofpfrNF/pub
+   },
+   note = {Unpublished}
 }
 @book{chen:2016,
    author = {F. Chen},
-   title = "{Introduction to Plasma Physics and Controlled Fusion}",
+   title = {{Introduction to Plasma Physics and Controlled Fusion}},
    year = 2016,
-   edition = {3rd},
    publisher = {Springer},
-   doi = {10.1007/978-3-319-22309-4}
+   doi = {10.1007/978-3-319-22309-4},
+   edition = {3rd}
 }
 @article{epperlein:1986,
    author = {E. M. Epperlein and M. G. Haynes},
-   title = "{
-      Plasma transport coefficients in a magnetic field by direct numerical
-      solution of the {Fokker–Planck} equation
-   }",
+   title = {
+      {   Plasma transport coefficients in a magnetic field by direct numerical
+      solution of the Fokker–Planck equation   }
+   },
    year = 1986,
    journal = {Physics of Fluids},
    volume = 29,
@@ -113,36 +122,38 @@ URL = {https://aip.scitation.org/doi/abs/10.1063/1.1706052},
    doi = {10.1063/1.865901}
 }
 @book{fried:1961,
-   author = {Burton D. Fried and Samuel D. Conte},
-   title = "{The Plasma Dispersion Function: The Hilbert Transformation of the Gaussian}",
+   author = {B. D. Fried and S. D. Conte},
+   title = {{The Plasma Dispersion Function: The Hilbert Transformation of the Gaussian}},
    year = 1961,
    publisher = {Academic Press},
-   doi = {10.1016/C2013-0-12176-9}
+   doi = {10.1016/c2013-0-12176-9}
 }
 @book{froula:2011,
    author = {D. H. Froula and S. H. Glenzer and N. C. Luhmann and J. Sheffield},
-   title = "{Plasma Scattering of Electromagnetic Radiation}",
+   title = {{Plasma Scattering of Electromagnetic Radiation}},
    year = 2011,
    publisher = {Academic Press},
-   edition = {2nd},
-   pages = {103142},
+   pages = 103142,
+   doi = {10.1016/c2009-0-20048-1},
    isbn = {978-0-12-374877-5},
-   doi = {10.1016/C2009-0-20048-1}
+   edition = {2nd}
 }
 @techreport{fundamenski:2007,
    author = {W. Fundamenski and O. E. Garcia},
-   title = "{
-      Comparison of Coulomb Collision Rates in the Plasma Physics and
-      Magnetically Confined Fusion Literature
-   }",
+   title = {
+      {   Comparison of Coulomb Collision Rates in the Plasma Physics and Magnetically
+      Confined Fusion Literature   }
+   },
    year = 2007,
-   institution = {EDFA-JET},
-   number = "{EFDA–JET–R(07)01}",
-   url = {https://scipub.euro-fusion.org/archives/jet-archive/comparison-of-coulomb-collision-rates-in-the-plasma-physics-and-magnetically-confined-fusion-literature}
+   number = {{Efda–jet–r(07)01}},
+   url = {
+      https://scipub.euro-fusion.org/archives/jet-archive/comparison-of-coulomb-collision-rates-in-the-plasma-physics-and-magnetically-confined-fusion-literature
+   },
+   institution = {Edfa-jet}
 }
 @article{gericke:2002,
    author = {D. O. Gericke and M. S. Murillo and M. Schlanges},
-   title = "{Dense plasma temperature equilibration in the binary collision approximation}",
+   title = {{Dense plasma temperature equilibration in the binary collision approximation}},
    year = 2002,
    journal = {Physical Review E},
    volume = 65,
@@ -150,52 +161,104 @@ URL = {https://aip.scitation.org/doi/abs/10.1063/1.1706052},
    pages = 036418,
    doi = {10.1103/PhysRevE.65.036418}
 }
+@article{hasegawa:1982,
+   author = {A. Hasegawa and C. Uberoi},
+   title = {{Alfven wave. DOE Critical Review Series}},
+   year = 1982,
+   journal = {U.S. Department of Energy Office of Scientific and Technical Information},
+   doi = {10.2172/5259641}
+}
+@article{haynes:2007,
+   author = {A. Haynes, A. and C. Parnell},
+   title = {{A trilinear method for finding null points in a three-dimensional vector space}},
+   year = 2007,
+   month = {08},
+   journal = {Physics of Plasmas},
+   volume = 14,
+   pages = {082107},
+   doi = {10.1063/1.2756751}
+}
+@article{hellinger:2011,
+   author = {P. Hellinger and L. Matteini and Š. Štverák and P. M. Trávníček  and E. Marsch},
+   title = {
+      {   Heating and cooling of protons in the fast solar wind between 0.3 and 1 AU:
+      Helios revisited   }
+   },
+   year = 2011,
+   journal = {Journal of Geophysical Research: Space Physics},
+   volume = 116,
+   number = {A9},
+   doi = {10.1029/2011ja016674}
+}
+@article{hirose:2004,
+   author = {A. Hirose and A. Ito and A. M. Mahajan and S. Ohsaki},
+   title = {{Relation between Hall-magnetohydrodynamics and the kinetic Alfv\'e}n wave}}
+}
+,
+   year = 2004,
+   journal = {Physics Letters A},
+   volume = 330,
+   number = 6,
+   pages = {474--480},
+   doi = {10.1016/j.physleta.2004.08.021}
+}
+@article{hollweg:1999,
+   author = {J. V. Hollweg},
+   title = {{Kinetic Alfvén wave revisited}},
+   year = 1999,
+   journal = {Journal of Geophysical Research},
+   volume = 104,
+   number = {A7},
+   doi = {10.1029/1998ja900132}
+}
 @article{ji:2013,
    author = {J.-Y. Ji and E. D. Held},
-   title = "{Closure and transport theory for high-collisionality electron-ion plasmas}",
+   title = {{Closure and transport theory for high-collisionality electron-ion plasmas}},
    year = 2013,
    journal = {Physics of Plasmas},
-   volume = {20},
+   volume = 20,
    number = {042114},
    doi = {10.1063/1.4801022}
 }
-@article{haynes:2007,
-   author = {Haynes, A. and Parnell, Clare},
-   year = {2007},
-   month = {08},
-   pages = {082107},
-   title = {A trilinear method for finding null points in a three-dimensional vector space},
-   volume = {14},
-   journal = {Physics of Plasmas},
-   doi = {10.1063/1.2756751}
-}
-@article{hollweg:1999,
-   author = {Hollweg, Joseph. V.},
-   title = {Kinetic Alfvén wave revisited},
-   journal = {Journal of Geophysical Research},
-   volume = {104},
-   number = {A7},
-   doi = {10.1029/1998JA900132},
-   year = {1999}
-}
 @book{khorikov:2020,
    author = {V. Khorikov},
-   title = "{Unit Testing Principles, Practices, and Patterns}",
+   title = {{Unit Testing Principles, Practices, and Patterns}},
    year = 2020,
    publisher = {Manning Press},
    url = {https://www.manning.com/books/unit-testing},
    edition = {1st}
 }
+@article{maruca:2013,
+   author = {
+      B. A. Maruca and S. D. Bale and L. Sorriso-Valvo and J. C. Kasper and M. L.
+      Stevens
+   },
+   title = {{Collisional Thermalization of Hydrogen and Helium in Solar-Wind Plasma}},
+   year = 2013,
+   journal = {Physical Review Letters},
+   publisher = {American Physical Society ({APS})},
+   volume = 111,
+   number = 24,
+   doi = {10.1103/physrevlett.111.241101}
+}
+@article{morales:1997,
+   author = {G. J. Morales and J. E. Maggs},
+   title = {{Structure of kinetic Alfven waves with small transverse scale length}},
+   year = 1997,
+   journal = {Physics of Plasmas},
+   volume = 4,
+   pages = {4118--4125}
+}
 @techreport{nrlformulary:2019,
    author = {A. S. Richardson},
-   title = "{{NRL} Plasma Formulary}",
+   title = {{NRL Plasma Formulary}},
    year = 2019,
    url = {https://www.nrl.navy.mil/News-Media/Publications/nrl-plasma-formulary},
    institution = {Naval Research Laboratory}
 }
 @book{osherove:2013,
    author = {R. Osherove},
-   title = "{The Art of Unit Testing: With Examples in .NET}",
+   title = {{The Art of Unit Testing: With Examples in .NET}},
    year = 2013,
    publisher = {Manning Press},
    isbn = 9781617290893,
@@ -203,71 +266,63 @@ URL = {https://aip.scitation.org/doi/abs/10.1063/1.1706052},
    edition = {2nd}
 }
 @article{parnell:1996,
-       author = {{Parnell}, C.~E. and {Smith}, J.~M. and {Neukirch}, T. and {Priest}, E.~R.},
-        title = "{The structure of three-dimensional magnetic neutral points}",
-      journal = {Physics of Plasmas},
-         year = 1996,
-       volume = {3},
-       number = {3},
-        pages = {759-770},
-          doi = {10.1063/1.871810}
+   author = {C. E. Parnell and J. M. Smith and T. Neukirch and E. R. Priest},
+   title = {{The structure of three-dimensional magnetic neutral points}},
+   year = 1996,
+   journal = {Physics of Plasmas},
+   volume = 3,
+   number = 3,
+   pages = {759--770},
+   doi = {10.1063/1.871810}
 }
 @book{priest:2000,
-    author = {{Priest}, E.~R. and {Forbes}, T.},
-    title = "{Magnetic Reconnection: MHD Theory and Applications}",
-    year = 2000,
-    publisher = {Cambridge University Press},
-    isbn = {978-0-521-03394-7},
+   author = {E. R. Priest and T. Forbes},
+   title = {{Magnetic Reconnection: MHD Theory and Applications}},
+   year = 2000,
+   publisher = {Cambridge University Press},
+   isbn = {978-0-521-03394-7}
 }
 @phdthesis{schaeffer:2014,
-   author = {Schaeffer, Derek},
+   author = {D. Schaeffer},
    title = {
-   Generation of Quasi-Perpendicular Collisionless Shocks by a Laser-Driven
-   Magnetic Piston
-      },
-   school = {University of California, Los Angeles},
+      {   Generation of Quasi-Perpendicular Collisionless Shocks by a Laser-Driven
+      Magnetic Piston   }
+   },
    year = 2014,
-   month = {dec},
+   month = dec,
    doi = {10.5281/zenodo.3766933},
    url = {https://doi.org/10.5281/zenodo.3766933},
+   school = {University of California, Los Angeles}
 }
 @book{sheffield:2011,
-   author = {
-      J. Sheffield and D. Froula and S. H. Glenzer and N. C. {Luhmann, Jr.}
-   },
+   author = {J. Sheffield and D. Froula and S. H. Glenzer and N. C. {Luhmann, Jr.}},
    title = {
-      Plasma Scattering of Electromagnetic Radiation: Theory and
-      Measurement Techniques
-      },
+      {  Plasma Scattering of Electromagnetic Radiation: Theory and Measurement
+      Techniques  }
+   },
    year = 2011,
    publisher = {Academic Press},
    isbn = {978-0-12-374877-5},
-   edition = {2nd},
+   edition = {2nd}
 }
 @incollection{sheffield:2011:ch3,
-   title = {Chapter 3 - Scattering Spectrum from a Plasma Theory},
-   author = {
-      John Sheffield and Dustin H. Froula and Siegfried H. Glenzer and
-      Neville C. Luhmann
-   },
-   editor = {
-      Dustin H. Froula and Siegfried H. Glenzer and Neville C. Luhmann
-      and John Sheffield
-   },
-   booktitle = {Plasma Scattering of Electromagnetic Radiation (Second Edition)},
+   author = {J. Sheffield and D. H. Froula and S. H. Glenzer and N. C. Luhmann},
+   title = {{Chapter 3 - Scattering Spectrum from a Plasma Theory}},
+   year = 2011,
+   booktitle = {{Plasma Scattering of Electromagnetic Radiation (Second Edition)}},
    publisher = {Academic Press},
-   edition = {Second Edition},
    address = {Boston},
-   pages = {45-68},
-   year = {2011},
+   pages = {45--68},
+   doi = {10.1016/b978-0-12-374877-5.00003-8},
    isbn = {978-0-12-374877-5},
-   doi = {10.1016/B978-0-12-374877-5.00003-8},
    url = {https://www.sciencedirect.com/science/article/pii/B9780123748775000038},
+   editor = {D. H. Froula and S. H. Glenzer and N. C. Luhmann and J. Sheffield},
+   edition = {Second Edition}
 }
 @article{spitzer:1953,
    author = {L. Spitzer and R. Härm},
-   title = "{Transport phenomena in a Completely Ionized Gas}",
-   year = {1953},
+   title = {{Transport phenomena in a Completely Ionized Gas}},
+   year = 1953,
    journal = {Phys. Rev.},
    volume = 89,
    pages = {977–981},
@@ -275,24 +330,26 @@ URL = {https://aip.scitation.org/doi/abs/10.1063/1.1706052},
 }
 @book{spitzer:1962,
    author = {L. Spitzer},
-   title = "{Physics of Fully Ionized Gases}",
+   title = {{Physics of Fully Ionized Gases}},
    year = 1962,
    publisher = {Interscience},
    edition = {2nd}
 }
 @book{stix:1992,
    author = {T. H. Stix},
-   title = "{Waves in Plasmas}",
+   title = {{Waves in Plasmas}},
    year = 1992,
    publisher = {AIP-Press},
-   url = {https://link.springer.com/book/9780883188590},
+   url = {https://link.springer.com/book/9780883188590}
 }
 @article{stringer:1963,
    author = {T. E. Stringer},
-   title = "{Low-frequency waves in an unbounded plasma}",
+   title = {{Low-frequency waves in an unbounded plasma}},
    year = 1963,
    journal = {
-      Journal of Nuclear Energy. Part C, Plasma Physics, Accelerators, Thermonuclear Research},
+      Journal of Nuclear Energy. Part C, Plasma Physics, Accelerators, Thermonuclear
+      Research
+   },
    publisher = {{IOP} Publishing},
    volume = 5,
    number = 2,
@@ -300,35 +357,56 @@ URL = {https://aip.scitation.org/doi/abs/10.1063/1.1706052},
    doi = {10.1088/0368-3281/5/2/304}
 }
 @article{thompson:1995,
-title = {Wave behaviour near critical frequencies in cold bi-ion plasmas},
-journal = {Planetary and Space Science},
-volume = {43},
-number = {5},
-pages = {625-634},
-year = {1995},
-issn = {0032-0633},
-doi = {https://doi.org/10.1016/0032-0633(94)00197-Y},
-url = {https://www.sciencedirect.com/science/article/pii/003206339400197Y},
-author = {P. Thompson and M.K. Dougherty and D.J. Southwood},
+   author = {P. Thompson and M. K. Dougherty and D. J. Southwood},
+   title = {{Wave behaviour near critical frequencies in cold bi-ion plasmas}},
+   year = 1995,
+   journal = {Planetary and Space Science},
+   volume = 43,
+   number = 5,
+   pages = {625--634},
+   doi = {https://doi.org/10.1016/0032-0633(94)00197-Y},
+   issn = {0032-0633},
+   url = {https://www.sciencedirect.com/science/article/pii/003206339400197Y}
+}
+@article{verscharen:2019,
+   author = {D. Verscharen and K. G. Klein and B. A. Maruca},
+   title = {{The multi-scale nature of the solar wind}},
+   year = 2019,
+   month = dec,
+   journal = {Living Reviews in Solar Physics},
+   publisher = {Springer Science and Business Media (LLC)},
+   volume = 16,
+   number = 1,
+   doi = {10.1007/s41116-019-0021-0}
 }
 @article{vincena:2013,
-author = {Vincena, S. T. and Farmer, W. A. and Maggs, J. E. and Morales, G. J.},
-title = {Investigation of an ion-ion hybrid Alfvén wave resonator},
-journal = {Physics of Plasmas},
-volume = {20},
-number = {1},
-pages = {012111},
-year = {2013},
-doi = {10.1063/1.4775777},
-URL = { https://doi.org/10.1063/1.4775777},
+   author = {S. T. Vincena and W. A. Farmer and J. E. Maggs and G. J. Morales},
+   title = {{Investigation of an ion-ion hybrid Alfvén wave resonator}},
+   year = 2013,
+   journal = {Physics of Plasmas},
+   volume = 20,
+   number = 1,
+   pages = {012111},
+   doi = {10.1063/1.4775777},
+   url = {https://doi.org/10.1063/1.4775777}
+}
+@article{william:1996,
+   author = {R. L. Lysak and W. Lotko},
+   title = {{On the kinetic dispersion relation for shear Alfvén waves}},
+   year = 1996,
+   journal = {Journal of Geophysical Research: Space Physics},
+   volume = 101,
+   number = {A3},
+   pages = {5085--5094},
+   doi = {10.1029/95ja03712}
 }
 @article{wilson:2014,
    author = {
-      G. Wilson and D. A. Aruliah and C. T. Brown and N. P. Chue Hong and
-      M. Davis and R. T. Guy and S. H. D. Haddock and K. D. Huff and I. M.
-      Mitchell and M. D. Plumbley and B. Waugh and E. P. White and P. Wilson
+      G. Wilson and D. A. Aruliah and C. T. Brown and N. P. Chue Hong and M. Davis and
+      R. T. Guy and S. H. D. Haddock and K. D. Huff and I. M. Mitchell and M. D.
+      Plumbley and B. Waugh and E. P. White and P. Wilson
    },
-   title = "{Best practices for scientific computing}",
+   title = {{Best practices for scientific computing}},
    year = 2014,
    journal = {PLoS Biology},
    volume = 12,
@@ -338,88 +416,14 @@ URL = { https://doi.org/10.1063/1.4775777},
 }
 @article{wilson:2017,
    author = {
-      G. Wilson and J. Bryan and K. Cranston and J. Kitzes and L. Nederbragt and
-      T. K. Teal
+      G. Wilson and J. Bryan and K. Cranston and J. Kitzes and L. Nederbragt and T. K.
+      Teal
    },
-   title = "{Good enough practices in scientific computing}",
+   title = {{Good enough practices in scientific computing}},
    year = 2017,
    journal = {PLOS Computational Biology},
    volume = 13,
    number = 6,
    pages = {e1005510},
    doi = {10.1371/journal.pcbi.1005510}
-}
-@article{hirose:2004,
-   author = {
-      Hirose, Akira and Ito, Atsushi and Mahajan, Swadesh M. and Ohsaki, Shuichi
-      },
-   title = "{Relation between Hall-magnetohydrodynamics and the kinetic Alfv{\'e}n wave}",
-   year = 2004,
-   journal = {Physics Letters A},
-   volume = 330,
-   number = 6,
-   pages = {474-480},
-   doi = {10.1016/j.physleta.2004.08.021}
-}
-@article{hasegawa:1982,
-   title={Alfven wave. {DOE} Critical Review Series},
-   doi={10.2172/5259641},
-   author={Hasegawa, A. and Uberoi, C.},
-   year={1982},
-   journal={U.S. Department of Energy Office of Scientific and Technical Information}
-}
-@article{morales:1997,
-   title={Structure of kinetic Alfven waves with small transverse scale length},
-   author={G. J. Morales and J. E. Maggs},
-   journal={Physics of Plasmas},
-   year={1997},
-   volume={4},
-   pages={4118-4125}
-}
-@article{william:1996,
-   author = {Lysak, Robert L. and Lotko, William},
-   title = {On the kinetic dispersion relation for shear Alfvén waves},
-   journal = {Journal of Geophysical Research: Space Physics},
-   volume = {101},
-   number = {A3},
-   pages = {5085-5094},
-   doi = {10.1029/95JA03712},
-   year = {1996}
-}
-@article{hellinger:2011,
-    author = {Hellinger, Petr and Matteini, Lorenzo and Štverák, Štěpán and Trávníček, Pavel M. and Marsch, Eckart},
-    title = {Heating and cooling of protons in the fast solar wind between 0.3 and 1 AU: Helios revisited},
-    journal = {Journal of Geophysical Research: Space Physics},
-    volume = {116},
-    number = {A9},
-    doi = {10.1029/2011JA016674},
-    year = {2011}
-}
-@article{maruca:2013,
-	doi = {10.1103/physrevlett.111.241101},
-	year = 2013,
-	publisher = {American Physical Society ({APS})},
-	volume = {111},
-	number = {24},
-	author = {B. A. Maruca and S. D. Bale and L. Sorriso-Valvo and J. C. Kasper and M. L. Stevens},
-	title = {Collisional Thermalization of Hydrogen and Helium in Solar-Wind Plasma},
-	journal = {Physical Review Letters}
-}
-@book{baumjohann:1997,
-    place={London},
-    title={Basic Space Plasma Physics},
-    publisher={Imperial College Press},
-    author={Baumjohann, W and Treumann, Rudolf A},
-    year=1997
-}
-@article{verscharen:2019,
-	doi = {10.1007/s41116-019-0021-0},
-	year = 2019,
-	month = {dec},
-	publisher = {Springer Science and Business Media (LLC) },
-	volume = {16},
-	number = {1},
-	author = {Daniel Verscharen and Kristopher G. Klein and Bennett A. Maruca},
-	title = {The multi-scale nature of the solar wind},
-	journal = {Living Reviews in Solar Physics}
 }

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -145,11 +145,11 @@
       Confined Fusion Literature   }
    },
    year = 2007,
-   number = {{Efda–jet–r(07)01}},
+   number = {{EFDA–JET–R(07)01}},
    url = {
       https://scipub.euro-fusion.org/archives/jet-archive/comparison-of-coulomb-collision-rates-in-the-plasma-physics-and-magnetically-confined-fusion-literature
    },
-   institution = {Edfa-jet}
+   institution = {{EFDA-JET}}
 }
 @article{gericke:2002,
    author = {D. O. Gericke and M. S. Murillo and M. Schlanges},
@@ -192,7 +192,7 @@
 }
 @article{hirose:2004,
    author = {A. Hirose and A. Ito and S. M. Mahajan and S. Ohsaki},
-   title = {{Relation between Hall-magnetohydrodynamics and the kinetic Alfv\'e}n wave}},
+   title = {{Relation between Hall-magnetohydrodynamics and the kinetic Alfvén wave}},
    year = 2004,
    journal = {Physics Letters A},
    volume = 330,
@@ -241,7 +241,7 @@
 }
 @article{morales:1997,
    author = {G. J. Morales and J. E. Maggs},
-   title = {{Structure of kinetic Alfven waves with small transverse scale length}},
+   title = {{Structure of kinetic Alfvén waves with small transverse scale length}},
    year = 1997,
    journal = {Physics of Plasmas},
    volume = 4,
@@ -370,7 +370,6 @@
    author = {D. Verscharen and K. G. Klein and B. A. Maruca},
    title = {{The multi-scale nature of the solar wind}},
    year = 2019,
-   month = dec,
    journal = {Living Reviews in Solar Physics},
    publisher = {Springer Science and Business Media (LLC)},
    volume = 16,

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -191,10 +191,8 @@
    doi = {10.1029/2011ja016674}
 }
 @article{hirose:2004,
-   author = {A. Hirose and A. Ito and A. M. Mahajan and S. Ohsaki},
-   title = {{Relation between Hall-magnetohydrodynamics and the kinetic Alfv\'e}n wave}}
-}
-,
+   author = {A. Hirose and A. Ito and S. M. Mahajan and S. Ohsaki},
+   title = {{Relation between Hall-magnetohydrodynamics and the kinetic Alfv\'e}n wave}},
    year = 2004,
    journal = {Physics Letters A},
    volume = 330,

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -1,29 +1,30 @@
 @article{alfven:1942,
    author = {H. Alfvén},
-   title = {Existence of Electromagnetic-Hydrodynamic Waves},
+   title = {{Existence of Electromagnetic-Hydrodynamic Waves}},
    year = 1942,
    journal = {Nature},
    volume = 150,
    number = 3805,
-   pages = {405–8/150405d0}
+   pages = {405–406},
+   doi = {10.1038/150405d0}
 }
 @book{baumjohann:1997,
    author = {W. Baumjohann and R. A. Treumann},
-   title = {Basic Space Plasma Physics},
+   title = {{Basic Space Plasma Physics}},
    year = 1997,
    publisher = {Imperial College Press},
    place = {London}
 }
 @book{bekefi:1966,
    author = {G. Bekefi},
-   title = {Radiation Processes in Plasmas},
+   title = {{Radiation Processes in Plasmas}},
    year = 1966,
    publisher = {Wiley},
    isbn = 9780471063506
 }
 @article{bellan:2012,
    author = {P. M. Bellan},
-   title = {Improved basis set for low frequency plasma waves},
+   title = {{Improved basis set for low frequency plasma waves}},
    year = 2012,
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 117,
@@ -32,7 +33,7 @@
 }
 @book{bernstein:2015,
    author = {D. S. Bernstein},
-   title = {Beyond Legacy Code: Nine Practices to Extend the Life (and Value) of Your Software},
+   title = {{Beyond Legacy Code: Nine Practices to Extend the Life (and Value) of Your Software}},
    year = 2015,
    publisher = {Pragmatic Bookshelf},
    isbn = 9781680500790,
@@ -41,28 +42,28 @@
 }
 @book{birdsall:2004,
    author = {C. K. Birdsall and A. B. Langdon},
-   title = {Plasma Physics via Computer Simulation},
+   title = {{Plasma Physics via Computer Simulation}},
    year = 2004,
    publisher = {{CRC} Press},
    doi = {10.1201/9781315275048}
 }
 @book{bohm:1949,
    author = {D. Bohm},
-   title = {The Characteristics of Electrical Discharges in Magnetic Fields},
+   title = {{The Characteristics of Electrical Discharges in Magnetic Fields}},
    year = 1949,
    publisher = {McGraw-Hill},
    editor = {A. Guthrie and R. K. Wakerling}
 }
 @book{bonitz:1998,
    author = {M. Bonitz},
-   title = {Quantum Kinetic Theory},
+   title = {{Quantum Kinetic Theory}},
    year = 1998,
    publisher = {Springer},
    doi = {10.1007/978-3-319-24121-0}
 }
 @inproceedings{boris:1970,
    author = {J. P. Boris},
-   title = {Relativistic plasma simulation — Optimization of a hybrid code},
+   title = {{Relativistic plasma simulation—Optimization of a hybrid code}},
    year = 1970,
    booktitle = {Proceedings of Fourth Conference on Numerical Simulation of Plasmas},
    publisher = {Naval Research Laboratory},
@@ -72,7 +73,7 @@
 }
 @article{braginskii:1965,
    author = {S. I. Braginskii},
-   title = {Transport Processes in a Plasma},
+   title = {{Transport Processes in a Plasma}},
    year = 1965,
    journal = {Reviews of Plasma Physics},
    volume = 1,
@@ -80,17 +81,17 @@
 }
 @article{buchsbaum:1960,
    author = {S. J. Buchsbaum},
-   title = {Resonance in a Plasma with Two Ion Species},
+   title = {{Resonance in a Plasma with Two Ion Species}},
    year = 1960,
    journal = {The Physics of Fluids},
    volume = 3,
    number = 3,
-   pages = {418–420},
+   pages = {418--420},
    doi = {10.1063/1.1706052},
 }
 @unpublished{callen:unpublished,
    author = {J. Callen},
-   title = {Draft Material For "Fundamentals of Plasma Physics" Book},
+   title = {{Draft Material For "Fundamentals of Plasma Physics" Book}},
    url = {
       https://docs.google.com/document/d/e/2PACX-1vQmvQ\%5Fb8p0P2cYsWGMQYVd92OBLX9Sm6XGiCMRBidoVSoJffj2MBvWiwpix46mqlq\%5FHQvHD5ofpfrNF/pub
    },
@@ -98,7 +99,7 @@
 }
 @book{chen:2016,
    author = {F. Chen},
-   title = {Introduction to Plasma Physics and Controlled Fusion},
+   title = {{Introduction to Plasma Physics and Controlled Fusion}},
    year = 2016,
    publisher = {Springer},
    doi = {10.1007/978-3-319-22309-4},
@@ -106,7 +107,7 @@
 }
 @article{epperlein:1986,
    author = {E. M. Epperlein and M. G. Haynes},
-   title = {Plasma transport coefficients in a magnetic field by direct numerical solution of the Fokker–Planck equation},
+   title = {{Plasma transport coefficients in a magnetic field by direct numerical solution of the Fokker–Planck equation}},
    year = 1986,
    journal = {Physics of Fluids},
    volume = 29,
@@ -115,14 +116,14 @@
 }
 @book{fried:1961,
    author = {B. D. Fried and S. D. Conte},
-   title = {The Plasma Dispersion Function: The Hilbert Transformation of the Gaussian},
+   title = {{The Plasma Dispersion Function: The Hilbert Transformation of the Gaussian}},
    year = 1961,
    publisher = {Academic Press},
    doi = {10.1016/c2013-0-12176-9}
 }
 @book{froula:2011,
    author = {D. H. Froula and S. H. Glenzer and N. C. Luhmann and J. Sheffield},
-   title = {Plasma Scattering of Electromagnetic Radiation},
+   title = {{Plasma Scattering of Electromagnetic Radiation}},
    year = 2011,
    publisher = {Academic Press},
    pages = 103142,
@@ -132,7 +133,7 @@
 }
 @techreport{fundamenski:2007,
    author = {W. Fundamenski and O. E. Garcia},
-   title = {Comparison of Coulomb Collision Rates in the Plasma Physics and Magnetically Confined Fusion Literature},
+   title = {{Comparison of Coulomb Collision Rates in the Plasma Physics and Magnetically Confined Fusion Literature}},
    year = 2007,
    number = {{EFDA–JET–R(07)01}},
    url = {
@@ -142,7 +143,7 @@
 }
 @article{gericke:2002,
    author = {D. O. Gericke and M. S. Murillo and M. Schlanges},
-   title = {Dense plasma temperature equilibration in the binary collision approximation},
+   title = {{Dense plasma temperature equilibration in the binary collision approximation}},
    year = 2002,
    journal = {Physical Review E},
    volume = 65,
@@ -152,14 +153,14 @@
 }
 @article{hasegawa:1982,
    author = {A. Hasegawa and C. Uberoi},
-   title = {Alfven wave. DOE Critical Review Series},
+   title = {{Alfven wave. DOE Critical Review Series}},
    year = 1982,
    journal = {U.S. Department of Energy Office of Scientific and Technical Information},
    doi = {10.2172/5259641}
 }
 @article{haynes:2007,
    author = {A. Haynes and C. Parnell},
-   title = {A trilinear method for finding null points in a three-dimensional vector space},
+   title = {{A trilinear method for finding null points in a three-dimensional vector space}},
    year = 2007,
    month = {08},
    journal = {Physics of Plasmas},
@@ -169,7 +170,7 @@
 }
 @article{hellinger:2011,
    author = {P. Hellinger and L. Matteini and Š. Štverák and P. M. Trávníček  and E. Marsch},
-   title = {Heating and cooling of protons in the fast solar wind between 0.3 and 1 AU: Helios revisited},
+   title = {{Heating and cooling of protons in the fast solar wind between 0.3 and 1 AU: Helios revisited}},
    year = 2011,
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 116,
@@ -178,17 +179,17 @@
 }
 @article{hirose:2004,
    author = {A. Hirose and A. Ito and S. M. Mahajan and S. Ohsaki},
-   title = {Relation between Hall-magnetohydrodynamics and the kinetic Alfvén wave},
+   title = {{Relation between Hall-magnetohydrodynamics and the kinetic Alfvén wave}},
    year = 2004,
    journal = {Physics Letters A},
    volume = 330,
    number = 6,
-   pages = {474–480},
+   pages = {474--480},
    doi = {10.1016/j.physleta.2004.08.021}
 }
 @article{hollweg:1999,
    author = {J. V. Hollweg},
-   title = {Kinetic Alfvén wave revisited},
+   title = {{Kinetic Alfvén wave revisited}},
    year = 1999,
    journal = {Journal of Geophysical Research},
    volume = 104,
@@ -197,7 +198,7 @@
 }
 @article{ji:2013,
    author = {J.-Y. Ji and E. D. Held},
-   title = {Closure and transport theory for high-collisionality electron-ion plasmas},
+   title = {{Closure and transport theory for high-collisionality electron-ion plasmas}},
    year = 2013,
    journal = {Physics of Plasmas},
    volume = 20,
@@ -206,7 +207,7 @@
 }
 @book{khorikov:2020,
    author = {V. Khorikov},
-   title = {Unit Testing Principles, Practices, and Patterns},
+   title = {{Unit Testing Principles, Practices, and Patterns}},
    year = 2020,
    publisher = {Manning Press},
    url = {https://www.manning.com/books/unit-testing},
@@ -217,7 +218,7 @@
       B. A. Maruca and S. D. Bale and L. Sorriso-Valvo and J. C. Kasper and M. L.
       Stevens
    },
-   title = {Collisional Thermalization of Hydrogen and Helium in Solar-Wind Plasma},
+   title = {{Collisional Thermalization of Hydrogen and Helium in Solar-Wind Plasma}},
    year = 2013,
    journal = {Physical Review Letters},
    publisher = {American Physical Society ({APS})},
@@ -227,22 +228,22 @@
 }
 @article{morales:1997,
    author = {G. J. Morales and J. E. Maggs},
-   title = {Structure of kinetic Alfvén waves with small transverse scale length},
+   title = {{Structure of kinetic Alfvén waves with small transverse scale length}},
    year = 1997,
    journal = {Physics of Plasmas},
    volume = 4,
-   pages = {4118–4125}
+   pages = {4118--4125}
 }
 @techreport{nrlformulary:2019,
    author = {A. S. Richardson},
-   title = {{NRL} Plasma Formulary},
+   title = {{NRL Plasma Formulary}},
    year = 2019,
    url = {https://www.nrl.navy.mil/News-Media/Publications/nrl-plasma-formulary},
    institution = {Naval Research Laboratory}
 }
 @book{osherove:2013,
    author = {R. Osherove},
-   title = {The Art of Unit Testing: With Examples in {.NET}},
+   title = {{The Art of Unit Testing: With Examples in .NET}},
    year = 2013,
    publisher = {Manning Press},
    isbn = 9781617290893,
@@ -251,24 +252,24 @@
 }
 @article{parnell:1996,
    author = {C. E. Parnell and J. M. Smith and T. Neukirch and E. R. Priest},
-   title = {The structure of three-dimensional magnetic neutral points},
+   title = {{The structure of three-dimensional magnetic neutral points}},
    year = 1996,
    journal = {Physics of Plasmas},
    volume = 3,
    number = 3,
-   pages = {759–770},
+   pages = {759--770},
    doi = {10.1063/1.871810}
 }
 @book{priest:2000,
    author = {E. R. Priest and T. Forbes},
-   title = {Magnetic Reconnection: {MHD} Theory and Applications},
+   title = {{Magnetic Reconnection: MHD Theory and Applications}},
    year = 2000,
    publisher = {Cambridge University Press},
    isbn = {978-0-521-03394-7}
 }
 @phdthesis{schaeffer:2014,
    author = {D. Schaeffer},
-   title = {Generation of Quasi-Perpendicular Collisionless Shocks by a Laser-Driven Magnetic Piston},
+   title = {{Generation of Quasi-Perpendicular Collisionless Shocks by a Laser-Driven Magnetic Piston}},
    year = 2014,
    month = dec,
    doi = {10.5281/zenodo.3766933},
@@ -276,7 +277,7 @@
 }
 @book{sheffield:2011,
    author = {J. Sheffield and D. Froula and S. H. Glenzer and N. C. {Luhmann, Jr.}},
-   title = {Plasma Scattering of Electromagnetic Radiation: Theory and Measurement Techniques},
+   title = {{Plasma Scattering of Electromagnetic Radiation: Theory and Measurement Techniques}},
    year = 2011,
    publisher = {Academic Press},
    isbn = {978-0-12-374877-5},
@@ -284,12 +285,12 @@
 }
 @incollection{sheffield:2011:ch3,
    author = {J. Sheffield and D. H. Froula and S. H. Glenzer and N. C. Luhmann},
-   title = {Chapter 3 - Scattering Spectrum from a Plasma Theory},
+   title = {{Chapter 3 - Scattering Spectrum from a Plasma Theory}},
    year = 2011,
-   booktitle = {Plasma Scattering of Electromagnetic Radiation (Second Edition)},
+   booktitle = {{Plasma Scattering of Electromagnetic Radiation (Second Edition)}},
    publisher = {Academic Press},
    address = {Boston},
-   pages = {45–68},
+   pages = {45--68},
    doi = {10.1016/b978-0-12-374877-5.00003-8},
    isbn = {978-0-12-374877-5},
    editor = {D. H. Froula and S. H. Glenzer and N. C. Luhmann and J. Sheffield},
@@ -297,7 +298,7 @@
 }
 @article{spitzer:1953,
    author = {L. Spitzer and R. Härm},
-   title = {Transport phenomena in a Completely Ionized Gas},
+   title = {{Transport phenomena in a Completely Ionized Gas}},
    year = 1953,
    journal = {Physical Review},
    volume = 89,
@@ -306,24 +307,26 @@
 }
 @book{spitzer:1962,
    author = {L. Spitzer},
-   title = {Physics of Fully Ionized Gases},
+   title = {{Physics of Fully Ionized Gases}},
    year = 1962,
    publisher = {Interscience},
    edition = {2nd}
 }
 @book{stix:1992,
    author = {T. H. Stix},
-   title = {Waves in Plasmas},
+   title = {{Waves in Plasmas}},
    year = 1992,
-   publisher = {American Institute of Physics},
-   isbn = {978-0-88318-859-0},
+   publisher = {AIP-Press},
    url = {https://link.springer.com/book/9780883188590}
 }
 @article{stringer:1963,
    author = {T. E. Stringer},
-   title = {Low-frequency waves in an unbounded plasma},
+   title = {{Low-frequency waves in an unbounded plasma}},
    year = 1963,
-   journal = {Journal of Nuclear Energy. Part C, Plasma Physics, Accelerators, Thermonuclear Research},
+   journal = {
+      Journal of Nuclear Energy. Part C, Plasma Physics, Accelerators, Thermonuclear
+      Research
+   },
    publisher = {{IOP} Publishing},
    volume = 5,
    number = 2,
@@ -332,7 +335,7 @@
 }
 @article{thompson:1995,
    author = {P. Thompson and M. K. Dougherty and D. J. Southwood},
-   title = {Wave behaviour near critical frequencies in cold bi-ion plasmas},
+   title = {{Wave behaviour near critical frequencies in cold bi-ion plasmas}},
    year = 1995,
    journal = {Planetary and Space Science},
    volume = 43,
@@ -343,7 +346,7 @@
 }
 @article{verscharen:2019,
    author = {D. Verscharen and K. G. Klein and B. A. Maruca},
-   title = {The multi-scale nature of the solar wind},
+   title = {{The multi-scale nature of the solar wind}},
    year = 2019,
    journal = {Living Reviews in Solar Physics},
    publisher = {Springer Science and Business Media (LLC)},
@@ -353,7 +356,7 @@
 }
 @article{vincena:2013,
    author = {S. T. Vincena and W. A. Farmer and J. E. Maggs and G. J. Morales},
-   title = {Investigation of an ion-ion hybrid Alfvén wave resonator},
+   title = {{Investigation of an ion-ion hybrid Alfvén wave resonator}},
    year = 2013,
    journal = {Physics of Plasmas},
    volume = 20,
@@ -363,7 +366,7 @@
 }
 @article{william:1996,
    author = {R. L. Lysak and W. Lotko},
-   title = {On the kinetic dispersion relation for shear Alfvén waves},
+   title = {{On the kinetic dispersion relation for shear Alfvén waves}},
    year = 1996,
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 101,
@@ -377,7 +380,7 @@
       R. T. Guy and S. H. D. Haddock and K. D. Huff and I. M. Mitchell and M. D.
       Plumbley and B. Waugh and E. P. White and P. Wilson
    },
-   title = {Best practices for scientific computing},
+   title = {{Best practices for scientific computing}},
    year = 2014,
    journal = {PLoS Biology},
    volume = 12,
@@ -390,7 +393,7 @@
       G. Wilson and J. Bryan and K. Cranston and J. Kitzes and L. Nederbragt and T. K.
       Teal
    },
-   title = {Good enough practices in scientific computing},
+   title = {{Good enough practices in scientific computing}},
    year = 2017,
    journal = {PLOS Computational Biology},
    volume = 13,

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -33,10 +33,7 @@
 }
 @book{bernstein:2015,
    author = {D. S. Bernstein},
-   title = {
-      {   Beyond Legacy Code: Nine Practices to Extend the Life (and Value) of Your
-      Software   }
-   },
+   title = {{Beyond Legacy Code: Nine Practices to Extend the Life (and Value) of Your Software}},
    year = 2015,
    publisher = {Pragmatic Bookshelf},
    isbn = 9781680500790,
@@ -91,7 +88,6 @@
    number = 3,
    pages = {418--420},
    doi = {10.1063/1.1706052},
-   url = {https://aip.scitation.org/doi/abs/10.1063/1.1706052}
 }
 @unpublished{callen:unpublished,
    author = {J. Callen},
@@ -111,10 +107,7 @@
 }
 @article{epperlein:1986,
    author = {E. M. Epperlein and M. G. Haynes},
-   title = {
-      {   Plasma transport coefficients in a magnetic field by direct numerical
-      solution of the Fokker–Planck equation   }
-   },
+   title = {{Plasma transport coefficients in a magnetic field by direct numerical solution of the Fokker–Planck equation}},
    year = 1986,
    journal = {Physics of Fluids},
    volume = 29,
@@ -140,10 +133,7 @@
 }
 @techreport{fundamenski:2007,
    author = {W. Fundamenski and O. E. Garcia},
-   title = {
-      {   Comparison of Coulomb Collision Rates in the Plasma Physics and Magnetically
-      Confined Fusion Literature   }
-   },
+   title = {{Comparison of Coulomb Collision Rates in the Plasma Physics and Magnetically Confined Fusion Literature}},
    year = 2007,
    number = {{EFDA–JET–R(07)01}},
    url = {
@@ -169,7 +159,7 @@
    doi = {10.2172/5259641}
 }
 @article{haynes:2007,
-   author = {A. Haynes, A. and C. Parnell},
+   author = {A. Haynes and C. Parnell},
    title = {{A trilinear method for finding null points in a three-dimensional vector space}},
    year = 2007,
    month = {08},
@@ -180,10 +170,7 @@
 }
 @article{hellinger:2011,
    author = {P. Hellinger and L. Matteini and Š. Štverák and P. M. Trávníček  and E. Marsch},
-   title = {
-      {   Heating and cooling of protons in the fast solar wind between 0.3 and 1 AU:
-      Helios revisited   }
-   },
+   title = {{Heating and cooling of protons in the fast solar wind between 0.3 and 1 AU: Helios revisited}},
    year = 2011,
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 116,
@@ -282,22 +269,15 @@
 }
 @phdthesis{schaeffer:2014,
    author = {D. Schaeffer},
-   title = {
-      {   Generation of Quasi-Perpendicular Collisionless Shocks by a Laser-Driven
-      Magnetic Piston   }
-   },
+   title = {{Generation of Quasi-Perpendicular Collisionless Shocks by a Laser-Driven Magnetic Piston}},
    year = 2014,
    month = dec,
    doi = {10.5281/zenodo.3766933},
-   url = {https://doi.org/10.5281/zenodo.3766933},
    school = {University of California, Los Angeles}
 }
 @book{sheffield:2011,
    author = {J. Sheffield and D. Froula and S. H. Glenzer and N. C. {Luhmann, Jr.}},
-   title = {
-      {  Plasma Scattering of Electromagnetic Radiation: Theory and Measurement
-      Techniques  }
-   },
+   title = {{Plasma Scattering of Electromagnetic Radiation: Theory and Measurement Techniques}},
    year = 2011,
    publisher = {Academic Press},
    isbn = {978-0-12-374877-5},
@@ -313,15 +293,14 @@
    pages = {45--68},
    doi = {10.1016/b978-0-12-374877-5.00003-8},
    isbn = {978-0-12-374877-5},
-   url = {https://www.sciencedirect.com/science/article/pii/B9780123748775000038},
    editor = {D. H. Froula and S. H. Glenzer and N. C. Luhmann and J. Sheffield},
-   edition = {Second Edition}
+   edition = {2nd}
 }
 @article{spitzer:1953,
    author = {L. Spitzer and R. Härm},
    title = {{Transport phenomena in a Completely Ionized Gas}},
    year = 1953,
-   journal = {Phys. Rev.},
+   journal = {Physical Review},
    volume = 89,
    pages = {977–981},
    doi = {10.1103/PhysRev.89.977}
@@ -361,10 +340,9 @@
    journal = {Planetary and Space Science},
    volume = 43,
    number = 5,
-   pages = {625--634},
-   doi = {https://doi.org/10.1016/0032-0633(94)00197-Y},
+   pages = {625–634},
+   doi = {10.1016/0032-0633(94)00197-Y},
    issn = {0032-0633},
-   url = {https://www.sciencedirect.com/science/article/pii/003206339400197Y}
 }
 @article{verscharen:2019,
    author = {D. Verscharen and K. G. Klein and B. A. Maruca},
@@ -384,8 +362,7 @@
    volume = 20,
    number = 1,
    pages = {012111},
-   doi = {10.1063/1.4775777},
-   url = {https://doi.org/10.1063/1.4775777}
+   doi = {10.1063/1.4775777}
 }
 @article{william:1996,
    author = {R. L. Lysak and W. Lotko},
@@ -394,7 +371,7 @@
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 101,
    number = {A3},
-   pages = {5085--5094},
+   pages = {5085–5094},
    doi = {10.1029/95ja03712}
 }
 @article{wilson:2014,

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -1,30 +1,29 @@
 @article{alfven:1942,
    author = {H. Alfvén},
-   title = {{Existence of Electromagnetic-Hydrodynamic Waves}},
+   title = {Existence of Electromagnetic-Hydrodynamic Waves},
    year = 1942,
    journal = {Nature},
    volume = 150,
    number = 3805,
-   pages = {405–406},
-   doi = {10.1038/150405d0}
+   pages = {405–8/150405d0}
 }
 @book{baumjohann:1997,
    author = {W. Baumjohann and R. A. Treumann},
-   title = {{Basic Space Plasma Physics}},
+   title = {Basic Space Plasma Physics},
    year = 1997,
    publisher = {Imperial College Press},
    place = {London}
 }
 @book{bekefi:1966,
    author = {G. Bekefi},
-   title = {{Radiation Processes in Plasmas}},
+   title = {Radiation Processes in Plasmas},
    year = 1966,
    publisher = {Wiley},
    isbn = 9780471063506
 }
 @article{bellan:2012,
    author = {P. M. Bellan},
-   title = {{Improved basis set for low frequency plasma waves}},
+   title = {Improved basis set for low frequency plasma waves},
    year = 2012,
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 117,
@@ -33,7 +32,7 @@
 }
 @book{bernstein:2015,
    author = {D. S. Bernstein},
-   title = {{Beyond Legacy Code: Nine Practices to Extend the Life (and Value) of Your Software}},
+   title = {Beyond Legacy Code: Nine Practices to Extend the Life (and Value) of Your Software},
    year = 2015,
    publisher = {Pragmatic Bookshelf},
    isbn = 9781680500790,
@@ -42,28 +41,28 @@
 }
 @book{birdsall:2004,
    author = {C. K. Birdsall and A. B. Langdon},
-   title = {{Plasma Physics via Computer Simulation}},
+   title = {Plasma Physics via Computer Simulation},
    year = 2004,
    publisher = {{CRC} Press},
    doi = {10.1201/9781315275048}
 }
 @book{bohm:1949,
    author = {D. Bohm},
-   title = {{The Characteristics of Electrical Discharges in Magnetic Fields}},
+   title = {The Characteristics of Electrical Discharges in Magnetic Fields},
    year = 1949,
    publisher = {McGraw-Hill},
    editor = {A. Guthrie and R. K. Wakerling}
 }
 @book{bonitz:1998,
    author = {M. Bonitz},
-   title = {{Quantum Kinetic Theory}},
+   title = {Quantum Kinetic Theory},
    year = 1998,
    publisher = {Springer},
    doi = {10.1007/978-3-319-24121-0}
 }
 @inproceedings{boris:1970,
    author = {J. P. Boris},
-   title = {{Relativistic plasma simulation—Optimization of a hybrid code}},
+   title = {Relativistic plasma simulation — Optimization of a hybrid code},
    year = 1970,
    booktitle = {Proceedings of Fourth Conference on Numerical Simulation of Plasmas},
    publisher = {Naval Research Laboratory},
@@ -73,7 +72,7 @@
 }
 @article{braginskii:1965,
    author = {S. I. Braginskii},
-   title = {{Transport Processes in a Plasma}},
+   title = {Transport Processes in a Plasma},
    year = 1965,
    journal = {Reviews of Plasma Physics},
    volume = 1,
@@ -81,17 +80,17 @@
 }
 @article{buchsbaum:1960,
    author = {S. J. Buchsbaum},
-   title = {{Resonance in a Plasma with Two Ion Species}},
+   title = {Resonance in a Plasma with Two Ion Species},
    year = 1960,
    journal = {The Physics of Fluids},
    volume = 3,
    number = 3,
-   pages = {418--420},
+   pages = {418–420},
    doi = {10.1063/1.1706052},
 }
 @unpublished{callen:unpublished,
    author = {J. Callen},
-   title = {{Draft Material For "Fundamentals of Plasma Physics" Book}},
+   title = {Draft Material For "Fundamentals of Plasma Physics" Book},
    url = {
       https://docs.google.com/document/d/e/2PACX-1vQmvQ\%5Fb8p0P2cYsWGMQYVd92OBLX9Sm6XGiCMRBidoVSoJffj2MBvWiwpix46mqlq\%5FHQvHD5ofpfrNF/pub
    },
@@ -99,7 +98,7 @@
 }
 @book{chen:2016,
    author = {F. Chen},
-   title = {{Introduction to Plasma Physics and Controlled Fusion}},
+   title = {Introduction to Plasma Physics and Controlled Fusion},
    year = 2016,
    publisher = {Springer},
    doi = {10.1007/978-3-319-22309-4},
@@ -107,7 +106,7 @@
 }
 @article{epperlein:1986,
    author = {E. M. Epperlein and M. G. Haynes},
-   title = {{Plasma transport coefficients in a magnetic field by direct numerical solution of the Fokker–Planck equation}},
+   title = {Plasma transport coefficients in a magnetic field by direct numerical solution of the Fokker–Planck equation},
    year = 1986,
    journal = {Physics of Fluids},
    volume = 29,
@@ -116,14 +115,14 @@
 }
 @book{fried:1961,
    author = {B. D. Fried and S. D. Conte},
-   title = {{The Plasma Dispersion Function: The Hilbert Transformation of the Gaussian}},
+   title = {The Plasma Dispersion Function: The Hilbert Transformation of the Gaussian},
    year = 1961,
    publisher = {Academic Press},
    doi = {10.1016/c2013-0-12176-9}
 }
 @book{froula:2011,
    author = {D. H. Froula and S. H. Glenzer and N. C. Luhmann and J. Sheffield},
-   title = {{Plasma Scattering of Electromagnetic Radiation}},
+   title = {Plasma Scattering of Electromagnetic Radiation},
    year = 2011,
    publisher = {Academic Press},
    pages = 103142,
@@ -133,7 +132,7 @@
 }
 @techreport{fundamenski:2007,
    author = {W. Fundamenski and O. E. Garcia},
-   title = {{Comparison of Coulomb Collision Rates in the Plasma Physics and Magnetically Confined Fusion Literature}},
+   title = {Comparison of Coulomb Collision Rates in the Plasma Physics and Magnetically Confined Fusion Literature},
    year = 2007,
    number = {{EFDA–JET–R(07)01}},
    url = {
@@ -143,7 +142,7 @@
 }
 @article{gericke:2002,
    author = {D. O. Gericke and M. S. Murillo and M. Schlanges},
-   title = {{Dense plasma temperature equilibration in the binary collision approximation}},
+   title = {Dense plasma temperature equilibration in the binary collision approximation},
    year = 2002,
    journal = {Physical Review E},
    volume = 65,
@@ -153,14 +152,14 @@
 }
 @article{hasegawa:1982,
    author = {A. Hasegawa and C. Uberoi},
-   title = {{Alfven wave. DOE Critical Review Series}},
+   title = {Alfven wave. DOE Critical Review Series},
    year = 1982,
    journal = {U.S. Department of Energy Office of Scientific and Technical Information},
    doi = {10.2172/5259641}
 }
 @article{haynes:2007,
    author = {A. Haynes and C. Parnell},
-   title = {{A trilinear method for finding null points in a three-dimensional vector space}},
+   title = {A trilinear method for finding null points in a three-dimensional vector space},
    year = 2007,
    month = {08},
    journal = {Physics of Plasmas},
@@ -170,7 +169,7 @@
 }
 @article{hellinger:2011,
    author = {P. Hellinger and L. Matteini and Š. Štverák and P. M. Trávníček  and E. Marsch},
-   title = {{Heating and cooling of protons in the fast solar wind between 0.3 and 1 AU: Helios revisited}},
+   title = {Heating and cooling of protons in the fast solar wind between 0.3 and 1 AU: Helios revisited},
    year = 2011,
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 116,
@@ -179,17 +178,17 @@
 }
 @article{hirose:2004,
    author = {A. Hirose and A. Ito and S. M. Mahajan and S. Ohsaki},
-   title = {{Relation between Hall-magnetohydrodynamics and the kinetic Alfvén wave}},
+   title = {Relation between Hall-magnetohydrodynamics and the kinetic Alfvén wave},
    year = 2004,
    journal = {Physics Letters A},
    volume = 330,
    number = 6,
-   pages = {474--480},
+   pages = {474–480},
    doi = {10.1016/j.physleta.2004.08.021}
 }
 @article{hollweg:1999,
    author = {J. V. Hollweg},
-   title = {{Kinetic Alfvén wave revisited}},
+   title = {Kinetic Alfvén wave revisited},
    year = 1999,
    journal = {Journal of Geophysical Research},
    volume = 104,
@@ -198,7 +197,7 @@
 }
 @article{ji:2013,
    author = {J.-Y. Ji and E. D. Held},
-   title = {{Closure and transport theory for high-collisionality electron-ion plasmas}},
+   title = {Closure and transport theory for high-collisionality electron-ion plasmas},
    year = 2013,
    journal = {Physics of Plasmas},
    volume = 20,
@@ -207,7 +206,7 @@
 }
 @book{khorikov:2020,
    author = {V. Khorikov},
-   title = {{Unit Testing Principles, Practices, and Patterns}},
+   title = {Unit Testing Principles, Practices, and Patterns},
    year = 2020,
    publisher = {Manning Press},
    url = {https://www.manning.com/books/unit-testing},
@@ -218,7 +217,7 @@
       B. A. Maruca and S. D. Bale and L. Sorriso-Valvo and J. C. Kasper and M. L.
       Stevens
    },
-   title = {{Collisional Thermalization of Hydrogen and Helium in Solar-Wind Plasma}},
+   title = {Collisional Thermalization of Hydrogen and Helium in Solar-Wind Plasma},
    year = 2013,
    journal = {Physical Review Letters},
    publisher = {American Physical Society ({APS})},
@@ -228,22 +227,22 @@
 }
 @article{morales:1997,
    author = {G. J. Morales and J. E. Maggs},
-   title = {{Structure of kinetic Alfvén waves with small transverse scale length}},
+   title = {Structure of kinetic Alfvén waves with small transverse scale length},
    year = 1997,
    journal = {Physics of Plasmas},
    volume = 4,
-   pages = {4118--4125}
+   pages = {4118–4125}
 }
 @techreport{nrlformulary:2019,
    author = {A. S. Richardson},
-   title = {{NRL Plasma Formulary}},
+   title = {{NRL} Plasma Formulary},
    year = 2019,
    url = {https://www.nrl.navy.mil/News-Media/Publications/nrl-plasma-formulary},
    institution = {Naval Research Laboratory}
 }
 @book{osherove:2013,
    author = {R. Osherove},
-   title = {{The Art of Unit Testing: With Examples in .NET}},
+   title = {The Art of Unit Testing: With Examples in {.NET}},
    year = 2013,
    publisher = {Manning Press},
    isbn = 9781617290893,
@@ -252,24 +251,24 @@
 }
 @article{parnell:1996,
    author = {C. E. Parnell and J. M. Smith and T. Neukirch and E. R. Priest},
-   title = {{The structure of three-dimensional magnetic neutral points}},
+   title = {The structure of three-dimensional magnetic neutral points},
    year = 1996,
    journal = {Physics of Plasmas},
    volume = 3,
    number = 3,
-   pages = {759--770},
+   pages = {759–770},
    doi = {10.1063/1.871810}
 }
 @book{priest:2000,
    author = {E. R. Priest and T. Forbes},
-   title = {{Magnetic Reconnection: MHD Theory and Applications}},
+   title = {Magnetic Reconnection: {MHD} Theory and Applications},
    year = 2000,
    publisher = {Cambridge University Press},
    isbn = {978-0-521-03394-7}
 }
 @phdthesis{schaeffer:2014,
    author = {D. Schaeffer},
-   title = {{Generation of Quasi-Perpendicular Collisionless Shocks by a Laser-Driven Magnetic Piston}},
+   title = {Generation of Quasi-Perpendicular Collisionless Shocks by a Laser-Driven Magnetic Piston},
    year = 2014,
    month = dec,
    doi = {10.5281/zenodo.3766933},
@@ -277,7 +276,7 @@
 }
 @book{sheffield:2011,
    author = {J. Sheffield and D. Froula and S. H. Glenzer and N. C. {Luhmann, Jr.}},
-   title = {{Plasma Scattering of Electromagnetic Radiation: Theory and Measurement Techniques}},
+   title = {Plasma Scattering of Electromagnetic Radiation: Theory and Measurement Techniques},
    year = 2011,
    publisher = {Academic Press},
    isbn = {978-0-12-374877-5},
@@ -285,12 +284,12 @@
 }
 @incollection{sheffield:2011:ch3,
    author = {J. Sheffield and D. H. Froula and S. H. Glenzer and N. C. Luhmann},
-   title = {{Chapter 3 - Scattering Spectrum from a Plasma Theory}},
+   title = {Chapter 3 - Scattering Spectrum from a Plasma Theory},
    year = 2011,
-   booktitle = {{Plasma Scattering of Electromagnetic Radiation (Second Edition)}},
+   booktitle = {Plasma Scattering of Electromagnetic Radiation (Second Edition)},
    publisher = {Academic Press},
    address = {Boston},
-   pages = {45--68},
+   pages = {45–68},
    doi = {10.1016/b978-0-12-374877-5.00003-8},
    isbn = {978-0-12-374877-5},
    editor = {D. H. Froula and S. H. Glenzer and N. C. Luhmann and J. Sheffield},
@@ -298,7 +297,7 @@
 }
 @article{spitzer:1953,
    author = {L. Spitzer and R. Härm},
-   title = {{Transport phenomena in a Completely Ionized Gas}},
+   title = {Transport phenomena in a Completely Ionized Gas},
    year = 1953,
    journal = {Physical Review},
    volume = 89,
@@ -307,26 +306,24 @@
 }
 @book{spitzer:1962,
    author = {L. Spitzer},
-   title = {{Physics of Fully Ionized Gases}},
+   title = {Physics of Fully Ionized Gases},
    year = 1962,
    publisher = {Interscience},
    edition = {2nd}
 }
 @book{stix:1992,
    author = {T. H. Stix},
-   title = {{Waves in Plasmas}},
+   title = {Waves in Plasmas},
    year = 1992,
-   publisher = {AIP-Press},
+   publisher = {American Institute of Physics},
+   isbn = {978-0-88318-859-0},
    url = {https://link.springer.com/book/9780883188590}
 }
 @article{stringer:1963,
    author = {T. E. Stringer},
-   title = {{Low-frequency waves in an unbounded plasma}},
+   title = {Low-frequency waves in an unbounded plasma},
    year = 1963,
-   journal = {
-      Journal of Nuclear Energy. Part C, Plasma Physics, Accelerators, Thermonuclear
-      Research
-   },
+   journal = {Journal of Nuclear Energy. Part C, Plasma Physics, Accelerators, Thermonuclear Research},
    publisher = {{IOP} Publishing},
    volume = 5,
    number = 2,
@@ -335,7 +332,7 @@
 }
 @article{thompson:1995,
    author = {P. Thompson and M. K. Dougherty and D. J. Southwood},
-   title = {{Wave behaviour near critical frequencies in cold bi-ion plasmas}},
+   title = {Wave behaviour near critical frequencies in cold bi-ion plasmas},
    year = 1995,
    journal = {Planetary and Space Science},
    volume = 43,
@@ -346,7 +343,7 @@
 }
 @article{verscharen:2019,
    author = {D. Verscharen and K. G. Klein and B. A. Maruca},
-   title = {{The multi-scale nature of the solar wind}},
+   title = {The multi-scale nature of the solar wind},
    year = 2019,
    journal = {Living Reviews in Solar Physics},
    publisher = {Springer Science and Business Media (LLC)},
@@ -356,7 +353,7 @@
 }
 @article{vincena:2013,
    author = {S. T. Vincena and W. A. Farmer and J. E. Maggs and G. J. Morales},
-   title = {{Investigation of an ion-ion hybrid Alfvén wave resonator}},
+   title = {Investigation of an ion-ion hybrid Alfvén wave resonator},
    year = 2013,
    journal = {Physics of Plasmas},
    volume = 20,
@@ -366,7 +363,7 @@
 }
 @article{william:1996,
    author = {R. L. Lysak and W. Lotko},
-   title = {{On the kinetic dispersion relation for shear Alfvén waves}},
+   title = {On the kinetic dispersion relation for shear Alfvén waves},
    year = 1996,
    journal = {Journal of Geophysical Research: Space Physics},
    volume = 101,
@@ -380,7 +377,7 @@
       R. T. Guy and S. H. D. Haddock and K. D. Huff and I. M. Mitchell and M. D.
       Plumbley and B. Waugh and E. P. White and P. Wilson
    },
-   title = {{Best practices for scientific computing}},
+   title = {Best practices for scientific computing},
    year = 2014,
    journal = {PLoS Biology},
    volume = 12,
@@ -393,7 +390,7 @@
       G. Wilson and J. Bryan and K. Cranston and J. Kitzes and L. Nederbragt and T. K.
       Teal
    },
-   title = {{Good enough practices in scientific computing}},
+   title = {Good enough practices in scientific computing},
    year = 2017,
    journal = {PLOS Computational Biology},
    volume = 13,


### PR DESCRIPTION
Minor formatting updates to `docs/bibliography.bib` using [bibtex-tidy](https://flamingtempura.github.io/bibtex-tidy). 

I attempted to set up a pre-commit hook for `bibtex-tidy` but wasn't able to get it to work successfully.