### PR TITLE
Update narrative docs for particle objects

### DIFF
--- a/changelog/2377.doc.rst
+++ b/changelog/2377.doc.rst
@@ -1,0 +1,3 @@
+Updated the narrative documentation on particle objects to
+include |CustomParticle|, |DimensionlessParticle|, and |ParticleList|
+objects.

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -1,6 +1,6 @@
 .. _particle-class:
 
-|Particle| Class
+Particle classes
 ****************
 
 The |Particle| class provides an object-oriented interface to access and
@@ -8,11 +8,11 @@ represent particle information.
 
 .. _particle-class-instantiation:
 
-Creating a |Particle| object
-============================
+Working with Particle objects
+=============================
 
-The simplest way to create a |Particle| object is to pass it a `str`
-representing a particle.
+We can create a |Particle| object is to pass it a `str` representing a
+particle.
 
 >>> from plasmapy.particles import Particle
 >>> electron = Particle('e-')
@@ -32,13 +32,13 @@ names and many aliases are not.
 
 An `int` may be used as the first positional argument to |Particle| to
 represent an atomic number. For isotopes and ions, the mass number may
-be represented with the ``mass_numb`` keyword and the integer charge may
-be represented with the ``Z`` keyword.
+be represented with the ``mass_numb`` keyword and the |charge number|
+may be represented with the ``Z`` keyword.
 
 >>> proton = Particle(1, mass_numb=1, Z=1)
 
 The most frequently used |Particle| objects may be imported directly
-from the atomic subpackage.
+from `plasmapy.particles`.
 
 >>> from plasmapy.particles import proton, electron
 
@@ -51,7 +51,7 @@ The |Particle| objects that may be imported directly are:
 .. _particle-class-properties:
 
 Accessing particle properties
-=============================
+-----------------------------
 
 The properties of each particle may be accessed using the attributes of
 the corresponding |Particle| object.
@@ -92,7 +92,7 @@ Strings representing particles may be accessed using the
 .. _particle-class-categories:
 
 Categories
-==========
+----------
 
 The `~plasmapy.particles.particle_class.Particle.categories` attribute
 returns a `set` with the classification categories corresponding to the
@@ -128,7 +128,7 @@ Valid particle categories are listed in the docstring for |is_category|.
 .. _particle-class-conditionals-equality:
 
 Conditionals and equality properties
-====================================
+------------------------------------
 
 Equality between particles may be tested either between two |Particle|
 objects, or between a |Particle| object and a `str`.
@@ -171,7 +171,7 @@ one of these categories.
 .. _particle-class-antiparticles:
 
 Returning antiparticles
-=======================
+-----------------------
 
 The antiparticle of an elementary particle or antiparticle may be found
 by either using Python's unary invert operator (``~``) or the
@@ -182,5 +182,8 @@ of a |Particle| object.
 Particle("e+")
 >>> antimuon.antiparticle
 Particle("mu-")
+
+Custom particles
+================
 
 .. |is_category| replace:: `~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -149,25 +149,6 @@ True
 False
 >>> deuteron.is_ion
 True
-
-The `~plasmapy.particles.particle_class.Particle.element` and
-`~plasmapy.particles.particle_class.Particle.isotope` attributes
-return `None` when the particle does not correspond to an element or
-isotope. Because non-empty strings evaluate to `True` and `None`
-evaluates to `False` when converted to a `bool`, these attributes may be
-used in conditional statements to test whether or not a particle is in
-one of these categories.
-
-.. code-block:: python
-
-    particles = [Particle("e-"), Particle("Fe-56"), Particle("alpha")]
-
-    for particle in particles:
-        if particle.element:
-            print(f"{particle} corresponds to element {particle.element}")
-        if particle.isotope:
-            print(f"{particle} corresponds to isotope {particle.isotope}")
-
 .. _particle-class-antiparticles:
 
 Returning antiparticles

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -1,6 +1,6 @@
 .. _particle-class:
 
-Particle classes
+Particle objects
 ****************
 
 PlasmaPy contains several classes to represent particles, including
@@ -12,7 +12,8 @@ PlasmaPy contains several classes to represent particles, including
 Particles
 =========
 
-To create a |Particle| object, pass it a `str` representing a particle.
+To create a |Particle| object, pass it a |particle-like| string that
+represents a particle.
 
 >>> from plasmapy.particles import Particle
 >>> electron = Particle('e-')
@@ -167,24 +168,17 @@ Particle("mu-")
 Custom particles
 ================
 
-There are many occasions where we might want to represent a particle
-that does not correspond to an exact ion or fundamental particle. For
-example, we might want a particle that represents an ion that represents
-the mean ionization level or a simple representation of a molecule. On
-these occasions, we can use |CustomParticle|.
-
-We can create a |CustomParticle| by providing it with a charge, mass,
-and/or a symbol. |CustomParticle| has many of the same attributes as
-|Particle|, and can often be used interchangeably.
+We can use |CustomParticle| to create particle objects with a mass,
+charge, and/or symbol that we provide. The mass and charge must be
+|Quantity| objects from `astropy.units`.
 
 >>> import astropy.units as u
 >>> from plasmapy.particles import CustomParticle
->>> cp = CustomParticle(
-...     mass = 9.3e-26 * u.kg,
-...     charge = 1.5e-18 * u.C,
-...     symbol = "Fe 9.5+",
-... )
-...
+>>> cp = CustomParticle(mass = 9.3e-26 * u.kg, charge = 1.5e-18 * u.C, symbol = "Fe 9.5+")
+
+|CustomParticle| has many of the same attributes and methods as
+|Particle|, and can often be used interchangeably.
+
 >>> cp.charge
 <Quantity 1.52e-18 C>
 >>> cp.mass
@@ -209,14 +203,20 @@ CustomParticle(mass=7.30786637819994e-26 kg, charge=1.602176634e-19 C, symbol=CO
 Particle lists
 ==============
 
-We can use |ParticleList| to work with multiple particles.
-A |ParticleList| can contain |Particle| or |CustomParticle| objects.
+|ParticleList| lets us work with multiple particles at once. A
+|ParticleList| can contain |Particle| and/or |CustomParticle| objects.
+
+We can create a |ParticleList| by providing it with a
+|particle-list-like| object (i.e., a `list` containing |particle-like|
+objects). For example, we could provide |ParticleList| with a `list` of
+strings that represent individual particles.
 
 >>> from plasmapy.particles import ParticleList
 >>> helium_ions = ParticleList(["He-4 0+", "He-4 1+"])
 
 |ParticleList| objects behave similarly to `list` objects, but convert
-new objects into the appropriate particle objects.
+its contents into the appropriate |Particle| or |CustomParticle|
+objects.
 
 >>> helium_ions.append("alpha")
 >>> print(helium_ions)
@@ -225,8 +225,9 @@ ParticleList(['He-4 0+', 'He-4 1+', 'He-4 2+'])
 Particle("He-4 1+")
 
 |ParticleList| shares many of the same attributes as |Particle| and
-|CustomParticle|. These attributes often return a |Quantity| array
-rather than a single-valued |Quantity|.
+|CustomParticle|. Attributes of |Particle| and |CustomParticle| that
+provide a scalar |Quantity| will provide a |Quantity| array from
+|ParticleList|.
 
 >>> helium_ions.charge
 <Quantity [0.00000000e+00, 1.60217663e-19, 3.20435327e-19] C>
@@ -279,6 +280,6 @@ normalized (i.e., both the mass and charge are dimensionless).
 
 Because |DimensionlessParticle| objects do not directly represent
 physical particles without normalization information, they cannot be
-contained within a |ParticleList|.
+contained within a |ParticleList| or used in `plasmapy.formulary`.
 
 .. |is_category| replace:: `~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -3,16 +3,16 @@
 Particle classes
 ****************
 
-The |Particle| class provides an object-oriented interface to access and
-represent particle information.
+PlasmaPy contains several classes to represent particles, including
+|Particle|, |CustomParticle|, |ParticleList|, and
+|DimensionlessParticle|.
 
 .. _particle-class-instantiation:
 
 Working with Particle objects
 =============================
 
-We can create a |Particle| object is to pass it a `str` representing a
-particle.
+To create a |Particle| object, pass it a `str` representing a particle.
 
 >>> from plasmapy.particles import Particle
 >>> electron = Particle('e-')
@@ -63,7 +63,7 @@ the corresponding |Particle| object.
 >>> triton.mass_number
 3
 
-Some of these properties are returned as a |Quantity| in SI units.
+These properties are often returned as a |Quantity| in SI units.
 
 >>> alpha.charge
 <Quantity 3.20435324e-19 C>

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -167,4 +167,120 @@ Particle("mu-")
 Custom particles
 ================
 
+There are many occasions where we might want to represent a particle
+that does not correspond to an exact ion or fundamental particle. For
+example, we might want a particle that represents an ion that represents
+the mean ionization level or a simple representation of a molecule. On
+these occasions, we can use |CustomParticle|.
+
+We can create a |CustomParticle| by providing it with a charge, mass,
+and/or a symbol. |CustomParticle| has many of the same attributes as
+|Particle|, and can often be used interchangeably.
+
+>>> import astropy.units as u
+>>> from plasmapy.particles import CustomParticle
+>>> cp = CustomParticle(
+...     mass = 9.3e-26 * u.kg,
+...     charge = 1.5e-18 * u.C,
+...     symbol = "Fe 9.5+",
+... )
+...
+>>> cp.charge
+<Quantity 1.52e-18 C>
+>>> cp.mass
+<Quantity 9.3e-26 kg>
+>>> cp.symbol
+'Fe 9.5+'
+
+If the charge and/or mass is not provided, the attribute will return
+|nan| in the appropriate units.
+
+Molecules
+---------
+
+We can use `~plasmapy.particles.particle_class.molecule` to convert a
+chemical symbol into a |CustomParticle| object with the appropriate
+mass, charge, and symbol.
+
+>>> from plasmapy.particles import molecule
+>>> molecule("CO2 1+")  # carbon dioxide cation
+CustomParticle(mass=7.30786637819994e-26 kg, charge=1.602176634e-19 C, symbol=CO2 1+)
+
+Particle lists
+==============
+
+We can use |ParticleList| to work with multiple particles.
+A |ParticleList| can contain |Particle| or |CustomParticle| objects.
+
+>>> from plasmapy.particles import ParticleList
+>>> helium_ions = ParticleList(["He-4 0+", "He-4 1+"])
+
+|ParticleList| objects behave similarly to `list` objects, but convert
+new objects into the appropriate particle objects.
+
+>>> helium_ions.append("alpha")
+>>> print(helium_ions)
+ParticleList(['He-4 0+', 'He-4 1+', 'He-4 2+'])
+>>> helium_ions[1]
+Particle("He-4 1+")
+
+|ParticleList| shares many of the same attributes as |Particle| and
+|CustomParticle|. These attributes often return a |Quantity| array
+rather than a single-valued |Quantity|.
+
+>>> helium_ions.charge
+<Quantity [0.00000000e+00, 1.60217663e-19, 3.20435327e-19] C>
+>>> helium_ions.mass
+<Quantity [6.64647907e-27, 6.64556813e-27, 6.64465719e-27] kg>
+
+
+If we provide a |Quantity| with units of mass or charge, it will get
+converted into a |CustomParticle|.
+
+>>> cp_list = ParticleList([1 * u.kg, 1 * u.C])
+>>> cp_list[0]
+CustomParticle(mass=1.0 kg, charge=nan C)
+>>> cp_list.charge
+<Quantity [nan,  1.] C>
+>>> cp_list.mass
+<Quantity [ 1., nan] kg>
+
+We can create a |CustomParticle| with the mean mass and charge of the
+particles in a |ParticleList| with its
+`~plasmapy.particles.particle_collections.ParticleList.average_particle`
+method.
+
+>>> helium_ions.average_particle()
+CustomParticle(mass=6.645568133213004e-27 kg, charge=1.602176634e-19 C)
+
+We can create a |ParticleList| by adding |Particle|, |CustomParticle|,
+and/or |ParticleList| objects together.
+
+>>> helium_ions + cp + proton
+ParticleList(['He-4 0+', 'He-4 1+', 'He-4 2+', 'Fe 9.5+', 'p+'])
+
+The machinery contained with |ParticleList| lets us calculate many
+plasma parameters from `plasmapy.formulary` for multiple particles at
+once.
+
+>>> from plasmapy.formulary import gyroradius
+>>> gyroradius(B = 5 * u.nT, particle=["e-", "p+"], Vperp = 100 * u.km/u.s)
+<Quantity [1.13712608e+02, 2.08793710e+05] m>
+
+Dimensionless particles
+=======================
+
+We can use |DimensionlessParticle| to represent particles that have been
+normalized (i.e., both the mass and charge are dimensionless).
+
+>>> dp = DimensionlessParticle(mass=1, charge=-1)
+>>> dp.charge
+-1.0
+>>> dp.mass
+1.0
+
+Because |DimensionlessParticle| objects do not directly represent
+physical particles without normalization information, they cannot be
+contained within a |ParticleList|.
+
 .. |is_category| replace:: `~plasmapy.particles.particle_class.AbstractPhysicalParticle.is_category`

--- a/docs/particles/particle_class.rst
+++ b/docs/particles/particle_class.rst
@@ -9,8 +9,8 @@ PlasmaPy contains several classes to represent particles, including
 
 .. _particle-class-instantiation:
 
-Working with Particle objects
-=============================
+Particles
+=========
 
 To create a |Particle| object, pass it a `str` representing a particle.
 
@@ -233,7 +233,6 @@ rather than a single-valued |Quantity|.
 >>> helium_ions.mass
 <Quantity [6.64647907e-27, 6.64556813e-27, 6.64465719e-27] kg>
 
-
 If we provide a |Quantity| with units of mass or charge, it will get
 converted into a |CustomParticle|.
 
@@ -259,9 +258,8 @@ and/or |ParticleList| objects together.
 >>> helium_ions + cp + proton
 ParticleList(['He-4 0+', 'He-4 1+', 'He-4 2+', 'Fe 9.5+', 'p+'])
 
-The machinery contained with |ParticleList| lets us calculate many
-plasma parameters from `plasmapy.formulary` for multiple particles at
-once.
+The machinery contained with |ParticleList| lets us calculate plasma
+parameters from `plasmapy.formulary` for multiple particles at once.
 
 >>> from plasmapy.formulary import gyroradius
 >>> gyroradius(B = 5 * u.nT, particle=["e-", "p+"], Vperp = 100 * u.km/u.s)

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2285,7 +2285,7 @@ class CustomParticle(AbstractPhysicalParticle):
     @property
     def charge_number(self) -> Real:
         """The ratio of the charge to the elementary charge."""
-        return self.charge / const.e.si
+        return (self.charge / const.e.si).value
 
     @charge_number.setter
     def charge_number(self, Z: int):


### PR DESCRIPTION
## Description

This PR extends the narrative docs for the `Particle` class to include `CustomParticle`, `DimensionlessParticle`, and `ParticleList` objects.

## Motivation and context

These are a bunch of changes I've been meaning to make for probably years.

## Related issues

Closes #1038.