### PR TITLE
Remove star imports from particles notebook

### DIFF
--- a/changelog/2311.doc.rst
+++ b/changelog/2311.doc.rst
@@ -1,0 +1,3 @@
+Replaced :py:`from plasmapy.particles import *` in
+:file:`docs/notebooks/getting_started/particles.ipynb` with imports of
+the actual functions and classes that were used.

--- a/docs/notebooks/getting_started/particles.ipynb
+++ b/docs/notebooks/getting_started/particles.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "24125310",
    "metadata": {},
    "outputs": [],
@@ -77,21 +77,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "006b8d3e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "26"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "atomic_number(\"Fe\")"
    ]
@@ -108,21 +97,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "69958326",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'iron'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "element_name(26)"
    ]
@@ -137,42 +115,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "16ca5b6f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "is_stable(\"e-\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "35d8e49e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "charge_number(\"proton\")"
    ]
@@ -189,24 +145,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "493a2d6f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$6.6446572 \\times 10^{-27} \\; \\mathrm{kg}$"
-      ],
-      "text/plain": [
-       "<Quantity 6.64465719e-27 kg>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "particle_mass(\"α\")"
    ]
@@ -226,24 +168,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "94fcf452",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$1.8082505 \\times 10^{11} \\; \\mathrm{s}$"
-      ],
-      "text/plain": [
-       "<Quantity 1.80825048e+11 s>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "half_life(\"C-14\")"
    ]
@@ -258,21 +186,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a65e15da",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "13"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "charge_number(\"Fe-56 13+\")"
    ]
@@ -291,48 +208,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "05e03a8b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$9.2870305 \\times 10^{-26} \\; \\mathrm{kg}$"
-      ],
-      "text/plain": [
-       "<Quantity 9.28703048e-26 kg>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "particle_mass(\"iron-56 +13\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "0dd9541b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$9.2870305 \\times 10^{-26} \\; \\mathrm{kg}$"
-      ],
-      "text/plain": [
-       "<Quantity 9.28703048e-26 kg>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "particle_mass(\"iron-56+++++++++++++\")"
    ]
@@ -347,24 +236,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "61e0f960",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$9.2870305 \\times 10^{-26} \\; \\mathrm{kg}$"
-      ],
-      "text/plain": [
-       "<Quantity 9.28703048e-26 kg>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "particle_mass(\"Fe\", Z=13, mass_numb=56)"
    ]
@@ -389,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "fe9f824a",
    "metadata": {},
    "outputs": [],
@@ -411,93 +286,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "bebcc477",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$1.6726219 \\times 10^{-27} \\; \\mathrm{kg}$"
-      ],
-      "text/plain": [
-       "<Quantity 1.67262192e-27 kg>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proton.mass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "df0f2eed",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$-1.6021766 \\times 10^{-19} \\; \\mathrm{C}$"
-      ],
-      "text/plain": [
-       "<Quantity -1.60217663e-19 C>"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "electron.charge"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "116cd6ad",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "-1"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "electron.charge_number"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "99d22bd3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$7.8868678 \\times 10^{-11} \\; \\mathrm{J}$"
-      ],
-      "text/plain": [
-       "<Quantity 7.88686781e-11 J>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "iron56_nuclide.binding_energy"
    ]
@@ -516,21 +338,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "f6663952",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Particle(\"e+\")"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "electron.antiparticle"
    ]
@@ -547,21 +358,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "180a1edf",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Particle(\"p-\")"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "~proton"
    ]
@@ -580,21 +380,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "186b1dfa",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Particle(\"D 1+\")"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "deuterium = Particle(\"D 0+\")\n",
     "deuterium.ionize()"
@@ -610,21 +399,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "242b53bd",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Particle(\"He-4 0+\")"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "alpha = Particle(\"alpha\")\n",
     "alpha.recombine(2)"
@@ -642,18 +420,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "bb2716c0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ar 1+\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "argon = Particle(\"Ar 0+\")\n",
     "argon.ionize(inplace=True)\n",
@@ -680,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "35b94505",
    "metadata": {},
    "outputs": [],
@@ -704,69 +474,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "8a4b412b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$9.27 \\times 10^{-26} \\; \\mathrm{kg}$"
-      ],
-      "text/plain": [
-       "<Quantity 9.27e-26 kg>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "custom_particle.mass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "a2da2b3b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$2.1789602 \\times 10^{-18} \\; \\mathrm{C}$"
-      ],
-      "text/plain": [
-       "<Quantity 2.17896022e-18 C>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "custom_particle.charge"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "ecb450f6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Fe 13.6+'"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "custom_particle.symbol"
    ]
@@ -783,24 +514,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "a31c421a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "${\\rm NaN} \\; \\mathrm{C}$"
-      ],
-      "text/plain": [
-       "<Quantity nan C>"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "CustomParticle(9.27e-26 * u.kg).charge"
    ]
@@ -839,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "30cc7d36",
    "metadata": {},
    "outputs": [],
@@ -859,69 +576,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "2434f71b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[9.2721873 \\times 10^{-26},~9.2720962 \\times 10^{-26},~9.2720051 \\times 10^{-26}] \\; \\mathrm{kg}$"
-      ],
-      "text/plain": [
-       "<Quantity [9.27218729e-26, 9.27209620e-26, 9.27200510e-26] kg>"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "iron_ions.mass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "14a431dd",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[1.922612 \\times 10^{-18},~2.0828296 \\times 10^{-18},~2.2430473 \\times 10^{-18}] \\; \\mathrm{C}$"
-      ],
-      "text/plain": [
-       "<Quantity [1.92261196e-18, 2.08282962e-18, 2.24304729e-18] C>"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "iron_ions.charge"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "48cd1c7a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Fe 12+', 'Fe 13+', 'Fe 14+']"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "iron_ions.symbols"
    ]
@@ -940,21 +618,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "3b953065",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ParticleList(['p+', 'e-', 'Fe 13.6+'])"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proton + electron + custom_particle"
    ]
@@ -980,21 +647,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "da22120e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'H2O'"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "water = molecule(\"H2O\")\n",
     "water.symbol"
@@ -1010,48 +666,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "1ae6284a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$2.9914611 \\times 10^{-26} \\; \\mathrm{kg}$"
-      ],
-      "text/plain": [
-       "<Quantity 2.99146113e-26 kg>"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "water.mass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "23c42034",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$-1.6021766 \\times 10^{-19} \\; \\mathrm{C}$"
-      ],
-      "text/plain": [
-       "<Quantity -1.60217663e-19 C>"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "acetic_acid_anion = molecule(\"CH3COOH 1-\")\n",
     "acetic_acid_anion.charge"
@@ -1078,21 +706,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "09f122ff",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'charged', 'fermion', 'lepton', 'matter', 'unstable'}"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "muon = Particle(\"muon\")\n",
     "muon.categories"
@@ -1111,21 +728,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "d278fa15",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "muon.is_category(\"lepton\")"
    ]
@@ -1142,21 +748,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "5b5e6ee7",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "electron.is_category(require=\"lepton\", exclude=\"baryon\", any_of={\"boson\", \"fermion\"})"
    ]
@@ -1173,18 +768,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "f57d6333",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'actinide', 'uncharged', 'custom', 'alkali metal', 'lanthanide', 'nonmetal', 'neutrino', 'antibaryon', 'stable', 'antimatter', 'isotope', 'element', 'metalloid', 'baryon', 'post-transition metal', 'neutron', 'matter', 'noble gas', 'electron', 'charged', 'boson', 'antineutrino', 'ion', 'halogen', 'alkaline earth metal', 'transition metal', 'antilepton', 'fermion', 'lepton', 'metal', 'positron', 'unstable', 'proton'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(valid_categories)"
    ]
@@ -1202,21 +789,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "0973c148",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[True, False, False]"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "particles = ParticleList([\"e-\", \"p+\", \"n\"])\n",
     "particles.is_category(require=\"lepton\")"
@@ -1242,22 +818,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "f57a0f64",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'DimensionlessParticle' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[40], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m dimensionless_particle \u001b[38;5;241m=\u001b[39m \u001b[43mDimensionlessParticle\u001b[49m(mass\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0.000545\u001b[39m, charge\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'DimensionlessParticle' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dimensionless_particle = DimensionlessParticle(mass=0.000545, charge=-1)"
    ]
@@ -1364,9 +928,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "efff1677",
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%xmode minimal"
@@ -1376,11 +938,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "67b32a3a",
-   "metadata": {
-    "tags": [
-     "raises-exception"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "deuteron + triton > alpha + 3 * neutron"
@@ -1403,8 +961,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/getting_started/particles.ipynb
+++ b/docs/notebooks/getting_started/particles.ipynb
@@ -20,12 +20,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "24125310",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from plasmapy.particles import *\n",
+    "from plasmapy.particles import (\n",
+    "    atomic_number,\n",
+    "    charge_number,\n",
+    "    CustomParticle,\n",
+    "    DimensionlessParticle,\n",
+    "    element_name,\n",
+    "    half_life,\n",
+    "    is_stable,\n",
+    "    molecule,\n",
+    "    Particle,\n",
+    "    particle_mass,\n",
+    "    ParticleList,\n",
+    ")\n",
     "from plasmapy.particles.particle_class import valid_categories"
    ]
   },
@@ -65,10 +77,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "006b8d3e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "26"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "atomic_number(\"Fe\")"
    ]
@@ -85,10 +108,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "69958326",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'iron'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "element_name(26)"
    ]
@@ -103,20 +137,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "16ca5b6f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "is_stable(\"e-\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "35d8e49e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "charge_number(\"proton\")"
    ]
@@ -133,10 +189,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "493a2d6f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$6.6446572 \\times 10^{-27} \\; \\mathrm{kg}$"
+      ],
+      "text/plain": [
+       "<Quantity 6.64465719e-27 kg>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "particle_mass(\"α\")"
    ]
@@ -156,10 +226,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "94fcf452",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$1.8082505 \\times 10^{11} \\; \\mathrm{s}$"
+      ],
+      "text/plain": [
+       "<Quantity 1.80825048e+11 s>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "half_life(\"C-14\")"
    ]
@@ -174,10 +258,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "a65e15da",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "13"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "charge_number(\"Fe-56 13+\")"
    ]
@@ -196,20 +291,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "05e03a8b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$9.2870305 \\times 10^{-26} \\; \\mathrm{kg}$"
+      ],
+      "text/plain": [
+       "<Quantity 9.28703048e-26 kg>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "particle_mass(\"iron-56 +13\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "0dd9541b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$9.2870305 \\times 10^{-26} \\; \\mathrm{kg}$"
+      ],
+      "text/plain": [
+       "<Quantity 9.28703048e-26 kg>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "particle_mass(\"iron-56+++++++++++++\")"
    ]
@@ -224,10 +347,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "61e0f960",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$9.2870305 \\times 10^{-26} \\; \\mathrm{kg}$"
+      ],
+      "text/plain": [
+       "<Quantity 9.28703048e-26 kg>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "particle_mass(\"Fe\", Z=13, mass_numb=56)"
    ]
@@ -252,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "fe9f824a",
    "metadata": {},
    "outputs": [],
@@ -274,40 +411,93 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "bebcc477",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$1.6726219 \\times 10^{-27} \\; \\mathrm{kg}$"
+      ],
+      "text/plain": [
+       "<Quantity 1.67262192e-27 kg>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "proton.mass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "df0f2eed",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$-1.6021766 \\times 10^{-19} \\; \\mathrm{C}$"
+      ],
+      "text/plain": [
+       "<Quantity -1.60217663e-19 C>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "electron.charge"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "116cd6ad",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-1"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "electron.charge_number"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "99d22bd3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$7.8868678 \\times 10^{-11} \\; \\mathrm{J}$"
+      ],
+      "text/plain": [
+       "<Quantity 7.88686781e-11 J>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "iron56_nuclide.binding_energy"
    ]
@@ -326,10 +516,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "f6663952",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Particle(\"e+\")"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "electron.antiparticle"
    ]
@@ -346,10 +547,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "180a1edf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Particle(\"p-\")"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "~proton"
    ]
@@ -368,10 +580,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "186b1dfa",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Particle(\"D 1+\")"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "deuterium = Particle(\"D 0+\")\n",
     "deuterium.ionize()"
@@ -387,10 +610,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "242b53bd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Particle(\"He-4 0+\")"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "alpha = Particle(\"alpha\")\n",
     "alpha.recombine(2)"
@@ -408,10 +642,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "bb2716c0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ar 1+\n"
+     ]
+    }
+   ],
    "source": [
     "argon = Particle(\"Ar 0+\")\n",
     "argon.ionize(inplace=True)\n",
@@ -438,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "35b94505",
    "metadata": {},
    "outputs": [],
@@ -462,30 +704,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "8a4b412b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$9.27 \\times 10^{-26} \\; \\mathrm{kg}$"
+      ],
+      "text/plain": [
+       "<Quantity 9.27e-26 kg>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "custom_particle.mass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "a2da2b3b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$2.1789602 \\times 10^{-18} \\; \\mathrm{C}$"
+      ],
+      "text/plain": [
+       "<Quantity 2.17896022e-18 C>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "custom_particle.charge"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "ecb450f6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Fe 13.6+'"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "custom_particle.symbol"
    ]
@@ -502,10 +783,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "a31c421a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "${\\rm NaN} \\; \\mathrm{C}$"
+      ],
+      "text/plain": [
+       "<Quantity nan C>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "CustomParticle(9.27e-26 * u.kg).charge"
    ]
@@ -544,7 +839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "30cc7d36",
    "metadata": {},
    "outputs": [],
@@ -564,30 +859,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "2434f71b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$[9.2721873 \\times 10^{-26},~9.2720962 \\times 10^{-26},~9.2720051 \\times 10^{-26}] \\; \\mathrm{kg}$"
+      ],
+      "text/plain": [
+       "<Quantity [9.27218729e-26, 9.27209620e-26, 9.27200510e-26] kg>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "iron_ions.mass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "14a431dd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$[1.922612 \\times 10^{-18},~2.0828296 \\times 10^{-18},~2.2430473 \\times 10^{-18}] \\; \\mathrm{C}$"
+      ],
+      "text/plain": [
+       "<Quantity [1.92261196e-18, 2.08282962e-18, 2.24304729e-18] C>"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "iron_ions.charge"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "48cd1c7a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Fe 12+', 'Fe 13+', 'Fe 14+']"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "iron_ions.symbols"
    ]
@@ -606,10 +940,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "3b953065",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ParticleList(['p+', 'e-', 'Fe 13.6+'])"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "proton + electron + custom_particle"
    ]
@@ -635,10 +980,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "da22120e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'H2O'"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "water = molecule(\"H2O\")\n",
     "water.symbol"
@@ -654,20 +1010,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "1ae6284a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$2.9914611 \\times 10^{-26} \\; \\mathrm{kg}$"
+      ],
+      "text/plain": [
+       "<Quantity 2.99146113e-26 kg>"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "water.mass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "23c42034",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$-1.6021766 \\times 10^{-19} \\; \\mathrm{C}$"
+      ],
+      "text/plain": [
+       "<Quantity -1.60217663e-19 C>"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "acetic_acid_anion = molecule(\"CH3COOH 1-\")\n",
     "acetic_acid_anion.charge"
@@ -694,10 +1078,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "09f122ff",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'charged', 'fermion', 'lepton', 'matter', 'unstable'}"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "muon = Particle(\"muon\")\n",
     "muon.categories"
@@ -716,10 +1111,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "d278fa15",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "muon.is_category(\"lepton\")"
    ]
@@ -736,10 +1142,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "5b5e6ee7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "electron.is_category(require=\"lepton\", exclude=\"baryon\", any_of={\"boson\", \"fermion\"})"
    ]
@@ -756,10 +1173,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "f57d6333",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'actinide', 'uncharged', 'custom', 'alkali metal', 'lanthanide', 'nonmetal', 'neutrino', 'antibaryon', 'stable', 'antimatter', 'isotope', 'element', 'metalloid', 'baryon', 'post-transition metal', 'neutron', 'matter', 'noble gas', 'electron', 'charged', 'boson', 'antineutrino', 'ion', 'halogen', 'alkaline earth metal', 'transition metal', 'antilepton', 'fermion', 'lepton', 'metal', 'positron', 'unstable', 'proton'}\n"
+     ]
+    }
+   ],
    "source": [
     "print(valid_categories)"
    ]
@@ -777,10 +1202,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "0973c148",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[True, False, False]"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "particles = ParticleList([\"e-\", \"p+\", \"n\"])\n",
     "particles.is_category(require=\"lepton\")"
@@ -806,10 +1242,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "f57a0f64",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'DimensionlessParticle' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[40], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m dimensionless_particle \u001b[38;5;241m=\u001b[39m \u001b[43mDimensionlessParticle\u001b[49m(mass\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0.000545\u001b[39m, charge\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'DimensionlessParticle' is not defined"
+     ]
+    }
+   ],
    "source": [
     "dimensionless_particle = DimensionlessParticle(mass=0.000545, charge=-1)"
    ]
@@ -955,7 +1403,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We had been doing a `from plasmapy.particles import *`, so this PR changes that to import everything directly.