### PR TITLE
Fix new GitHub Action that checks hyperlinks

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -72,11 +72,10 @@ jobs:
           toxenv: build_docs-sphinxdev
           toxposargs: -q
 
-        - name: Documentation hyperlinks
+        - name: Documentation build with hyperlink check
           os: ubuntu-latest
           python: '3.11'
           toxenv: build_docs_linkcheck
-          toxposargs: -q
 
         - name: Python 3.9 with xarray dev
           os: ubuntu-latest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -72,7 +72,7 @@ jobs:
           toxenv: build_docs-sphinxdev
           toxposargs: -q
 
-        - name: Documentation check hyperlinks
+        - name: Documentation hyperlinks
           os: ubuntu-latest
           python: '3.11'
           toxenv: build_docs_linkcheck

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -72,7 +72,7 @@ jobs:
           toxenv: build_docs-sphinxdev
           toxposargs: -q
 
-        - name: Check hyperlinks in documentation
+        - name: Documentation check hyperlinks
           os: ubuntu-latest
           python: '3.11'
           toxenv: build_docs_linkcheck


### PR DESCRIPTION
A follow-up of #2328.  

This PR renames the environment so that pandoc and graphviz get installed.