### PR TITLE
Update author check error message

### DIFF
--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -55,16 +55,19 @@ The entry should be of the form:
   affiliation: <affiliation>
   orcid: https://orcid.org/<ORCiD number>
   alias: {missing_github_username}
+  email: <email address>
 
 This file can be edited directly on GitHub at:
 
 https://github.com/{REPO}/edit/{branch_name}/CITATION.cff
 
-All fields are optional except "alias", which is the GitHub username.
-
 We encourage all contributors to sign up for an ORCID iD: a unique,
 persistent identifier used by researchers, authors, and open source
 contributors. Sign up at: https://orcid.org/register
+
+All fields are optional except "alias", which is the GitHub username.
+The "affiliation", "orcid", and/or "email" fields are sometimes needed
+for conference abstract or journal article submissions.
 
 Thank you for contributing!
 """

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -67,7 +67,7 @@ contributors. Sign up at: https://orcid.org/register
 
 All fields are optional except "alias", which is the GitHub username.
 The "affiliation", "orcid", and/or "email" fields are sometimes needed
-for conference abstract or journal article submissions.
+for conference abstract or journal article submissions about PlasmaPy.
 
 Thank you for contributing!
 """


### PR DESCRIPTION
This PR amends the author check error message with some contextual information about how some of the fields are needed for abstract submission. It also adds the `email` field to the example entry for `CITATION.cff`.