### PR TITLE
Add weekly test of hyperlinks in documentation

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -72,6 +72,12 @@ jobs:
           toxenv: build_docs-sphinxdev
           toxposargs: -q
 
+        - name: Check hyperlinks in documentation
+          os: ubuntu-latest
+          python: '3.11'
+          toxenv: build_docs_linkcheck
+          toxposargs: -q
+
         - name: Python 3.9 with xarray dev
           os: ubuntu-latest
           python: 3.9

--- a/changelog/2328.trivial.rst
+++ b/changelog/2328.trivial.rst
@@ -1,0 +1,1 @@
+Added a weekly test of hyperlinks in the documentation.

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ isolated_build = True
 allowlist_externals =
     /bin/bash
     /usr/bin/bash
+    cat
     echo
 setenv =
     MPLBACKEND = agg
@@ -60,6 +61,16 @@ setenv =
 commands =
     sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
     echo "Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting"
+deps = -r{toxinidir}/requirements.txt
+
+[testenv:build_docs_linkcheck]
+changedir = {toxinidir}
+setenv =
+    HOME = {envtmpdir}
+    PYDEVD_DISABLE_FILE_VALIDATION=1
+commands =
+    sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b linkcheck {posargs}
+    cat docs/_build/html/output.txt
 deps = -r{toxinidir}/requirements.txt
 
 [testenv:build_docs-sphinxdev]


### PR DESCRIPTION
## Description

 - I added a `tox` environment called `build_docs_linkcheck` which verifies hyperlinks in the documentation.  This is essentially `make linkcheck`.
 - I added this environment to our weekly GitHub Actions, which can also be run by workflow dispatch. 

## Motivation and context

This PR is a way to make sure hyperlinks in our docs are up-to-date and we don't have any new cases of [link rot](https://en.wikipedia.org/wiki/Link_rot).

## Related issues

Closes #1266.  See also #2309.
