### PR TITLE
Update ion_thermal_conductivity docstring

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -575,3 +575,8 @@ authors:
 - given-names: Julia
   family-names: Guimiot
   alias: JuliaGuimiot
+
+- given-names: Evan
+  family-names: Jones
+  orcid: https://orcid.org/0009-0004-6699-4869
+  alias: E-W-Jones

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -945,7 +945,7 @@ def ion_thermal_conductivity(
 
     See Also
     --------
-    ion_thermal_conductivity
+    electron_thermal_conductivity
 
     """
     ct = ClassicalTransport(

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -559,7 +559,7 @@ class ClassicalTransport:
 
         See Also
         --------
-        ion_thermal_conductivity
+        electron_thermal_conductivity
 
         """
         kappa_hat = _nondim_thermal_conductivity(


### PR DESCRIPTION
## Description

Updated the docstring in formulary/braginskii.py, where it said `see also: ion_thermal_conductivity` in the documentation instead of `see also: electron_thermal_conductivity`.


## Related issues

Closes #2365