### PR TITLE
Update stale GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,8 +23,4 @@ jobs:
         days-before-issue-close: 90
         days-before-pr-stale: 366
         days-before-pr-close: 60
-        exempt-issue-labels:
-        - Bug
-        - 'Bug: needs more info'
-        - 'Priority: high'
-        - 'Priority: critical'
+        exempt-issue-labels: 'bug,bug: needs more info,epic,priority: high,priority: very high,revisit in 2024,revisit in 2025,revisit in 2026,revisit in 2027'


### PR DESCRIPTION
There was a syntax error in our [stale](https://github.com/actions/stale) GitHub Action.  I put in a list/sequence when it was supposed to be a comma-separated string.  Will merge this so that I can see if it is working now.