### PR TITLE
Update author information and improve functionality that generates the author list for the docs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -175,6 +175,8 @@ authors:
 
 - given-names: Thomas
   family-names: Fan
+  affiliation: Quansight Labs
+  alias: thomasjpfan
 
 - given-names: Samaiyah I.
   family-names: Farid

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -212,6 +212,7 @@ authors:
 
 - given-names: Silvina
   family-names: Guidoni
+  orcid: https://orcid.org/0000-0003-1439-4218
   affiliation: American University
 
 - given-names: Colby
@@ -254,11 +255,11 @@ authors:
   orcid: https://orcid.org/0000-0002-4227-2544
   alias: NabilHumphrey
 
-- alias: itsraasshi
-
 - given-names: Maria
   family-names: Isupova
   alias: misupova
+
+- alias: itsraashi
 
 - given-names: Alexis
   family-names: Jeandet

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -106,6 +106,7 @@ authors:
 - given-names: Khalil
   family-names: Bryant
   affiliation: University of Michigan
+  orcid: https://orcid.org/0000-0002-2105-0280
   alias: KhalilBryant
 
 - given-names: Sean
@@ -188,6 +189,7 @@ authors:
 
 - given-names: Bryan
   family-names: Foo
+  orcid: https://orcid.org/0000-0001-5308-6870
   alias: bryancfoo
 
 - given-names: Rajagopalan
@@ -247,6 +249,7 @@ authors:
 
 - given-names: Nabil
   family-names: Humphrey
+  orcid: https://orcid.org/0000-0002-4227-2544
   alias: NabilHumphrey
 
 - alias: itsraasshi
@@ -264,6 +267,7 @@ authors:
 - given-names: Elliot
   family-names: Johnson
   affiliation: University of Delaware
+  orcid: https://orcid.org/0000-0003-2892-6924
   alias: ejohnson-96
 
 - given-names: Marcin

--- a/changelog/2307.doc.rst
+++ b/changelog/2307.doc.rst
@@ -1,3 +1,4 @@
-Refactored and improved the functionality in :file:`docs/cff_to_rst.py`
-that converts author information contained in :file:`CITATION.cff` into
-a |reStructuredText| author list.
+Renamed :file:`docs/cff_to_rst.py` to :file:`docs/_cff_to_rst.py`, and
+updated the functionality contained within that file for converting
+author information in :file:`CITATION.cff` into a |reStructuredText|
+author list to be included in the documentation.

--- a/changelog/2307.doc.rst
+++ b/changelog/2307.doc.rst
@@ -1,0 +1,3 @@
+Refactored and improved the functionality in :file:`docs/cff_to_rst.py`
+that converts author information contained in :file:`CITATION.cff` into
+a |reStructuredText| author list.

--- a/changelog/2307.trivial.rst
+++ b/changelog/2307.trivial.rst
@@ -1,0 +1,1 @@
+Updated and corrected author information in :file:`CITATION.cff`.

--- a/docs/_cff_to_rst.py
+++ b/docs/_cff_to_rst.py
@@ -198,6 +198,6 @@ if __name__ == "__main__":
 
     .. code-block: bash
 
-        python cff_to_rst.py
+        python _cff_to_rst.py
     """
     main(verbose=True)

--- a/docs/cff_to_rst.py
+++ b/docs/cff_to_rst.py
@@ -6,6 +6,14 @@ import pathlib
 import yaml
 
 from typing import Union
+from unidecode import unidecode
+
+# If a contributor changed their contributor name and we don't know
+# the new name to update in in CITATION.cff, add their old username to
+# the following set to prevent generating a broken link that would get
+# detected when doing a `make linkcheck`.
+
+obsolete_github_usernames = {}
 
 
 def parse_cff(filename: str) -> dict[str, Union[str, list[dict[str, str]]]]:
@@ -21,27 +29,20 @@ def parse_cff(filename: str) -> dict[str, Union[str, list[dict[str, str]]]]:
     -------
     `dict`
         A dictionary containing the parsed data from :file:`CITATION.cff`.
-
-    Raises
-    ------
-    `yaml.YAMLError`
-        If :file:`CITATION.cff` cannot be parsed.
     """
     with pathlib.Path(filename).open() as stream:
-        try:
-            return yaml.safe_load(stream)
-        except yaml.YAMLError as e:
-            print(e)  # noqa: T201
+        return yaml.safe_load(stream)
 
 
-def sorting_key(author: dict[str, str]) -> str:
+def author_sorting_key(author: dict[str, str]) -> str:
     """
     Provide sorting key for an author.
 
     Parameters
     ----------
-    author : `dict`
-        A dictionary containing author information.
+    author : `dict` of `str` to `str`
+        A dictionary containing author information, which should be an
+        item in the list returned by `parse_cff`.
 
     Returns
     -------
@@ -49,13 +50,103 @@ def sorting_key(author: dict[str, str]) -> str:
         The key for sorting authors.
     """
     if "family-names" in author:
-        return author["family-names"]
+        key = author["family-names"].lower()
     elif "given-names" in author:
-        return author["given-names"]
+        key = author["given-names"].lower()
     elif "alias" in author:
-        return author["alias"]
+        key = author["alias"].lower()
     else:
-        return ""
+        msg = (
+            "Need to specify 'family-names', 'given-names', and/or "
+            f"'alias' in CITATION.cff for author: {author}"
+        )
+        raise RuntimeError(msg)
+
+    return unidecode(key)
+
+
+def get_author_name(author: dict[str, str]) -> str:
+    """
+    Return the full name of the author if available, and otherwise
+    return the author's alias.
+
+    Parameters
+    ----------
+    author : `dict` of `str` to `str`
+        A dictionary containing author information, which should be an
+        item in the list returned by `parse_cff`.
+
+    Returns
+    -------
+    str
+        The author name (if available) or the author alias.
+    """
+
+    given_names = author.get("given-names", "")
+    family_names = author.get("family-names", "")
+    alias = author.get("alias", "")
+
+    if given_names or family_names:
+        return f"{given_names} {family_names}".strip()
+
+    if alias:
+        return alias
+
+    msg = (
+        "Invalid author information. Need at least one of "
+        "'alias', 'family-names', or 'given-names' in "
+        "CITATION.cff. Author information: {author}"
+    )
+
+    raise RuntimeError(msg)
+
+
+def begin_author_line(author: dict[str, str]) -> str:
+    """
+    Return the beginning of the author line, using the ``:user:`` role
+    if the alias is available.
+
+    Parameters
+    ----------
+    author : `dict` of `str` to `str`
+        A dictionary containing author information, which should be an
+        item in the list returned by `parse_cff`.
+
+    Returns
+    -------
+    str
+        The beginning of the author line.
+    """
+    name = get_author_name(author)
+    alias = author.get("alias", None)
+
+    if not alias or alias in obsolete_github_usernames:
+        return f"- {name}"
+
+    if alias == name:
+        return f"- :user:`{alias}`"
+
+    return f"- :user:`{name} <{alias}>`"
+
+
+def get_orcid(author: dict[str, str]) -> str:
+    """
+    Return the string that returns a string containing ORCID information
+    using the ``:orcid:`` role.
+
+    Parameters
+    ----------
+    author : `dict` of `str` to `str`
+        A dictionary containing author information, which should be an
+        item in the list returned by `parse_cff`.
+
+    Returns
+    -------
+    str
+        The ORCID information using the ``:orcid:`` role.
+    """
+    orcid = author.get("orcid", "").removeprefix("https://orcid.org/")
+    return f" (:orcid:`{orcid}`)" if orcid else ""
 
 
 def generate_rst_author_list(authors: list[dict[str, str]]) -> str:
@@ -64,36 +155,21 @@ def generate_rst_author_list(authors: list[dict[str, str]]) -> str:
 
     Parameters
     ----------
-    authors : list of dict
-        A list of dictionaries, each containing information about an
-        author.
+    authors : `list` of `dict` from `str` to `str`
+        A list of dictionaries containing information about an author,
+        as read in by `parse_cff`.
 
     Returns
     -------
     str
         The reStructuredText formatted list of authors.
     """
-    authors = sorted(authors, key=sorting_key)
-    authors_rst = ""
-    for author in authors:
-        if "given-names" in author and "family-names" in author:
-            name = f'{author["given-names"]} {author["family-names"]}'
-        elif "alias" in author:
-            name = f'{author["alias"]}'
-        else:
-            continue
-
-        if "orcid" in author and "alias" in author:
-            orcid = author["orcid"].removeprefix("https://orcid.org/")
-            authors_rst += f'- :user:`{name} <{author["alias"]}>` (:orcid:`{orcid}`)\n'
-        elif "alias" in author:
-            authors_rst += f'- :user:`{name} <{author["alias"]}>`\n'
-        else:
-            authors_rst += f"- :user:`{name}`\n"
-    return authors_rst
+    authors = sorted(authors, key=author_sorting_key)
+    author_lines = [begin_author_line(author) + get_orcid(author) for author in authors]
+    return "\n".join(author_lines)
 
 
-def main(cff_file="../CITATION.cff", rst_file="about/_authors.rst"):
+def main(cff_file="../CITATION.cff", rst_file="about/_authors.rst", verbose=False):
     """
     Parse :file:`CITATION.cff` file and generate a reStructuredText
     formatted list of authors.
@@ -108,5 +184,20 @@ def main(cff_file="../CITATION.cff", rst_file="about/_authors.rst"):
     """
     cff_data = parse_cff(cff_file)
     authors_rst = generate_rst_author_list(cff_data["authors"])
+
+    if verbose:
+        print(authors_rst)  # noqa: T201
+
     with pathlib.Path(rst_file).open("w") as file:
         file.write(authors_rst)
+
+
+if __name__ == "__main__":
+    """
+    To test the functionality in this file, run:
+
+    .. code-block: bash
+
+        python cff_to_rst.py
+    """
+    main(verbose=True)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))  # noqa: PTH100
 sys.path.insert(0, os.path.abspath("."))  # noqa: PTH100
 # isort: on
 
-import cff_to_rst
+import _cff_to_rst
 
 from _global_substitutions import global_substitutions
 from datetime import datetime
@@ -23,7 +23,7 @@ from sphinx.application import Sphinx
 
 # Generate author list from CITATION.cff
 
-cff_to_rst.main()
+_cff_to_rst.main()
 
 from plasmapy import __version__ as release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ docs = [
   "sphinxcontrib-globalsubs >= 0.1.1",
   "towncrier >= 22.12",
   "tox >= 4.4.0",
+  "unidecode >= 1.3.6",
 ]
 tests = [
   "hypothesis >= 6.35.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ executing==1.2.0
     # via stack-data
 fastjsonschema==2.18.0
     # via nbformat
-filelock==3.12.2
+filelock==3.12.3
     # via
     #   tox
     #   virtualenv
@@ -100,7 +100,7 @@ future==0.18.3
     # via uncertainties
 h5py==3.9.0
     # via plasmapy (setup.py)
-hypothesis==6.82.6
+hypothesis==6.82.7
     # via plasmapy (setup.py)
 identify==2.5.27
     # via pre-commit
@@ -365,7 +365,7 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rpds-py==0.9.2
+rpds-py==0.10.0
     # via
     #   jsonschema
     #   referencing
@@ -498,6 +498,8 @@ tzdata==2023.3
     # via pandas
 uncertainties==3.1.7
     # via lmfit
+unidecode==1.3.6
+    # via plasmapy (setup.py)
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.0.4


### PR DESCRIPTION
 - Added ORCID IDs for several contributors who I could disambiguate
 - Updated and fixed GitHub usernames which had been causing errors when doing `make linkcheck`
 - Improved the functionality that converts author information in `CITATION.cff` to a reStructuredText list.  In addition to breaking up large functions into smaller functions, this PR fixed a problem where the `:user:` role was being used even when the `alias` key representing GitHub username is unavailable (which was causing broken links to be generated).
 - Perform a Unicode to ASCII conversion in the sorting key for authors.  This way, if someone's surname starts with an Á, it will get sorted as A. 

I recently also just updated the author list in our `v2023.5.1` release.