### PR TITLE
Consistentify type specifications in docstrings

### DIFF
--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -728,7 +728,7 @@ The **type specification** may include:
 * Size and/or shape information
 * Type information
 * Valid choices for the parameter
-* Whether the parameter is optional, |keyword-only|, and/or
+* Whether the parameter is |keyword-only|, optional, and/or
   positional-only
 * Default values
 

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -1418,9 +1418,8 @@ def _vspace_iterator(vspace, maxiter=500, err=1e-10):
         vector values, and the third element containing the delta values
         for each dimension.
 
-    maxiter : int
-        The maximum iterations of the Newton-Raphson method. Defaults to
-        500.
+    maxiter : int, default: 500
+        The maximum iterations of the Newton-Raphson method.
 
     err : float, default: ``1e-10``
         The threshold/error that determines if convergence has occurred
@@ -1499,9 +1498,8 @@ def null_point_find(
         the vector space. If not given, the vector values are generated
         over the vector space using the function func.
 
-    maxiter: int
-        The maximum iterations of the Newton-Raphson method. Defaults to
-        500.
+    maxiter: int, default: 500
+        The maximum iterations of the Newton-Raphson method.
 
     err: float, default: ``1e-10``
         The threshold/error that determines if convergence has occurred

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -127,17 +127,17 @@ def gyroradius(  # noqa: C901
         ionized helium-4). If no charge state information is
         provided, then the particles are assumed to be singly charged.
 
-    Vperp : `~astropy.units.Quantity`, optional, |keyword-only|
+    Vperp : `~astropy.units.Quantity`, |keyword-only|, optional
         The component of particle velocity that is perpendicular to
         the magnetic field in units convertible to meters per second.
 
-    T : `~astropy.units.Quantity`, optional, |keyword-only|
+    T : `~astropy.units.Quantity`, |keyword-only|, optional
         The particle temperature in units convertible to kelvin.
 
-    lorentzfactor : `float` or `~numpy.ndarray`, optional, |keyword-only|
+    lorentzfactor : `float` or `~numpy.ndarray`, |keyword-only|, optional
         The Lorentz factor for the particles, use for high precision.
 
-    relativistic : `bool`, optional, |keyword-only|
+    relativistic : `bool`, |keyword-only|, optional
         Whether or not you want to use a relativistic approximation.
         `True` by default.
 

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -210,29 +210,29 @@ class RelativisticBody:
         The momentum of the relativistic body in units convertible to
         kg·m/s.
 
-    total_energy : |Quantity|, optional, |keyword-only|
+    total_energy : |Quantity|, |keyword-only|, optional
        The sum of the mass energy and the kinetic energy in units
        convertible to joules. Must be non-negative.
 
-    kinetic_energy : |Quantity|, optional, |keyword-only|
+    kinetic_energy : |Quantity|, |keyword-only|, optional
        The kinetic energy of the relativistic body in units convertible
        to joules. Must be non-negative.
 
-    v_over_c : real number or |Quantity|, optional, |keyword-only|
+    v_over_c : real number or |Quantity|, |keyword-only|, optional
        The ratio of the velocity to the speed of light. Must have an
        absolute magnitude :math:`≤ 1`\ .
 
-    lorentz_factor : real number or |Quantity|, optional, |keyword-only|
+    lorentz_factor : real number or |Quantity|, |keyword-only|, optional
        The Lorentz factor of the relativistic body. Must be
        :math:`≥ 1`\ .
 
-    Z : integer, optional, |keyword-only|
+    Z : integer, |keyword-only|, optional
         The charge number associated with ``particle``.
 
-    mass_numb : integer, optional, |keyword-only|
+    mass_numb : integer, |keyword-only|, optional
         The mass number associated with ``particle``.
 
-    dtype : |DTypeLike|, optional, |keyword-only|, default: `numpy.longdouble`
+    dtype : |DTypeLike|, |keyword-only|, optional, default: `numpy.longdouble`
         The `numpy` data type to use to store the inputs.
 
     Notes

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -232,7 +232,7 @@ class RelativisticBody:
     mass_numb : integer, |keyword-only|, optional
         The mass number associated with ``particle``.
 
-    dtype : |DTypeLike|, |keyword-only|, optional, default: `numpy.longdouble`
+    dtype : |DTypeLike|, |keyword-only|, default: `numpy.longdouble`
         The `numpy` data type to use to store the inputs.
 
     Notes

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -204,7 +204,7 @@ class RelativisticBody:
     V : |Quantity|, optional
         The velocity of the relativistic body in units convertible to
         m/s. The absolute magnitude of ``V`` cannot be greater than
-        :math:`c`\ .
+        :math:`c`.
 
     momentum : |Quantity|, optional
         The momentum of the relativistic body in units convertible to
@@ -220,11 +220,11 @@ class RelativisticBody:
 
     v_over_c : real number or |Quantity|, |keyword-only|, optional
        The ratio of the velocity to the speed of light. Must have an
-       absolute magnitude :math:`≤ 1`\ .
+       absolute magnitude :math:`≤ 1`.
 
     lorentz_factor : real number or |Quantity|, |keyword-only|, optional
-       The Lorentz factor of the relativistic body. Must be
-       :math:`≥ 1`\ .
+       The Lorentz factor, :math:`γ` of the relativistic body. Must have
+       :math:`γ ≥ 1`.
 
     Z : integer, |keyword-only|, optional
         The charge number associated with ``particle``.

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -200,10 +200,10 @@ def particle_mass(
         particle; an integer representing an atomic number; or a
         |Particle|.
 
-    mass_numb : integer, optional, |keyword-only|
+    mass_numb : integer, |keyword-only|, optional
         The mass number of an isotope.
 
-    Z : integer, optional, |keyword-only|
+    Z : integer, |keyword-only|, optional
         The |charge number| of an ion or neutral atom.
 
     Returns

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -1068,7 +1068,7 @@ def ionic_levels(
     particle : |atom-like|
         Representation of an element, ion, or isotope.
 
-    min_charge : integer, optional, default: ``0``
+    min_charge : integer, default: ``0``
         The starting charge number.
 
     max_charge : integer, optional

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -163,10 +163,10 @@ class _ParticleInput:
         Categories that a particle cannot be in.  If a particle is in
         any of these categories, then a |ParticleError| will be raised.
 
-    allow_custom_particles : bool, |keyword-only|, optional, default: `True`
+    allow_custom_particles : bool, |keyword-only|, default: `True`
         If `True`, allow |CustomParticle| instances to be passed through.
 
-    allow_particle_lists : bool, |keyword-only|, optional, default: `True`
+    allow_particle_lists : bool, |keyword-only|, default: `True`
         If `True`, allow |ParticleList| instances to be passed through.
     """
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -151,22 +151,22 @@ class _ParticleInput:
     callable_ : callable
         The callable_ or method to be decorated.
 
-    require : `str`, `set`, `list`, or `tuple`, optional, |keyword-only|
+    require : `str`, `set`, `list`, or `tuple`, |keyword-only|, optional
         Categories that a particle must be in.  If a particle is not in
         all of these categories, then a |ParticleError| will be raised.
 
-    any_of : `str`, `set`, `list`, or `tuple`, optional, |keyword-only|
+    any_of : `str`, `set`, `list`, or `tuple`, |keyword-only|, optional
         Categories that a particle may be in.  If a particle is not in
         any of these categories, then a |ParticleError| will be raised.
 
-    exclude : `str`, `set`, `list`, or `tuple`, optional, |keyword-only|
+    exclude : `str`, `set`, `list`, or `tuple`, |keyword-only|, optional
         Categories that a particle cannot be in.  If a particle is in
         any of these categories, then a |ParticleError| will be raised.
 
-    allow_custom_particles : bool, optional, |keyword-only|, default: `True`
+    allow_custom_particles : bool, |keyword-only|, optional, default: `True`
         If `True`, allow |CustomParticle| instances to be passed through.
 
-    allow_particle_lists : bool, optional, |keyword-only|, default: `True`
+    allow_particle_lists : bool, |keyword-only|, optional, default: `True`
         If `True`, allow |ParticleList| instances to be passed through.
     """
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -280,7 +280,7 @@ class _ParticleInput:
     def allow_custom_particles(self) -> bool:
         """
         If `True`, then the decorated argument may be or include
-        |CustomParticle| instances. Defaults to `True`.
+        |CustomParticle| instances.
 
         Returns
         -------
@@ -296,7 +296,6 @@ class _ParticleInput:
     def allow_particle_lists(self) -> bool:
         """
         If `True`, then the decorated argument may be a |ParticleList|.
-        Defaults to `True`.
 
         Returns
         -------

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -194,7 +194,7 @@ class IonizationState:
         The number density of the element, including neutrals and all
         ions.
 
-    tol : `float` or integer, |keyword-only|, optional, default: ``1e-15``
+    tol : `float` or integer, |keyword-only|, default: ``1e-15``
         The absolute tolerance used by `~numpy.isclose` and similar
         functions when testing normalizations and making comparisons.
 
@@ -811,15 +811,15 @@ class IonizationState:
 
         Parameters
         ----------
-        include_neutrals : `bool`, |keyword-only|, optional, default: `True`
+        include_neutrals : `bool`, |keyword-only|, default: `True`
             If `True`, include neutrals when calculating the mean values
             of the different particles.  If `False`, exclude neutrals.
 
-        use_rms_charge : `bool`, |keyword-only|, optional, default: `False`
+        use_rms_charge : `bool`, |keyword-only|, default: `False`
             If `True`, use the root-mean-square charge instead of the
             mean charge.
 
-        use_rms_mass : `bool`, |keyword-only|, optional, default: `False`
+        use_rms_mass : `bool`, |keyword-only|, default: `False`
             If `True`, use the root-mean-square mass instead of the mean
             mass.
 

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -811,15 +811,15 @@ class IonizationState:
 
         Parameters
         ----------
-        include_neutrals : `bool`, optional, |keyword-only|, default: `True`
+        include_neutrals : `bool`, |keyword-only|, optional, default: `True`
             If `True`, include neutrals when calculating the mean values
             of the different particles.  If `False`, exclude neutrals.
 
-        use_rms_charge : `bool`, optional, |keyword-only|, default: `False`
+        use_rms_charge : `bool`, |keyword-only|, optional, default: `False`
             If `True`, use the root-mean-square charge instead of the
             mean charge.
 
-        use_rms_mass : `bool`, optional, |keyword-only|, default: `False`
+        use_rms_mass : `bool`, |keyword-only|, optional, default: `False`
             If `True`, use the root-mean-square mass instead of the mean
             mass.
 

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -64,7 +64,7 @@ class IonizationStateCollection:
     kappa : `float`, |keyword-only|, optional
         The value of kappa for a kappa distribution function.
 
-    tol : `float` or `integer`, |keyword-only|, optional, default: ``1e-15``
+    tol : `float` or `integer`, |keyword-only|, default: ``1e-15``
         The absolute tolerance used by `~numpy.isclose` when testing
         normalizations and making comparisons.
 
@@ -850,15 +850,15 @@ class IonizationStateCollection:
 
         Parameters
         ----------
-        include_neutrals : `bool`, |keyword-only|, optional, default: `True`
+        include_neutrals : `bool`, |keyword-only|, default: `True`
             If `True`, include neutrals when calculating the mean values
             of the different particles.  If `False`, exclude neutrals.
 
-        use_rms_charge : `bool`, |keyword-only|, optional, default: `False`
+        use_rms_charge : `bool`, |keyword-only|, default: `False`
             If `True`, use the root-mean-square charge instead of the
             mean charge.
 
-        use_rms_mass : `bool`, |keyword-only|, optional, default: `False`
+        use_rms_mass : `bool`, |keyword-only|, default: `False`
             If `True`, use the root-mean-square mass instead of the mean
             mass.
 

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -42,29 +42,29 @@ class IonizationStateCollection:
         with elements or isotopes as keys and `~astropy.units.Quantity`
         instances with units of number density.
 
-    abundances : `dict`, optional, |keyword-only|
+    abundances : `dict`, |keyword-only|, optional
         A `dict` with `~plasmapy.particles.particle_class.ParticleLike`
         objects used as the keys and the corresponding relative abundance as the
         values.  The values must be positive real numbers.
 
-    log_abundances : `dict`, optional, |keyword-only|
+    log_abundances : `dict`, |keyword-only|, optional
         A `dict` with `~plasmapy.particles.particle_class.ParticleLike`
         objects used as the keys and the corresponding base 10 logarithms of their
         relative abundances as the values.  The values must be real numbers.
 
-    n0 : `~astropy.units.Quantity`, optional, |keyword-only|
+    n0 : `~astropy.units.Quantity`, |keyword-only|, optional
         The number density normalization factor corresponding to the
         abundances.  The number density of each element is the product
         of its abundance and ``n0``.
 
-    T_e : `~astropy.units.Quantity`, optional, |keyword-only|
+    T_e : `~astropy.units.Quantity`, |keyword-only|, optional
         The electron temperature in units of temperature or thermal
         energy per particle.
 
-    kappa : `float`, optional, |keyword-only|
+    kappa : `float`, |keyword-only|, optional
         The value of kappa for a kappa distribution function.
 
-    tol : `float` or `integer`, optional, |keyword-only|, default: ``1e-15``
+    tol : `float` or `integer`, |keyword-only|, optional, default: ``1e-15``
         The absolute tolerance used by `~numpy.isclose` when testing
         normalizations and making comparisons.
 
@@ -850,15 +850,15 @@ class IonizationStateCollection:
 
         Parameters
         ----------
-        include_neutrals : `bool`, optional, |keyword-only|, default: `True`
+        include_neutrals : `bool`, |keyword-only|, optional, default: `True`
             If `True`, include neutrals when calculating the mean values
             of the different particles.  If `False`, exclude neutrals.
 
-        use_rms_charge : `bool`, optional, |keyword-only|, default: `False`
+        use_rms_charge : `bool`, |keyword-only|, optional, default: `False`
             If `True`, use the root-mean-square charge instead of the
             mean charge.
 
-        use_rms_mass : `bool`, optional, |keyword-only|, default: `False`
+        use_rms_mass : `bool`, |keyword-only|, optional, default: `False`
             If `True`, use the root-mean-square mass instead of the mean
             mass.
 

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -118,12 +118,12 @@ def nuclear_reaction_energy(*args, **kwargs) -> u.J:  # noqa: C901, PLR0915
         A string representing the reaction, like
         ``"D + T --> alpha + n"`` or ``"Be-8 --> 2 * He-4"``.
 
-    reactants : |particle-like| or |particle-list-like|, optional, |keyword-only|
+    reactants : |particle-like| or |particle-list-like|, |keyword-only|, optional
         A `list` or `tuple` containing the reactants of a nuclear
         reaction (e.g., ``['D', 'T']``), or a string representing the
         sole reactant.
 
-    products : |particle-like| or |particle-list-like|, optional, |keyword-only|
+    products : |particle-like| or |particle-list-like|, |keyword-only|, optional
         A list or tuple containing the products of a nuclear reaction
         (e.g., ``['alpha', 'n']``), or a string representing the sole
         product.

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -240,17 +240,17 @@ class AbstractPhysicalParticle(AbstractParticle):
             Required categories in the form of one or more `str` objects
             or an iterable.
 
-        require : `str` or iterable of `str`, optional, |keyword-only|
+        require : `str` or iterable of `str`, |keyword-only|, optional
             One or more particle categories. This method will return
             `False` if the particle does not belong to all of these
             categories.
 
-        any_of : `str` or iterable of `str`, optional, |keyword-only|
+        any_of : `str` or iterable of `str`, |keyword-only|, optional
             One or more particle categories. This method will return
             `False` if the particle does not belong to at least one of
             these categories.
 
-        exclude : `str` or iterable of `str`, optional, |keyword-only|
+        exclude : `str` or iterable of `str`, |keyword-only|, optional
             One or more particle categories.  This method will return
             `False` if the particle belongs to any of these categories.
 
@@ -393,10 +393,10 @@ class Particle(AbstractPhysicalParticle):
         integer representing the atomic number of an element; or a
         |Particle|.
 
-    mass_numb : integer, optional, |keyword-only|
+    mass_numb : integer, |keyword-only|, optional
         The mass number of an isotope.
 
-    Z : integer, optional, |keyword-only|
+    Z : integer, |keyword-only|, optional
         The |charge number| of an ion or neutral atom.
 
     Raises
@@ -1848,13 +1848,13 @@ class DimensionlessParticle(AbstractParticle):
 
     Parameters
     ----------
-    mass : positive real number, optional, |keyword-only|, default: |nan|
+    mass : positive real number, |keyword-only|, optional, default: |nan|
         The mass of the dimensionless particle.
 
-    charge : real number, optional, |keyword-only|, default: |nan|
+    charge : real number, |keyword-only|, optional, default: |nan|
         The electric charge of the dimensionless particle.
 
-    symbol : str, optional, |keyword-only|
+    symbol : str, |keyword-only|, optional
         The symbol to be assigned to the dimensionless particle.
 
     See Also
@@ -2041,7 +2041,7 @@ class CustomParticle(AbstractPhysicalParticle):
         `~astropy.units.Quantity`, then it must be in units of electric
         charge. Defaults to |nan| C.
 
-    Z : ~numbers.Real, optional, |keyword-only|
+    Z : ~numbers.Real, |keyword-only|, optional
         The :term:`charge number`, which is equal to the ratio of the
         charge to the elementary charge.
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -1697,7 +1697,7 @@ class Particle(AbstractPhysicalParticle):
 
         Parameters
         ----------
-        n : positive integer, optional, default: ``1``
+        n : positive integer, default: ``1``
             The number of bound electrons to remove from the |Particle|
             object.
 
@@ -1848,10 +1848,10 @@ class DimensionlessParticle(AbstractParticle):
 
     Parameters
     ----------
-    mass : positive real number, |keyword-only|, optional, default: |nan|
+    mass : positive real number, |keyword-only|, default: |nan|
         The mass of the dimensionless particle.
 
-    charge : real number, |keyword-only|, optional, default: |nan|
+    charge : real number, |keyword-only|, default: |nan|
         The electric charge of the dimensionless particle.
 
     symbol : str, |keyword-only|, optional

--- a/plasmapy/particles/symbols.py
+++ b/plasmapy/particles/symbols.py
@@ -166,10 +166,10 @@ def ionic_symbol(
         A `str` representing an element, isotope, or ion; or an
         `int` representing an atomic number.
 
-    mass_numb : integer, optional, |keyword-only|
+    mass_numb : integer, |keyword-only|, optional
         The mass number of an isotope.
 
-    Z : integer, optional, |keyword-only|
+    Z : integer, |keyword-only|, optional
         The |charge number| of an ion or neutral atom.
 
     Returns
@@ -232,10 +232,10 @@ def particle_symbol(
         A `str` representing a particle, element, isotope, or ion or an
         `int` representing an atomic number
 
-    mass_numb : integer, optional, |keyword-only|
+    mass_numb : integer, |keyword-only|, optional
         The mass number of an isotope.
 
-    Z : integer, optional, |keyword-only|
+    Z : integer, |keyword-only|, optional
         The |charge number| of an ion or neutral atom.
 
     Returns

--- a/plasmapy/utils/code_repr.py
+++ b/plasmapy/utils/code_repr.py
@@ -208,10 +208,10 @@ def call_string(
     kwargs : `dict`, optional
         A `dict` containing keyword arguments.
 
-    max_items : `int`, optional
+    max_items : `int`, default: 12
         The maximum number of items to include in a `~numpy.ndarray` or
         `~astropy.units.Quantity`; additional items will be truncated
-        with an ellipsis.  Defaults to 12.
+        with an ellipsis.
 
     Returns
     -------
@@ -275,10 +275,10 @@ def attribute_call_string(
         A `dict` containing the keyword arguments to be used during
         instantiation of ``cls``.
 
-    max_items : `int`, optional
+    max_items : `int`, default: 12
         The maximum number of items to include in a `~numpy.ndarray` or
         `~astropy.units.Quantity`; additional items will be truncated
-        with an ellipsis.  Defaults to 12.
+        with an ellipsis.
 
     Returns
     -------
@@ -360,10 +360,10 @@ def method_call_string(
         A `dict` containing the keyword arguments to be used during
         the method call.
 
-    max_items : int, |keyword-only|, optional
+    max_items : int, |keyword-only|, default: 12
         The maximum number of items to include in a `~numpy.ndarray` or
         `~astropy.units.Quantity`; additional items will be truncated
-        with an ellipsis.  Defaults to 12.
+        with an ellipsis.
 
     Returns
     -------


### PR DESCRIPTION
This PR makes some autoreplacements and a couple of manual changes to type specifications, in this order:

 - `optional, |keyword-only|` → `|keyword-only|, optional` 
 - `optional, default:` → `default:` (since we don't need to say it's optional if there's a default)
 - Moving default values from parameter description to type specification