### PR TITLE
Fix and expand pre-commit-search-and-replace configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     # be put in quotes. However, the pretty-format-yaml hook will
     # remove the quotes which will break that action, so we should not
     # run this hook on `labeler.yml`.
-    exclude: .github/labeler.yml|.pre-commit-search-and-replace.yaml|docs/common_links.rst
+    exclude: .github/labeler.yml|.pre-commit-search-and-replace.yaml
 
 - repo: https://github.com/pre-commit/mirrors-csslint
   rev: v1.0.5
@@ -46,7 +46,7 @@ repos:
   rev: v1.0.5
   hooks:
   - id: search-and-replace
-    exclude: changelog/.*|docs/changelog/.*|.sourcery.yaml
+    exclude: changelog/.*|docs/changelog/.*|.sourcery.yaml|docs/common_links.rst
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     # be put in quotes. However, the pretty-format-yaml hook will
     # remove the quotes which will break that action, so we should not
     # run this hook on `labeler.yml`.
-    exclude: .github/labeler.yml
+    exclude: .github/labeler.yml|.pre-commit-search-and-replace.yaml|docs/common_links.rst
 
 - repo: https://github.com/pre-commit/mirrors-csslint
   rev: v1.0.5
@@ -46,7 +46,7 @@ repos:
   rev: v1.0.5
   hooks:
   - id: search-and-replace
-    exclude: changelog/.*|docs/changelog/.*
+    exclude: changelog/.*|docs/changelog/.*|.sourcery.yaml
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     # For the labeler GitHub Action, labels with spaces in them must
     # be put in quotes. However, the pretty-format-yaml hook will
     # remove the quotes which will break that action, so we should not
-    # run this hook on certain files.
+    # run this hook on `labeler.yml` (or certain other files).
     exclude: .github/labeler.yml|.pre-commit-search-and-replace.yaml
 
 - repo: https://github.com/pre-commit/mirrors-csslint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     # For the labeler GitHub Action, labels with spaces in them must
     # be put in quotes. However, the pretty-format-yaml hook will
     # remove the quotes which will break that action, so we should not
-    # run this hook on `labeler.yml`.
+    # run this hook on certain files.
     exclude: .github/labeler.yml|.pre-commit-search-and-replace.yaml
 
 - repo: https://github.com/pre-commit/mirrors-csslint

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,6 +1,20 @@
+- search: Plasmapy
+  replacement: /PlasmaPy|PlasmaPY/PlasmPy|Plasmpy|Palsmapy|PlasmaPY/
+  description: Fix common misspellings and use consistent capitalization for PlasmaPy
+
+- search: /plasmpy|plaspmy|plasapy|palsmapy/
+  replacement: plasmapy
+  description: Fix common misspellings of plasmapy
+
 - search: from astropy import units as u
   replacement: import astropy.units as u
+
 - search: from astropy import constants as const
   replacement: import astropy.constants as const
-- search: Plasmapy|PlasmPy|Plasmpy|Palsmapy
-  replacement: PlasmaPy
+
+- search: '|array-like|'
+  replacement: '|array_like|'
+  description: NumPy uses an underscore in array_like
+
+- search: ':term:`particle-like`'
+  replacement: '|particle-like|'

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,3 +1,7 @@
+# Include regular expressions between slashes. The "|" means "or".
+# If there are special characters in one of the fields, put it in single
+# quotes.
+
 - search: /Plasmapy|PlasmaPY/PlasmPy|Plasmpy|Palsmapy|PlasmaPY/
   replacement: PlasmaPy
   description: Fix common misspellings and use consistent capitalization for PlasmaPy
@@ -14,7 +18,12 @@
 
 - search: '|array-like|'
   replacement: '|array_like|'
-  description: NumPy uses an underscore in array_like
+  description: NumPy uses an underscore in 'array_like'
 
 - search: ':term:`particle-like`'
   replacement: '|particle-like|'
+  description: Apply reStructuredText substitution
+
+- search: ':term:`array_like`'
+  replacement: '|array_like|'
+  description: Apply reStructuredText substitution

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,5 +1,5 @@
-- search: Plasmapy
-  replacement: /PlasmaPy|PlasmaPY/PlasmPy|Plasmpy|Palsmapy|PlasmaPY/
+- search: /Plasmapy|PlasmaPY/PlasmPy|Plasmpy|Palsmapy|PlasmaPY/
+  replacement: PlasmaPy
   description: Fix common misspellings and use consistent capitalization for PlasmaPy
 
 - search: /plasmpy|plaspmy|plasapy|palsmapy/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -615,7 +615,7 @@ Trivial/Internal Changes
 - Added ``tryceratops`` as a flake8_ extension. (:pr:`1782`)
 
 
-Plasmapy 0.8.1 (2022-07-05)
+PlasmaPy 0.8.1 (2022-07-05)
 ===========================
 
 Backwards Incompatible Changes
@@ -812,7 +812,7 @@ Bug Fixes
   `~plasmapy.formulary.collisions.frequencies.collision_frequency`. (`#1546 <https://github.com/plasmapy/plasmapy/pull/1546>`__)
 - Updated the regular expression matching used by
   `~plasmapy.particles.particle_class.Particle` to parse and identify a
-  :term:`particle-like` string.  This fixes the bug where a string with
+  |particle-like| string.  This fixes the bug where a string with
   a trailing space (e.g. ``"Ar "``) was converted into a negatively charged
   ion (e.g. ``"Ar -1"``). (`#1555 <https://github.com/plasmapy/plasmapy/pull/1555>`__)
 - Exposed `plasmapy.formulary.radiation` and functions therein to the
@@ -1071,7 +1071,7 @@ Trivial/Internal Changes
   version ``0.8.1`` release. (`#1606 <https://github.com/plasmapy/plasmapy/pull/1606>`__)
 
 
-Plasmapy v0.7.0 (2021-11-18)
+PlasmaPy v0.7.0 (2021-11-18)
 ============================
 
 Backwards Incompatible Changes
@@ -1108,7 +1108,7 @@ Backwards Incompatible Changes
 - Changed |ParticleList| so that if it is provided with no arguments, then it creates
   an empty |ParticleList|.  This behavior is analogous to how `list` and `tuple` work. (`#1223 <https://github.com/plasmapy/plasmapy/pull/1223>`__)
 - Changed the behavior of |Particle| in equality comparisons. Comparing a
-  |Particle| with an object that is not :term:`particle-like` will now
+  |Particle| with an object that is not |particle-like| will now
   return `False` instead of raising a `TypeError`. (`#1225 <https://github.com/plasmapy/plasmapy/pull/1225>`__)
 - Changed the behavior of `~plasmapy.particles.particle_class.CustomParticle`
   so that it returns `False` when compared for equality with another type.
@@ -1372,7 +1372,7 @@ Trivial/Internal Changes
   with matplotlib 3.5.0. (`#1334 <https://github.com/plasmapy/plasmapy/pull/1334>`__)
 
 
-Plasmapy v0.6.0 (2021-03-14)
+PlasmaPy v0.6.0 (2021-03-14)
 ============================
 
 Backwards Incompatible Changes
@@ -1578,7 +1578,7 @@ Trivial/Internal Changes
 - Properly handled warnings in `test_proton_radiography.py` (`#1050 <https://github.com/plasmapy/plasmapy/pull/1050>`__)
 
 
-Plasmapy v0.5.0 (2020-12-09)
+PlasmaPy v0.5.0 (2020-12-09)
 ============================
 
 Backwards Incompatible Changes
@@ -1655,7 +1655,7 @@ Trivial/Internal Changes
   easier for contributors. Moved away from Travis CI for test cron jobs. (`#952 <https://github.com/plasmapy/plasmapy/pull/952>`__)
 
 
-Plasmapy v0.4.0 (2020-07-20)
+PlasmaPy v0.4.0 (2020-07-20)
 ============================
 
 Backwards Incompatible Changes
@@ -1780,7 +1780,7 @@ Trivial/Internal Changes
   `mass` and `charge` can accept string representations of astropy `Quantities`. (`#862 <https://github.com/plasmapy/plasmapy/pull/862>`__)
 
 
-Plasmapy v0.3.0 (2020-01-25)
+PlasmaPy v0.3.0 (2020-01-25)
 ============================
 
 Backwards Incompatible Changes

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -718,7 +718,7 @@ Particles
 ---------
 
 The |Particle| class provides an object-oriented interface for accessing
-basic particle data. |Particle| accepts :term:`particle-like` inputs.
+basic particle data. |Particle| accepts |particle-like| inputs.
 
 .. code-block:: pycon
 

--- a/plasmapy/dispersion/analytical/stix_.py
+++ b/plasmapy/dispersion/analytical/stix_.py
@@ -44,8 +44,8 @@ def stix(  # noqa: C901, PLR0912, PLR0915
         Wavefrequency in units convertible to rad/s.  Either singled
         valued or 1-D array of length :math:`N`.
 
-    ions: a single or `list` of :term:`particle-like` object(s)
-        A list or single instance of :term:`particle-like` objects
+    ions: a single or `list` of |particle-like| object(s)
+        A list or single instance of |particle-like| objects
         representing the ion species (e.g., ``"p"`` for protons,
         ``"D+"`` for deuterium, ``["H+", "He+"]`` for hydrogen and
         helium, etc.).  All ions must be positively charged.


### PR DESCRIPTION
I had set up one of the patterns to replace incorrectly, so this PR fixes that.

I'm also adding a few more to automagically change to use some substitutions.

I had to exclude `.pre-commit-search-and-replace.yaml` from the yaml autoformatter in pre-commit because it kept removing quotes.