### PR TITLE
Move linkcheck settings to separate file & expand linkcheck ignore list

### DIFF
--- a/docs/_linkcheck_settings.py
+++ b/docs/_linkcheck_settings.py
@@ -1,0 +1,115 @@
+"""Customizations for running `make linkcheck` using regular expressions."""
+
+linkcheck_anchors = True
+
+linkcheck_anchors_ignore = [
+    "/room",
+    r".+openastronomy.+",
+    "L[0-9].+",
+    "!forum/plasmapy",
+]
+
+linkcheck_allowed_redirects = {
+    r"https://doi\.org/.+": r"https://.+",  # DOI links are more persistent
+    r"https://docs.+\.org": r"https://docs.+\.org/en/.+",
+    r"https://docs.+\.io": r"https://docs.+\.io/en/.+",
+    r"https://docs.+\.com": r"https://docs.+\.com/en/.+",
+    r"https://docs.+\.dev": r"https://docs.+\.dev/en/.+",
+    r"https://en.wikipedia.org/wiki.+": "https://en.wikipedia.org/wiki.+",
+    r"https://.+\.readthedocs\.io": r"https://.+\.readthedocs\.io/en/.+",
+    r"https://www\.sphinx-doc\.org": r"https://www\.sphinx-doc\.org/en/.+",
+    r"https://.+/github\.io": r"https://.+/github\.io/en/.+",
+    r"https://.+": r".+(google|github).+[lL]ogin.+",  # some links require logins
+    r"https://jinja\.palletsprojects\.com": r"https://jinja\.palletsprojects\.com/.+",
+    r"https://pip\.pypa\.io": r"https://pip\.pypa\.io/en/.+",
+    r"https://www.python.org/dev/peps/pep.+": "https://peps.python.org/pep.+",
+}
+
+# Hyperlinks for `make linkcheck` to ignore. This may include:
+#
+#  - Stable links (i.e. DOI links that have been tested)
+#  - Links that point to setting options in PlasmaPy's GitHub account
+#    that require a login
+#  - Links that require you to verify as human
+#  - Domains that timeout a lot
+
+linkcheck_ignore = [
+    "https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2012JA017856",
+    "https://doi.org/10.1007/978-3-319-22309-4",
+    "https://doi.org/10.1007/978-3-319-24121-0",
+    "https://doi.org/10.1007/978-3-319-67711-8.*",
+    "https://doi.org/10.1007/s11207-014-0526-6",
+    "https://doi.org/10.1007/s41116-019-0021-0",
+    r"https://doi.org/10.1016/0032-0633\(94\)00197-Y",
+    "https://doi.org/10.1016/c2009-0-20048-1",
+    "https://doi.org/10.1016/c2013-0-12176-9",
+    "https://doi.org/10.1016/j.physleta.2004.08.021",
+    "https://doi.org/10.1029/1998ja900132",
+    "https://doi.org/10.1029/2011ja016674",
+    "https://doi.org/10.1029/2012ja017856",
+    "https://doi.org/10.1029/9503712",
+    "https://doi.org/10.1038/150405d0",
+    "https://doi.org/10.1063/1.1706052",
+    "https://doi.org/10.1063/1.2756751",
+    "https://doi.org/10.1063/1.4775777",
+    "https://doi.org/10.1063/1.4801022",
+    "https://doi.org/10.1063/1.865901",
+    "https://doi.org/10.1063/1.871810",
+    "https://doi.org/10.1086/523671",
+    "https://doi.org/10.1088/0004-637X/751/1/20",
+    "https://doi.org/10.1088/0368-3281/5/2/304",
+    "https://doi.org/10.1103/PhysRev.89.977",
+    "https://doi.org/10.1103/PhysRevE.65.036418",
+    "https://doi.org/10.1103/physrevlett.111.241101",
+    "https://doi.org/10.1146/annurev-astro-082708-101726",
+    "https://doi.org/10.1201/9781315275048",
+    "https://doi.org/10.1371/journal.pbio.1001745",
+    "https://doi.org/10.1371/journal.pcbi.1005510",
+    "https://doi.org/10.2172/5259641",
+    "https://doi.org/10.3847/1538-4357/accc32",
+    "https://doi.org/10.5281/zenodo.1436011",
+    "https://doi.org/10.5281/zenodo.1460977",
+    "https://doi.org/10.5281/zenodo.3406803",
+    "https://doi.org/10.5281/zenodo.4602818",
+    "https://doi.org/10.5281/zenodo.7734998",
+    "https://doi.org/10.5281/zenodo.8015753",
+    "https://github.com/PlasmaPy/PlasmaPy/settings/secrets/actions",
+    "https://orcid.org/0000-0001-5050-6606",
+    "https://orcid.org/0000-0001-5270-7487",
+    "https://orcid.org/0000-0001-5394-9445",
+    "https://orcid.org/0000-0001-6079-8307",
+    "https://orcid.org/0000-0001-6291-8843",
+    "https://orcid.org/0000-0001-6628-8033",
+    "https://orcid.org/0000-0001-6849-3612",
+    "https://orcid.org/0000-0001-7381-1996",
+    "https://orcid.org/0000-0001-7959-8495",
+    "https://orcid.org/0000-0001-8358-0482",
+    "https://orcid.org/0000-0001-8745-204X",
+    "https://orcid.org/0000-0002-0486-1292",
+    "https://orcid.org/0000-0002-0762-3708",
+    "https://orcid.org/0000-0002-1073-6383",
+    "https://orcid.org/0000-0002-1192-2057",
+    "https://orcid.org/0000-0002-1365-1908",
+    "https://orcid.org/0000-0002-1984-7303",
+    "https://orcid.org/0000-0002-2160-7288",
+    "https://orcid.org/0000-0002-3056-6334",
+    "https://orcid.org/0000-0002-3713-6337",
+    "https://orcid.org/0000-0002-4237-2211",
+    "https://orcid.org/0000-0002-4914-6612",
+    "https://orcid.org/0000-0002-5598-046X",
+    "https://orcid.org/0000-0002-6468-5710",
+    "https://orcid.org/0000-0002-7616-0946",
+    "https://orcid.org/0000-0002-7757-5879",
+    "https://orcid.org/0000-0002-8335-1441",
+    "https://orcid.org/0000-0002-8644-8118",
+    "https://orcid.org/0000-0002-8676-1710",
+    "https://orcid.org/0000-0002-9258-4490",
+    "https://orcid.org/0000-0003-0079-4114",
+    "https://orcid.org/0000-0003-0223-7004",
+    "https://orcid.org/0000-0003-0602-8381",
+    "https://orcid.org/0000-0003-2892-6924",
+    "https://orcid.org/0000-0003-3530-7910",
+    "https://orcid.org/0000-0003-4217-4642",
+    "https://orcid.org/0009-0009-9490-5284",
+    "https://www.iter.org/",
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,12 @@ sys.path.insert(0, os.path.abspath("."))  # noqa: PTH100
 import cff_to_rst
 
 from _global_substitutions import global_substitutions
+from _linkcheck_settings import (
+    linkcheck_allowed_redirects,
+    linkcheck_anchors,
+    linkcheck_anchors_ignore,
+    linkcheck_ignore,
+)
 from datetime import datetime
 from pkg_resources import parse_version
 from sphinx.application import Sphinx
@@ -232,37 +238,6 @@ html_extra_path = ["robots.txt"]
 todo_include_todos = False
 
 default_role = "py:obj"
-
-# Customizations for make linkcheck using regular expressions
-
-linkcheck_allowed_redirects = {
-    r"https://doi\.org/.+": r"https://.+",  # DOI links are more persistent
-    r"https://docs.+\.org": r"https://docs.+\.org/en/.+",
-    r"https://docs.+\.io": r"https://docs.+\.io/en/.+",
-    r"https://docs.+\.com": r"https://docs.+\.com/en/.+",
-    r"https://docs.+\.dev": r"https://docs.+\.dev/en/.+",
-    r"https://en.wikipedia.org/wiki.+": "https://en.wikipedia.org/wiki.+",
-    r"https://.+\.readthedocs\.io": r"https://.+\.readthedocs\.io/en/.+",
-    r"https://www\.sphinx-doc\.org": r"https://www\.sphinx-doc\.org/en/.+",
-    r"https://.+/github\.io": r"https://.+/github\.io/en/.+",
-    r"https://.+": r".+(google|github).+[lL]ogin.+",  # some links require logins
-    r"https://jinja\.palletsprojects\.com": r"https://jinja\.palletsprojects\.com/.+",
-    r"https://pip\.pypa\.io": r"https://pip\.pypa\.io/en/.+",
-    r"https://www.python.org/dev/peps/pep.+": "https://peps.python.org/pep.+",
-}
-
-# Hyperlinks for `make linkcheck` to ignore, such as links that point to
-# setting options in PlasmaPy's GitHub account that require a login.
-
-linkcheck_ignore = ["https://github.com/PlasmaPy/PlasmaPy/settings/secrets/actions"]
-
-linkcheck_anchors = True
-linkcheck_anchors_ignore = [
-    "/room",
-    r".+openastronomy.+",
-    "L[0-9].+",
-    "!forum/plasmapy",
-]
 
 redirects = {
     "contributing/install_dev": "../contributing/getting_ready.html",


### PR DESCRIPTION
I'm hoping to add a documentation linkcheck to our weekly tests, in particular because there are some things that a nitpicky documentation build will not catch (i.e. soemthing formatting like an external link where the target is ). 

However, `make linkcheck` often results in spurious results. For example, `doi.org` requests can get a `403` error when checking our bibliography because there are a whole bunch of DOIs there. We actually only need to check each DOI link *once* because they are persistent identifiers. 

I'm debating about whether we want to move the linkheck configuration variables to `docs/_linkcheck_settings.py` to avoid cluttering `docs/conf.py`.  I don't really like either option.  