### PR TITLE
Reformat validators docstrings in the style of black

### DIFF
--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -397,28 +397,22 @@ class CheckUnits(CheckBase):
         import astropy.units as u
         from plasmapy.utils.decorators import CheckUnits
 
-        @CheckUnits(arg1={'units': u.cm},
-                    arg2=u.cm,
-                    checks_on_return=[u.cm, u.km])
+        @CheckUnits(arg1={"units": u.cm}, arg2=u.cm, checks_on_return=[u.cm, u.km])
         def foo(arg1, arg2):
             return arg1 + arg2
 
         # or on a method
         class Foo:
-            @CheckUnits(arg1={'units': u.cm},
-                        arg2=u.cm,
-                        checks_on_return=[u.cm, u.km])
+            @CheckUnits(arg1={"units": u.cm}, arg2=u.cm, checks_on_return=[u.cm, u.km])
             def bar(self, arg1, arg2):
                 return arg1 + arg2
 
     Define units with function annotations::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import CheckUnits
-
         @CheckUnits()
         def foo(arg1: u.cm, arg2: u.cm) -> u.cm:
             return arg1 + arg2
+
 
         # or on a method
         class Foo:
@@ -428,32 +422,28 @@ class CheckUnits(CheckBase):
 
     Allow `None` values to pass, on input and output::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import CheckUnits
-
         @CheckUnits(checks_on_return=[u.cm, None])
         def foo(arg1: u.cm = None):
             return arg1
 
     Allow return values to have equivalent units::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import CheckUnits
-
-        @CheckUnits(arg1={'units': u.cm},
-                    checks_on_return={'units': u.km,
-                                      'pass_equivalent_units': True})
+        @CheckUnits(
+            arg1={"units": u.cm},
+            checks_on_return={"units": u.km, "pass_equivalent_units": True},
+        )
         def foo(arg1):
             return arg1
 
     Allow equivalent units to pass with specified equivalencies::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import CheckUnits
-
-        @CheckUnits(arg1={'units': u.K,
-                          'equivalencies': u.temperature_energy(),
-                          'pass_equivalent_units': True})
+        @CheckUnits(
+            arg1={
+                "units": u.K,
+                "equivalencies": u.temperature_energy(),
+                "pass_equivalent_units": True,
+            }
+        )
         def foo(arg1):
             return arg1
 
@@ -1130,24 +1120,17 @@ def check_units(
         import astropy.units as u
         from plasmapy.utils.decorators import check_units
 
-        @check_units(arg1={'units': u.cm},
-                     arg2=u.cm,
-                     checks_on_return=[u.cm, u.km])
+        @check_units(arg1={"units": u.cm}, arg2=u.cm, checks_on_return=[u.cm, u.km])
         def foo(arg1, arg2):
             return arg1 + arg2
 
         # or on a method
         class Foo:
-            @check_units(arg1={'units': u.cm},
-                         arg2=u.cm,
-                         checks_on_return=[u.cm, u.km])
+            @check_units(arg1={"units": u.cm}, arg2=u.cm, checks_on_return=[u.cm, u.km])
             def bar(self, arg1, arg2):
                 return arg1 + arg2
 
     Define units with function annotations::
-
-        import astropy.units as u
-        from plasmapy.utils.decorators import check_units
 
         @check_units
         def foo(arg1: u.cm, arg2: u.cm) -> u.cm:
@@ -1161,32 +1144,28 @@ def check_units(
 
     Allow `None` values to pass::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import check_units
-
-        @check_units(checks_on_return=[u.cm, None])
+        @check_units(checks_on_return = [u.cm, None])
         def foo(arg1: u.cm = None):
             return arg1
 
     Allow return values to have equivalent units::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import check_units
-
-        @check_units(arg1={'units': u.cm},
-                     checks_on_return={'units': u.km,
-                                       'pass_equivalent_units': True})
+        @check_units(
+            arg1={"units": u.cm},
+            checks_on_return={"units": u.km, "pass_equivalent_units": True},
+        )
         def foo(arg1):
             return arg1
 
     Allow equivalent units to pass with specified equivalencies::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import check_units
-
-        @check_units(arg1={'units': u.K,
-                           'equivalencies': u.temperature(),
-                           'pass_equivalent_units': True})
+        @check_units(
+            arg1={
+                "units": u.K,
+                "equivalencies": u.temperature(),
+                "pass_equivalent_units": True,
+            }
+        )
         def foo(arg1):
             return arg1
 

--- a/plasmapy/utils/decorators/converter.py
+++ b/plasmapy/utils/decorators/converter.py
@@ -45,7 +45,7 @@ def angular_freq_to_hz(fn):
         from plasmapy.utils.decorators.converter import angular_freq_to_hz
         from plasmapy.utils.decorators.validators import validate_quantities
 
-        @validate_quantities(validations_on_return={'units': [u.rad / u.s, u.Hz]})
+        @validate_quantities(validations_on_return={"units": [u.rad / u.s, u.Hz]})
         @angular_freq_to_hz
         def foo(x: u.rad / u.s) -> u.rad / u.s
             return x

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -78,43 +78,37 @@ class ValidateQuantities(CheckUnits, CheckValues):
         import astropy.units as u
         from plasmapy.utils.decorators import ValidateQuantities
 
-        @ValidateQuantities(mass={'units': u.g,
-                                  'can_be_negative': False},
-                            vel=u.cm / u.s,
-                            validations_on_return=[u.g * u.cm / u.s, u.kg * u.m / u.s])
+        @ValidateQuantities(
+            mass={"units": u.g, "can_be_negative": False},
+            vel=u.cm / u.s,
+            validations_on_return=[u.g * u.cm / u.s, u.kg * u.m / u.s],
+        )
         def foo(mass, vel):
             return mass * vel
 
         # on a method
         class Foo:
-            @ValidateQuantities(mass={'units': u.g,
-                                      'can_be_negative': False},
-                                vel=u.cm / u.s,
-                                validations_on_return=[u.g * u.cm / u.s,
-                                                       u.kg * u.m / u.s])
+            @ValidateQuantities(
+                mass={"units": u.g, "can_be_negative": False},
+                vel=u.cm / u.s,
+                validations_on_return=[u.g * u.cm / u.s, u.kg * u.m / u.s],
+            )
             def bar(self, mass, vel):
                 return mass * vel
 
-
     Define units with function annotations::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import ValidateQuantities
-
-        @ValidateQuantities(mass={'can_be_negative': False})
+        @ValidateQuantities(mass={"can_be_negative": False})
         def foo(mass: u.g, vel: u.cm / u.s) -> u.g * u.cm / u.s:
             return mass * vel
 
         # on a method
         class Foo:
-            @ValidateQuantities(mass={'can_be_negative': False})
+            @ValidateQuantities(mass={"can_be_negative": False})
             def bar(self, mass: u.g, vel: u.cm / u.s) -> u.g * u.cm / u.s:
                 return mass * vel
 
     Allow `None` values to pass::
-
-        import astropy.units as u
-        from plasmapy.utils.decorators import ValidateQuantities
 
         @ValidateQuantities(checks_on_return=[u.cm, None])
         def foo(arg1: u.cm = None):
@@ -122,23 +116,22 @@ class ValidateQuantities(CheckUnits, CheckValues):
 
     Allow return values to have equivalent units::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import ValidateQuantities
-
-        @ValidateQuantities(arg1={'units': u.cm},
-                            checks_on_return={'units': u.km,
-                                              'pass_equivalent_units': True})
+        @ValidateQuantities(
+            arg1={"units": u.cm},
+            checks_on_return={"units": u.km, "pass_equivalent_units": True},
+        )
         def foo(arg1):
             return arg1
 
     Allow equivalent units to pass with specified equivalencies::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import ValidateQuantities
-
-        @ValidateQuantities(arg1={'units': u.K,
-                                  'equivalencies': u.temperature(),
-                                  'pass_equivalent_units': True})
+        @ValidateQuantities(
+            arg1={
+                "units": u.K,
+                "equivalencies": u.temperature(),
+                "pass_equivalent_units": True,
+            }
+        )
         def foo(arg1):
             return arg1
 
@@ -311,8 +304,9 @@ class ValidateQuantities(CheckUnits, CheckValues):
         Raises
         ------
         TypeError
-            if argument is not an AstroPy :class:`~astropy.units.Quantity`
+            if argument is not an Astropy :class:`~astropy.units.Quantity`
             or not convertible to a :class:`~astropy.units.Quantity`
+
         ValueError
             if validations fail
         """
@@ -455,29 +449,27 @@ def validate_quantities(func=None, validations_on_return=None, **validations):
         import astropy.units as u
         from plasmapy.utils.decorators import validate_quantities
 
-        @validate_quantities(mass={'units': u.g,
-                                   'can_be_negative': False},
-                             vel=u.cm / u.s,
-                             validations_on_return=[u.g * u.cm / u.s, u.kg * u.m / u.s])
+        @validate_quantities(
+            mass={"units": u.g, "can_be_negative": False},
+            vel=u.cm / u.s,
+            validations_on_return=[u.g * u.cm / u.s, u.kg * u.m / u.s],
+        )
         def foo(mass, vel):
             return mass * vel
 
         # on a method
         class Foo:
-            @validate_quantities(mass={'units': u.g,
-                                       'can_be_negative': False},
-                                 vel=u.cm / u.s,
-                                 validations_on_return=[u.g * u.cm / u.s,
-                                                        u.kg * u.m / u.s])
+            @validate_quantities(
+                mass={"units": u.g, "can_be_negative": False},
+                vel=u.cm / u.s,
+                validations_on_return=[u.g * u.cm / u.s, u.kg * u.m / u.s],
+            )
             def bar(self, mass, vel):
                 return mass * vel
 
     Define units with function annotations::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import validate_quantities
-
-        @validate_quantities(mass={'can_be_negative': False})
+        @validate_quantities(mass={"can_be_negative": False})
         def foo(mass: u.g, vel: u.cm / u.s) -> u.g * u.cm / u.s:
             return mass * vel
 
@@ -488,14 +480,11 @@ def validate_quantities(func=None, validations_on_return=None, **validations):
 
         # on a method
         class Foo:
-            @validate_quantities(mass={'can_be_negative': False})
+            @validate_quantities(mass={"can_be_negative": False})
             def bar(self, mass: u.g, vel: u.cm / u.s) -> u.g * u.cm / u.s:
                 return mass * vel
 
     Define units using type hint annotations::
-
-        import astropy.units as u
-        from plasmapy.decorators import validate_quantities
 
         @validate_quantities
         def foo(x: u.Quantity[u.m], time: u.Quantity[u.s]) -> u.Quantity[u.m / u.s]:
@@ -503,33 +492,24 @@ def validate_quantities(func=None, validations_on_return=None, **validations):
 
     Allow `None` values to pass::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import validate_quantities
-
-        @validate_quantities(arg2={'none_shall_pass': True},
-                             checks_on_return=[u.cm, None])
-        def foo(arg1: u.cm = None, arg2: u.cm):
+        @validate_quantities(arg2={"none_shall_pass": True}, checks_on_return=[u.cm, None])
+        def foo(arg1: u.cm, arg2: u.cm = None):
             return None
 
     Allow return values to have equivalent units::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import validate_quantities
-
-        @validate_quantities(arg1={'units': u.cm},
-                             checks_on_return={'units': u.km,
-                                               'pass_equivalent_units': True})
+        @validate_quantities(
+            arg1={"units": u.cm},
+            checks_on_return={"units": u.km, "pass_equivalent_units": True},
+        )
         def foo(arg1):
             return arg1
 
     Allow equivalent units to pass with specified equivalencies::
 
-        import astropy.units as u
-        from plasmapy.utils.decorators import validate_quantities
-
-        @validate_quantities(arg1={'units': u.K,
-                                   'equivalencies': u.temperature(),
-                                   'pass_equivalent_units': True})
+        @validate_quantities(
+            arg1={"units": u.K, "equivalencies": u.temperature(), "pass_equivalent_units": True}
+        )
         def foo(arg1):
             return arg1
 


### PR DESCRIPTION
This PR does some minor reformatting of the validators docstrings, since we added those before we started using black as an autoformatter.