### PR TITLE
Make `@validate_quantities` accept `Quantity[Unit]` style annotations

### DIFF
--- a/changelog/2346.trivial.rst
+++ b/changelog/2346.trivial.rst
@@ -1,0 +1,2 @@
+Enabled |validate_quantities| to accept annotations of the form
+``u.Quantity[u.m]``, where we have run :py:`import astropy.units as u`.

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -217,8 +217,8 @@ class CheckValues(CheckBase):
         Returns
         -------
         Dict[str, Dict[str, bool]]
-            A complete 'checks' dictionary for checking function input arguments
-            and return.
+            A complete 'checks' dictionary for checking function input
+            arguments and return.
         """
         # initialize validation dictionary
         out_checks = {}
@@ -289,18 +289,18 @@ class CheckValues(CheckBase):
         Parameters
         ----------
         arg
-            The argument to be checked
+            The argument to be checked.
 
         arg_name: str
-            The name of the argument to be checked
+            The name of the argument to be checked.
 
         arg_checks: Dict[str, bool]
-            The requested checks for the argument
+            The requested checks for the argument.
 
         Raises
         ------
         ValueError
-            raised if a check fails
+            If a check fails.
 
         """
         if arg_name == "checks_on_return":
@@ -344,8 +344,8 @@ class CheckValues(CheckBase):
 
 class CheckUnits(CheckBase):
     """
-    A decorator class to 'check' — limit/control — the units of input and return
-    arguments to a function or method.
+    A decorator class to 'check' — limit/control — the units of input
+    and return arguments to a function or method.
 
     Parameters
     ----------
@@ -908,37 +908,42 @@ class CheckUnits(CheckBase):
         return arg, unit, equiv, err
 
     @staticmethod
-    def _condition_target_units(targets: list, from_annotations: bool = False) -> list:
+    def _condition_target_units(
+            targets: list[Union[str, u.Unit, u.Quantity]],
+            from_annotations: bool = False,
+    ) -> list:
         """
-        From a list of target units (either as a string or astropy
-        :class:`~astropy.units.Unit` objects), return a list of conditioned
-        :class:`~astropy.units.Unit` objects.
+        From a `list` of target objects that have or represent units,
+        return a `list` of conditioned :class:`~astropy.units.Unit`
+        objects.
 
         Parameters
         ----------
-        targets: list of target units
-            list of units (either as a string or :class:`~astropy.units.Unit`)
-            to be conditioned into astropy :class:`~astropy.units.Unit` objects
+        targets: `list` of  `str`, `~astropy.units.Unit`, or `~astropy.units.Quantity`
+            A list containing strings representing units (e.g., ``"kg"``,
+            `~astropy.units.Unit` objects (e.g., ``u.kg``), or
+            |Quantity| objects indexed with a `~astropy.units.U nit`
+            object (e.g., ``u.Quantity[u.kg]``).
 
-        from_annotations: bool
-            (Default `False`) Indicates if `targets` originated from function/method
+        from_annotations: bool, default: `False`
+            Indicates if ``targets`` originated from function/method
             annotations versus decorator input arguments.
 
         Returns
         -------
         list:
-            list of `targets` converted into astropy
-            :class:`~astropy.units.Unit` objects
+            `list` of ``targets`` converted into
+            :class:`~astropy.units.Unit` objects.
 
         Raises
         ------
         TypeError
-            If `target` is not a valid type for :class:`~astropy.units.Unit` when
-            `from_annotations == True`,
+            If `target` is not a valid type for
+            :class:`~astropy.units.Unit` when ``from_annotations == True``,
 
         ValueError
-            If a `target` is a valid unit type but not a valid value for
-            :class:`~astropy.units.Unit`.
+            If a ``target`` is a valid unit type but not a valid value
+            for :class:`~astropy.units.Unit`.
         """
         # Note: this method does not allow for astropy physical types. This is
         #       done because we expect all use cases of CheckUnits to define the
@@ -954,13 +959,13 @@ class CheckUnits(CheckBase):
 
             annotation_metadata = getattr(target, "__metadata__", None)
             annotation_original_class = getattr(target, "__origin__", None)
+            tuple_that_should_have_unit =
 
             if (
                 annotation_original_class is u.Quantity
                 and annotation_metadata is not None
             ):
-                if tuple_that_should_have_unit := getattr(target, "__metadata__", None):
-                    target = tuple_that_should_have_unit[0]
+                target = tuple_that_should_have_unit[0]
 
             try:
                 target_unit = u.Unit(target)

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -909,8 +909,8 @@ class CheckUnits(CheckBase):
 
     @staticmethod
     def _condition_target_units(
-            targets: list[Union[str, u.Unit, u.Quantity]],
-            from_annotations: bool = False,
+        targets: list[Union[str, u.Unit, u.Quantity]],
+        from_annotations: bool = False,
     ) -> list:
         """
         From a `list` of target objects that have or represent units,
@@ -964,7 +964,7 @@ class CheckUnits(CheckBase):
                 annotation_original_class is u.Quantity
                 and annotation_metadata is not None
             ):
-                target = annotation_metadata[0]
+                target = annotation_metadata[0]  # noqa: PLW2901
 
             try:
                 target_unit = u.Unit(target)

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -946,7 +946,6 @@ class CheckUnits(CheckBase):
         #
         allowed_units = []
         for target in targets:
-
             # The following two blocks are to create extract the unit from
             # annotations of the form u.Quantity[u.m], which is an annotated
             # alias.  The unit is stored as the first item in the __metadata__
@@ -956,7 +955,10 @@ class CheckUnits(CheckBase):
             annotation_metadata = getattr(target, "__metadata__", None)
             annotation_original_class = getattr(target, "__origin__", None)
 
-            if annotation_original_class is u.Quantity and annotation_metadata is not None:
+            if (
+                annotation_original_class is u.Quantity
+                and annotation_metadata is not None
+            ):
                 if tuple_that_should_have_unit := getattr(target, "__metadata__", None):
                     target = tuple_that_should_have_unit[0]
 

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -948,7 +948,7 @@ class CheckUnits(CheckBase):
         # Note: this method does not allow for astropy physical types. This is
         #       done because we expect all use cases of CheckUnits to define the
         #       exact units desired.
-        #
+
         allowed_units = []
         for target in targets:
             # The following two blocks are to create extract the unit from
@@ -959,13 +959,12 @@ class CheckUnits(CheckBase):
 
             annotation_metadata = getattr(target, "__metadata__", None)
             annotation_original_class = getattr(target, "__origin__", None)
-            tuple_that_should_have_unit =
 
             if (
                 annotation_original_class is u.Quantity
                 and annotation_metadata is not None
             ):
-                target = tuple_that_should_have_unit[0]
+                target = annotation_metadata[0]
 
             try:
                 target_unit = u.Unit(target)

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -946,6 +946,20 @@ class CheckUnits(CheckBase):
         #
         allowed_units = []
         for target in targets:
+
+            # The following two blocks are to create extract the unit from
+            # annotations of the form u.Quantity[u.m], which is an annotated
+            # alias.  The unit is stored as the first item in the __metadata__
+            # attribute and the original class is stored in the __origin__
+            # attribute.
+
+            annotation_metadata = getattr(target, "__metadata__", None)
+            annotation_original_class = getattr(target, "__origin__", None)
+
+            if annotation_original_class is u.Quantity and annotation_metadata is not None:
+                if tuple_that_should_have_unit := getattr(target, "__metadata__", None):
+                    target = tuple_that_should_have_unit[0]
+
             try:
                 target_unit = u.Unit(target)
                 allowed_units.append(target_unit)

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -630,7 +630,11 @@ class TestValidateClassAttributes:
                     getattr(test_case, method)
 
 
-def test_validate_quantities_decorate_argument():
+def test_validate_quantities_argument_type_annotation():
+    """
+    Test that |validate_quantities| works with type hint annotations of
+    the form ``u.Quantity[u.m]`` on a function argument.
+    """
 
     @validate_quantities
     def f(x: u.Quantity[u.m]):
@@ -644,7 +648,12 @@ def test_validate_quantities_decorate_argument():
     assert actual.unit == expected.unit
 
 
-def test_validate_quantities_return_annotation():
+def test_validate_quantities_return_type_annotation():
+    """
+    Test that |validate_quantities| works with type hint annotations of
+    the form ``u.Quantity[u.m]`` as a return argument.
+    """
+
     @validate_quantities
     def f(x) -> u.Quantity[u.m]:
         return x

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -637,3 +637,28 @@ class TestValidateClassAttributes:
             else:
                 with pytest.raises(ValueError):
                     getattr(test_case, method)
+
+# add this to class later
+def test_validate_quantities_decorate_argument():
+    @validate_quantities
+    def f(x: u.Quantity[u.m]):
+        return x
+
+    argument = 100 * u.cm
+    expected = 1 * u.m
+    actual = f(argument)
+
+    assert u.isclose(actual, expected)
+    assert actual.unit == expected.unit
+
+def test_validate_quantities_return_annotation():
+    @validate_quantities
+    def f(x) -> u.Quantity[u.m]:
+        return x
+
+    argument = 100 * u.cm
+    expected = 1 * u.m
+    actual = f(argument)
+
+    assert u.isclose(actual, expected)
+    assert actual.unit == expected.unit

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -638,6 +638,7 @@ class TestValidateClassAttributes:
                 with pytest.raises(ValueError):
                     getattr(test_case, method)
 
+
 # add this to class later
 def test_validate_quantities_decorate_argument():
     @validate_quantities
@@ -650,6 +651,7 @@ def test_validate_quantities_decorate_argument():
 
     assert u.isclose(actual, expected)
     assert actual.unit == expected.unit
+
 
 def test_validate_quantities_return_annotation():
     @validate_quantities

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -6,7 +6,6 @@ import astropy.units as u
 import inspect
 import pytest
 
-from functools import cached_property
 from typing import Optional
 from unittest import mock
 
@@ -573,29 +572,29 @@ class TestValidateClassAttributes:
             self.y = y
             self.z = z
 
-        @cached_property
+        @property
         @validate_class_attributes(expected_attributes=["x"])
         def require_x(self):
             return 0
 
-        @cached_property
+        @property
         @validate_class_attributes(expected_attributes=["x", "y"])
         def require_x_and_y(self):
             return 0
 
-        @cached_property
+        @property
         @validate_class_attributes(both_or_either_attributes=[("x", "y")])
         def require_x_or_y(self):
             return 0
 
-        @cached_property
+        @property
         @validate_class_attributes(
             expected_attributes=["x"], both_or_either_attributes=[("y", "z")]
         )
         def require_x_and_either_y_or_z(self):
             return 0
 
-        @cached_property
+        @property
         @validate_class_attributes(mutually_exclusive_attributes=[("x", "y")])
         def require_only_either_x_or_y(self):
             return 0

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -17,9 +17,6 @@ from plasmapy.utils.decorators.validators import (
 )
 
 
-# ----------------------------------------------------------------------------------------
-# Test Decorator class `ValidateQuantities` and decorator `validate_quantities`
-# ----------------------------------------------------------------------------------------
 class TestValidateQuantities:
     """
     Test for decorator
@@ -297,7 +294,7 @@ class TestValidateQuantities:
             },
         ]
 
-        # setup wrapped function
+        # set up wrapped function
         vq = ValidateQuantities()
         vq.f = self.foo
 
@@ -345,8 +342,6 @@ class TestValidateQuantities:
 
     def test_vq_preserves_signature(self):
         """Test `ValidateQuantities` preserves signature of wrapped function."""
-        # I'd like to directly test the @preserve_signature is used (??)
-
         wfoo = ValidateQuantities()(self.foo_anno)
         assert hasattr(wfoo, "__signature__")
         assert wfoo.__signature__ == inspect.signature(self.foo_anno)
@@ -534,12 +529,10 @@ class TestValidateQuantities:
                     #  @validate_quantities(x=check)
                     #      def foo(x):
                     #          return x
-                    #
                     wfoo = validate_quantities(**case["setup"]["validations"])(mock_foo)
                 else:
                     continue
 
-                # test
                 args = case["setup"]["args"]
                 kwargs = case["setup"]["kwargs"]
                 assert wfoo(*args, **kwargs) == case["output"]
@@ -555,7 +548,6 @@ class TestValidateQuantities:
                 for arg_name, validations in case["setup"]["validations"].items():
                     assert mock_vq_class.call_args[1][arg_name] == validations
 
-                # reset
                 mock_vq_class.reset_mock()
                 mock_foo.reset_mock()
 
@@ -638,8 +630,8 @@ class TestValidateClassAttributes:
                     getattr(test_case, method)
 
 
-# add this to class later
 def test_validate_quantities_decorate_argument():
+
     @validate_quantities
     def f(x: u.Quantity[u.m]):
         return x

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -62,7 +62,7 @@ class TestValidateQuantities:
         # 'output' = expected return from `_get_validations`
         # 'raises' = if `_get_validations` raises an Exception
         # 'warns' = if `_get_validations` issues a warning
-        #
+
         _cases = [
             {
                 "descr": "typical call...using 'can_be_negative'",
@@ -229,7 +229,7 @@ class TestValidateQuantities:
         # 'output' = expected return from `_get_validations`
         # 'raises' = if `_get_validations` raises an Exception
         # 'warns' = if `_get_validations` issues a warning
-        #
+
         _cases = [
             # typical call
             {
@@ -361,7 +361,7 @@ class TestValidateQuantities:
         # 'output' = expected return from wrapped function
         # 'raises' = if an Exception is expected to be raised
         # 'warns' = if a warning is expected to be issued
-        #
+
         _cases = [
             {
                 "descr": "clean execution",
@@ -496,7 +496,7 @@ class TestValidateQuantities:
         # 'output' = expected return from wrapped function
         # 'raises' = a raised Exception is expected
         # 'warns' = an issued warning is expected
-        #
+
         _cases = [
             # only argument checks
             {

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -472,7 +472,6 @@ def validate_quantities(func=None, validations_on_return=None, **validations):
             def bar(self, mass, vel):
                 return mass * vel
 
-
     Define units with function annotations::
 
         import astropy.units as u
@@ -492,6 +491,15 @@ def validate_quantities(func=None, validations_on_return=None, **validations):
             @validate_quantities(mass={'can_be_negative': False})
             def bar(self, mass: u.g, vel: u.cm / u.s) -> u.g * u.cm / u.s:
                 return mass * vel
+
+    Define units using type hint annotations::
+
+        import astropy.units as u
+        from plasmapy.decorators import validate_quantities
+
+        @validate_quantities
+        def foo(x: u.Quantity[u.m], time: u.Quantity[u.s]) -> u.Quantity[u.m / u.s]:
+            return x / time
 
     Allow `None` values to pass::
 


### PR DESCRIPTION
## Description

This PR makes it so that `@validate_quantities` accepts annotations of the style:

```python
@validate_quantities
def convert_to_meters(x: u.Quantity[u.m]) -> u.Quantity[u.m]:
    return x
```

I still need to update the documentation and make more thorough tests.

~~**This might not work for Python 3.9, but it should work for Python 3.10+.** We can add the capability now, but we will not be able to apply it in our repository until we drop Python 3.9 support for our 2024.5.0 release.~~

I was pleasantly surprised that this is working for Python 3.9 as well as 3.10 & 3.11.  Not sure why...but I'll take it!

## Motivation and context

<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->

Before this pull request, annotations used by `@validate_quantities` had to be unit-like objects, like `f(x: u.m):`.  However, this is incompatible with mypy, which is expecting `Quantity` as an annotation.  This PR will make it so that annotations can actually be type hint annotations.

## Related issues

Closes #1413. Related to #268.
