### PR TITLE
Remove deprecated flag pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,8 +92,6 @@ repos:
   - id: nbqa-black
     additional_dependencies:
     - black==23.3.0
-    args:
-    - --nbqa-mutate
   - id: nbqa-isort
     additional_dependencies:
     - isort==5.12.0


### PR DESCRIPTION
Just started getting a deprecation warning regarding the `--nbqa-mutate` flag for `nbqa-black`, so I'm removing that there.  The message said that the flag is now unnecessary so this shouldn't cause any issues.