### PR TITLE
Add pre-commit hook to validate GitHub workflows

### DIFF
--- a/.github/workflows/add-no-changelog-label.yml
+++ b/.github/workflows/add-no-changelog-label.yml
@@ -12,30 +12,30 @@ jobs:
       pull-requests: write
     steps:
     - name: Label the PR
-    uses: actions/github-script@v6
-    with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      script: |
-        // Regular expression to match the PR title pattern "Bump * from * to *"
-        const bumpPattern = /^Bump .* from .* to .*/;
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          // Regular expression to match the PR title pattern "Bump * from * to *"
+          const bumpPattern = /^Bump .* from .* to .*/;
 
-        // Fetch the PR
-        const { data: pullRequest } = await github.rest.pulls.get({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          pull_number: context.issue.number,
-        });
-
-        if (
-          pullRequest.title.includes('Update pinned requirements') ||
-          pullRequest.title.includes('autoupdate') ||
-          bumpPattern.test(pullRequest.title)
-        ) {
-          // If yes, then apply the label "No changelog entry needed"
-          await github.rest.issues.addLabels({
+          // Fetch the PR
+          const { data: pullRequest } = await github.rest.pulls.get({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            issue_number: context.issue.number,
-            labels: ['No changelog entry needed'],
+            pull_number: context.issue.number,
           });
-        }
+
+          if (
+            pullRequest.title.includes('Update pinned requirements') ||
+            pullRequest.title.includes('autoupdate') ||
+            bumpPattern.test(pullRequest.title)
+          ) {
+            // If yes, then apply the label "No changelog entry needed"
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['No changelog entry needed'],
+            });
+          }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,9 +73,6 @@ jobs:
     name: Documentation, pinned dependencies
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -100,9 +97,6 @@ jobs:
   import-plasmapy:
     name: Importing PlasmaPy
     runs-on: windows-latest
-
-    strategy:
-      fail-fast: false
 
     steps:
     - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,12 @@ repos:
   - id: check-toml
   - id: check-yaml
 
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.27.0
+  hooks:
+  - id: check-github-workflows
+    args: [--verbose]
+
 - repo: https://github.com/sirosen/texthooks
   rev: 0.6.2
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
   rev: 0.27.0
   hooks:
   - id: check-github-workflows
-    args: [--verbose]
 
 - repo: https://github.com/sirosen/texthooks
   rev: 0.6.2

--- a/changelog/2380.trivial.rst
+++ b/changelog/2380.trivial.rst
@@ -1,0 +1,1 @@
+Added a |pre-commit| hook to validate |GitHub Actions|.


### PR DESCRIPTION
In #2379, I ended up noticing (with the help of PyCharm) that there were a few mistakes in our GitHub workflows.  I don't think these actually did any harm, but there were inconsistencies with the schema.

This PR adds a pre-commit hook that validates GitHub workflows, and makes a few fixes.