### PR TITLE
Update changelog prior to next release

### DIFF
--- a/changelog/2068.feature.rst
+++ b/changelog/2068.feature.rst
@@ -1,1 +1,2 @@
-Added the `~plasmapy.plasma.equilibria1d.HarrisSheet` class to calculate magnetic field, current density, and plasma pressure for 1D Harris Sheets.
+Added the `~plasmapy.plasma.equilibria1d.HarrisSheet` class to calculate
+magnetic field, current density, and plasma pressure for 1D Harris sheets.

--- a/changelog/2195.doc.rst
+++ b/changelog/2195.doc.rst
@@ -1,1 +1,0 @@
-Fixed a typo in the Stix notebook.

--- a/changelog/2229.trivial.rst
+++ b/changelog/2229.trivial.rst
@@ -1,1 +1,2 @@
-Distributions defined in the `~plasmapy.formulary.distribution` module will now raise a ``ValueError`` for an improper ``units`` parameter.
+Distributions defined in the `~plasmapy.formulary.distribution` module
+will now raise a `ValueError` for an improper ``units`` parameter.

--- a/changelog/2248.bugfix.rst
+++ b/changelog/2248.bugfix.rst
@@ -1,1 +1,2 @@
-Fixed a bug that had been causing incorrect results in `~plasmapy.formulary.collisions.helio.collisional_analysis.temp_ratio`.
+Fixed a bug that had been causing incorrect results
+in `~plasmapy.formulary.collisions.helio.collisional_analysis.temp_ratio`.

--- a/changelog/2262.trivial.rst
+++ b/changelog/2262.trivial.rst
@@ -1,3 +1,3 @@
-Improved the error message from `~plasmapy.formulary.speeds.Alfven_speed`
+Improved the error message issued by `~plasmapy.formulary.speeds.Alfven_speed`
 when the argument provided to ``density`` has a physical type of
 number density and ``ion`` is not provided.

--- a/changelog/2262.trivial.rst
+++ b/changelog/2262.trivial.rst
@@ -1,3 +1,3 @@
-Improved the error message to `~plasmapy.formulary.speeds.Alfven_speed`
+Improved the error message from `~plasmapy.formulary.speeds.Alfven_speed`
 when the argument provided to ``density`` has a physical type of
 number density and ``ion`` is not provided.

--- a/changelog/2268.doc.rst
+++ b/changelog/2268.doc.rst
@@ -1,2 +1,2 @@
-Enabled the ``sphinx.ext.duration`` extension to add links to the source code of an
-object.
+Enabled the `sphinx.ext.duration` extension to show the the times required
+to process different pages during documentation builds.

--- a/changelog/2268.doc.rst
+++ b/changelog/2268.doc.rst
@@ -1,2 +1,2 @@
-Enabled the `sphinx.ext.duration` extension to show the the times required
+Enabled the `sphinx.ext.duration` extension to show the times required
 to process different pages during documentation builds.

--- a/changelog/2269.doc.rst
+++ b/changelog/2269.doc.rst
@@ -1,1 +1,2 @@
-Enabled a Sphinx extension for adding links to source code pages.
+Enabled the `sphinx.ext.viewcode` extension for adding links in the
+documentation to pages containing the source code.

--- a/changelog/2272.doc.rst
+++ b/changelog/2272.doc.rst
@@ -1,3 +1,4 @@
-Moved definitions of |reStructuredText| substitutions from :file:`docs/common_links.rst`
-to the file :file:`docs/contributing/doc_guide.rst` in order to speed up the
+Moved definitions of certain |reStructuredText| substitutions
+from :file:`docs/common_links.rst` to the
+file :file:`docs/contributing/doc_guide.rst` in order to speed up the
 documentation build (see :issue:`2277`\ ).

--- a/changelog/2282.doc.rst
+++ b/changelog/2282.doc.rst
@@ -1,5 +1,4 @@
-Changed ``from astropy import units as u``
-to ``import astropy.units as u``
-and ``from astropy import constants as const``
-to ``import astropy.constants as const`` in order to increase
-consistency of import statements.
+Changed :py:`from astropy import units as u` to :py:`import astropy.units as u`
+and :py:`from astropy import constants as const`
+to :py:`import astropy.constants as const` throughout the code in order to
+increase consistency of import statements.

--- a/changelog/2289.feature.rst
+++ b/changelog/2289.feature.rst
@@ -1,1 +1,3 @@
-Added the `~plasmapy.plasma.cylindrical_equilibria.ForceFreeFluxRope` class to calculate magnetic field for the Lundquist solution for cylindrical equilibria.
+Added the `~plasmapy.plasma.cylindrical_equilibria.ForceFreeFluxRope`
+class to calculate magnetic field for the Lundquist solution for
+force-free cylindrical equilibria.

--- a/changelog/2295.trivial.rst
+++ b/changelog/2295.trivial.rst
@@ -1,1 +1,1 @@
-Expanded the ``ruff`` settings to include more linter rules.
+Expanded the |ruff| settings to include more linter rules.

--- a/changelog/2296.trivial.rst
+++ b/changelog/2296.trivial.rst
@@ -1,2 +1,2 @@
-Add |ruff| linter rules that check for :py:`print` and :py:`pprint`, as
+Add |ruff| linter rules that check for `print` and :py:`pprint`, as
 the `logging` library is generally preferred for production code.

--- a/changelog/2296.trivial.rst
+++ b/changelog/2296.trivial.rst
@@ -1,2 +1,2 @@
-Add ``ruff`` linter rules that check for ``print`` and ``pprint``, as
+Add |ruff| linter rules that check for :py:`print` and :py:`pprint`, as
 the `logging` library is generally preferred for production code.

--- a/changelog/2308.doc.rst
+++ b/changelog/2308.doc.rst
@@ -1,1 +1,1 @@
-Fixed broken hyperlinks and reStructuredText references.
+Fixed broken hyperlinks and |reStructuredText| references.

--- a/changelog/2309.doc.rst
+++ b/changelog/2309.doc.rst
@@ -1,3 +1,0 @@
-Moved the settings for linkcheck documentation builds into
-:file:`docs/_linkcheck_settings.py`, and expanded the list of links to
-be ignored when doing a linkcheck documentation build.

--- a/changelog/2328.trivial.rst
+++ b/changelog/2328.trivial.rst
@@ -1,1 +1,2 @@
-Added a weekly test of hyperlinks in the documentation.
+Added a weekly linkcheck test that verifies that hyperlinks in the
+documentation are up-to-date.

--- a/changelog/2346.trivial.rst
+++ b/changelog/2346.trivial.rst
@@ -1,2 +1,2 @@
 Enabled |validate_quantities| to accept annotations of the form
-``u.Quantity[u.m]``, where we have run :py:`import astropy.units as u`.
+:py:`u.Quantity[u.m]`, where we have run :py:`import astropy.units as u`.

--- a/changelog/2346.trivial.rst
+++ b/changelog/2346.trivial.rst
@@ -1,2 +1,2 @@
 Enabled |validate_quantities| to accept annotations of the form
-:py:`u.Quantity[u.m]`, where we have run :py:`import astropy.units as u`.
+:py:`u.Quantity[u.m]`, where we have previously run :py:`import astropy.units as u`.

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -800,7 +800,7 @@ The type specification should not include information about the
    conventions from the `numpydoc style guide
    <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`__,
    the `matplotlib documentation guide
-   <https://matplotlib.org/stable/devel/documenting_mpl.html#parameter-type-descriptions>`__,
+   <https://matplotlib.org/stable/devel/document.html#parameter-type-descriptions>`__,
    or the `LSST docstring guide
    <https://developer.lsst.io/python/numpydoc.html>`__.
 


### PR DESCRIPTION
This PR revises some changelog entries that have been made since the previous release.

I applied the "No changelog entry needed" label so that the Giles check doesn't give errors related to editing changelog entries for pull requests other than this one.