### PR TITLE
Make it so no warnings are issued during tests by `plasmapy.plasma`

### DIFF
--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -172,6 +172,8 @@ def test_AbstractGrid_creation(args, kwargs, shape, error):
             grids.CartesianGrid(*args, **kwargs)
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_print_summary(abstract_grid_uniform, abstract_grid_nonuniform):
     """
     Verify that both __str__ methods can be called without errors
@@ -229,6 +231,7 @@ abstract_attrs = [
 
 
 @pytest.mark.parametrize(("attr", "type_", "type_in_iter", "value"), abstract_attrs)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_AbstractGrid_uniform_attributes(
     attr,
     type_,
@@ -265,6 +268,7 @@ abstract_attrs = [
 
 
 @pytest.mark.parametrize(("attr", "type_", "type_in_iter", "value"), abstract_attrs)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_AbstractGrid_nonuniform_attributes(
     attr,
     type_,
@@ -422,6 +426,7 @@ on_grid = [
 
 
 @pytest.mark.parametrize(("fixture", "pos", "result"), on_grid)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_AbstractGrid_on_grid(
     abstract_grid_uniform, abstract_grid_nonuniform, fixture, pos, result
 ):
@@ -445,6 +450,7 @@ vector_intersect = [
 
 
 @pytest.mark.parametrize(("fixture", "p1", "p2", "result"), vector_intersect)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_AbstractGrid_vector_intersects(
     abstract_grid_uniform, abstract_grid_nonuniform, fixture, p1, p2, result
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,10 @@ NORMALIZE_WHITESPACE
 ELLIPSIS
 NUMBER"""
 addopts = "--doctest-modules --doctest-continue-on-failure"
-filterwarnings = ["ignore:.*Creating", "a"]
+filterwarnings = [
+  "ignore:.*deprecated in traitlets 4.2.*:DeprecationWarning",
+  "ignore:.*MultiIndex.*:DeprecationWarning",  # https://github.com/PlasmaPy/PlasmaPy/issues/2319
+]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
See #844.  Related to #2319.