### PR TITLE
Update doctests that were not being run until a recent pytest bugfix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,43 @@ _cff_to_rst.main()
 from plasmapy import __version__ as release
 
 # -- General configuration ------------------------------------------------
+
+# If your documentation needs a minimal Sphinx version, state it here.
+
+needs_sphinx = "6.1.3"
+
+# Add Sphinx extension module names here. When extensions are removed or
+# added, please update the corresponding section in docs/doc_guide.rst.
+
+extensions = [
+    "hoverxref.extension",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "nbsphinx",
+    "notfound.extension",
+    "plasmapy_sphinx",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.duration",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.graphviz",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+    "sphinx_changelog",
+    "sphinx_codeautolink",
+    "sphinx_copybutton",
+    "sphinx_gallery.load_style",
+    "sphinx_issues",
+    "sphinx_reredirects",
+    "sphinx_tabs.tabs",
+    "sphinx_toolbox.collapse",
+    "sphinxcontrib.bibtex",
+    "sphinxcontrib.globalsubs",
+]
+
+# plasmapy_sphinx settings
+
 autosummary_generate = True
 automodapi_custom_groups = {
     "aliases": {
@@ -76,42 +113,6 @@ automodapi_group_order = (
     "lite-functions",
     "variables",
 )
-
-# If your documentation needs a minimal Sphinx version, state it here.
-
-needs_sphinx = "6.1.3"
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones. When extensions are removed or added, please update the section
-# in docs/doc_guide.rst on Sphinx extensions.
-
-extensions = [
-    "hoverxref.extension",
-    "IPython.sphinxext.ipython_console_highlighting",
-    "nbsphinx",
-    "notfound.extension",
-    "plasmapy_sphinx",
-    "sphinx.ext.autodoc",
-    "sphinx.ext.duration",
-    "sphinx.ext.extlinks",
-    "sphinx.ext.graphviz",
-    "sphinx.ext.intersphinx",
-    "sphinx.ext.mathjax",
-    "sphinx.ext.napoleon",
-    "sphinx.ext.todo",
-    "sphinx.ext.viewcode",
-    "sphinx_changelog",
-    "sphinx_codeautolink",
-    "sphinx_copybutton",
-    "sphinx_gallery.load_style",
-    "sphinx_issues",
-    "sphinx_reredirects",
-    "sphinx_tabs.tabs",
-    "sphinx_toolbox.collapse",
-    "sphinxcontrib.bibtex",
-    "sphinxcontrib.globalsubs",
-]
 
 # Configure sphinxcontrib-bibtex
 

--- a/plasmapy/formulary/collisions/frequencies.py
+++ b/plasmapy/formulary/collisions/frequencies.py
@@ -519,7 +519,7 @@ class MaxwellianCollisionFrequencies:
         ...     "e-", "Na+", v_drift=v_drift, n_a=n_a, T_a=T_a, n_b=n_b, T_b=T_b, Coulomb_log=Coulomb_log
         ... )
         >>> electron_ion_collisions.Maxwellian_avg_ei_collision_freq
-        <Quantity 2906316911556553.5 Hz>
+        <Quantity 2.8053078...e+15 Hz>
         """
 
         if not self.test_particle.is_electron or not self.field_particle.is_ion:
@@ -576,7 +576,7 @@ class MaxwellianCollisionFrequencies:
         ...     "Na+", "Na+", v_drift=v_drift, n_a=n_a, T_a=T_a, n_b=n_b, T_b=T_b, Coulomb_log=Coulomb_log
         ... )
         >>> ion_ion_collisions.Maxwellian_avg_ii_collision_freq
-        <Quantity 79364412.21510696 Hz>
+        <Quantity 1.1223822...e+08 Hz>
         """
 
         if not self.test_particle.is_ion or not self.field_particle.is_ion:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ arrow==1.2.3
     # via isoduration
 asteval==0.9.31
     # via lmfit
-astropy==5.3.2
+astropy==5.3.3
     # via plasmapy (setup.py)
 asttokens==2.4.0
     # via stack-data
@@ -76,7 +76,7 @@ cssutils==2.7.1
     # via dict2css
 cycler==0.11.0
     # via matplotlib
-debugpy==1.6.7.post1
+debugpy==1.7.0
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -346,7 +346,7 @@ pyparsing==3.0.9
     # via matplotlib
 pyproject-api==1.6.1
     # via tox
-pytest==7.4.1
+pytest==7.4.2
     # via
     #   plasmapy (setup.py)
     #   pytest-datadir


### PR DESCRIPTION
This PR fixes a few doctests that just started failing.

One thing that's strange...  The doctests are now failing both for the newly pinned dependencies as well as the minimal dependencies.  This should not be the case.  