### PR TITLE
Update stale GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,7 @@ name: Close stale issues and PRs
 on:
   schedule:
   - cron: 42 4 * * 6
+  workflow_dispatch:
 
 permissions:
   issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,8 +23,4 @@ jobs:
         days-before-issue-close: 90
         days-before-pr-stale: 366
         days-before-pr-close: 60
-        exempt-issue-labels:
-        - Bug
-        - 'Bug: needs more info'
-        - 'Priority: high'
-        - 'Priority: critical'
+        exempt-issue-labels: 'bug,bug: needs more info,epic,priority: high,priority: very high,revisit in 2024,revisit in 2025,revisit in 2026,revisit in 2027'


### PR DESCRIPTION
A quick follow-up to #2336 to enable the stale GitHub Action to be run by workflow dispatch (i.e. so we can trigger it manually).