### PR TITLE
Set default concatenation option for sphinx-codeautolink

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,6 +116,9 @@ bibtex_default_style = "plain"
 bibtex_reference_style = "author_year"
 bibtex_cite_id = "{key}"
 
+
+codeautolink_concat_default = True
+
 # Intersphinx generates automatic links to the documentation of objects
 # in other packages. When mappings are removed or added, please update
 # the section in docs/doc_guide.rst on references to other packages.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,6 +116,7 @@ bibtex_default_style = "plain"
 bibtex_reference_style = "author_year"
 bibtex_cite_id = "{key}"
 
+# Configure sphinx-codeautolink
 
 codeautolink_concat_default = True
 


### PR DESCRIPTION
We use sphinx-codeautolink (added in #1410) to create links within code blocks to code objects that were imported and have documentation pages.  This PR sets [`codeautolink_concat_default`](https://sphinx-codeautolink.readthedocs.io/en/latest/reference.html#confval-codeautolink_concat_default) such that it is not required that the import statement be in the same code block, but rather can be in a previous one.