### PR TITLE
Discuss when to use aliases in coding guide and adopt usage of `:py:` role

### DIFF
--- a/changelog/2324.doc.rst
+++ b/changelog/2324.doc.rst
@@ -1,0 +1,3 @@
+Updated the |coding guide| by discussing when to use aliases and
+applied the ``:py:`` role so that in-line code gets formatted the same
+as Python code blocks.

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -37,11 +37,11 @@ Coding guidelines
 
 * Write short functions that do exactly one thing with no side effects.
 
-* Use |NumPy| array options instead of ``for`` loops to make code more
+* Use |NumPy| array options instead of :py:`for` loops to make code more
   compact, readable, and performant.
 
-* Instead of defining variables like ``a0``, ``a1``, & ``a2``, define
-  these values in a collection such as an |ndarray| or a `list`.
+* Instead of defining variables like :py:`a0`, :py:`a1`, & :py:`a2`,
+  define these values in a collection such as an |ndarray| or a `list`.
 
 * Use the `property` :term:`decorator` instead of getters and setters.
 
@@ -61,26 +61,26 @@ Coding guidelines
 
      f(T_i=1e6 * u.K, T_e=2e6 * u.K)
 
-  Similarly, when a function has parameters named ``T_e`` and ``T_i``,
-  these parameters should be made |keyword-only| to avoid ambiguity and
-  reduce the chance of errors.
+  Similarly, when a function has parameters named :py:`T_e` and
+  :py:`T_i`, these parameters should be made |keyword-only| to avoid
+  ambiguity and reduce the chance of errors.
 
   .. code-block:: python
 
      def f(*, T_i, T_e):
          ...
 
-* The ``__eq__`` and ``__ne__`` methods of a class should not raise
+* The :py:`__eq__` and :py:`__ne__` methods of a class should not raise
   exceptions. If the comparison for equality is being made between
   objects of different types, these methods should return `False`
   instead. This behavior is for consistency with operations like
   :py:`1 == "1"` which will return `False`.
 
-* Limit usage of ``lambda`` functions to one-liners, such as when
+* Limit usage of :py:`lambda` functions to one-liners, such as when
   defining the default factory of a `~collections.defaultdict`). For
-  anything longer than one line, use ``def`` instead.
+  anything longer than one line, use :py:`def` instead.
 
-* List and dictionary comprehensions can be used for simple ``for``
+* List and dictionary comprehensions can be used for simple :py:`for`
   loops, like:
 
   .. code-block:: pycon
@@ -94,18 +94,20 @@ Coding guidelines
 
 * Avoid defining global variables when possible.
 
-* Use ``assert`` statements only in tests.
+* Use :py:`assert` statements only in tests.
 
 * Use formatted string literals (f-strings) instead of legacy formatting
   for strings.
 
-  >>> package_name = "PlasmaPy"
-  >>> print(f"The name of the package is {package_name}.")
-  The name of the package is PlasmaPy.
-  >>> print(f"{package_name=}")
-  package_name='PlasmaPy'
-  >>> print(f"{package_name!r}")  # shortcut for f"{repr(package_name)}"
-  'PlasmaPy'
+  .. code-block:: pycon
+
+     >>> package_name = "PlasmaPy"
+     >>> print(f"The name of the package is {package_name}.")
+     The name of the package is PlasmaPy.
+     >>> print(f"{package_name=}")
+     package_name='PlasmaPy'
+     >>> print(f"{package_name!r}")  # shortcut for f"{repr(package_name)}"
+     'PlasmaPy'
 
 * Functions that accept |array_like| or |Quantity| inputs should accept
   and return |nan| (`not a number`_) values. This guideline applies when
@@ -115,7 +117,7 @@ Coding guidelines
   .. tip::
 
      Normally, :py:`numpy.nan == numpy.nan` evaluates to `False`, which
-     complicates testing |nan| behavior. The ``equal_nan`` keyword of
+     complicates testing |nan| behavior. The :py:`equal_nan` keyword of
      functions like `numpy.allclose` and `numpy.testing.assert_allclose`
      makes it so that |nan| is considered equal to itself.
 
@@ -146,24 +148,24 @@ code is supposed to be doing.
 * PlasmaPy generally uses the :pep:`8` conventions for variable names.
 
   - Use lowercase words separated by underscores for function and
-    variable names (e.g., ``function_name`` and ``variable_name``).
+    variable names (e.g., :py:`function_name` and :py:`variable_name`).
 
   - Use capitalized words without separators when naming a class (e.g.,
-    ``ClassName``), but keep acronyms capitalized (e.g.,
-    ``MHDEquations``).
+    :py:`ClassName`), but keep acronyms capitalized (e.g.,
+    :py:`MHDEquations`).
 
   - Use capital letters words separated by underscores when naming
-    constants (e.g., ``CONSTANT`` or ``CONSTANT_NAME``).
+    constants (e.g., :py:`CONSTANT` or :py:`CONSTANT_NAME`).
 
   There are some situations in PlasmaPy which justify a departure from
   the :pep:`8` conventions.
 
   - Functions based on plasma parameters that are named after people may
-    be capitalized (e.g., ``Alfven_speed``).
+    be capitalized (e.g., :py:`Alfven_speed`).
 
   - Capital letters may be used for a variable when it matches the
-    standard usage in plasma science (e.g., ``B`` for magnetic field and
-    ``T`` for temperature).
+    standard usage in plasma science (e.g., :py:`B` for magnetic field
+    and :py:`T` for temperature).
 
 * Choose names that are pronounceable to make them more memorable and
   compatible with text-to-speech technology.
@@ -180,31 +182,31 @@ code is supposed to be doing.
      Measure the length of a variable not by the number of characters,
      but rather by the time needed to understand its meaning.
 
-     By this measure, ``cggglm`` is significantly longer than
-     ``solve_gauss_markov_linear_model``.
+     By this measure, :py:`cggglm` is significantly longer than
+     :py:`solve_gauss_markov_linear_model`.
 
-* Avoid ambiguity. Does ``temp`` mean "temperature", "temporary", or
+* Avoid ambiguity. Does :py:`temp` mean "temperature", "temporary", or
   "template"?
 
-* Append ``_e`` to a variable name to indicate that it refers to
-  electrons, ``_i`` for ions, and ``_p`` for protons (e.g., ``T_e``,
-  ``T_i``, and ``T_p``).
+* Append :py:`_e` to a variable name to indicate that it refers to
+  electrons, :py:`_i` for ions, and :py:`_p` for protons (e.g.,
+  :py:`T_e`, :py:`T_i`, and :py:`T_p`).
 
 * Only ASCII_ characters should be used in code that is part of the
   public :wikipedia:`API`.
 
 * Python allows alphanumeric Unicode characters to be used in object
-  names (e.g., ``πλάσμα`` or ``φυσική``). These characters may be used
-  for *internal* code when doing so improves readability (i.e., to match
-  a commonly used symbol) and in |Jupyter| notebooks.
+  names (e.g., :py:`πλάσμα` or :py:`φυσική`). These characters may be
+  used for *internal* code when doing so improves readability (i.e.,
+  to match a commonly used symbol) and in |Jupyter| notebooks.
 
 * If a plasma parameter has multiple names, then use the name that
-  provides the most physical insight. For example, ``gyrofrequency``
-  indicates gyration but ``Larmor_frequency`` does not.
+  provides the most physical insight. For example, :py:`gyrofrequency`
+  indicates gyration but :py:`Larmor_frequency` does not.
 
 * It is *usually* preferable to name a variable after its name rather
-  than its symbol.  An object named ``Debye_length`` is more broadly
-  understandable and searchable than ``lambda_D``. However, there are
+  than its symbol.  An object named :py:`Debye_length` is more broadly
+  understandable and searchable than :py:`lambda_D`. However, there are
   some exceptions to this guideline.
 
   * Symbols used widely across plasma science can be used with low risk
@@ -217,8 +219,8 @@ code is supposed to be doing.
   * Sometimes code that represents an equation will be more readable if
     the Unicode characters for the symbols are used, especially for
     complex equations. For someone who is familiar with the symbols,
-    ``λ = c / ν`` will be more readable than ``lambda = c / nu`` or
-    ``wavelength = speed_of_light / frequency``.
+    :py:`λ = c / ν` will be more readable than :py:`lambda = c / nu` or
+    :py:`wavelength = speed_of_light / frequency`.
 
   * If an implementation is based on a journal article, then variable
     names may be based on the symbols used in that article. The article
@@ -227,11 +229,11 @@ code is supposed to be doing.
 
 * To mark that an object is not part of PlasmaPy's public
   :wikipedia:`API`, begin its name with a leading underscore (e.g.,
-  ``_private_variable``). Private variables should not be included in
-  ``__all__``.
+  :py:`_private_variable`). Private variables should not be included in
+  :py:`__all__`.
 
 * Avoid single character variable names except for standard plasma
-  physics symbols (e.g., ``B``) or as indices in ``for`` loops.
+  physics symbols (e.g., :py:`B`) or as indices in :py:`for` loops.
 
 * Avoid encoding type information in a variable name.
 
@@ -254,8 +256,8 @@ code is supposed to be doing.
      if point_is_in_grid_cell:
          ...
 
-  In ``for`` loops, this may take the form of assignment expressions
-  with the walrus operator (``:=``).
+  In :py:`for` loops, this may take the form of assignment expressions
+  with the walrus operator (:py:`:=`).
 
 .. tip::
 
@@ -317,7 +319,8 @@ unmaintained comment may contain inaccurate or misleading information
 
 * Remove commented out code before merging a pull request.
 
-* When updating code, be sure to review and update, if necessary, associated comments too!
+* When updating code, be sure to review and update, if necessary,
+  associated comments too!
 
 * When a comment is used as the header for a section of code, consider
   extracting that section of code into its own function. For example, we
@@ -430,8 +433,8 @@ Imports
 * For infrequently used objects, import the package, subpackage, or
   module rather than the individual code object. Including more of the
   namespace provides contextual information that can make code easier to
-  read. For example, ``json.loads`` is more readable than using only
-  ``loads``.
+  read. For example, :py:`json.loads` is more readable than using only
+  :py:`loads`.
 
 * For frequently used objects (e.g., |Particle|) and type hint
   annotations (e.g., `~typing.Optional` and `~numbers.Real`), import the
@@ -502,8 +505,8 @@ their code while maintaining some readability and explicit meaning. As
 such, :term:`aliases` are given to functionality that already has a
 widely-used symbol in plasma literature.
 
-Here is a minimal example of an alias ``f_`` to ``function`` as would be
-defined in :file:`plasmapy/subpackage/module.py`.
+Here is a minimal example of an alias :py:`f_` to :py:`function` as
+would be defined in :file:`plasmapy/subpackage/module.py`.
 
 .. code-block:: python
 
@@ -520,11 +523,11 @@ defined in :file:`plasmapy/subpackage/module.py`.
    f_ = function
    """Alias to `~plasmapy.subpackage.module.function`."""
 
-* Aliases should only be defined for functionality that already has a
-  symbol that is widely used in the community's literature.  This is to
-  ensure that the abbreviated function name is still widely
-  understandable. For example, `~plasmapy.formulary.lengths.cwp_` is a
-  shortcut for :math:`c/ω_p`\ .
+* Aliases should only be defined for frequently used plasma parameters
+  which already have a symbol that is widely used in the community's
+  literature.  This is to ensure that the abbreviated function name is
+  still reasonably understandable. For example,
+  `~plasmapy.formulary.lengths.cwp_` is a shortcut for :math:`c/ω_p`\ .
 
 * The name of an alias should end with a trailing underscore.
 
@@ -533,10 +536,10 @@ defined in :file:`plasmapy/subpackage/module.py`.
 * Each alias should have a one-line docstring that refers users to the
   original function.
 
-* The name of the original function should be included in ``__all__``
+* The name of the original function should be included in :py:`__all__`
   near the top of each module, and the name of the alias should be
-  included in ``__aliases__``, which will then get appended to
-  ``__all__``. This is done so both the :term:`alias` and the original
+  included in :py:`__aliases__`, which will then get appended to
+  :py:`__all__`. This is done so both the :term:`alias` and the original
   function get properly documented.
 
 * Aliases are intended for end users, and should not be used in PlasmaPy
@@ -570,8 +573,8 @@ performance. Most :term:`lite-functions` are defined in
    :term:`lite-functions`, it is vital to double-check your
    implementation!
 
-Here is a minimal example of a :term:`lite-function` ``function_lite``
-that corresponds to ``function`` as would be defined in
+Here is a minimal example of a :term:`lite-function` :py:`function_lite`
+that corresponds to :py:`function` as would be defined in
 :file:`plasmapy/subpackage/module.py`.
 
 .. code-block:: python
@@ -603,7 +606,7 @@ that corresponds to ``function`` as would be defined in
        ...
 
 * The name of each :term:`lite-function` should be the name of the
-  original function with ``_lite`` appended at the end. For example,
+  original function with :py:`_lite` appended at the end. For example,
   `~plasmapy.formulary.speeds.thermal_speed_lite` is the
   :term:`lite-function` associated with
   `~plasmapy.formulary.speeds.thermal_speed`.
@@ -619,7 +622,7 @@ that corresponds to ``function`` as would be defined in
   reduce code duplication.
 
 * :term:`Lite-functions` are bound to their normal version as the
-  ``lite`` attribute using the
+  :py:`lite` attribute using the
   `~plasmapy.utils.decorators.lite_func.bind_lite_func` decorator. This
   allows the :term:`lite-function` to also be accessed like
   :py:`thermal_speed.lite()`.
@@ -636,11 +639,12 @@ that corresponds to ``function`` as would be defined in
   or utilize Cython_.  At a minimum any "extra" code beyond the raw
   calculation should be removed.
 
-* The name of the original function should be included in ``__all__``
+* The name of the original function should be included in :py:`__all__`
   near the top of each module, and the name of the :term:`lite-function`
-  should be included in ``__lite_funcs__``, which will then get
-  appended to ``__all__``. This is done so both the :term:`lite-function`
-  and the original function get properly documented.
+  should be included in :py:`__lite_funcs__`, which will then get
+  appended to :py:`__all__`. This is done so both the
+  :term:`lite-function` and the original function get properly
+  documented.
 
 Physics
 =======
@@ -749,7 +753,7 @@ notebook on particles`_.
      def get_particle(particle: ParticleLike):
          return particle
 
-  If we use ``get_particle`` on something |particle-like|, it will
+  If we use :py:`get_particle` on something |particle-like|, it will
   return the corresponding particle object.
 
   .. code-block:: pycon
@@ -795,18 +799,18 @@ Unit conversions involving angles must be treated with care. Angles are
 dimensionless but do have units. Angular velocity is often given in
 units of radians per second, though dimensionally this is equivalent to
 inverse seconds. Astropy will treat radians dimensionlessly when using
-the ``dimensionless_angles`` equivalency, but ``dimensionless_angles``
-does not account for the multiplicative factor of ``2*pi`` that is used
-when converting between frequency (1 / s) and angular frequency (rad /
-s). An explicit way to do this conversion is to set up an equivalency
-between cycles/s and Hz:
+the :py:`dimensionless_angles` equivalency, but
+:py:`dimensionless_angles` does not account for the multiplicative
+factor of :math:`2π` that is used when converting between frequency
+(1/s) and angular frequency (rad/s). An explicit way to do this
+conversion is to set up an equivalency between cycles/s and Hz:
 
 .. code-block:: python
 
    import astropy.units as u
    f_ce = omega_ce.to(u.Hz, equivalencies=[(u.cy/u.s, u.Hz)])  # doctest: +SKIP
 
-However, ``dimensionless_angles`` does work when dividing a velocity by
+However, :py:`dimensionless_angles` does work when dividing a velocity by
 an angular frequency to get a length scale:
 
 .. code-block:: python
@@ -841,11 +845,11 @@ accomplishes two goals:
   Currently, reviewers should ensure that submitted notebooks have outputs stripped.
 
 If you have an example notebook that includes packages unavailable in
-the documentation building environment (e.g., ``bokeh``) or runs some
+the documentation building environment (e.g., :py:`bokeh`) or runs some
 heavy computation that should not be executed on every commit, *keep the
 outputs in the notebook* but store it in the repository with a
-``preexecuted_`` prefix, e.g.,
-:file:`preexecuted_full_3d_mhd_chaotic_turbulence_simulation.ipynb`.
+:file:`preexecuted_` prefix (e.g.,
+:file:`preexecuted_full_3d_mhd_chaotic_turbulence_simulation.ipynb`).
 
 Compatibility with Prior Versions of Python, NumPy, and Astropy
 ===============================================================


### PR DESCRIPTION
Was going through old issues and figured I could close this one quickly.  Then I did some more cleanup of the coding guide (i.e., using the `:py:` role so that in-line code gets formatted as Python code).

Closes #1214.