### PR TITLE
Remove `# coverage: ignore` in most places for more realistic coverage reports

### DIFF
--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -166,7 +166,7 @@ class Characteristic:
         if len(np.unique(self.bias)) != len(self.bias):
             raise ValueError("Bias array contains duplicate values.")
 
-    def get_padded_limit(self, padding, log=False):  # coverage: ignore
+    def get_padded_limit(self, padding, log=False):
         r"""Return the limits of the current range for plotting, taking into
         account padding. Matplotlib lacks this functionality.
 
@@ -196,7 +196,7 @@ class Characteristic:
                 ymax + padding * (ymax - ymin),
             ] * u.A
 
-    def plot(self):  # coverage: ignore
+    def plot(self):
         r"""Plot the characteristic in matplotlib."""
         import matplotlib.pyplot as plt
 
@@ -362,7 +362,7 @@ def swept_probe_analysis(  # noqa: PLR0915
         I_es, reduce_bimaxwellian_temperature(T_e, hot_fraction), probe_area
     )
 
-    if visualize:  # coverage: ignore
+    if visualize:
         import matplotlib.pyplot as plt
 
         with quantity_support():
@@ -428,7 +428,7 @@ def swept_probe_analysis(  # noqa: PLR0915
 
     # Obtain and show the EEDF. This is only useful if the characteristic data
     # has been preprocessed to be sufficiently smooth and noiseless.
-    if plot_EEDF:  # coverage: ignore
+    if plot_EEDF:
         get_EEDF(probe_characteristic, visualize=True)
 
     # Compile the results dictionary
@@ -967,7 +967,7 @@ def get_electron_temperature(
         # If bi-Maxwellian, return main temperature first
         T_e = np.array([T0, T0 + Delta_T]) * u.eV
 
-    if visualize:  # coverage: ignore
+    if visualize:
         import matplotlib.pyplot as plt
 
         with quantity_support():
@@ -1075,7 +1075,7 @@ def extrapolate_electron_current(
         probe_characteristic.bias, electron_current
     )
 
-    if visualize:  # coverage: ignore
+    if visualize:
         import matplotlib.pyplot as plt
 
         with quantity_support():
@@ -1231,7 +1231,7 @@ def get_ion_density_OML(
         / (probe_area**2 * const.e**3 * 2)
     )
 
-    if visualize:  # coverage: ignore
+    if visualize:
         import matplotlib.pyplot as plt
 
         with quantity_support():
@@ -1298,7 +1298,7 @@ def extrapolate_ion_current_OML(probe_characteristic, fit, visualize=False):
 
     ion_characteristic = Characteristic(probe_characteristic.bias, ion_current)
 
-    if visualize:  # coverage: ignore
+    if visualize:
         import matplotlib.pyplot as plt
 
         with quantity_support():
@@ -1393,7 +1393,7 @@ def get_EEDF(probe_characteristic, visualize=False):
     integral = np.abs(np.trapz(probability, x=energy.to(u.eV).value))
     probability = probability / integral
 
-    if visualize:  # coverage: ignore
+    if visualize:
         import matplotlib.pyplot as plt
 
         with quantity_support():

--- a/plasmapy/formulary/__init__.py
+++ b/plasmapy/formulary/__init__.py
@@ -60,7 +60,7 @@ for modname in (
 ):
     try:
         obj = globals()[modname]
-    except KeyError:  # coverage: ignore
+    except KeyError:
         continue
 
     with contextlib.suppress(AttributeError):

--- a/plasmapy/formulary/collisions/dimensionless.py
+++ b/plasmapy/formulary/collisions/dimensionless.py
@@ -205,7 +205,7 @@ def coupling_parameter(
         kinetic_energy = 2 * k_B * T / denominator
         if np.all(np.imag(kinetic_energy) < 1e-15 * u.J):
             kinetic_energy = np.real(kinetic_energy)
-        else:  # coverage: ignore
+        else:
             raise ValueError(
                 "Kinetic energy should not be imaginary."
                 "Something went horribly wrong."

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -178,7 +178,7 @@ def relativistic_energy(
     # TODO: Remove references to the parameters ``m`` and ``v`` in the
     # docstring and below no sooner than 2024.
 
-    if m is not None or v is not None:  # coverage: ignore
+    if m is not None or v is not None:
         raise TypeError(
             "The parameters 'm' and 'v' to relativistic_energy have "
             " been removed. Use 'particle' instead of 'm' and 'V' "

--- a/plasmapy/particles/_factory.py
+++ b/plasmapy/particles/_factory.py
@@ -90,7 +90,7 @@ def _make_custom_particle_with_real_charge_number(
 
     if not base_particle.is_category(require="element", exclude="ion"):
         # Add tests if this function becomes part of public API
-        raise InvalidParticleError("Cannot create CustomParticle.")  # coverage: ignore
+        raise InvalidParticleError("Cannot create CustomParticle.")
 
     if Z > base_particle.atomic_number:
         raise ChargeError("The charge number cannot exceed the atomic number.")

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -382,7 +382,7 @@ def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
 
         return ion
 
-    if not isinstance(argument, (str, Integral)):  # coverage: ignore
+    if not isinstance(argument, (str, Integral)):
         raise TypeError(f"The argument {argument} is not an integer or string.")
 
     arg = dealias_particle_aliases(argument)

--- a/plasmapy/particles/_special_particles.py
+++ b/plasmapy/particles/_special_particles.py
@@ -176,7 +176,7 @@ def create_particles_dict() -> dict[str, dict]:  # noqa: C901, PLR0912
     for fermion in particle_zoo.fermions:
         particles[fermion]["spin"] = 0.5
 
-    for boson in particle_zoo.bosons:  # coverage: ignore
+    for boson in particle_zoo.bosons:
         particles[boson]["spin"] = 0
 
     for lepton in particle_zoo.leptons:

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -332,7 +332,7 @@ class AbstractPhysicalParticle(AbstractParticle):
                 return {arg}
             return set(arg[0]) if isinstance(arg[0], (tuple, list, set)) else set(arg)
 
-        if category_tuple and require:  # coverage: ignore
+        if category_tuple and require:
             raise ParticleError(
                 "No positional arguments are allowed if the `require` keyword "
                 "is set in is_category."
@@ -848,7 +848,7 @@ class Particle(AbstractPhysicalParticle):
             other
         )
 
-        if no_symbol_attr or no_attributes_attr:  # coverage: ignore
+        if no_symbol_attr or no_attributes_attr:
             return False
 
         same_particle = self.symbol == other.symbol
@@ -869,7 +869,7 @@ class Particle(AbstractPhysicalParticle):
 
         same_attributes = self._attributes == other._attributes
 
-        if same_particle and not same_attributes:  # coverage: ignore
+        if same_particle and not same_attributes:
             raise ParticleError(
                 f"{self} and {other} should be the same Particle, but "
                 f"have differing attributes.\n\n"
@@ -1172,7 +1172,7 @@ class Particle(AbstractPhysicalParticle):
         """
         if self.isotope or self.is_ion or not self.element:
             raise InvalidElementError(_category_errmsg(self, "element"))
-        if self._attributes["standard atomic weight"] is None:  # coverage: ignore
+        if self._attributes["standard atomic weight"] is None:
             return np.nan * u.kg
         return self._attributes["standard atomic weight"].to(u.kg)
 
@@ -1273,7 +1273,7 @@ class Particle(AbstractPhysicalParticle):
 
         base_mass = self._attributes["isotope mass"]
 
-        if base_mass is None:  # coverage: ignore
+        if base_mass is None:
             return np.nan * u.kg
 
         _nuclide_mass = (
@@ -1432,7 +1432,7 @@ class Particle(AbstractPhysicalParticle):
             return 1
         elif self.isotope:
             return self.mass_number - self.atomic_number
-        else:  # coverage: ignore
+        else:
             raise InvalidIsotopeError(_category_errmsg(self, "isotope"))
 
     @property
@@ -1459,7 +1459,7 @@ class Particle(AbstractPhysicalParticle):
             return 1
         elif self.ionic_symbol:
             return self.atomic_number - self.charge_number
-        else:  # coverage: ignore
+        else:
             raise InvalidIonError(_category_errmsg(self, "ion"))
 
     @property
@@ -1483,7 +1483,7 @@ class Particle(AbstractPhysicalParticle):
         """
         from plasmapy.particles.atomic import common_isotopes
 
-        if not self.isotope or self.is_ion:  # coverage: ignore
+        if not self.isotope or self.is_ion:
             raise InvalidIsotopeError(_category_errmsg(self.symbol, "isotope"))
 
         abundance = self._attributes.get("isotopic abundance", 0.0)
@@ -1517,7 +1517,7 @@ class Particle(AbstractPhysicalParticle):
         >>> alpha.baryon_number
         4
         """
-        if self._attributes["baryon number"] is None:  # coverage: ignore
+        if self._attributes["baryon number"] is None:
             raise MissingParticleDataError(
                 f"The baryon number for '{self.symbol}' is not available."
             )
@@ -1545,7 +1545,7 @@ class Particle(AbstractPhysicalParticle):
         >>> Particle('He-4 0+').lepton_number
         0
         """
-        if self._attributes["lepton number"] is None:  # coverage: ignore
+        if self._attributes["lepton number"] is None:
             raise MissingParticleDataError(
                 f"The lepton number for {self.symbol} is not available."
             )
@@ -1631,7 +1631,7 @@ class Particle(AbstractPhysicalParticle):
         """
         if self.element:
             return self._attributes["periodic table"]
-        else:  # coverage: ignore
+        else:
             raise InvalidElementError(_category_errmsg(self.symbol, "element"))
 
     @property

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -268,7 +268,7 @@ class AbstractGrid(ABC):
         uniformly spaced.
         """
 
-        if self._is_uniform is None:  # coverage: ignore
+        if self._is_uniform is None:
             raise ValueError(
                 "The `is_uniform` attribute is not accessible "
                 "before a grid has been loaded."

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -100,7 +100,7 @@ class ParticleTracker:
         nt=np.inf,
         integrator="explicit_boris",
     ):
-        if np.isinf(dt) and np.isinf(nt):  # coverage: ignore
+        if np.isinf(dt) and np.isinf(nt):
             raise ValueError("Both dt and nt are infinite.")
 
         self.q = atomic.charge_number(particle_type) * constants.e.si
@@ -230,7 +230,7 @@ class ParticleTracker:
             f'name="{self.name}",NT={self.NT})'
         )
 
-    def __str__(self) -> str:  # coverage: ignore
+    def __str__(self) -> str:
         return (
             f"{self.N} {self.scaling:.2e}-{self.name} with "
             f"q = {self.q:.2e}, m = {self.m:.2e}, "
@@ -238,7 +238,7 @@ class ParticleTracker:
             f"steps over {self.NT} iterations"
         )
 
-    def plot_trajectories(self):  # coverage: ignore
+    def plot_trajectories(self):
         r"""Draw trajectory history."""
         import matplotlib.pyplot as plt
 
@@ -257,7 +257,7 @@ class ParticleTracker:
         ax.set_zlabel("$z$ position")
         plt.show()
 
-    def plot_time_trajectories(self, plot="xyz"):  # coverage: ignore
+    def plot_time_trajectories(self, plot="xyz"):
         r"""
         Draw position history versus time.
 

--- a/plasmapy/utils/_pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/_pytest_helpers/pytest_helpers.py
@@ -31,7 +31,7 @@ from plasmapy.utils.code_repr import _name_with_article, _object_name, call_stri
 from plasmapy.utils.exceptions import PlasmaPyWarning
 
 
-def _process_input(wrapped_function: Callable):  # coverage: ignore
+def _process_input(wrapped_function: Callable):
     """
     Allow `run_test` to take a single positional argument that is a
     `list` or `tuple` in lieu of using multiple positional/keyword
@@ -72,7 +72,7 @@ def run_test(  # noqa: C901
     expected_outcome: Any = None,
     rtol: float = 0.0,
     atol: float = 0.0,
-):  # coverage: ignore
+):
     """
     Test that a function or class returns the expected result, raises
     the expected exception, or issues an expected warning for the
@@ -379,7 +379,7 @@ def run_test(  # noqa: C901
     try:
         if result == expected["result"]:
             return None
-    except Exception as exc_equality:  # coverage: ignore
+    except Exception as exc_equality:
         raise TypeError(
             f"The equality of {_object_name(result)} and "
             f"{_object_name(expected['result'])} "
@@ -602,7 +602,7 @@ def run_test_equivalent_calls(  # noqa: C901
 
     try:
         equals_first_result = [result == results[0] for result in results]
-    except Exception as exc:  # coverage: ignore
+    except Exception as exc:
         raise UnexpectedExceptionFail(
             "Unable to determine equality properties of results."
         ) from exc

--- a/plasmapy/utils/data/downloader.py
+++ b/plasmapy/utils/data/downloader.py
@@ -48,7 +48,7 @@ def get_file(basename, base_url=_BASE_URL, directory=None):
     if "." not in str(basename):
         raise ValueError(f"'filename' ({basename}) must include an extension.")
 
-    if directory is None:  # coverage: ignore
+    if directory is None:
         directory = Path(Path.home(), ".plasmapy", "downloads")
 
         # Create the .plasmapy/downloads directory if it does not already

--- a/plasmapy/utils/decorators/lite_func.py
+++ b/plasmapy/utils/decorators/lite_func.py
@@ -116,7 +116,7 @@ def bind_lite_func(lite_func, attrs: Optional[dict[str, Callable]] = None):
             # build origin name
             if hasattr(attr, "__module__"):
                 modname = attr.__module__
-            else:  # coverage: ignore
+            else:
                 # assume attr is defined in the module the function being
                 # decorated in
                 modname = wrapper.__module__


### PR DESCRIPTION
## Description

This PR removes most comments which say that code coverage checks should be ignored.

## Motivation and context

We currently use `# coverage: ignore` when we have a block of code that do not want to include in code coverage checks.  We've used that somewhat liberally in the past.  The problem with this practice is that we end up sweeping lines of code under the rug, which means that we think our code coverage is higher than it is.  Removing the `# coverage: ignore` comments will make it so that the lines of code that aren't tested show up as not being tested.  Also, some lines of code with that comment might actually be run during tests.

## Related issues

It's common for other projects to use `# pragma: no cover`, but we decided on using `# coverage: ignore` because it's less confusing to newcomers to the project.


This PR is also a check to make sure that changes to GitHub Actions in #2379 and #2380 are still working okay.
