### PR TITLE
Remove labeler configuration for adding "No changelog entry needed"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,9 +41,6 @@ linters:
 - .sourcery.yaml
 - .pre-commit-config.yaml
 
-'No changelog entry needed':
-- any: ['.pre-commit-config.yaml', '.github/**/*.*', '.codecov.yml', '.editorconfig', '.gitignore', 'CODEOWNERS', 'requirements.txt']
-
 notebooks:
 - docs/notebooks/**/*
 


### PR DESCRIPTION
I don't think this setting has been working correctly, so I'm removing it. 