### PR TITLE
Enable Sphinx extension for adding links to source code pages

### DIFF
--- a/changelog/2269.doc.rst
+++ b/changelog/2269.doc.rst
@@ -1,0 +1,1 @@
+Enabled a Sphinx extension for adding links to source code pages.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
     "sphinx_changelog",
     "sphinx_codeautolink",
     "sphinx_copybutton",

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -951,6 +951,7 @@ extensions:
 * `sphinx.ext.mathjax` for math rendering with MathJax_.
 * `sphinx.ext.napoleon` for allowing NumPy style docstrings.
 * `sphinx.ext.todo` to support ``todo`` |directives|.
+* `sphinx.ext.viewcode` to generate links to pages showing source code.
 * |nbsphinx|_ for including Jupyter_ notebooks.
 * |sphinxcontrib-bibtex|_ to enable usage of a BibTeX_ file to create
   the :doc:`../bibliography`.


### PR DESCRIPTION
This PR enables [`sphinx.ext.viewcode`](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) which adds links to highlighted source code.  