### PR TITLE
Fix path for literal backslash (Issue 2036)

### DIFF
--- a/docs/contributing/getting_ready.rst
+++ b/docs/contributing/getting_ready.rst
@@ -245,7 +245,7 @@ when you :py:`import plasmapy`.
 
    .. note::
 
-      In Windows, the directory path will be :file:`C:\Users\<username>\repos\PlasmaPy`.
+      In Windows, the directory path will be :file:`C:\\Users\\<username>\\repos\\PlasmaPy`.
 
 3. If you created a Conda_ environment for contributing to PlasmaPy,
    activate it with:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

<!-- Please summarize the changes here. -->

Fix contribute page directory path with literal backlashes for .rst (`C:\Users\<username>\repos\PlasmaPy`)


