### PR TITLE
Apply `ruff` rule RUF100 to remove unused `noqa` directives

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ from sphinx.application import Sphinx
 
 cff_to_rst.main()
 
-from plasmapy import __version__ as release  # noqa: E402
+from plasmapy import __version__ as release
 
 # -- General configuration ------------------------------------------------
 autosummary_generate = True

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
 # This is the same check as the one at the top of setup.py
 import sys
 
-if sys.version_info < (3, 9):  # coverage: ignore # noqa: UP036
+if sys.version_info < (3, 9):  # coverage: ignore
     raise ImportError(
         f"This version of PlasmaPy does not support Python {sys.version.split()[0]}."
         "Please upgrade to a newer version."

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -627,7 +627,7 @@ def _bilinear_root(a1, b1, c1, d1, a2, b2, c2, d2):  # noqa: C901, PLR0911, PLR0
             return np.array([(x1, y1), (x2, y2)])
 
 
-def _trilinear_analysis(vspace, cell):  # noqa: C901, PLR0911, PLR0912, PLR0915
+def _trilinear_analysis(vspace, cell):  # noqa: C901, PLR0915
     r"""
     Return a true or false value based on whether a grid cell which has
     passed the reduction step, contains a null point, using trilinear
@@ -1261,7 +1261,7 @@ def _locate_null_point(vspace, cell, n, err):
         )
         return is_x_in_bound and is_y_in_bound and is_z_in_bound
 
-    starting_pos = []  # noqa: FURB138
+    starting_pos = []
     # Adding the Corners
     starting_pos = [
         [
@@ -1326,7 +1326,7 @@ def _locate_null_point(vspace, cell, n, err):
     return None
 
 
-def _classify_null_point(vspace, cell, loc):  # noqa: PLR0912
+def _classify_null_point(vspace, cell, loc):
     r"""
     Return the coordinates of a null point within a given grid cell in a
     vector space using the Newton-Rapshon method.
@@ -1393,11 +1393,11 @@ def _classify_null_point(vspace, cell, loc):  # noqa: PLR0912
                 if np.isclose(determinant, 0, atol=_EQUALITY_ATOL)
                 else "Improper radial null"
             )
-        elif np.isclose(determinant, 0, atol=_EQUALITY_ATOL):  # noqa: PLR5501
+        elif np.isclose(determinant, 0, atol=_EQUALITY_ATOL):
             null_point_type = "Continuous X-points"
         else:
             null_point_type = "Skewed improper null"
-    elif np.isclose(determinant, 0, atol=_EQUALITY_ATOL):  # noqa: PLR5501
+    elif np.isclose(determinant, 0, atol=_EQUALITY_ATOL):
         null_point_type = "Continuous concentric ellipses"
     else:
         null_point_type = "Spiral null"

--- a/plasmapy/analysis/swept_langmuir/floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/floating_potential.py
@@ -264,7 +264,7 @@ def find_floating_potential(  # noqa: C901, PLR0912, PLR0915
         isl_stop = np.concatenate(
             (cp_candidates[threshold_indices] + 1, [cp_candidates[-1] + 1])
         )
-        rtn_extras["islands"] = [  # noqa: FURB140
+        rtn_extras["islands"] = [
             slice(start, stop) for start, stop in zip(isl_start, isl_stop)
         ]
 

--- a/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -1137,7 +1137,7 @@ class Tracker:
             disable=not self.verbose,
             desc="Particles on grid",
             unit="particles",
-            bar_format="{l_bar}{bar}{n:.1e}/{total:.1e} {unit}",  # noqa: FS003
+            bar_format="{l_bar}{bar}{n:.1e}/{total:.1e} {unit}",
             file=sys.stdout,
         )
 

--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -217,7 +217,7 @@ class Test__Characteristic_inherited_methods:
     bias_4length_arr = np.array(np.random.rand(N - 1)) * u.V  # noqa: NPY002
     current_5length_arr = np.array(np.random.rand(N)) * u.A  # noqa: NPY002
 
-    bias_duplicates_arr = np.array((1, 2) * int(N / 2)) * u.V  # noqa: NPY002
+    bias_duplicates_arr = np.array((1, 2) * int(N / 2)) * u.V
 
     def test_invalid_bias_dimensions(self):
         r"""Test error on non-1D bias array"""

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -472,7 +472,7 @@ def spectral_density(  # noqa: C901, PLR0912, PLR0915
 
     try:
         if sum(ion.charge_number <= 0 for ion in ions):
-            raise ValueError("All ions must be positively charged.")  # noqa: TC301
+            raise ValueError("All ions must be positively charged.")
     # Catch error if charge information is missing
     except ChargeError as ex:
         raise ValueError("All ions must be positively charged.") from ex
@@ -828,7 +828,7 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
 
     try:
         if sum(ion.charge_number <= 0 for ion in ions):
-            raise ValueError("All ions must be positively charged.")  # noqa: TC301
+            raise ValueError("All ions must be positively charged.")
     # Catch error if charge information is missing
     except ChargeError as ex:
         raise ValueError("All ions must be positively charged.") from ex

--- a/plasmapy/dispersion/analytical/tests/test_two_fluid_.py
+++ b/plasmapy/dispersion/analytical/tests/test_two_fluid_.py
@@ -173,7 +173,7 @@ class TestTwoFluid:
         assert isinstance(ws, dict)
         assert len({"acoustic_mode", "alfven_mode", "fast_mode"} - set(ws.keys())) == 0
 
-        for val in ws.values():  # noqa: B007
+        for val in ws.values():
             assert isinstance(val, u.Quantity)
             assert val.unit == u.rad / u.s
             assert val.shape == expected["shape"]

--- a/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/plasmapy/dispersion/analytical/two_fluid_.py
@@ -26,7 +26,7 @@ from plasmapy.utils.exceptions import PhysicsWarning
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def two_fluid(  # noqa: C901, PLR0912, PLR0915
+def two_fluid(
     B: u.T,
     ion: ParticleLike,
     k: u.rad / u.m,

--- a/plasmapy/dispersion/numerical/kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/kinetic_alfven_.py
@@ -28,7 +28,7 @@ c_si_unitless = c.value
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def kinetic_alfven(  # noqa: C901, PLR0912, PLR0915
+def kinetic_alfven(  # noqa: C901, PLR0912
     B: u.T,
     ion: ParticleLike,
     k: u.rad / u.m,

--- a/plasmapy/dispersion/numerical/tests/test_hollweg_.py
+++ b/plasmapy/dispersion/numerical/tests/test_hollweg_.py
@@ -367,7 +367,7 @@ class TestHollweg:
         assert isinstance(ws, dict)
         assert len({"acoustic_mode", "alfven_mode", "fast_mode"} - set(ws.keys())) == 0
 
-        for val in ws.values():  # noqa: B007
+        for val in ws.values():
             assert isinstance(val, u.Quantity)
             assert val.unit == u.rad / u.s
             assert val.shape == expected["shape"]

--- a/plasmapy/dispersion/numerical/tests/test_kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/tests/test_kinetic_alfven_.py
@@ -95,7 +95,7 @@ class TestKinetic_Alfven:
 
         assert isinstance(ws, dict)
 
-        for val in ws.values():  # noqa: B007
+        for val in ws.values():
             assert isinstance(val, u.Quantity)
             assert val.unit == u.rad / u.s
             assert val.shape == expected["shape"]

--- a/plasmapy/formulary/collisions/helio/collisional_analysis.py
+++ b/plasmapy/formulary/collisions/helio/collisional_analysis.py
@@ -16,7 +16,7 @@ from plasmapy.utils.decorators import validate_quantities
     T_1={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_2={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def temp_ratio(  # noqa: C901, PLR0912, PLR0915
+def temp_ratio(  # noqa: C901
     *,
     r_0: u.au,
     r_n: u.au,

--- a/plasmapy/formulary/collisions/lengths.py
+++ b/plasmapy/formulary/collisions/lengths.py
@@ -286,7 +286,7 @@ def impact_parameter(  # noqa: C901
         ionRadius = Wigner_Seitz_radius(n_i)
         bmax = (lambdaDe**2 + ionRadius**2) ** (1 / 2)
         bmin = (lambdaBroglie**2 + bPerp**2) ** (1 / 2)
-    elif method in ("ls_clamp_mininterp", "GMS-3"):  # noqa: SIM114
+    elif method in ("ls_clamp_mininterp", "GMS-3"):
         # 3rd method listed in Table 1 of reference [1]
         # same as GMS-1, but not Lambda has a clamp at Lambda_min = 2
         # where Lambda is the argument to the Coulomb logarithm.

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -466,12 +466,10 @@ class IonizationState:
 
         try:
             if np.min(fractions) < 0:
-                raise ParticleError(  # noqa: TC301
-                    "Cannot have negative ionic fractions."
-                )
+                raise ParticleError("Cannot have negative ionic fractions.")
 
             if len(fractions) != self.atomic_number + 1:
-                raise ParticleError(  # noqa: TC301
+                raise ParticleError(
                     "The length of ionic_fractions must be "
                     f"{self.atomic_number + 1}."
                 )

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -212,9 +212,7 @@ class IonizationStateCollection:
                 )
 
             if not isinstance(int_charge, Integral):
-                raise TypeError(  # noqa: TC301
-                    f"{int_charge} is not a valid charge for {particle}."
-                )
+                raise TypeError(f"{int_charge} is not a valid charge for {particle}.")
             elif not 0 <= int_charge <= atomic_number(particle):
                 raise ChargeError(f"{int_charge} is not a valid charge for {particle}.")
 
@@ -296,7 +294,7 @@ class IonizationStateCollection:
                         f"defined."
                     )
 
-        try:  # noqa: TC101
+        try:
             new_fractions = np.array(value, dtype=float)
         except TypeError as exc:
             raise TypeError(

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -219,7 +219,7 @@ def nuclear_reaction_energy(*args, **kwargs) -> u.J:  # noqa: C901, PLR0915
                     raise ParticleError(errmsg) from exc
 
                 if particle.element and not particle.isotope:
-                    raise ParticleError(errmsg)  # noqa: TC301
+                    raise ParticleError(errmsg)
 
                 particles += [particle] * multiplier
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1919,9 +1919,7 @@ class DimensionlessParticle(AbstractParticle):
         elif isinstance(obj, bool):
             raise TypeError("Expecting a real number, not a bool.")
         elif isinstance(obj, u.Quantity) and not isinstance(obj.value, Real):
-            raise ValueError(  # noqa: TRY004
-                "The value of a Quantity must be a real number."
-            )
+            raise ValueError("The value of a Quantity must be a real number.")
 
         try:
             new_obj = np.float64(obj)

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -556,7 +556,7 @@ def test_Particle_class(arg, kwargs, expected_dict):
                 errmsg += f"\n{call}.{key} raises an unexpected exception."
 
     if errmsg:
-        raise Exception(f"Problems with {call}:{errmsg}")  # noqa: BLE001, TRY002
+        raise Exception(f"Problems with {call}:{errmsg}")  # noqa: TRY002
 
 
 equivalent_particles_table = [

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -82,7 +82,7 @@ class HDF5Reader(GenericPlasma):
             if _valid_version(openPMD_version):
                 return True
             else:
-                raise DataStandardError(  # noqa: TC301
+                raise DataStandardError(
                     f"We currently only support HDF5 versions"
                     f"starting from v{_OUTDATED_VERSION} and "
                     f"lower than v{_NEWER_VERSION}. You can "

--- a/plasmapy/plasma/sources/tests/test_plasmablob.py
+++ b/plasmapy/plasma/sources/tests/test_plasmablob.py
@@ -291,7 +291,7 @@ class Test_PlasmaBlobRegimes:
 
 class Test_PlasmaBlob:
     @classmethod
-    def setup_class(cls):  # noqa: N804
+    def setup_class(cls):
         """Initializing parameters for tests"""
         cls.T_e = 5 * 11e3 * u.K
         cls.n_e = 1e23 * u.cm**-3

--- a/plasmapy/utils/calculator/widget_helpers.py
+++ b/plasmapy/utils/calculator/widget_helpers.py
@@ -267,7 +267,7 @@ class _FloatBox(_GenericWidget):
         self.min = min
         self.max = max
 
-    def create_widget(self, style=None):  # noqa: B006
+    def create_widget(self, style=None):
         """
         Implements create_widget. description_width is set to initial
         to make the widget as wide as possible.
@@ -338,7 +338,7 @@ class _ParticleBox(_GenericWidget):
         `bool`
             `True` if the value is empty, `False` otherwise
         """
-        return value is None or value == ""  # noqa: PLC1901
+        return value is None or value == ""
 
     def edge_case(self, value):  # noqa: ARG002
         """
@@ -370,7 +370,7 @@ class _ParticleBox(_GenericWidget):
         self.widget.layout.border = ""
         self.widget.description = ""
 
-    def create_widget(self, style=None):  # noqa: B006
+    def create_widget(self, style=None):
         """
         Implements create_widget. description_width is set to initial
         to make the widget as wide as possible.

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -641,7 +641,7 @@ class CheckUnits(CheckBase):
                     msg += f"argument {param.name} "
                 msg += f"of function {self.f.__name__}()."
                 raise ValueError(msg)
-            elif _units is None:  # noqa: RET507
+            elif _units is None:
                 _units = _units_anno
                 _units_are_from_anno = True
                 _units_anno = None
@@ -959,7 +959,7 @@ class CheckUnits(CheckBase):
         return allowed_units
 
     @staticmethod
-    def _normalize_equivalencies(equivalencies):  # noqa: D400
+    def _normalize_equivalencies(equivalencies):
         """
         Normalize equivalencies to ensure each is in a 4-tuple of the
         form `(from_unit, to_unit, forward_func, backward_func)`.

--- a/plasmapy/utils/decorators/tests/test_checks.py
+++ b/plasmapy/utils/decorators/tests/test_checks.py
@@ -63,7 +63,7 @@ class TestCheckUnits:
     check_defaults = CheckUnits._CheckUnits__check_defaults  # type: Dict[str, Any]
 
     @staticmethod
-    def foo_no_anno(x, y):  # noqa: FURB118
+    def foo_no_anno(x, y):
         return x + y
 
     @staticmethod
@@ -723,7 +723,7 @@ class TestCheckValues:
     check_defaults = CheckValues._CheckValues__check_defaults  # type: Dict[str, bool]
 
     @staticmethod
-    def foo(x, y):  # noqa: FURB118
+    def foo(x, y):
         return x + y
 
     @staticmethod

--- a/plasmapy/utils/decorators/tests/test_helpers.py
+++ b/plasmapy/utils/decorators/tests/test_helpers.py
@@ -114,7 +114,7 @@ class TestModifyDocstring:
 # --------------------------------------------------------------------------------------
 def test_preserve_signature():
     # create function to mock
-    def foo(x: float, y: float) -> float:  # noqa: FURB118
+    def foo(x: float, y: float) -> float:
         return x + y
 
     mock_foo = mock.Mock(side_effect=foo, name="mock_foo", autospec=True)

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -260,7 +260,7 @@ class ValidateQuantities(CheckUnits, CheckValues):
                     _none_shall_pass is False
                     and validations[arg_name]["none_shall_pass"] is True
                 ):
-                    raise ValueError(  # noqa: TC301
+                    raise ValueError(
                         f"Validation 'none_shall_pass' for argument '{arg_name}' is "
                         f"inconsistent between function annotations "
                         f"({validations[arg_name]['none_shall_pass']}) and decorator "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,7 @@ extend-select = [
   "RUF010", # explicit-f-string-type-conversion
   "RUF011", # static-key-dict-comprehension
   "RUF013", # implicit-optional
+  "RUF100", # unused-qa
   "RUF200", # invalid-pyproject-toml
   "S", # flake8-bandit
   "SIM", # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ extend-select = [
   "RUF010", # explicit-f-string-type-conversion
   "RUF011", # static-key-dict-comprehension
   "RUF013", # implicit-optional
-  "RUF100", # unused-qa
+  "RUF100", # unused-noqa
   "RUF200", # invalid-pyproject-toml
   "S", # flake8-bandit
   "SIM", # flake8-simplify


### PR DESCRIPTION
This PR adds a `ruff` rule that goes through code and removes the `# noqa` comments that are no longer needed.  There are no actual substantive changes.