### PR TITLE
Add ruff rule that prohibits implicit `typing.Optional`

### DIFF
--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -7,6 +7,7 @@ import pytest
 
 from astropy import units as u
 from functools import cached_property
+from typing import Optional
 from unittest import mock
 
 from plasmapy.utils.decorators.checks import CheckUnits, CheckValues
@@ -562,7 +563,12 @@ class TestValidateQuantities:
 
 class TestValidateClassAttributes:
     class SampleCase:  # noqa: D106
-        def __init__(self, x: int = None, y: int = None, z: int = None):
+        def __init__(
+            self,
+            x: Optional[int] = None,
+            y: Optional[int] = None,
+            z: Optional[int] = None,
+        ):
             self.x = x
             self.y = y
             self.z = z

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ extend-select = [
   "RUF009", # function-call-in-dataclass-default-argument
   "RUF010", # explicit-f-string-type-conversion
   "RUF011", # static-key-dict-comprehension
+  "RUF012", # mutable-class-default
   "RUF013", # implicit-optional
   "RUF200", # invalid-pyproject-toml
   "S", # flake8-bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,6 @@ extend-select = [
   "RUF009", # function-call-in-dataclass-default-argument
   "RUF010", # explicit-f-string-type-conversion
   "RUF011", # static-key-dict-comprehension
-  "RUF012", # mutable-class-default
   "RUF013", # implicit-optional
   "RUF200", # invalid-pyproject-toml
   "S", # flake8-bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ extend-select = [
   "RUF009", # function-call-in-dataclass-default-argument
   "RUF010", # explicit-f-string-type-conversion
   "RUF011", # static-key-dict-comprehension
+  "RUF013", # implicit-optional
   "RUF200", # invalid-pyproject-toml
   "S", # flake8-bandit
   "SIM", # flake8-simplify


### PR DESCRIPTION
A few years ago, a convention with type hints allowed us to skip using `typing.Optional` when the default value was `None`.  That convention is now not recommended.  This PR applies ruff rule `RUF012` which changes things like `f(x: int = None)` to `f(x: Optional[int] = None)`.

Feel free to merge if this looks good!