### PR TITLE
Reduce warnings emitted during tests of `plasmapy.dispersion`

### DIFF
--- a/plasmapy/dispersion/analytical/tests/test_stix_.py
+++ b/plasmapy/dispersion/analytical/tests/test_stix_.py
@@ -132,6 +132,7 @@ class TestStix:
             ),
         ],
     )
+    @pytest.mark.filterwarnings("ignore::astropy.units.UnitsWarning")
     def test_return_structure(self, kwargs, expected):
         k = stix(**kwargs)
 

--- a/plasmapy/dispersion/numerical/tests/test_hollweg_.py
+++ b/plasmapy/dispersion/numerical/tests/test_hollweg_.py
@@ -188,6 +188,8 @@ class TestHollweg:
             ),
         ],
     )
+    @pytest.mark.filterwarnings("ignore::astropy.units.UnitsWarning")
+    @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
     def test_handle_k_theta_arrays(self, kwargs, expected):
         """Test scenarios involving k and theta arrays."""
         ws = hollweg(**kwargs)
@@ -263,6 +265,7 @@ class TestHollweg:
             ),
         ],
     )
+    @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
     def test_hollweg1999_vals(self, kwargs, expected, desired_beta):
         """
         Test calculated values based on Figure 2 of Hollweg1999
@@ -323,6 +326,7 @@ class TestHollweg:
             ),
         ],
     )
+    @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
     def test_Z_override(self, kwargs, expected):
         """Test overriding behavior of kw 'Z'."""
         ws = hollweg(**kwargs)
@@ -331,6 +335,7 @@ class TestHollweg:
         for mode in ws:
             assert np.isclose(ws[mode], ws_expected[mode], atol=1e-5, rtol=1.7e-4)
 
+    @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
     @pytest.mark.parametrize(
         ("kwargs", "expected"),
         [

--- a/plasmapy/dispersion/numerical/tests/test_kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/tests/test_kinetic_alfven_.py
@@ -89,6 +89,7 @@ class TestKinetic_Alfven:
             ),
         ],
     )
+    @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
     def test_return_structure(self, kwargs, expected):
         """Test the structure of the returned values."""
         ws = kinetic_alfven(**kwargs)


### PR DESCRIPTION
This PR applies `@pytest.mark.filterwarnings` to many of the tests in `plasmapy.dispersion`.  I did not attempt this with doctests yet.

See also #844.
