### PR TITLE
dependabot -> dependabot[bot]

### DIFF
--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -11,7 +11,7 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 PR_NUMBER = os.getenv("PR_NUMBER")
 REPO = os.getenv("GITHUB_REPOSITORY")
 
-EXCLUDED_USERS = ["dependabot", "pre-commit-ci[bot]", "sourcery-ai"]
+EXCLUDED_USERS = ["dependabot[bot]", "pre-commit-ci[bot]", "sourcery-ai"]
 
 
 def get_pr_authors() -> set[str]:


### PR DESCRIPTION
Author workflow in #2243 failed with:

> To ensure that you get credit for your contribution to PlasmaPy, please
add 'dependabot[bot]' as an author to CITATION.cff.

therefore I propose we change `dependabot` to `dependabot[bot]` in the workflow script