### PR TITLE
Add Sphinx extension for measuring durations in doc builds

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -95,7 +95,7 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade tox
 
     - name: Build docs
-      run: tox -e build_docs_pins -- -q
+      run: tox -e build_docs_pins
 
   import-plasmapy:
     name: Importing PlasmaPy

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -95,7 +95,7 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade tox
 
     - name: Build docs
-      run: tox -e build_docs_pins
+      run: tox -e build_docs_pins -- -q
 
   import-plasmapy:
     name: Importing PlasmaPy

--- a/changelog/2268.doc.rst
+++ b/changelog/2268.doc.rst
@@ -1,0 +1,2 @@
+Enabled a Sphinx_ extension that adds links to the source code of an
+object.

--- a/changelog/2268.doc.rst
+++ b/changelog/2268.doc.rst
@@ -1,2 +1,2 @@
-Enabled a Sphinx_ extension that adds links to the source code of an
+Enabled the ``sphinx.ext.duration`` extension to add links to the source code of an
 object.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,7 @@ extensions = [
     "notfound.extension",
     "plasmapy_sphinx",
     "sphinx.ext.autodoc",
+    "sphinx.ext.duration",
     "sphinx.ext.extlinks",
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",


### PR DESCRIPTION
This PR adds [`sphinx.ext.duration`](https://www.sphinx-doc.org/en/master/usage/extensions/duration.html) as a Sphinx extension to provide output on the durations for creating documentation. It could help us figure out where the performance bottlenecks are.  

I'm not sure if it'll be helpful to add this, or just use it when figuring out how to improve performance of doc builds.