### PR TITLE
Add `CONTRIBUTING.md` and link it to Contributor Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contributing to PlasmaPy
 
-Thank you your interest in contributing to PlasmaPy! ✨ The future of the project depends on contributors like you, so we deeply appreciate it! 🌱
+Thank you your interest in contributing to PlasmaPy! ✨ The future of the project depends on contributions from the community, so we deeply appreciate it! 🌱
 
-For more information on how to contribute, please check out our [**contributor guide**](https://docs.plasmapy.org/en/latest/contributing/index.html), which has information on 
+For more information on how to contribute, please check out our [**contributor guide**](https://docs.plasmapy.org/en/latest/contributing/index.html), which has information on:
 
  - [Getting ready to contribute](https://docs.plasmapy.org/en/latest/contributing/getting_ready.html#getting-ready-to-contribute)
- - [Code contribution workflow](https://docs.plasmapy.org/en/latest/contributing/workflow.html#code-contribution-workflow)
+ - The [code contribution workflow](https://docs.plasmapy.org/en/latest/contributing/workflow.html#code-contribution-workflow)
  - Using [`astropy.units`](https://docs.plasmapy.org/en/latest/notebooks/getting_started/units.html#Using-Astropy-Units) and [`plasmapy.particles`](https://docs.plasmapy.org/en/latest/notebooks/getting_started/particles.html#Using-PlasmaPy-Particles)
  - [Coding tips and guidelines](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html#coding-guide)
- - [Writing documentation](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#writing-documentation) (in [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#restructuredtext-primer) with [numpydoc style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)).
- - [Writing tests](https://docs.plasmapy.org/en/latest/contributing/testing_guide.html#testing-guide) using [pytest](https://docs.pytest.org)
+ - [Writing and building documentation](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#writing-documentation)
+ - [Writing and running tests](https://docs.plasmapy.org/en/latest/contributing/testing_guide.html#testing-guide)
  - [Adding a changelog entry](https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry) (needed except for minor changes)
 
 You can also find us in our [**chat room**](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html) or weekly [**community meeting**](https://www.plasmapy.org/meetings/weekly) & [**office hours**](https://www.plasmapy.org/meetings/office_hours).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,6 @@ For more information on how to contribute, please check out our [**contributor g
  - [Writing and running tests](https://docs.plasmapy.org/en/latest/contributing/testing_guide.html#testing-guide)
  - [Adding a changelog entry](https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry) (needed except for minor changes)
 
-You can also find us in our [**chat room**](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html) or weekly [**community meeting**](https://www.plasmapy.org/meetings/weekly) & [**office hours**](https://www.plasmapy.org/meetings/office_hours).
+You can also find us in our [**chat room**](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html) or weekly [**community meetings**](https://www.plasmapy.org/meetings/weekly) & [**office hours**](https://www.plasmapy.org/meetings/office_hours).
 
 We thank you once again!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,17 @@
-[Contributor Covenant Code of Conduct]: https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md
-[Contributor Guide]: https://docs.plasmapy.org/en/latest/contributing/
-
 # Contributing to PlasmaPy
 
-Thank you for your interest in contributing to PlasmaPy!  Please check
-out our [Contributor Guide] for more details on how to contribute.
+Thank you your interest in contributing to PlasmaPy! ✨ The future of the project depends on contributors like you, so we deeply appreciate it! 🌱
 
-PlasmaPy abides by the [Contributor Covenant Code of Conduct].
+For more information on how to contribute, please check out our [**contributor guide**](https://docs.plasmapy.org/en/latest/contributing/index.html), which has information on 
+
+ - [Getting ready to contribute](https://docs.plasmapy.org/en/latest/contributing/getting_ready.html#getting-ready-to-contribute)
+ - [Code contribution workflow](https://docs.plasmapy.org/en/latest/contributing/workflow.html#code-contribution-workflow)
+ - Using [`astropy.units`](https://docs.plasmapy.org/en/latest/notebooks/getting_started/units.html#Using-Astropy-Units) and [`plasmapy.particles`](https://docs.plasmapy.org/en/latest/notebooks/getting_started/particles.html#Using-PlasmaPy-Particles)
+ - [Coding tips and guidelines](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html#coding-guide)
+ - [Writing documentation](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#writing-documentation) (in [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#restructuredtext-primer) with [numpydoc style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)).
+ - [Writing tests](https://docs.plasmapy.org/en/latest/contributing/testing_guide.html#testing-guide) using [pytest](https://docs.pytest.org)
+ - [Adding a changelog entry](https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry) (needed except for minor changes)
+
+You can find us in our [**chat room**](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html) or weekly [**community meeting**](https://www.plasmapy.org/meetings/weekly) & [**office hours**](https://www.plasmapy.org/meetings/office_hours). Here are some tips:
+
+We thank you once again!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+[Contributor Covenant Code of Conduct]: https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md
+[Contributor Guide]: https://docs.plasmapy.org/en/latest/contributing/
+
+# Contributing to PlasmaPy
+
+Thank you for your interest in contributing to PlasmaPy!  Please check
+out our [Contributor Guide] for more details on how to contribute.
+
+PlasmaPy abides by the [Contributor Covenant Code of Conduct].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,6 @@ For more information on how to contribute, please check out our [**contributor g
  - [Writing tests](https://docs.plasmapy.org/en/latest/contributing/testing_guide.html#testing-guide) using [pytest](https://docs.pytest.org)
  - [Adding a changelog entry](https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry) (needed except for minor changes)
 
-You can find us in our [**chat room**](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html) or weekly [**community meeting**](https://www.plasmapy.org/meetings/weekly) & [**office hours**](https://www.plasmapy.org/meetings/office_hours). Here are some tips:
+You can also find us in our [**chat room**](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html) or weekly [**community meeting**](https://www.plasmapy.org/meetings/weekly) & [**office hours**](https://www.plasmapy.org/meetings/office_hours).
 
 We thank you once again!

--- a/changelog/2266.doc.rst
+++ b/changelog/2266.doc.rst
@@ -1,0 +1,3 @@
+Added :file:`CONTRIBUTING.md` to PlasmaPy's GitHub repository.  This
+page refers contributors to PlasmaPy's [contributor guide] and code of
+conduct.

--- a/changelog/2266.doc.rst
+++ b/changelog/2266.doc.rst
@@ -1,3 +1,2 @@
 Added :file:`CONTRIBUTING.md` to PlasmaPy's GitHub repository.  This
-page refers contributors to PlasmaPy's [contributor guide] and code of
-conduct.
+page refers contributors to PlasmaPy's |contributor guide|.


### PR DESCRIPTION
## Description

This PR adds `CONTRIBUTING.md` and adds high-level information about how to contribute to PlasmaPy.  Because of the risk of duplicating content, this page should:

 - Include high-level content that is unlikely to change over time;
 - Refer contributors to the relevant sections of the Contributor Guide, Code of Conduct, and other resources (in the `latest` version of the documentation).

## Motivation and context

One of the requirements for pyOpenSci peer review is to have a `CONTRIBUTING.md`.  We previously did not have it because we referred contributors to our Contributor Guide instead.

## Related issues

https://github.com/PlasmaPy/plasmapy-project/issues/11