### PR TITLE
Add GitHub Action for Sourcery

### DIFF
--- a/.github/workflows/sourcery.yml
+++ b/.github/workflows/sourcery.yml
@@ -12,7 +12,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.10'
 
     - uses: sourcery-ai/action@v1
       with:

--- a/.github/workflows/sourcery.yml
+++ b/.github/workflows/sourcery.yml
@@ -1,0 +1,20 @@
+name: Check PR using Sourcery
+
+on: pull_request
+
+jobs:
+  review-with-sourcery:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - uses: sourcery-ai/action@v1
+      with:
+        token: ${{ secrets.SOURCERY_TOKEN }}
+        diff_ref: ${{ github.event.pull_request.base.sha }}

--- a/changelog/2220.trivial.rst
+++ b/changelog/2220.trivial.rst
@@ -1,0 +1,1 @@
+Added a GitHub Action to perform checks using Sourcery.


### PR DESCRIPTION
This PR adds a [GitHub Action](https://github.com/sourcery-ai/action) using [Sourcery](https://docs.sourcery.ai), which is an automated refactoring tool that offers some really neat suggestions.  The GitHub Action *should* be set up to only check the code that was changed in a pull request compared to the `main` branch.

We shouldn't set this check as required until we have more experience with it.  For the time being, let's treat Sourcery as advisory and optional (like we do with codecov checks).  We may need to limit the Sourcery rules that get checked, or add `# noqa` comments to ignore certain Sourcery rules in certain locations.  

Occasionally, automated refactorings from Sourcery will remove comments, so sometimes human intervention will be needed.  This GitHub Action shouldn't automatically apply changes, so this shouldn't be a problem here, since the suggestions will need to be automatically applied.

With #2219, all automated changes by Sourcery have been applied except for mutable default arguments in `test_thomson.py` and a bunch of removed comments in `test_checks.py`.  This will probably change with future versions of Sourcery.  

With that said, there are still a bunch of issues that show up, mostly related to having conditionals and loops in tests (which is an antipattern that I only learned recently):

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
┃ Rule ID                  ┃ Count ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
│ no-conditionals-in-tests │   161 │
│ no-loop-in-tests         │    99 │
│ low-code-quality         │    16 │
│ raise-specific-error     │     3 │
│ merge-list-extend        │     2 │
│ default-mutable-arg      │     1 │
│ move-assign              │     1 │
├──────────────────────────┼───────┤
│ Total                    │   283 │
└──────────────────────────┴───────┘
```

I set my personal token Sourcery as a GitHub secret, but we may want to set something up specifically for PlasmaPy.  Sourcery now appears to be free for open source projects.