### PR TITLE
Update search and replace for type specifications

### DIFF
--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -27,3 +27,11 @@
 - search: ':term:`array_like`'
   replacement: '|array_like|'
   description: Apply reStructuredText substitution
+
+- search: 'optional, |keyword-only|'
+  replacement: '|keyword-only|, optional'
+  description: Keep a consistent order in type specifications
+
+- search: ', optional, default:'
+  replacement: ', default:'
+  description: No need to specify that a parameter is optional if there is a default value

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -302,9 +302,9 @@ Here is an example docstring in the numpydoc_ format:
        b : `float`
            The right multiplicand.
 
-       switch_order : `bool`, optional, |keyword-only|
+       switch_order : `bool`, |keyword-only|, default: `True`
            If `True`, return :math:`a - b`. If `False`, then return
-           :math:`b - a`. Defaults to `True`.
+           :math:`b - a`.
 
        Returns
        -------


### PR DESCRIPTION
This PR updates the settings for pre-commit-search-and-replace to help us have a consistent style for docstrings:

 - `optional, |keyword-only|` → `|keyword-only|, optional`
 - `, optional, default:` → `, default:`

Related to #2358.