### PR TITLE
Fixed Improper Method Call: `__exit__()`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -583,3 +583,8 @@ authors:
 
 - given-names: Oscar
   alias: 0scvr
+
+- given-names: Ataf Fazledin
+  family-names: Ahamed
+  affiliation: OpenRefactory Inc.
+  alias: fazledyn-or

--- a/changelog/2402.bugfix.rst
+++ b/changelog/2402.bugfix.rst
@@ -1,1 +1,1 @@
-Modified |__exit__| method of |HDF5Reader| for context management
+Modified ``__exit__`` method of ``HDF5Reader`` for context management

--- a/changelog/2402.bugfix.rst
+++ b/changelog/2402.bugfix.rst
@@ -1,0 +1,1 @@
+Modified |__exit__| method of |HDF5Reader| for context management

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -72,7 +72,7 @@ class HDF5Reader(GenericPlasma):
     def close(self):
         self.h5.close()
 
-    def __exit__(self):  # noqa: PLE0302, PYI036
+    def __exit__(self, exc_type, exc_value, traceback):  # noqa: PLE0302, PYI036
         self.h5.close()
 
     def _check_valid_openpmd_version(self):

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -72,7 +72,7 @@ class HDF5Reader(GenericPlasma):
     def close(self):
         self.h5.close()
 
-    def __exit__(self, exc_type, exc_value, traceback):  # noqa: PLE0302, PYI036
+    def __exit__(self, exc_type, exc_value, traceback):
         self.h5.close()
 
     def _check_valid_openpmd_version(self):


### PR DESCRIPTION
## Description
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [openpmd_hdf5.py](https://github.com/PlasmaPy/PlasmaPy/blob/main/plasmapy/plasma/sources/openpmd_hdf5.py#L75), class: HDF5Reader, there is a special method `__exit__` that contains an unexpected number of parameters. Each call to this method will result in a TypeError. iCR suggested that special methods should have an expected number of parameters. More infomation can be found in the [Python documentation on the various special method](https://docs.python.org/3/reference/datamodel.html#object.__exit__).

### Proof of Concept / Explanation
Let's take the code example below. We're using a sample HDF5 file from this [link](https://github.com/openPMD/openPMD-example-datasets/blob/draft/example-femm-3d.h5).

```py
from plasmapy.plasma.sources.openpmd_hdf5 import HDF5Reader

hdf5 = "example.h5"
print("Before entering context")
with HDF5Reader(hdf5) as f:
    print("Inside the context")
print("After exiting context")
```
Output:
```bash
(env) ataf@openrefactory:~/BFAS/Source/PlasmaPy$ python3 _test.py 
Before entering context
Inside the context
Traceback (most recent call last):
  File "/home/ataf/BFAS/Source/PlasmaPy/_test.py", line 5, in <module>
    with HDF5Reader(hdf5) as f:
TypeError: HDF5Reader.__exit__() takes 1 positional argument but 4 were given
```
However, after changing the `__exit__` method, we get the following output - 
```bash
(env) ataf@openrefactory:~/BFAS/Source/PlasmaPy$ python3 _test.py 
Before entering context
Inside the context
After exiting context
```

If the `HDF5Reader` class is to be used as a context manager, you must change the `__exit__` method as suggested in this PR. Otherwise, you can delete both `__enter__` and `__exit__` methods to avoid confusion.


## Changes
- Modified the method signature of `__exit__` according to documentation


## Previously Found & Fixed
- https://www.github.com/OCR-D/core/pull/1130


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.