### PR TITLE
Temporarily remove Numba dependency for `v2023.10.0` release before returning it in `v2023.10.1`

### DIFF
--- a/plasmapy/formulary/frequencies.py
+++ b/plasmapy/formulary/frequencies.py
@@ -14,7 +14,6 @@ import numbers
 import numpy as np
 
 from astropy.constants.si import e, eps0
-from numba import njit
 from typing import Optional
 
 from plasmapy import particles
@@ -156,7 +155,6 @@ wc_ = gyrofrequency
 
 
 @preserve_signature
-@njit
 def plasma_frequency_lite(
     n: numbers.Real,
     mass: numbers.Real,

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -15,7 +15,6 @@ import numpy as np
 import warnings
 
 from astropy.constants.si import k_B, mu0
-from numba import njit
 from numbers import Integral, Real
 from typing import Optional
 
@@ -473,7 +472,6 @@ def thermal_speed_coefficients(method: str, ndim: int) -> float:
 
 
 @preserve_signature
-@njit
 def thermal_speed_lite(T: Real, mass: Real, coeff: Real) -> Real:
     r"""
     The :term:`lite-function` for

--- a/plasmapy/formulary/tests/test_plasma_frequency.py
+++ b/plasmapy/formulary/tests/test_plasma_frequency.py
@@ -174,8 +174,6 @@ class TestPlasmaFrequencyLite:
             inputs_unitless["to_hz"] = inputs["to_hz"]
 
         lite = plasma_frequency_lite(**inputs_unitless)
-        pylite = plasma_frequency_lite.py_func(**inputs_unitless)
-        assert pylite == lite
 
         normal = plasma_frequency(**inputs)
         assert np.allclose(normal.value, lite)

--- a/plasmapy/formulary/tests/test_plasma_frequency.py
+++ b/plasmapy/formulary/tests/test_plasma_frequency.py
@@ -11,7 +11,6 @@ import numpy as np
 import pytest
 
 from astropy.constants.si import m_p
-from numba.extending import is_jitted
 
 from plasmapy.formulary.frequencies import plasma_frequency, plasma_frequency_lite, wp_
 from plasmapy.particles._factory import _physical_particle_factory
@@ -148,10 +147,6 @@ class TestPlasmaFrequency:
 
 class TestPlasmaFrequencyLite:
     """Test class for `plasma_frequency_lite`."""
-
-    def test_is_jitted(self):
-        """Ensure `plasmapy_frequency_lite` was jitted by `numba`."""
-        assert is_jitted(plasma_frequency_lite)
 
     @pytest.mark.parametrize(
         "inputs",

--- a/plasmapy/formulary/tests/test_thermal_speed.py
+++ b/plasmapy/formulary/tests/test_thermal_speed.py
@@ -322,8 +322,6 @@ class TestThermalSpeedLite:
         coeff = thermal_speed_coefficients(method=inputs["method"], ndim=inputs["ndim"])
 
         lite = thermal_speed_lite(T=T_unitless, mass=m_unitless, coeff=coeff)
-        pylite = thermal_speed_lite.py_func(T=T_unitless, mass=m_unitless, coeff=coeff)
-        assert pylite == lite
 
         normal = thermal_speed(**inputs)
         assert np.isclose(normal.value, lite)

--- a/plasmapy/formulary/tests/test_thermal_speed.py
+++ b/plasmapy/formulary/tests/test_thermal_speed.py
@@ -14,7 +14,6 @@ import numpy as np
 import pytest
 
 from astropy.constants.si import k_B
-from numba.extending import is_jitted
 
 from plasmapy.formulary.speeds import (
     kappa_thermal_speed,
@@ -292,10 +291,6 @@ class TestThermalSpeed:
 
 class TestThermalSpeedLite:
     """Test class for `thermal_speed_lite`."""
-
-    def test_is_jitted(self):
-        """Ensure `thermal_speed_lite` was jitted by `numba`."""
-        assert is_jitted(thermal_speed_lite)
 
     @pytest.mark.parametrize(
         "inputs",

--- a/plasmapy/utils/decorators/lite_func.py
+++ b/plasmapy/utils/decorators/lite_func.py
@@ -91,9 +91,6 @@ def bind_lite_func(lite_func, attrs: Optional[dict[str, Callable]] = None):
             " the 'lite_func' argument."
         )
 
-    if inspect.isbuiltin(lite_func) or not inspect.isfunction(lite_func):
-        raise ValueError("The given lite-function is not a user-defined function.")
-
     def decorator(f):
         @functools.wraps(f)
         def wrapper(*args, **kwargs):

--- a/plasmapy/utils/decorators/lite_func.py
+++ b/plasmapy/utils/decorators/lite_func.py
@@ -7,7 +7,6 @@ __all__ = ["bind_lite_func"]
 import functools
 import inspect
 
-from numba.extending import is_jitted
 from typing import Callable, Optional
 
 
@@ -92,9 +91,7 @@ def bind_lite_func(lite_func, attrs: Optional[dict[str, Callable]] = None):
             " the 'lite_func' argument."
         )
 
-    if inspect.isbuiltin(lite_func) or not (
-        is_jitted(lite_func) or inspect.isfunction(lite_func)
-    ):
+    if inspect.isbuiltin(lite_func) or not inspect.isfunction(lite_func):
         raise ValueError("The given lite-function is not a user-defined function.")
 
     def decorator(f):
@@ -107,7 +104,7 @@ def bind_lite_func(lite_func, attrs: Optional[dict[str, Callable]] = None):
         attrs["lite"] = lite_func
         for bound_name, attr in attrs.items():
             # only allow functions or jitted functions
-            if not (inspect.isfunction(attr) or is_jitted(attr)):
+            if not (inspect.isfunction(attr)):
                 raise ValueError(
                     f"Can not bind obj '{attr}' to function '{wrapper.__name__}'."
                     f"  Only functions are allowed to be bound. Skipping."

--- a/plasmapy/utils/decorators/tests/test_lite_func.py
+++ b/plasmapy/utils/decorators/tests/test_lite_func.py
@@ -3,8 +3,6 @@ Test module for `plasmapy.utils.decorators.lite_func.bind_lite_func`.
 """
 import pytest
 
-from numba import jit, njit
-
 from plasmapy.utils.decorators.lite_func import bind_lite_func
 
 
@@ -51,8 +49,6 @@ def test_raises(lite_func, attrs, _error):
     ("lite_func", "attrs"),
     [
         (foo_lite, None),
-        (jit(foo_lite, nopython=True), None),
-        (njit(foo_lite), None),
         (foo_lite, {"bar": bar}),
     ],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
   "lmfit >= 1.0.3",
   "matplotlib >= 3.5.1",
   "mpmath >= 1.2.1",
-  "numba >= 0.56.0",
   "numpy >= 1.21.0",
   "packaging >= 22.0",
   "pandas >= 1.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,9 +45,7 @@ beautifulsoup4==4.12.2
 bleach==6.1.0
     # via nbconvert
 cachecontrol[filecache]==0.13.1
-    # via
-    #   cachecontrol
-    #   sphinx-toolbox
+    # via sphinx-toolbox
 cachetools==5.3.1
     # via tox
 certifi==2023.7.22
@@ -127,7 +125,7 @@ h5py==3.10.0
     # via plasmapy (setup.py)
 html5lib==1.1
     # via sphinx-toolbox
-hypothesis==6.88.0
+hypothesis==6.88.1
     # via plasmapy (setup.py)
 identify==2.5.30
     # via pre-commit
@@ -210,8 +208,6 @@ kiwisolver==1.4.5
     # via matplotlib
 latexcodec==2.0.1
     # via pybtex
-llvmlite==0.41.0
-    # via numba
 lmfit==1.2.2
     # via plasmapy (setup.py)
 markupsafe==2.1.3
@@ -254,16 +250,13 @@ nest-asyncio==1.5.8
     # via ipykernel
 nodeenv==1.8.0
     # via pre-commit
-numba==0.58.0
-    # via plasmapy (setup.py)
-numpy==1.25.2
+numpy==1.26.1
     # via
     #   astropy
     #   contourpy
     #   h5py
     #   lmfit
     #   matplotlib
-    #   numba
     #   pandas
     #   plasmapy (setup.py)
     #   pyerfa
@@ -569,7 +562,7 @@ unidecode==1.3.7
     # via plasmapy (setup.py)
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.0.6
+urllib3==2.0.7
     # via requests
 virtualenv==20.24.5
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -127,7 +127,6 @@ deps =
     lmfit == 1.0.3
     matplotlib == 3.5.1
     mpmath == 1.2.1
-    numba == 0.56.0
     numpy == 1.21.0
     packaging == 22.0
     pandas == 1.2.0


### PR DESCRIPTION
## Description

This PR temporarily (and experimentally!) removes Numba as a dependency for our `v2023.10.0`.  This PR will be reverted in a subsequent PR for a `v2023.10.1` release.

## Motivation and context

After a new version of Python is released in October of each year, it can take close to half a year before Numba becomes compatible with it.  Because PlasmaPy requires Numba, we are unable to use PlasmaPy on Python 3.12 during that time period.  By removing our Numba dependency on lite-functions, we will have a recent release that can be used on Python 3.12.  The lite functions won't be jitted, but everything will at least work.  

## Additional context

I am going to put the changelog entry in a different PR so that this PR can be reverted more easily.