### PR TITLE
Reduce warnings issued in tests & deprecate passing real number to `charge` in `CustomParticle`

### DIFF
--- a/changelog/2369.breaking.rst
+++ b/changelog/2369.breaking.rst
@@ -1,5 +1,5 @@
 Providing a real number to the ``charge`` parameter in |CustomParticle|
-will now result in a `TypeError` instead of a deprecation warning. Now,
+will now result in a |InvalidParticleError| instead of a deprecation warning. Now,
 ``charge`` must be a |Quantity| with units of electrical charge. To
 express the charge as a multiple of the elementary charge, provide a
 real number to the ``Z`` parameter instead.

--- a/changelog/2369.breaking.rst
+++ b/changelog/2369.breaking.rst
@@ -1,0 +1,5 @@
+Providing a real number to the ``charge`` parameter in |CustomParticle|
+will now result in a `TypeError` instead of a deprecation warning. Now,
+``charge`` must be a |Quantity| with units of electrical charge. To
+express the charge as a multiple of the elementary charge, provide a
+real number to the ``Z`` parameter instead.

--- a/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
@@ -274,6 +274,7 @@ class TestFindIonSaturationCurrent:
         assert np.isclose(extras.rsq, 1.0)
         assert extras.fitted_indices == expected[1].fitted_indices
 
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     def test_on_pace_data(self):
         """
         Test functionality on D. Pace data.

--- a/plasmapy/formulary/collisions/frequencies.py
+++ b/plasmapy/formulary/collisions/frequencies.py
@@ -161,7 +161,7 @@ class SingleParticleCollisionFrequencies:
         v_drift: u.m / u.s,
         T_b: u.K,
         n_b: u.m**-3,
-        Coulomb_log: u.dimensionless_unscaled,
+        Coulomb_log,
     ):
         # Note: This class uses CGS units internally to coincide
         #       with our references.  Input is taken in MKS units and

--- a/plasmapy/formulary/frequencies.py
+++ b/plasmapy/formulary/frequencies.py
@@ -621,8 +621,8 @@ def Buchsbaum_frequency(
     """
     omega_c1_squared = gyrofrequency(B, ion1, signed=False, Z=Z1) ** 2
     omega_c2_squared = gyrofrequency(B, ion2, signed=False, Z=Z2) ** 2
-    omega_p1_squared = plasma_frequency(n1, ion1, z_mean=Z1) ** 2
-    omega_p2_squared = plasma_frequency(n2, ion2, z_mean=Z2) ** 2
+    omega_p1_squared = plasma_frequency(n1, ion1, Z=Z1) ** 2
+    omega_p2_squared = plasma_frequency(n2, ion2, Z=Z2) ** 2
 
     return np.sqrt(
         (omega_p1_squared * omega_c2_squared + omega_p2_squared * omega_c1_squared)

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -127,7 +127,7 @@ class Test_permittivity_1D_Maxwellian:
                 "T": 30 * 11600 * u.K,
                 "n": 1e18 * u.cm**-3,
                 "particle": "Ne",
-                "z_mean": 8,
+                "Z": 8,
                 "omega": 5.635e14 * 2 * np.pi * u.rad / u.s,
             },
             (-6.729556105413448e-08 + 5.761632594678113e-07j)

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -127,7 +127,7 @@ class Test_permittivity_1D_Maxwellian:
                 "T": 30 * 11600 * u.K,
                 "n": 1e18 * u.cm**-3,
                 "particle": "Ne",
-                "Z": 8,
+                "z_mean": 8,
                 "omega": 5.635e14 * 2 * np.pi * u.rad / u.s,
             },
             (-6.729556105413448e-08 + 5.761632594678113e-07j)

--- a/plasmapy/formulary/tests/test_plasma_frequency.py
+++ b/plasmapy/formulary/tests/test_plasma_frequency.py
@@ -61,7 +61,6 @@ class TestPlasmaFrequency:
     @pytest.mark.parametrize(
         ("args", "kwargs", "_error"),
         [
-            ((u.m**-3, "e-"), {}, TypeError),
             (("not a density", "e-"), {}, TypeError),
             ((5 * u.s, "e-"), {}, u.UnitTypeError),
             ((5 * u.m**-2, "e-"), {}, u.UnitTypeError),

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -37,7 +37,7 @@ from plasmapy.particles.exceptions import (
     ParticleError,
     ParticleWarning,
 )
-from plasmapy.utils import PlasmaPyDeprecationWarning, roman
+from plasmapy.utils import roman
 from plasmapy.utils._units_helpers import _get_physical_type_dict
 
 if TYPE_CHECKING:
@@ -2255,16 +2255,10 @@ class CustomParticle(AbstractPhysicalParticle):
         if np.isnan(q):
             self._charge = q
         elif isinstance(q, Real):
-            self._charge = q * const.e.si
-            warnings.warn(
-                f"CustomParticle charge set to {q} times the elementary charge."
-            )
-            warnings.warn(
-                "Providing a real number to 'charge' is deprecated. To "
-                "specify the charge as a multiple of the elementary "
-                "charge, use 'Z' as a keyword argument instead, or pass, "
-                "e.g., '2 * astropy.constants.e.si' into 'charge'.",
-                PlasmaPyDeprecationWarning,
+            raise TypeError(
+                "'charge' must be a Quantity with units of electrical charge. "
+                "To specify the charge as a multiple of the elementary charge, "
+                "use 'Z' as a keyword argument instead."
             )
         elif isinstance(q, u.Quantity):
             if not isinstance(q.value, Real):

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1046,7 +1046,7 @@ custom_particle_errors = [
     (CustomParticle, {"charge": "not a charge"}, InvalidParticleError),
     (CustomParticle, {"charge": "5.0 km"}, InvalidParticleError),
     (CustomParticle, {"charge": 1 * u.C, "Z": -1}, InvalidParticleError),
-    (CustomParticle, {"charge": 1}, TypeError),
+    (CustomParticle, {"charge": 1}, InvalidParticleError),
 ]
 
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -1046,6 +1046,7 @@ custom_particle_errors = [
     (CustomParticle, {"charge": "not a charge"}, InvalidParticleError),
     (CustomParticle, {"charge": "5.0 km"}, InvalidParticleError),
     (CustomParticle, {"charge": 1 * u.C, "Z": -1}, InvalidParticleError),
+    (CustomParticle, {"charge": 1}, TypeError),
 ]
 
 

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -928,7 +928,6 @@ customized_particle_tests = [
     (CustomParticle, {}, "charge", np.nan * u.C),
     (CustomParticle, {"mass": 1.1 * u.kg, "charge": -0.1 * u.C}, "mass", 1.1 * u.kg),
     (CustomParticle, {"charge": -0.1 * u.C}, "charge", -0.1 * u.C),
-    (CustomParticle, {"charge": -2}, "charge", -2 * const.e.si),
     (CustomParticle, {"mass": np.inf * u.g}, "mass", np.inf * u.kg),
     (CustomParticle, {"mass": "100.0 g"}, "mass", 100.0 * u.g),
     (CustomParticle, {"charge": -np.inf * u.kC}, "charge", -np.inf * u.C),

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -714,6 +714,9 @@ def test_nonuniform_cartesian_NN_interp(
     assert np.allclose(pout, expected, atol=dx_max, equal_nan=True)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*MultiIndex.*:DeprecationWarning"
+)  # see issue 2319
 @pytest.mark.slow()
 def test_nonuniform_cartesian_nearest_neighbor_interpolator():
     """

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -174,6 +174,9 @@ def test_AbstractGrid_creation(args, kwargs, shape, error):
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.filterwarnings(
+    "ignore:.*MultiIndex.*:DeprecationWarning"
+)  # see issue 2319
 def test_print_summary(abstract_grid_uniform, abstract_grid_nonuniform):
     """
     Verify that both __str__ methods can be called without errors
@@ -269,6 +272,9 @@ abstract_attrs = [
 
 @pytest.mark.parametrize(("attr", "type_", "type_in_iter", "value"), abstract_attrs)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.filterwarnings(
+    "ignore:.*MultiIndex.*:DeprecationWarning"
+)  # see issue 2319
 def test_AbstractGrid_nonuniform_attributes(
     attr,
     type_,
@@ -427,6 +433,9 @@ on_grid = [
 
 @pytest.mark.parametrize(("fixture", "pos", "result"), on_grid)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.filterwarnings(
+    "ignore:.*MultiIndex.*:DeprecationWarning"
+)  # see issue 2319
 def test_AbstractGrid_on_grid(
     abstract_grid_uniform, abstract_grid_nonuniform, fixture, pos, result
 ):
@@ -451,6 +460,9 @@ vector_intersect = [
 
 @pytest.mark.parametrize(("fixture", "p1", "p2", "result"), vector_intersect)
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.filterwarnings(
+    "ignore:.*MultiIndex.*:DeprecationWarning"
+)  # see issue 2319
 def test_AbstractGrid_vector_intersects(
     abstract_grid_uniform, abstract_grid_nonuniform, fixture, p1, p2, result
 ):
@@ -683,6 +695,9 @@ def test_NonUniformCartesianGrid_creation(args, kwargs, shape, error):
         (np.array([2, -0.3, 0]) * u.cm, ["x"], np.array([np.nan]) * u.cm),
     ],
 )
+@pytest.mark.filterwarnings(
+    "ignore:.*MultiIndex.*:DeprecationWarning"
+)  # see issue 2319
 def test_nonuniform_cartesian_NN_interp(
     pos, quantities, expected, nonuniform_cartesian_grid
 ):
@@ -912,6 +927,9 @@ def test_volume_averaged_interpolator_compare_NN_3D(uniform_cartesian_grid):
     assert va_error < nn_error
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*MultiIndex.*:DeprecationWarning"
+)  # see issue 2319
 def test_NonUniformCartesianGrid():
     grid = grids.NonUniformCartesianGrid(-1 * u.cm, 1 * u.cm, num=10)
 

--- a/plasmapy/utils/calculator/main_interface.py
+++ b/plasmapy/utils/calculator/main_interface.py
@@ -5,6 +5,7 @@ __all__ = []
 
 import astropy.units as u
 import json
+import warnings
 
 from ipywidgets import widgets
 from pathlib import Path
@@ -21,6 +22,12 @@ from plasmapy.utils.calculator.widget_helpers import (
     _ParticleBox,
     _process_queue,
 )
+
+warnings.filterwarnings(
+    action="ignore",
+    message="Passing unrecognized arguments",
+    category=DeprecationWarning,
+)  # see issue 2370 for a deprecation warning from traitlets
 
 LIGHT_BLUE = "#00BFD8"
 """


### PR DESCRIPTION
This PR reduces the number of warnings issued by tests.  I'm resolving a few of them and filtering others.

This PR also removes the (previously deprecated) ability to pass a real number to the `charge` parameter in `CustomParticle`, since the preferred behavior is now to pass it to `Z`.  I made sure to issue a descriptive error.

I'm filtering deprecation warnings for `MultiIndex` in `test_grids.py` (see #2319) and traitlets (see #2370).  These deprecations could possibly cause problems later on, but we don't need to see the warnings every time tests run since we have issues now created.