### PR TITLE
Improve error message for `Alfven_speed`

### DIFF
--- a/changelog/2262.trivial.rst
+++ b/changelog/2262.trivial.rst
@@ -1,0 +1,3 @@
+Improved the error message to `~plasmapy.formulary.speeds.Alfven_speed`
+when the argument provided to ``density`` has a physical type of
+number density and ``ion`` is not provided.

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -160,6 +160,11 @@ def Alfven_speed(
             "physical type of mass density."
         )
 
+    if density.unit.physical_type = u.physical.number_density and ion is None:
+        raise ValueError(
+            "When calculating the Alfvén speed, "
+        )
+
     if density.unit.physical_type == u.physical.mass_density:
         rho = density
     else:

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -163,7 +163,7 @@ def Alfven_speed(
     if density.unit.physical_type == u.physical.number_density and ion is None:
         raise ValueError(
             "When calculating the Alfvén speed, the ion must be specified "
-            "when the 'density' parameter is provided an argument with a "
+            "when the 'density' argument has a "
             "physical type of number density."
         )
 

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -163,8 +163,7 @@ def Alfven_speed(
     if density.unit.physical_type == u.physical.number_density and ion is None:
         raise ValueError(
             "When calculating the Alfvén speed, the ion must be specified "
-            "when the 'density' argument has a "
-            "physical type of number density."
+            "when 'density' has a physical type of number density."
         )
 
     if density.unit.physical_type == u.physical.mass_density:

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -160,9 +160,11 @@ def Alfven_speed(
             "physical type of mass density."
         )
 
-    if density.unit.physical_type = u.physical.number_density and ion is None:
+    if density.unit.physical_type == u.physical.number_density and ion is None:
         raise ValueError(
-            "When calculating the Alfvén speed, "
+            "When calculating the Alfvén speed, the ion must be specified "
+            "when the 'density' parameter is provided an argument with a "
+            "physical type of number density."
         )
 
     if density.unit.physical_type == u.physical.mass_density:

--- a/plasmapy/formulary/tests/test_speeds.py
+++ b/plasmapy/formulary/tests/test_speeds.py
@@ -53,6 +53,7 @@ class TestAlfvenSpeed:
             ((1 * u.T, 1.0e18 * u.m**-3), {"ion": ["He"]}, InvalidIonError),
             ((1 * u.T, 1.0e-9 * u.kg * u.m**-3), {"ion": ["He+"]}, ValueError),
             (("not a Bfield", 1.0e-10 * u.kg * u.m**-3), {}, TypeError),
+            ((1 * u.T,), {"density": 1e9 * u.m**-3}, ValueError),
             ((10 * u.T, "not a density"), {}, TypeError),
             ((10 * u.T, 5), {"ion": "p"}, TypeError),
             ((1 * u.T, 1.0e18 * u.m**-3), {"ion": "He", "Z": "nope"}, TypeError),

--- a/plasmapy/formulary/tests/test_speeds.py
+++ b/plasmapy/formulary/tests/test_speeds.py
@@ -53,7 +53,7 @@ class TestAlfvenSpeed:
             ((1 * u.T, 1.0e18 * u.m**-3), {"ion": ["He"]}, InvalidIonError),
             ((1 * u.T, 1.0e-9 * u.kg * u.m**-3), {"ion": ["He+"]}, ValueError),
             (("not a Bfield", 1.0e-10 * u.kg * u.m**-3), {}, TypeError),
-            ((1 * u.T,), {"density": 1e9 * u.m**-3}, ValueError),
+            ((1 * u.T,), {"density": 1e9 * u.m**-3, "ion": None}, ValueError),
             ((10 * u.T, "not a density"), {}, TypeError),
             ((10 * u.T, 5), {"ion": "p"}, TypeError),
             ((1 * u.T, 1.0e18 * u.m**-3), {"ion": "He", "Z": "nope"}, TypeError),


### PR DESCRIPTION
This PR improves the error message for `Alfven_speed` when `density` is a number density and `ion` is not provided. Previously, there was an error message about being able to do an operation with a `NoneType` object.

Thank you to @ejohnson-96 for bringing this up!

<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

<!-- Please summarize the changes here. -->



## Motivation and context

<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->



## Related issues

<!-- Please link to any related issues and PRs. If this PR will fully resolve and issue, include text like "Closes #1542" so that the issue will be automatically closed when this PR is merged. -->
