### PR TITLE
fix typo in test for ExcessStatistics class

### DIFF
--- a/plasmapy/analysis/time_series/tests/test_excess_statistics.py
+++ b/plasmapy/analysis/time_series/tests/test_excess_statistics.py
@@ -76,7 +76,7 @@ from plasmapy.analysis.time_series.excess_statistics import ExcessStatistics
     ],
 )
 def test_ExcessStatistics(signal, thresholds, time_step, pdf, bins, expected):
-    """Test excess_stat function"""
+    """Test ExcessStatistics class"""
     excess_stats = ExcessStatistics(signal, thresholds, time_step)
     assert excess_stats.total_time_above_threshold == expected[0]
     assert excess_stats.number_of_crossings == expected[1]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

While working on the next PR for the time_series sub-module I discovered that I didn't update the docstring of a test for the ExcessStatistics class. Originally I implemented the code as a function and forgot to update the docstring when I turned it into a class.



## Motivation and context

<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->



## Related issues

None
