### PR TITLE
Update tolerances in Langmuir tests

### DIFF
--- a/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
@@ -291,7 +291,7 @@ class TestFindIonSaturationCurrent:
             voltage, current, fit_type="exp_plus_linear", current_bound=3.6
         )
 
-        assert np.isclose(isat.params.m, 3.81079e-6)
-        assert np.isclose(isat.params.b, 0.000110284)
-        assert np.isclose(extras.rsq, 0.982, atol=0.001)
-        assert np.isclose(np.min(isat(voltage)), -0.00014275)
+        assert np.isclose(isat.params.m, 3.81079e-6, rtol=1e-3, atol=0)
+        assert np.isclose(isat.params.b, 0.000110422, rtol=1e-3, atol=0)
+        assert np.isclose(extras.rsq, 0.982, rtol=0, atol=0.001)
+        assert np.isclose(np.min(isat(voltage)), -0.00014275, rtol=1e-4, atol=0)

--- a/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
@@ -292,6 +292,6 @@ class TestFindIonSaturationCurrent:
         )
 
         assert np.isclose(isat.params.m, 3.81079e-6, rtol=1e-3, atol=0)
-        assert np.isclose(isat.params.b, 0.000110422, rtol=1e-3, atol=0)
-        assert np.isclose(extras.rsq, 0.982, rtol=0, atol=0.001)
-        assert np.isclose(np.min(isat(voltage)), -0.00014275, rtol=1e-4, atol=0)
+        assert np.isclose(isat.params.b, 0.000110422, rtol=2e-3, atol=0)
+        assert np.isclose(extras.rsq, 0.982, rtol=0, atol=0.002)
+        assert np.isclose(np.min(isat(voltage)), -0.00014275, rtol=2e-3, atol=0)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

<!-- Please summarize the changes here. -->

 - Updated the value of `b` in a test of finding the ion saturation current.
 - Added values for `rtol` and `atol` in this test.

There also seem to be slight differences ($𝒪(10^{-3}$?) in some of the fitted values depending on if it's NumPy 1.24 or 1.25.  Hm...

## Related issues

See #2347.
