### PR TITLE
Update installation instructions and add changelog entry for #2372

### DIFF
--- a/changelog/2372.trivial.rst
+++ b/changelog/2372.trivial.rst
@@ -1,4 +1,4 @@
 Temporarily removed the dependency on |Numba| to enable installation
 of PlasmaPy on Python 3.12 prior to the release of Numba
 ``v0.59.0``. The dependency on Numba for |lite-functions| will be
-restored in Plasmapy ``v2023.10.1``.
+restored in PlasmaPy ``v2023.10.1``.

--- a/changelog/2372.trivial.rst
+++ b/changelog/2372.trivial.rst
@@ -1,0 +1,4 @@
+Temporarily removed the dependency on |Numba| to enable installation
+of PlasmaPy on Python 3.12 prior to the release of Numba
+``v0.59.0``. The dependency on Numba for |lite-functions| will be
+restored in Plasmapy ``v2023.10.1``.

--- a/changelog/2373.doc.rst
+++ b/changelog/2373.doc.rst
@@ -1,0 +1,4 @@
+Expanded the installation instructions to mention that if you are
+having trouble installing PlasmaPy on a new release of Python, then
+you should try installing PlasmaPy ``v2023.10.0`` instead because it
+does not include a |Numba| dependency.

--- a/docs/_global_substitutions.py
+++ b/docs/_global_substitutions.py
@@ -146,7 +146,7 @@ links = {
     "Python's documentation": "https://docs.python.org/3",
     "Read the Docs": "https://about.readthedocs.com/",
     "reStructuredText": "https://docutils.sourceforge.io/rst.html",
-    "ruff": "https://beta.ruff.rs/docs",
+    "ruff": "https://docs.astral.sh/ruff",
     "SciPy": "https://scipy.org",
     "Sphinx": "https://www.sphinx-doc.org",
     "towncrier": "https://github.com/twisted/towncrier",

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -44,9 +44,8 @@ on, such as `Astropy <https://www.astropy.org/acknowledging.html>`__,
 
 .. tip::
 
-   A paper written using `AASTeX
-   <https://journals.aas.org/author-resources/aastex-package-for-manuscript-preparation/aastexguide>`__
-   should use the ``\software{}`` command to cite PlasmaPy.
+   A paper written using `AASTeX <https://journals.aas.org/aastexguide>`__
+   should use the ``\software`` command to cite PlasmaPy.
 
 .. note::
 

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -44,8 +44,9 @@ on, such as `Astropy <https://www.astropy.org/acknowledging.html>`__,
 
 .. tip::
 
-   A paper written using `AASTeX <https://journals.aas.org/aastexguide>`__
-   should use the ``\software{PlasmaPy}`` command to cite PlasmaPy.
+   A paper written using `AASTeX
+   <https://journals.aas.org/author-resources/aastex-package-for-manuscript-preparation/aastexguide>`__
+   should use the ``\software{}`` command to cite PlasmaPy.
 
 .. note::
 

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -925,7 +925,7 @@ Up-to-date instructions on running the benchmark suite will be located
 in the README file of `benchmarks-repo`_.
 
 .. _ASCII: https://en.wikipedia.org/wiki/ASCII
-.. _cognitive complexity: https://www.sonarsource.com/docs/CognitiveComplexity.pdf
+.. _cognitive complexity: https://docs.codeclimate.com/docs/cognitive-complexity
 .. _Cython: https://cython.org
 .. _equivalencies: https://docs.astropy.org/en/stable/units/equivalencies.html
 .. _example notebook on particles: ../notebooks/getting_started/particles.ipynb

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -1407,20 +1407,20 @@ Document isn't included in any toctree
 --------------------------------------
 
 In general, each source file in the documentation must be included in a
-table of contents (toctree_). Otherwise, Sphinx_ will issue a warning
-like:
+table of contents or ``toctree``. Otherwise, Sphinx_ will issue a
+warning like:
 
 .. code-block::
 
    WARNING: document isn't included in any toctree
 
 This warning may occur when adding a new :file:`.rst` file or example
-Jupyter notebook without adding it to a toctree.
+Jupyter notebook without adding it to a ``toctree``.
 
 This warning can be resolved by:
 
-* Adding the file to the appropriate toctree (see Sphinx's
-  `documentation page on tables of contents <toctree>`_), or
+* Adding the file to the appropriate ``toctree`` (see the
+  `Sphinx documentation page on tables of contents`_), or
 
 * Adding the ``orphan`` `metadata field`_ at the top of the file (not
   recommended in most situations).
@@ -1465,10 +1465,10 @@ For example Jupyter notebooks, the tables of contents are in
 .. _SciPy: https://scipy.org
 .. _sphinx-build: https://www.sphinx-doc.org/en/master/man/sphinx-build.html
 .. _sphinx-codeautolink: https://sphinx-codeautolink.readthedocs.io
+.. _Sphinx documentation page on tables of contents: https://docutils.sourceforge.io/docs/ref/rst/directives.html#table-of-contents
 .. _Sphinx's glossary: https://www.sphinx-doc.org/en/master/glossary.html
 .. _Sphinx's templating page: https://www.sphinx-doc.org/en/master/development/templating.html
 .. _style overrides: https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html
-.. _toctree: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree
 .. _warns: https://numpydoc.readthedocs.io/en/latest/format.html#warns
 .. _weekly tests: https://github.com/PlasmaPy/PlasmaPy/actions/workflows/weekly.yml
 .. _Wikipedia: https://www.wikipedia.org

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,13 +19,19 @@ PlasmaPy requires a version of |Python| between |minpython| and
 |maxpython|. If you do not have |Python| installed already, here are the
 instructions to `download Python`_ and install it.
 
-.. tip::
+.. collapse:: Click here if you have trouble installing PlasmaPy on the newest Python release
 
-   New versions of |Python| are released annually in October, and it can
-   take a few months for the scientific Python ecosystem to catch up. If
-   you have trouble installing `plasmapy` on the most recent |Python|
-   version between October and March, then try installing it on the
-   second most recent version.
+   .. tip::
+
+      New version of |Python| are released annually in October, and it
+      can take a few months for the scientific Python ecosystem to catch
+      up. If you have trouble installing PlasmaPy on the newest version
+      of Python between October and ∼March, try either:
+
+      * Downgrading to the previous release of Python, or
+      * Installing PlasmaPy with
+        ``python -m pip install plasmapy==2023.10.0`` (which drops
+        PlasmaPy's dependency on |Numba|).
 
 .. _install-pip:
 
@@ -40,9 +46,9 @@ terminal and run:
 
    python -m pip install plasmapy
 
-On some systems, it might be necessary to specify the |Python| version
-number by using ``python3``, ``python3.8``, ``python3.9``,
-``python3.10``, or ``python3.11`` instead of ``python``.
+Sometimes it might be necessary to specify the |Python| version number
+by using ``python3``, ``python3.9``, ``python3.10``, ``python3.11``, or
+``python3.12`` instead of ``python``.
 
 To install PlasmaPy on Windows, run:
 

--- a/docs/notebooks/formulary/magnetosphere.ipynb
+++ b/docs/notebooks/formulary/magnetosphere.ipynb
@@ -16,7 +16,7 @@
     "[magnetic reconnection]: https://en.wikipedia.org/wiki/Magnetic_reconnection\n",
     "[plasmapy.formulary]: https://docs.plasmapy.org/en/stable/formulary/index.html\n",
     "\n",
-    "The [Magnetospheric Multiscale Mission](https://www.nasa.gov/mission_pages/mms/overview/index.html) (MMS) is a constellation of four identical spacecraft. The goal of MMS is to investigate the small-scale physics of [magnetic reconnection] in Earth's magnetosphere. In order to do this, the satellites need to orbit in a tight configuration.  But how tight does the tetrahedron have to be?  Let's use [plasmapy.formulary] to find out."
+    "The [Magnetospheric Multiscale Mission](https://science.nasa.gov/mission/mms) (MMS) is a constellation of four identical spacecraft. The goal of MMS is to investigate the small-scale physics of [magnetic reconnection] in Earth's magnetosphere. In order to do this, the satellites need to orbit in a tight configuration.  But how tight does the tetrahedron have to be?  Let's use [plasmapy.formulary] to find out."
    ]
   },
   {


### PR DESCRIPTION
This is a companion PR to #2372.  This PR:

 - Updates the installation instructions to mention that PlasmaPy `v2023.10.0` can be used in new versions of Python for when Numba hasn't been released.
 - Adds a changelog entry for #2372
 - Fixes a few links

