### PR TITLE
Add numpydoc docstring validator to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   rev: v1.6.0
   hooks:
   - id: numpydoc-validation
-    exclude: docs/plasmapy_sphinx
+    exclude: docs/plasmapy_sphinx|plasmapy/formulary/collisions/coulomb.py|plasmapy/formulary/braginskii.py
 
 - repo: https://github.com/sirosen/texthooks
   rev: 0.6.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
   hooks:
   - id: check-github-workflows
 
+- repo: https://github.com/numpy/numpydoc
+  rev: v1.6.0
+  hooks:
+  - id: numpydoc-validation
+    exclude: docs/plasmapy_sphinx
+
 - repo: https://github.com/sirosen/texthooks
   rev: 0.6.3
   hooks:


### PR DESCRIPTION
This PR is a prototype to add numpydoc's docstring validator to our pre-commit configuration.