### PR TITLE
Set labeler GitHub Action to not remove labels

### DIFF
--- a/.github/workflows/pr-lableler.yml
+++ b/.github/workflows/pr-lableler.yml
@@ -10,5 +10,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4
-      with:
-        sync-labels: true


### PR DESCRIPTION
This PR changes the labeler GitHub Action so that it doesn't remove labels that no longer meet the criteria. 

This setting had been causing a problem where it would remove the "No changelog entry needed" label that I had set manually because of a rule for adding that label.  I didn't see an option for turning off syncing for certain labels, unfortunately.