### PR TITLE
Update docstrings and annotations in formulary length calculations

### DIFF
--- a/changelog/2356.doc.rst
+++ b/changelog/2356.doc.rst
@@ -1,0 +1,1 @@
+Updated the docstrings and type hint annotations in `plasmapy.formulary.lengths`.

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -297,14 +297,14 @@ Here is an example docstring in the numpydoc_ format:
        Parameters
        ----------
        a : `float`
-           The left multiplicand.
+           The number from which ``b`` will be subtracted.
 
        b : `float`
-           The right multiplicand.
+           The number being subtracted from ``a``.
 
-       switch_order : `bool`, optional, |keyword-only|
+       switch_order : `bool`, |keyword-only|, default: `True`
            If `True`, return :math:`a - b`. If `False`, then return
-           :math:`b - a`. Defaults to `True`.
+           :math:`b - a`.
 
        Returns
        -------
@@ -356,7 +356,7 @@ Here is an example docstring in the numpydoc_ format:
        if np.isinf(a) or np.isinf(b):
            raise ValueError("Cannot perform subtraction operations involving infinity.")
 
-       warnings.warn("The subtract function encountered a nan value.", UserWarning)
+       warnings.warn("The `subtract` function encountered a nan value.", UserWarning)
 
        return b - a if switch_order else a - b
 

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -653,7 +653,7 @@ def _spectral_density_model(wavelengths, settings=None, **params):
     electron_vel = electron_speed[:, np.newaxis] * electron_vdir
     ion_vel = ion_speed[:, np.newaxis] * ion_vdir
 
-    # Convert temperatures from eV to Kelvin (required by fast_spectral_density)
+    # Convert temperatures from eV to kelvin (required by fast_spectral_density)
     T_e *= 11604.51812155
     T_i *= 11604.51812155
 

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -232,7 +232,7 @@ def gyroradius(  # noqa: C901
     :math:`k_B T`, to ``T``.
 
     >>> gyroradius(B = 5 * u.T, particle=["D+", "T+"], T = 13 * u.keV)
-    <Quantity 0.0046... m>
+    <Quantity [0.00465..., 0.00570...] m>
 
     Relativistic effects are included by default, but can be turned
     off using the ``relativistic`` parameter. Let's use this in the

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -118,7 +118,7 @@ def gyroradius(  # noqa: C901
 ) -> u.Quantity[u.m]:
     r"""
     Calculate the radius of circular motion for a charged particle in a
-    uniform magnetic field.
+    uniform magnetic field (including relativistic effects by default).
 
     **Aliases:** `rc_`, `rhoc_`
 
@@ -144,8 +144,8 @@ def gyroradius(  # noqa: C901
         ``Vperp`` is provided.
 
     lorentzfactor : `float` or `~numpy.ndarray`, |keyword-only|, optional
-        The :wikipedia:`Lorentz factor` of the particle corresponding
-        to the direction perpendicular to the magnetic field. Cannot be
+        The :wikipedia:`Lorentz factor` of the particle corresponding to
+        the direction perpendicular to the magnetic field. Cannot be
         provided if ``Vperp`` or ``T`` is provided.
 
     relativistic : `bool`, |keyword-only|, default: `True`


### PR DESCRIPTION
## Description

I'm updating the docstring of `gyroradius`, including some reorganization and more narrative examples.

## Motivation and context

I was looking through the online documentation and noticed that some of the symbols in the docstring for `gyroradius` were specific to ions.
