### PR TITLE
Make minor updates related to testing and CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
           toxargs: --develop
 
         - name: Python 3.10 (MacOS), code coverage
-          os: windows-latest
+          os: macos-latest
           python: '3.10'
           toxenv: py310-cov-all
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -121,6 +121,6 @@ jobs:
 
     - name: Upload coverage to codecov
       if: ${{ contains(matrix.toxenv,'-cov') }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
     COLUMNS = 180
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 -n=auto --tb=short --dist=loadfile
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 -n=auto --dist=loadfile
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
     COLUMNS = 180
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 -n=auto --dist=loadfile
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 -n=auto --tb=short --dist=loadfile
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
     COLUMNS = 180
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals -n=auto --dist=loadfile
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 -n=auto --dist=loadfile
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
@@ -110,8 +110,6 @@ conda_deps =
     matplotlib >= 3.5.1
     mpmath >= 1.2.1
     numpy >= 1.21.0
-    numpydoc
-    pillow
     pytest >= 5.4.0
     scipy >= 1.5.0
     sphinx
@@ -122,21 +120,18 @@ conda_deps =
 basepython = python3.9
 extras = tests
 deps =
-    astropy == 5.0.1
+    astropy == 5.0.2
     h5py == 3.3.0
     ipykernel == 5.5.6
     ipywidgets == 7.6.5
-    hypothesis == 6.35.1
     lmfit == 1.0.3
     matplotlib == 3.5.1
     mpmath == 1.2.1
     numba == 0.56.0
     numpy == 1.21.0
+    packaging == 22.0
     pandas == 1.2.0
     pillow == 9.5.0
-    pytest == 6.0.0
-    pytest-cov
-    pytest-regressions == 2.3.1
     requests == 2.27.1
     scipy == 1.7.0
     tqdm == 4.60.0
@@ -144,7 +139,7 @@ deps =
     wrapt == 1.12.1
     xarray == 2022.3.0
 setenv =
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=25 --showlocals
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5
 
 [testenv:linters]
 deps =


### PR DESCRIPTION
 - The testing environment defined in `tox.ini` for running tests against our minimal dependencies now only contains the dependencies listed in `pyproject.toml` for regular installation (i.e. excluding docs & tests dependencies)
 - I updated a GitHub Action so that the OS for an environment actually matches the name of the test.