### PR TITLE
Move substitutions from `common_links.rst` to `doc_guide.rst`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -95,7 +95,7 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade tox
 
     - name: Build docs
-      run: tox -e build_docs_pins -- -q
+      run: tox -e build_docs_pins
 
   import-plasmapy:
     name: Importing PlasmaPy

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -95,7 +95,7 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade tox
 
     - name: Build docs
-      run: tox -e build_docs_pins
+      run: tox -e build_docs_pins -- -q
 
   import-plasmapy:
     name: Importing PlasmaPy

--- a/changelog/2272.doc.rst
+++ b/changelog/2272.doc.rst
@@ -1,2 +1,3 @@
-Moved reST_ substitutions from :file:`docs/common_links.rst` to the file
-the substitutions are used in.
+Moved definitions of reST_ substitutions from :file:`docs/common_links.rst`
+to the file :file:`docs/contributing/doc_guide.rst` in order to speed up the
+documentation build (see :issue:`2277`\ ).

--- a/changelog/2272.doc.rst
+++ b/changelog/2272.doc.rst
@@ -1,0 +1,2 @@
+Moved reST_ substitutions from :file:`docs/common_links.rst` the file
+the substitutions are used in.

--- a/changelog/2272.doc.rst
+++ b/changelog/2272.doc.rst
@@ -1,2 +1,2 @@
-Moved reST_ substitutions from :file:`docs/common_links.rst` the file
+Moved reST_ substitutions from :file:`docs/common_links.rst` to the file
 the substitutions are used in.

--- a/docs/changelog/0.7.0.rst
+++ b/docs/changelog/0.7.0.rst
@@ -235,7 +235,7 @@ Improved Documentation
 - Updated the |documentation guide| to include a description on how to
   add and cite references to PlasmaPy's global bibliography BibTeX_ file,
   :file:`docs/bibliography.bib`. (`#1263 <https://github.com/plasmapy/plasmapy/pull/1263>`__)
-- Added sphinxcontrib-bibtex_ as a Sphinx_ extension to enable references
+- Added ``sphinxcontrib-bibtex`` as a Sphinx_ extension to enable references
   to be stored in a BibTeX_ file. (`#1263 <https://github.com/plasmapy/plasmapy/pull/1263>`__)
 - Began a documentation-wide |bibliography| page. (`#1263 <https://github.com/plasmapy/plasmapy/pull/1263>`__)
 - Updated the |documentation guide| to describe where formulae should go in

--- a/docs/changelog/0.8.1.rst
+++ b/docs/changelog/0.8.1.rst
@@ -406,7 +406,7 @@ Improved Documentation
 - Updated the cold magnetized plasma dielectric permittivity tensor
   notebook. (`#1396
   <https://github.com/plasmapy/plasmapy/pull/1396>`__)
-- Configured the Sphinx_ extension `sphinx-hoverxref`. (`#1437
+- Configured the Sphinx_ extension ``sphinx-hoverxref``. (`#1437
   <https://github.com/plasmapy/plasmapy/pull/1437>`__)
 - Removed the following files from :file:`docs/api_static`\ :
   ``plasmapy.particles.elements.rst``,
@@ -443,13 +443,13 @@ Improved Documentation
 - Described the GitHub Action for `codespell
   <https://github.com/codespell-project/codespell>`__ in the |testing
   guide|. (`#1530 <https://github.com/plasmapy/plasmapy/pull/1530>`__)
-- Added the |sphinx-issues|_ extension to Sphinx_ to simplify linking
+- Added the ``sphinx-issues`` extension to Sphinx_ to simplify linking
   to GitHub issues, pull requests, users, and commits. (`#1532
   <https://github.com/plasmapy/plasmapy/pull/1532>`__)
 - Added the `sphinx.ext.extlinks` extension to Sphinx_ to simplify
   adding links to external domains which have a common base
   URL. (`#1532 <https://github.com/plasmapy/plasmapy/pull/1532>`__)
-- Added the |sphinx-notfound-page|_ extension to Sphinx_ so that the
+- Added the ``sphinx-notfound-page`` extension to Sphinx_ so that the
   documentation now has a :wikipedia:`404 <HTTP_404>` page in the same
   style as the rest of the documentation. (`#1532
   <https://github.com/plasmapy/plasmapy/pull/1532>`__)
@@ -487,7 +487,7 @@ Improved Documentation
   set up redirects from the original hyperlinks to the new ones for
   the contributor guide. (`#1605
   <https://github.com/plasmapy/plasmapy/pull/1605>`__)
-- Added |sphinx-reredirects|_ as a Sphinx_ extension to allow website
+- Added ``sphinx-reredirects`` as a Sphinx_ extension to allow website
   redirects. (`#1605
   <https://github.com/plasmapy/plasmapy/pull/1605>`__)
 - Added a :file:`robots.txt` file to the online documentation to tell

--- a/docs/changelog/0.9.0.rst
+++ b/docs/changelog/0.9.0.rst
@@ -228,7 +228,7 @@ Trivial/Internal Changes
 - Applied automated refactorings from `Sourcery
   <https://sourcery.ai/>`__. (:pr:`1714`)
 - Changed the minimum version of towncrier_ to 22.8.0 and the minimum
-  version of |sphinx_changelog|_ to 1.2.0. (:pr:`1717`)
+  version of ``sphinx_changelog`` to 1.2.0. (:pr:`1717`)
 - Changed `~plasmapy.formulary.quantum.chemical_potential` to use the
   :wikipedia:`Broyden-Fletcher-Goldfarb-Shanno algorithm` to implicitly
   solve for the ideal chemical potential. (:pr:`1726`)

--- a/docs/changelog/2023.5.0.rst
+++ b/docs/changelog/2023.5.0.rst
@@ -179,9 +179,9 @@ Improved Documentation
 - Updated the code contribution workflow instructions in the |contributor
   guide|
   to reflect that first-time contributors should add themselves to the author
-  list in |CITATION.cff|_ instead of in |docs/about/credits.rst|_. (:pr:`2155`)
+  list in |CITATION.cff|_ instead of in ``docs/about/credits.rst``. (:pr:`2155`)
 - Added functionality to automatically generate the author list included
-  in |docs/about/credits.rst|_ directly from |CITATION.cff|_. The script
+  in ``docs/about/credits.rst`` directly from |CITATION.cff|_. The script
   is located at :file:`docs/cff_to_rst.py`. (:pr:`2156`)
 
 

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -223,6 +223,9 @@
 .. _`astropy.units`: https://docs.astropy.org/en/stable/units/index.html
 .. |astropy.units| replace:: `astropy.units`
 
+.. _`CITATION.cff`: https://github.com/PlasmaPy/PlasmaPy/blob/main/CITATION.cff
+.. |CITATION.cff| replace:: :file:`CITATION.cff`
+
 .. _git: https://git-scm.com
 .. |git| replace:: `git`
 
@@ -234,6 +237,9 @@
 
 .. _mpmath: https://mpmath.org/doc/current/
 .. |mpmath| replace:: `mpmath`
+
+.. _nbsphinx: https://nbsphinx.readthedocs.io
+.. |nbsphinx| replace:: `nbsphinx`
 
 .. _numba: https://numba.readthedocs.io
 .. |numba| replace:: `numba`

--- a/docs/common_links.rst
+++ b/docs/common_links.rst
@@ -223,50 +223,17 @@
 .. _`astropy.units`: https://docs.astropy.org/en/stable/units/index.html
 .. |astropy.units| replace:: `astropy.units`
 
-.. _`CITATION.cff`: https://github.com/PlasmaPy/PlasmaPy/blob/main/CITATION.cff
-.. |CITATION.cff| replace:: :file:`CITATION.cff`
-
-.. _`docs/_static/`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/_static
-.. |docs/_static/| replace:: :file:`docs/_static/`
-
-.. _`docs/_static/css/`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/_static/css
-.. |docs/_static/css/| replace:: :file:`docs/_static/css/`
-
-.. _`docs/about/credits.rst`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/about/credits.rst
-.. |docs/about/credits.rst| replace:: :file:`docs/about/credits.rst`
-
-.. _`docs/api_static/`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/api_static
-.. |docs/api_static/| replace:: :file:`docs/api_static/`
-
-.. _`docs/conf.py`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/conf.py
-.. |docs/conf.py| replace:: :file:`docs/conf.py`
-
-.. _`docs/glossary.rst`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/glossary.rst
-.. |docs/glossary.rst| replace:: :file:`docs/glossary.rst`
-
-.. _`docs/common_links.rst`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/common_links.rst
-.. |docs/common_links.rst| replace:: :file:`docs/common_links.rst`
-
-.. _`docs/bibliography.bib`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/bibliography.bib
-.. |docs/bibliography.bib| replace:: :file:`docs/bibliography.bib`
-
 .. _git: https://git-scm.com
 .. |git| replace:: `git`
 
 .. _h5py: https://www.h5py.org/
 .. |h5py| replace:: `h5py`
 
-.. _`IPython.sphinxext.ipython_console_highlighting`: https://ipython.readthedocs.io/en/stable/sphinxext.html?highlight=IPython.sphinxext.ipython_console_highlighting#ipython-sphinx-directive-module
-.. |IPython.sphinxext.ipython_console_highlighting| replace:: `IPython.sphinxext.ipython_console_highlighting`
-
 .. _lmfit: https://lmfit.github.io/lmfit-py/
 .. |lmfit| replace:: `lmfit`
 
 .. _mpmath: https://mpmath.org/doc/current/
 .. |mpmath| replace:: `mpmath`
-
-.. _nbsphinx: https://nbsphinx.readthedocs.io
-.. |nbsphinx| replace:: `nbsphinx`
 
 .. _numba: https://numba.readthedocs.io
 .. |numba| replace:: `numba`
@@ -279,33 +246,6 @@
 
 .. _`pyproject.toml`: https://github.com/PlasmaPy/PlasmaPy/blob/main/pyproject.toml
 .. |pyproject.toml| replace:: :file:`pyproject.toml`
-
-.. _`sphinxcontrib-bibtex`: https://sphinxcontrib-bibtex.readthedocs.io
-.. |sphinxcontrib-bibtex| replace:: `sphinxcontrib-bibtex`
-
-.. _`sphinx_copybutton`: https://sphinx-copybutton.readthedocs.io
-.. |sphinx_copybutton| replace:: `sphinx_copybutton`
-
-.. _`sphinx_gallery.load_style`: https://sphinx-gallery.github.io/stable/advanced.html?highlight=load_style#using-only-sphinx-gallery-styles
-.. |sphinx_gallery.load_style| replace:: `sphinx_gallery.load_style`
-
-.. _`sphinx_changelog`: https://sphinx-changelog.readthedocs.io
-.. |sphinx_changelog| replace:: `sphinx_changelog`
-
-.. _`sphinx-reredirects`: https://documatt.gitlab.io/sphinx-reredirects
-.. |sphinx-reredirects| replace:: `sphinx-reredirects`
-
-.. _`sphinx-hoverxref`: https://sphinx-hoverxref.readthedocs.io
-.. |sphinx-hoverxref| replace:: `sphinx-hoverxref`
-
-.. _`sphinx-issues`: https://github.com/sloria/sphinx-issues
-.. |sphinx-issues| replace:: `sphinx-issues`
-
-.. _`sphinx-notfound-page`: https://sphinx-notfound-page.readthedocs.io
-.. |sphinx-notfound-page| replace:: `sphinx-notfound-page`
-
-.. _`sphinx-tabs`: https://sphinx-tabs.readthedocs.io/
-.. |sphinx-tabs| replace:: `sphinx-tabs`
 
 .. _`tox.ini`: https://github.com/PlasmaPy/PlasmaPy/blob/main/tox.ini
 .. |tox.ini| replace:: :file:`tox.ini`

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -1432,9 +1432,6 @@ version of the package that can be revisited later.
    nitpick_ignore_regex in docs/conf.py so that it doesn't get counted
    as an error in a nitpicky doc build (e.g., tox -e doc_build_nitpicky).
 
-.. _`CITATION.cff`: https://github.com/PlasmaPy/PlasmaPy/blob/main/CITATION.cff
-.. |CITATION.cff| replace:: :file:`CITATION.cff`
-
 .. _`docs/_static/`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/_static
 .. |docs/_static/| replace:: :file:`docs/_static/`
 
@@ -1461,9 +1458,6 @@ version of the package that can be revisited later.
 
 .. _`IPython.sphinxext.ipython_console_highlighting`: https://ipython.readthedocs.io/en/stable/sphinxext.html?highlight=IPython.sphinxext.ipython_console_highlighting#ipython-sphinx-directive-module
 .. |IPython.sphinxext.ipython_console_highlighting| replace:: `IPython.sphinxext.ipython_console_highlighting`
-
-.. _nbsphinx: https://nbsphinx.readthedocs.io
-.. |nbsphinx| replace:: `nbsphinx`
 
 .. _`sphinxcontrib-bibtex`: https://sphinxcontrib-bibtex.readthedocs.io
 .. |sphinxcontrib-bibtex| replace:: `sphinxcontrib-bibtex`

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -1417,3 +1417,77 @@ version of the package that can be revisited later.
 .. _Sphinx's templating page: https://www.sphinx-doc.org/en/master/templating.html
 .. _style overrides: https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html
 .. _warns: https://numpydoc.readthedocs.io/en/latest/format.html#warns
+
+.. ----------------------
+.. Nested inline literals
+.. ----------------------
+
+.. A workaround for nested inline literals so that the filename will get
+   formatted like a file but will be a link. In the text, these get used
+   with the syntax for a substitution followed by an underscore to
+   indicate that it's for a link: |docs/_static|_
+
+.. For these workarounds, if the replacement is something in single back
+   ticks (e.g., `xarray`), then it should also be added to
+   nitpick_ignore_regex in docs/conf.py so that it doesn't get counted
+   as an error in a nitpicky doc build (e.g., tox -e doc_build_nitpicky).
+
+.. _`CITATION.cff`: https://github.com/PlasmaPy/PlasmaPy/blob/main/CITATION.cff
+.. |CITATION.cff| replace:: :file:`CITATION.cff`
+
+.. _`docs/_static/`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/_static
+.. |docs/_static/| replace:: :file:`docs/_static/`
+
+.. _`docs/_static/css/`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/_static/css
+.. |docs/_static/css/| replace:: :file:`docs/_static/css/`
+
+.. _`docs/about/credits.rst`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/about/credits.rst
+.. |docs/about/credits.rst| replace:: :file:`docs/about/credits.rst`
+
+.. _`docs/api_static/`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/api_static
+.. |docs/api_static/| replace:: :file:`docs/api_static/`
+
+.. _`docs/conf.py`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/conf.py
+.. |docs/conf.py| replace:: :file:`docs/conf.py`
+
+.. _`docs/glossary.rst`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/glossary.rst
+.. |docs/glossary.rst| replace:: :file:`docs/glossary.rst`
+
+.. _`docs/common_links.rst`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/common_links.rst
+.. |docs/common_links.rst| replace:: :file:`docs/common_links.rst`
+
+.. _`docs/bibliography.bib`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/bibliography.bib
+.. |docs/bibliography.bib| replace:: :file:`docs/bibliography.bib`
+
+.. _`IPython.sphinxext.ipython_console_highlighting`: https://ipython.readthedocs.io/en/stable/sphinxext.html?highlight=IPython.sphinxext.ipython_console_highlighting#ipython-sphinx-directive-module
+.. |IPython.sphinxext.ipython_console_highlighting| replace:: `IPython.sphinxext.ipython_console_highlighting`
+
+.. _nbsphinx: https://nbsphinx.readthedocs.io
+.. |nbsphinx| replace:: `nbsphinx`
+
+.. _`sphinxcontrib-bibtex`: https://sphinxcontrib-bibtex.readthedocs.io
+.. |sphinxcontrib-bibtex| replace:: `sphinxcontrib-bibtex`
+
+.. _`sphinx_copybutton`: https://sphinx-copybutton.readthedocs.io
+.. |sphinx_copybutton| replace:: `sphinx_copybutton`
+
+.. _`sphinx_gallery.load_style`: https://sphinx-gallery.github.io/stable/advanced.html?highlight=load_style#using-only-sphinx-gallery-styles
+.. |sphinx_gallery.load_style| replace:: `sphinx_gallery.load_style`
+
+.. _`sphinx_changelog`: https://sphinx-changelog.readthedocs.io
+.. |sphinx_changelog| replace:: `sphinx_changelog`
+
+.. _`sphinx-reredirects`: https://documatt.gitlab.io/sphinx-reredirects
+.. |sphinx-reredirects| replace:: `sphinx-reredirects`
+
+.. _`sphinx-hoverxref`: https://sphinx-hoverxref.readthedocs.io
+.. |sphinx-hoverxref| replace:: `sphinx-hoverxref`
+
+.. _`sphinx-issues`: https://github.com/sloria/sphinx-issues
+.. |sphinx-issues| replace:: `sphinx-issues`
+
+.. _`sphinx-notfound-page`: https://sphinx-notfound-page.readthedocs.io
+.. |sphinx-notfound-page| replace:: `sphinx-notfound-page`
+
+.. _`sphinx-tabs`: https://sphinx-tabs.readthedocs.io/
+.. |sphinx-tabs| replace:: `sphinx-tabs`


### PR DESCRIPTION
We use `docs/common_links.rst` as a place to define links and substitutions across the documentation.  Essentially the content in `common_links.rst` gets added to the epilogue of each `.rst` file and docstring.  This has the potential to slow down documentation builds.

This PR is an attempt to consolidate some of the shortcuts into the documentation guide, since that's the main place that they get used.  

Unfortunately we don't have a good or consistent way to benchmark documentation builds yet, so I don't know for sure that it'll speed things up noticeably.  At the very least, it'll keep these definitions in a place that's closer to where they get used.

