### PR TITLE
Removed imports from subpackages from `plasmapy/utils/__init__.py`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -588,3 +588,6 @@ authors:
   family-names: Ahamed
   affiliation: OpenRefactory Inc.
   alias: fazledyn-or
+
+- given-names: Tomasz Adam
+  family-names: Skrzypczak

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -591,3 +591,4 @@ authors:
 
 - given-names: Tomasz Adam
   family-names: Skrzypczak
+  alias: tomasz-adam-skrzypczak

--- a/changelog/2403.breaking.rst
+++ b/changelog/2403.breaking.rst
@@ -1,1 +1,1 @@
-Removed sub-packages' imports from ``plasmapy.utils``, all classes and functions from the sub-packages have to be imported directly
+Removed imports from subpackages in `plasmapy.utils`. All classes and functions from the subpackages now must be imported directly.

--- a/changelog/2403.breaking.rst
+++ b/changelog/2403.breaking.rst
@@ -1,1 +1,1 @@
-Removed sub-packages' imports from `plasmapy.utils.__init__.py`, all classes and functions from `plasmapy.utils` sub-packages have to be imported directly
+Removed sub-packages' imports from ``plasmapy.utils``, all classes and functions from the sub-packages have to be imported directly

--- a/changelog/2403.breaking.rst
+++ b/changelog/2403.breaking.rst
@@ -1,0 +1,1 @@
+Removed sub-packages' imports from `plasmapy.utils.__init__.py`, all classes and functions from `plasmapy.utils` sub-packages have to be imported directly

--- a/plasmapy/dispersion/dispersionfunction.py
+++ b/plasmapy/dispersion/dispersionfunction.py
@@ -17,8 +17,8 @@ import warnings
 from typing import Union
 
 from plasmapy.dispersion import dispersion_functions
-from plasmapy.utils import PlasmaPyFutureWarning
 from plasmapy.utils.decorators import bind_lite_func, preserve_signature
+from plasmapy.utils.exceptions import PlasmaPyFutureWarning
 
 
 @preserve_signature

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -133,7 +133,7 @@ import warnings
 
 from astropy.constants.si import e, k_B, m_e
 
-from plasmapy import particles, utils
+from plasmapy import particles
 from plasmapy.formulary.collisions import (
     Coulomb_logarithm,
     fundamental_electron_collision_freq,
@@ -143,8 +143,8 @@ from plasmapy.formulary.dimensionless import Hall_parameter
 from plasmapy.formulary.misc import _grab_charge
 from plasmapy.particles.atomic import _is_electron
 from plasmapy.particles.exceptions import InvalidParticleError
-from plasmapy.utils import PhysicsError
 from plasmapy.utils.decorators import validate_quantities
+from plasmapy.utils.exceptions import CouplingWarning, PhysicsError
 
 
 class ClassicalTransport:
@@ -394,7 +394,7 @@ class ClassicalTransport:
             warnings.warn(
                 f"Coulomb logarithm is {coulomb_log_ei},"
                 f" you might have strong coupling effects",
-                utils.CouplingWarning,
+                CouplingWarning,
             )
 
         if coulomb_log_ii is not None:
@@ -418,7 +418,7 @@ class ClassicalTransport:
             warnings.warn(
                 f"Coulomb logarithm is {coulomb_log_ii},"
                 f" you might have strong coupling effects",
-                utils.CouplingWarning,
+                CouplingWarning,
             )
 
         # calculate Hall parameters if not forced in input
@@ -1299,7 +1299,7 @@ def _check_Z(allowed_Z, Z):
             # return a Z_idx pointing to the 'arbitrary'
             Z_idx = the_arbitrary_idx
         else:
-            raise utils.PhysicsError(f"{Z} is not an allowed Z value")
+            raise PhysicsError(f"{Z} is not an allowed Z value")
     # we have got the Z_idx we want. return
     return Z_idx
 

--- a/plasmapy/formulary/collisions/coulomb.py
+++ b/plasmapy/formulary/collisions/coulomb.py
@@ -23,9 +23,10 @@ import warnings
 
 from numbers import Real
 
-from plasmapy import particles, utils
+from plasmapy import particles
 from plasmapy.formulary.collisions import lengths
 from plasmapy.utils.decorators import validate_quantities
+from plasmapy.utils.exceptions import CouplingWarning
 
 
 @validate_quantities(
@@ -475,14 +476,14 @@ def Coulomb_logarithm(
             f"min(ln Λ) = {min_ln_Lambda:.4f} which is likely to be inaccurate "
             f"due to strong coupling effects, in particular because "
             f"{method = } assumes weak coupling.",
-            utils.CouplingWarning,
+            CouplingWarning,
         )
     elif min_ln_Lambda < 4:
         warnings.warn(
             f"The calculation of the Coulomb logarithm has found a value of "
             f"min(ln Λ) = {min_ln_Lambda:.4f}. Coulomb logarithms of ≲ 4 may "
             f"have increased uncertainty due to strong coupling effects.",
-            utils.CouplingWarning,
+            CouplingWarning,
         )
 
     return ln_Lambda

--- a/plasmapy/formulary/collisions/misc.py
+++ b/plasmapy/formulary/collisions/misc.py
@@ -12,11 +12,12 @@ import numpy as np
 from astropy.constants.si import e
 from numbers import Real
 
-from plasmapy import particles, utils
+from plasmapy import particles
 from plasmapy.formulary.collisions import frequencies
 from plasmapy.formulary.speeds import thermal_speed
 from plasmapy.utils.decorators import validate_quantities
 from plasmapy.utils.decorators.checks import _check_relativistic
+from plasmapy.utils.exceptions import PhysicsError
 
 
 @validate_quantities(T={"equivalencies": u.temperature_energy()})
@@ -56,7 +57,7 @@ def _replace_nan_velocity_with_thermal_velocity(
     ``T`` and ``m`` are okay.
     """
     if np.any(V == 0):
-        raise utils.PhysicsError("Collisions are not possible with a zero velocity.")
+        raise PhysicsError("Collisions are not possible with a zero velocity.")
 
     if V is None:
         return thermal_speed(T, species, mass=m)

--- a/plasmapy/formulary/collisions/tests/test_coulomb.py
+++ b/plasmapy/formulary/collisions/tests/test_coulomb.py
@@ -8,9 +8,14 @@ from astropy.tests.helper import assert_quantity_allclose
 import plasmapy.particles.exceptions
 
 from plasmapy.formulary.collisions.coulomb import Coulomb_logarithm
-from plasmapy.utils import exceptions
 from plasmapy.utils._pytest_helpers import assert_can_handle_nparray
-from plasmapy.utils.exceptions import CouplingWarning
+from plasmapy.utils.exceptions import (
+    CouplingWarning,
+    PhysicsError,
+    PhysicsWarning,
+    RelativityError,
+    RelativityWarning,
+)
 
 
 class Test_Coulomb_logarithm:
@@ -117,7 +122,7 @@ class Test_Coulomb_logarithm:
 
     def test_handle_zero_V(self):
         """Test that V == 0 returns a PhysicsError"""
-        with pytest.raises(exceptions.PhysicsError):
+        with pytest.raises(PhysicsError):
             Coulomb_logarithm(
                 self.T_arr[0],
                 self.n_arr[0],
@@ -239,7 +244,7 @@ class Test_Coulomb_logarithm:
         # velocity. Chen uses v**2 = k * T / m  whereas we use
         # v ** 2 = 2 * k * T / m
         lnLambdaChen = 16 + np.log(2)
-        with pytest.warns(exceptions.RelativityWarning):
+        with pytest.warns(RelativityWarning):
             lnLambda = Coulomb_logarithm(T, n, ("e", "p"))
         testTrue = np.isclose(lnLambda, lnLambdaChen, rtol=1e-1, atol=0.0)
         errStr = (
@@ -261,7 +266,7 @@ class Test_Coulomb_logarithm:
         # velocity. Chen uses v**2 = k * T / m  whereas we use
         # v ** 2 = 2 * k * T / m
         lnLambdaChen = 6.8 + np.log(2)
-        with pytest.warns(exceptions.RelativityWarning):
+        with pytest.warns(RelativityWarning):
             lnLambda = Coulomb_logarithm(T, n, ("e", "p"))
         testTrue = np.isclose(lnLambda, lnLambdaChen, rtol=1e-1, atol=0.0)
         errStr = (
@@ -275,7 +280,7 @@ class Test_Coulomb_logarithm:
         Test for first version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -296,7 +301,7 @@ class Test_Coulomb_logarithm:
         Test for first version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -318,7 +323,7 @@ class Test_Coulomb_logarithm:
         Murillo, and Schlanges PRE (2002). This checks for when
         a negative (invalid) Coulomb logarithm is returned.
         """
-        with pytest.warns(exceptions.CouplingWarning, match="strong coupling effects"):
+        with pytest.warns(CouplingWarning, match="strong coupling effects"):
             Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -334,7 +339,7 @@ class Test_Coulomb_logarithm:
         Murillo, and Schlanges PRE (2002). This checks for when
         a negative (invalid) Coulomb logarithm is returned.
         """
-        with pytest.warns(exceptions.CouplingWarning, match="strong coupling effects"):
+        with pytest.warns(CouplingWarning, match="strong coupling effects"):
             Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -349,7 +354,7 @@ class Test_Coulomb_logarithm:
         Test for second version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -370,7 +375,7 @@ class Test_Coulomb_logarithm:
         Test for second version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -392,7 +397,7 @@ class Test_Coulomb_logarithm:
         Murillo, and Schlanges PRE (2002). This checks for when
         a negative (invalid) Coulomb logarithm is returned.
         """
-        with pytest.warns(exceptions.CouplingWarning, match="strong coupling effects"):
+        with pytest.warns(CouplingWarning, match="strong coupling effects"):
             Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -408,7 +413,7 @@ class Test_Coulomb_logarithm:
         Murillo, and Schlanges PRE (2002). This checks for when
         a negative (invalid) Coulomb logarithm is returned.
         """
-        with pytest.warns(exceptions.CouplingWarning, match="strong coupling effects"):
+        with pytest.warns(CouplingWarning, match="strong coupling effects"):
             Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -423,7 +428,7 @@ class Test_Coulomb_logarithm:
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -444,7 +449,7 @@ class Test_Coulomb_logarithm:
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -467,7 +472,7 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -492,7 +497,7 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -515,7 +520,7 @@ class Test_Coulomb_logarithm:
         passing in a collection of density values returns a
         collection of Coulomb logarithm values.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 10 * 1160 * u.K,
                 (1e23 * u.cm**-3, 1e20 * u.cm**-3),
@@ -540,7 +545,7 @@ class Test_Coulomb_logarithm:
         passing in a collection of density values returns a
         collection of Coulomb logarithm values.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 10 * 1160 * u.K,
                 (1e23 * u.cm**-3, 1e20 * u.cm**-3),
@@ -561,7 +566,7 @@ class Test_Coulomb_logarithm:
         Test for fourth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -582,7 +587,7 @@ class Test_Coulomb_logarithm:
         Test for fourth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -605,7 +610,7 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -630,7 +635,7 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -651,7 +656,7 @@ class Test_Coulomb_logarithm:
         Test for fifth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -672,7 +677,7 @@ class Test_Coulomb_logarithm:
         Test for fifth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -695,7 +700,7 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -720,7 +725,7 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -741,7 +746,7 @@ class Test_Coulomb_logarithm:
         Test for sixth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -762,7 +767,7 @@ class Test_Coulomb_logarithm:
         Test for sixth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature1,
                 self.density1,
@@ -785,7 +790,7 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -810,7 +815,7 @@ class Test_Coulomb_logarithm:
         a positive value is returned whereas the classical Coulomb
         logarithm would return a negative value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Coulomb_logarithm(
                 self.temperature2,
                 self.density2,
@@ -897,12 +902,12 @@ class Test_Coulomb_logarithm:
 
     def test_relativity_warn(self):
         """Tests whether relativity warning is raised at high velocity."""
-        with pytest.warns(exceptions.RelativityWarning):
+        with pytest.warns(RelativityWarning):
             Coulomb_logarithm(1e5 * u.K, 1 * u.m**-3, ("e", "p"), V=0.9 * c)
 
     def test_relativity_error(self):
         """Tests whether relativity error is raised at light speed."""
-        with pytest.raises(exceptions.RelativityError):
+        with pytest.raises(RelativityError):
             Coulomb_logarithm(1e5 * u.K, 1 * u.m**-3, ("e", "p"), V=1.1 * c)
 
     def test_unit_conversion_error(self):

--- a/plasmapy/formulary/collisions/tests/test_dimensionless.py
+++ b/plasmapy/formulary/collisions/tests/test_dimensionless.py
@@ -6,9 +6,8 @@ from plasmapy.formulary.collisions.dimensionless import (
     coupling_parameter,
     Knudsen_number,
 )
-from plasmapy.utils import exceptions
 from plasmapy.utils._pytest_helpers import assert_can_handle_nparray
-from plasmapy.utils.exceptions import CouplingWarning
+from plasmapy.utils.exceptions import CouplingWarning, PhysicsWarning
 
 
 class Test_coupling_parameter:
@@ -142,7 +141,7 @@ class Test_Knudsen_number:
         """
         Test for known value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Knudsen_number(
                 self.length,
                 self.T,
@@ -162,7 +161,7 @@ class Test_Knudsen_number:
         value comparison by some quantity close to numerical error.
         """
         fail1 = self.True1 * (1 + 1e-15)
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = Knudsen_number(
                 self.length,
                 self.T,

--- a/plasmapy/formulary/collisions/tests/test_frequencies.py
+++ b/plasmapy/formulary/collisions/tests/test_frequencies.py
@@ -12,9 +12,8 @@ from plasmapy.formulary.collisions.frequencies import (
     SingleParticleCollisionFrequencies,
 )
 from plasmapy.particles import Particle
-from plasmapy.utils import exceptions
 from plasmapy.utils._pytest_helpers import assert_can_handle_nparray
-from plasmapy.utils.exceptions import CouplingWarning, PhysicsError
+from plasmapy.utils.exceptions import CouplingWarning, PhysicsError, PhysicsWarning
 
 
 class TestSingleParticleCollisionFrequencies:
@@ -690,7 +689,7 @@ class Test_collision_frequency:
         """
         Test for known value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
                 self.n,
@@ -709,7 +708,7 @@ class Test_collision_frequency:
         value comparison by some quantity close to numerical error.
         """
         fail1 = self.True1 * (1 + 1e-15)
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
                 self.n,
@@ -745,7 +744,7 @@ class Test_collision_frequency:
         """
         Testing collision frequency between electrons.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
                 self.n,
@@ -767,7 +766,7 @@ class Test_collision_frequency:
         """
         Testing collision frequency between protons (ions).
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
                 self.n,
@@ -789,7 +788,7 @@ class Test_collision_frequency:
         """
         Test collisional frequency function when given arbitrary z_mean.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = collision_frequency(
                 self.T,
                 self.n,

--- a/plasmapy/formulary/collisions/tests/test_lengths.py
+++ b/plasmapy/formulary/collisions/tests/test_lengths.py
@@ -3,9 +3,8 @@ import numpy as np
 import pytest
 
 from plasmapy.formulary.collisions import coulomb, lengths
-from plasmapy.utils import exceptions
 from plasmapy.utils._pytest_helpers import assert_can_handle_nparray
-from plasmapy.utils.exceptions import CouplingWarning
+from plasmapy.utils.exceptions import CouplingWarning, PhysicsWarning
 
 
 class Test_impact_parameter_perp:
@@ -214,7 +213,7 @@ class Test_mean_free_path:
         """
         Test for known value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = lengths.mean_free_path(
                 self.T,
                 self.n_e,
@@ -233,7 +232,7 @@ class Test_mean_free_path:
         value comparison by some quantity close to numerical error.
         """
         fail1 = self.True1 * (1 + 1e-15)
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = lengths.mean_free_path(
                 self.T,
                 self.n_e,

--- a/plasmapy/formulary/collisions/tests/test_misc.py
+++ b/plasmapy/formulary/collisions/tests/test_misc.py
@@ -5,7 +5,7 @@ import pytest
 from plasmapy.formulary.collisions.misc import mobility, Spitzer_resistivity
 from plasmapy.utils import exceptions
 from plasmapy.utils._pytest_helpers import assert_can_handle_nparray
-from plasmapy.utils.exceptions import CouplingWarning
+from plasmapy.utils.exceptions import CouplingWarning, PhysicsWarning
 
 
 class Test_Spitzer_resistivity:
@@ -108,7 +108,7 @@ class Test_mobility:
         """
         Test for known value.
         """
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = mobility(
                 self.T,
                 self.n_e,
@@ -127,7 +127,7 @@ class Test_mobility:
         value comparison by some quantity close to numerical error.
         """
         fail1 = self.True1 * (1 + 1e-15)
-        with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
+        with pytest.warns(PhysicsWarning, match="strong coupling effects"):
             methodVal = mobility(
                 self.T,
                 self.n_e,

--- a/plasmapy/formulary/quantum.py
+++ b/plasmapy/formulary/quantum.py
@@ -23,8 +23,8 @@ from lmfit import minimize, Parameters
 from plasmapy.formulary import mathematics
 from plasmapy.formulary.relativity import Lorentz_factor
 from plasmapy.particles import particle_input, ParticleLike
-from plasmapy.utils import RelativityError
 from plasmapy.utils.decorators import validate_quantities
+from plasmapy.utils.exceptions import RelativityError
 
 __all__ += __aliases__
 

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -10,11 +10,11 @@ from numbers import Integral, Real
 from numpy.typing import DTypeLike
 from typing import Optional, Union
 
-from plasmapy import utils
 from plasmapy.particles import particle_input
 from plasmapy.particles.particle_class import CustomParticle, Particle, ParticleLike
 from plasmapy.particles.particle_collections import ParticleList
 from plasmapy.utils.decorators import validate_quantities
+from plasmapy.utils.exceptions import RelativityError
 
 
 @validate_quantities(V={"can_be_negative": True})
@@ -71,7 +71,7 @@ def Lorentz_factor(V: u.m / u.s):
     """
 
     if not np.all((np.abs(V) <= c) | (np.isnan(V))):
-        raise utils.RelativityError(
+        raise RelativityError(
             "The Lorentz factor cannot be calculated for "
             "speeds faster than the speed of light."
         )

--- a/plasmapy/formulary/tests/test_dimensionless.py
+++ b/plasmapy/formulary/tests/test_dimensionless.py
@@ -17,8 +17,8 @@ from plasmapy.formulary.dimensionless import (
     Rm_,
 )
 from plasmapy.particles import Particle
-from plasmapy.utils import RelativityWarning
 from plasmapy.utils._pytest_helpers import assert_can_handle_nparray
+from plasmapy.utils.exceptions import RelativityWarning
 
 Z = 1
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -23,7 +23,7 @@ from plasmapy.particles.exceptions import (
 )
 from plasmapy.particles.particle_class import CustomParticle, Particle, ParticleLike
 from plasmapy.particles.particle_collections import ParticleList, ParticleListLike
-from plasmapy.utils import PlasmaPyDeprecationWarning
+from plasmapy.utils.exceptions import PlasmaPyDeprecationWarning
 
 _basic_particle_input_annotations = (
     Particle,  # deprecated

--- a/plasmapy/particles/exceptions.py
+++ b/plasmapy/particles/exceptions.py
@@ -13,7 +13,7 @@ __all__ = [
     "UnexpectedParticleError",
 ]
 
-from plasmapy.utils import PlasmaPyError, PlasmaPyWarning
+from plasmapy.utils.exceptions import PlasmaPyError, PlasmaPyWarning
 
 
 class ParticleError(PlasmaPyError):

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -17,9 +17,9 @@ from plasmapy.particles.exceptions import (
     ParticleError,
 )
 from plasmapy.particles.particle_class import CustomParticle, Particle, ParticleLike
-from plasmapy.utils import PlasmaPyDeprecationWarning
 from plasmapy.utils.code_repr import call_string
 from plasmapy.utils.decorators.validators import validate_quantities
+from plasmapy.utils.exceptions import PlasmaPyDeprecationWarning
 
 
 @particle_input

--- a/plasmapy/plasma/exceptions.py
+++ b/plasmapy/plasma/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions and warnings for functionality defined in `plasmapy.plasma`."""
 __all__ = ["DataStandardError"]
 
-from plasmapy.utils import PlasmaPyError
+from plasmapy.utils.exceptions import PlasmaPyError
 
 
 class DataStandardError(PlasmaPyError):

--- a/plasmapy/utils/__init__.py
+++ b/plasmapy/utils/__init__.py
@@ -2,3 +2,19 @@
 Package of functions and classes used to develop clean, readable, and informative
 code.
 """
+
+__all__ = [
+    "code_repr",
+    "datatype_factory_base",
+    "decorators",
+    "exceptions",
+    "roman",
+]
+
+from plasmapy.utils import (
+    code_repr,
+    datatype_factory_base,
+    decorators,
+    exceptions,
+    roman,
+)

--- a/plasmapy/utils/__init__.py
+++ b/plasmapy/utils/__init__.py
@@ -2,36 +2,3 @@
 Package of functions and classes used to develop clean, readable, and informative
 code.
 """
-__all__ = [
-    "CouplingWarning",
-    "PhysicsError",
-    "PhysicsWarning",
-    "PlasmaPyError",
-    "PlasmaPyWarning",
-    "RelativityError",
-    "RelativityWarning",
-    "decorators",
-    "exceptions",
-    "roman",
-]
-
-import contextlib
-
-from plasmapy.utils import (
-    code_repr,
-    datatype_factory_base,
-    decorators,
-    exceptions,
-    roman,
-)
-from plasmapy.utils.exceptions import (
-    CouplingWarning,
-    PhysicsError,
-    PhysicsWarning,
-    PlasmaPyDeprecationWarning,
-    PlasmaPyError,
-    PlasmaPyFutureWarning,
-    PlasmaPyWarning,
-    RelativityError,
-    RelativityWarning,
-)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

<!-- Please summarize the changes here. -->
I've deleted imports from sub-packages from pyplasma.utils, also I've adjusted imports in code


## Motivation and context
<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->
Resolving issue #921, this would prevent from namespace pollution

## Related issues
<!-- Please link to any related issues and PRs. If this PR will fully resolve and issue, include text like "Closes #1542" so that the issue will be automatically closed when this PR is merged. -->
Closes #921 
