### PR TITLE
Make it so no warnings are issued during tests by `plasmapy.diagnostics`

### DIFF
--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -132,6 +132,7 @@ def _test_grid(  # noqa: C901, PLR0912
 
 
 @pytest.mark.slow()
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_multiple_grids():
     """
     Test that a case with two grids runs.
@@ -605,6 +606,7 @@ class TestSyntheticRadiograph:
         assert isinstance(histogram, np.ndarray)
         assert histogram.shape == expected["bins"]
 
+    @pytest.mark.filterwarnings("ignore:divide by zero:RuntimeWarning")
     def test_optical_density_histogram(self):
         """
         Test the optical density calculation is correct and stuffed
@@ -898,6 +900,7 @@ def test_add_wire_mesh():
 
 
 @pytest.mark.slow()
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_multiple_grids2():
     """
     Test that a case with two grids runs.

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -221,7 +221,7 @@ def test_spectral_density_minimal_arguments(single_species_collective_args):
     """
     Check that spectral density runs with minimal arguments
     """
-    wavelengths = single_species_collective_args["wavelengths"]
+    single_species_collective_args["wavelengths"]
     args, kwargs = spectral_density_args_kwargs(single_species_collective_args)
 
     # Delete the arguments that have default values
@@ -240,8 +240,6 @@ def test_spectral_density_minimal_arguments(single_species_collective_args):
             del kwargs[key]
 
     alpha, Skw = thomson.spectral_density(*args, **kwargs)
-
-    return (alpha, wavelengths, Skw)
 
 
 def test_single_species_collective_lite(single_species_collective_args):
@@ -1062,6 +1060,7 @@ def test_fit_iaw_single_species(iaw_single_species_settings_params):
 
 
 @pytest.mark.slow()
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_fit_iaw_instr_func(iaw_single_species_settings_params):
     """
     Tests fitting with an instrument function
@@ -1095,6 +1094,7 @@ def test_fit_noncollective_single_species(noncollective_single_species_settings_
 
 
 @pytest.mark.slow()
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_fit_with_instr_func(epw_single_species_settings_params):
     """
 


### PR DESCRIPTION
See also #844.