### PR TITLE
Separate GitHub Action for checking hyperlinks into its own action

### DIFF
--- a/.github/workflows/check-hyperlinks.yml
+++ b/.github/workflows/check-hyperlinks.yml
@@ -1,0 +1,31 @@
+name: Check hyperlinks
+
+on:
+  schedule:
+  - cron: 37 8 * * 1
+  workflow_dispatch:
+
+jobs:
+
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade tox
+
+    - name: Install graphviz & pandoc
+      run: sudo apt-get install graphviz pandoc
+
+    - name: Check hyperlinks
+      run: tox -e build_docs_linkcheck

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -72,11 +72,6 @@ jobs:
           toxenv: build_docs-sphinxdev
           toxposargs: -q
 
-        - name: Documentation build with hyperlink check
-          os: ubuntu-latest
-          python: '3.11'
-          toxenv: build_docs_linkcheck
-
         - name: Python 3.9 with xarray dev
           os: ubuntu-latest
           python: 3.9

--- a/changelog/2392.trivial.rst
+++ b/changelog/2392.trivial.rst
@@ -1,0 +1,2 @@
+Separated the GitHub Action for checking hyperlinks in the
+documentation into its own GitHub Action.


### PR DESCRIPTION
## Description

This PR moves the `make linkcheck` GitHub Action from the weekly tests into a separate file so that it can be run separately.

## Motivation and context

Because [link rot](https://en.wikipedia.org/wiki/Link_rot) is so pervasive, our hyperlink check frequently fails.  We will sometimes get intermittent test failures when a hyperlink temporarily becomes unavailable before being restored.  The nature of this failure is quite different than other failures in our cron tests since it is in an external, changing environment.
