### PR TITLE
Improve `@particle_input`'s ability to handle variadic positional arguments

### DIFF
--- a/changelog/2428.feature.rst
+++ b/changelog/2428.feature.rst
@@ -1,2 +1,2 @@
-Enable |particle_input| to decorate functions which have variadic
+Enabled |particle_input| to decorate functions which have variadic
 positional arguments followed by keyword arguments. See :issue:`2150`.

--- a/changelog/2428.feature.rst
+++ b/changelog/2428.feature.rst
@@ -1,0 +1,2 @@
+Enable |particle_input| to decorate functions which have variadic
+positional arguments followed by keyword arguments. See :issue:`2150`.

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -588,8 +588,8 @@ class _ParticleInput:
         if Z_or_mass_numb and multiple_annotated_parameters:
             raise ParticleError(
                 "The arguments Z and mass_numb are not allowed when more "
-                "than one argument or keyword is annotated with Particle "
-                "in callables decorated with particle_input."
+                "than one argument or keyword is annotated with ParticleLike "
+                "in callables decorated with @particle_input."
             )
 
     def process_arguments(

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -563,9 +563,12 @@ class _ParticleInput:
 
     def perform_pre_validations(self, Z, mass_numb):
         """
-        Check that there are annotated parameters, that ``Z`` and
-        ``mass_numb`` are integers, and that ``Z`` and ``mass_numb`` are
-        not parameters when more than one parameter is annotated.
+        Perform a variety of pre-checks on the arguments.
+
+        Check that there are annotated parameters. Check that ``Z`` is
+        a real number if not `None`. Check that ``mass_numb`` is an
+        integer if not `None`. Verify that ``Z`` and ``mass_numb`` are
+        not included if there are multiple annotated parameters.
         """
 
         if not self.parameters_to_process:

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -204,6 +204,12 @@ class _ParticleInput:
         self._data["callable"] = callable_
         self._data["annotations"] = _get_annotations(callable_)
         self._data["parameters_to_process"] = self.find_parameters_to_process()
+        self._data["signature"] = inspect.signature(callable_)
+
+    @property
+    def signature(self) -> inspect.Signature:
+        """The signature of the wrapped callable."""
+        return self._data["signature"]
 
     def find_parameters_to_process(self) -> list[str]:
         """

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -9,6 +9,7 @@ import warnings
 import wrapt
 
 from collections.abc import Iterable
+from inspect import BoundArguments
 from numbers import Integral, Real
 from typing import Any, Callable, NoReturn, Optional, Union
 
@@ -594,7 +595,7 @@ class _ParticleInput:
 
     def process_arguments(
         self, args: tuple, kwargs: dict[str, Any], instance=None
-    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    ) -> BoundArguments:
         """
         Process the arguments passed to the callable_ callable.
 
@@ -634,7 +635,7 @@ class _ParticleInput:
         for parameter in processed_kwargs:
             bound_arguments.arguments[parameter] = processed_kwargs[parameter]
 
-        return bound_arguments.args, bound_arguments.kwargs
+        return bound_arguments
 
 
 def particle_input(
@@ -919,9 +920,7 @@ def particle_input(
     def wrapper(
         callable__: Callable, instance: Any, args: tuple, kwargs: dict[str, Any]
     ):
-        new_args, new_kwargs = particle_validator.process_arguments(
-            args, kwargs, instance
-        )
-        return callable__(*new_args, **new_kwargs)
+        bound_arguments = particle_validator.process_arguments(args, kwargs, instance)
+        return callable__(*bound_arguments.args, **bound_arguments.kwargs)
 
     return wrapper(callable_)

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -88,7 +88,7 @@ def _bind_arguments(
 
     callable_ : callable
         The function or method to which to bind ``args`` and ``kwargs``.
-        This argument is only needed for error messages.
+        This argument is only needed for a deprecation warning message.
 
     args : tuple, optional
         Positional arguments.

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -592,7 +592,7 @@ class _ParticleInput:
 
     def process_arguments(
         self, args: tuple, kwargs: dict[str, Any], instance=None
-    ) -> dict[str, Any]:
+    ) -> tuple[list, dict[str, Any]]:
         """
         Process the arguments passed to the callable_ callable.
 
@@ -619,10 +619,15 @@ class _ParticleInput:
 
         self.perform_pre_validations(Z, mass_numb)
 
-        return {
-            parameter: self.process_argument(parameter, argument, Z, mass_numb)
-            for parameter, argument in arguments.items()
-        }
+        new_args = []
+        new_kwargs = {}
+
+        for parameter, argument in arguments.items():
+            new_kwargs[parameter] = self.process_argument(
+                parameter, argument, Z, mass_numb
+            )
+
+        return new_args, new_kwargs
 
 
 def particle_input(
@@ -907,7 +912,9 @@ def particle_input(
     def wrapper(
         callable__: Callable, instance: Any, args: tuple, kwargs: dict[str, Any]
     ):
-        new_kwargs = particle_validator.process_arguments(args, kwargs, instance)
-        return callable__(**new_kwargs)
+        new_args, new_kwargs = particle_validator.process_arguments(
+            args, kwargs, instance
+        )
+        return callable__(*new_args, **new_kwargs)
 
     return wrapper(callable_)

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -69,6 +69,7 @@ def _make_into_set_or_none(obj) -> Optional[set]:
 
 
 def _bind_arguments(
+    wrapped_signature: inspect.Signature,
     callable_: Callable,
     args: Optional[tuple] = None,
     kwargs: Optional[dict[str, Any]] = None,
@@ -81,8 +82,13 @@ def _bind_arguments(
 
     Parameters
     ----------
+    wrapped_signature : `inspect.Signature`
+        The signature of the function or method to which to bind
+        ``args`` and ``kwargs``.
+
     callable_ : callable
         The function or method to which to bind ``args`` and ``kwargs``.
+        This argument is only needed for error messages.
 
     args : tuple, optional
         Positional arguments.
@@ -101,7 +107,6 @@ def _bind_arguments(
         the corresponding arguments as values, but removing ``self`` and
         ``cls``.
     """
-    wrapped_signature = inspect.signature(callable_)
 
     # We should keep the warning about "z_mean" for perhaps ∼2
     # releases following the last pull request that removes a "z_mean"
@@ -605,7 +610,9 @@ class _ParticleInput:
             belongs.
         """
 
-        arguments = _bind_arguments(self.callable_, args, kwargs, instance)
+        arguments = _bind_arguments(
+            self.signature, self.callable_, args, kwargs, instance
+        )
 
         Z = arguments.pop("Z", None)
         mass_numb = arguments.pop("mass_numb", None)

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -74,7 +74,7 @@ def _bind_arguments(
     args: Optional[tuple] = None,
     kwargs: Optional[dict[str, Any]] = None,
     instance=None,
-) -> dict:
+) -> inspect.BoundArguments:
     """
     Bind the arguments provided by ``args`` and ``kwargs`` to
     the corresponding parameters in the signature of the callable_
@@ -139,12 +139,11 @@ def _bind_arguments(
         bound_arguments = wrapped_signature.bind(instance, *args, **kwargs)
 
     bound_arguments.apply_defaults()
-    arguments_to_be_processed = bound_arguments.arguments
 
-    arguments_to_be_processed.pop("self", None)
-    arguments_to_be_processed.pop("cls", None)
+    bound_arguments.arguments.pop("self", None)
+    bound_arguments.arguments.pop("cls", None)
 
-    return arguments_to_be_processed
+    return bound_arguments
 
 
 class _ParticleInput:
@@ -610,19 +609,19 @@ class _ParticleInput:
             belongs.
         """
 
-        arguments = _bind_arguments(
+        bound_arguments = _bind_arguments(
             self.signature, self.callable_, args, kwargs, instance
         )
 
-        Z = arguments.pop("Z", None)
-        mass_numb = arguments.pop("mass_numb", None)
+        Z = bound_arguments.arguments.pop("Z", None)
+        mass_numb = bound_arguments.arguments.pop("mass_numb", None)
 
         self.perform_pre_validations(Z, mass_numb)
 
         new_args = []
         new_kwargs = {}
 
-        for parameter, argument in arguments.items():
+        for parameter, argument in bound_arguments.arguments.items():
             new_kwargs[parameter] = self.process_argument(
                 parameter, argument, Z, mass_numb
             )

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -594,7 +594,7 @@ class _ParticleInput:
 
     def process_arguments(
         self, args: tuple, kwargs: dict[str, Any], instance=None
-    ) -> tuple[list, dict[str, Any]]:
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         """
         Process the arguments passed to the callable_ callable.
 
@@ -610,6 +610,11 @@ class _ParticleInput:
             If the callable_ callable is a class instance method, then
             ``instance`` should be the class instance to which ``func``
             belongs.
+
+        Notes
+        -----
+        This method does not work when there are positional arguments
+        before variadic positional arguments.  See :issue:`2150`.
         """
 
         bound_arguments = _bind_arguments(
@@ -621,15 +626,15 @@ class _ParticleInput:
 
         self.perform_pre_validations(Z, mass_numb)
 
-        new_args = []
-        new_kwargs = {}
+        processed_kwargs = {
+            parameter: self.process_argument(parameter, argument, Z, mass_numb)
+            for parameter, argument in bound_arguments.arguments.items()
+        }
 
-        for parameter, argument in bound_arguments.arguments.items():
-            new_kwargs[parameter] = self.process_argument(
-                parameter, argument, Z, mass_numb
-            )
+        for parameter in processed_kwargs:
+            bound_arguments.arguments[parameter] = processed_kwargs[parameter]
 
-        return new_args, new_kwargs
+        return bound_arguments.args, bound_arguments.kwargs
 
 
 def particle_input(

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -656,14 +656,41 @@ def test_particle_input_warning_for_float_z_mean():
     assert u.isclose(Z, z_mean)
 
 
-@particle_input
-def function_with_positional_arguments(*args, particle: ParticleLike = None):
-    return args, particle
+def test_particle_input_with_var_positional_arguments():
+    """
+    Test that |particle_input| works with functions that accept
+    variadic positional arguments and keyword arguments.
+    """
 
+    @particle_input
+    def function_with_var_positional_arguments(*args, particle: ParticleLike = None):
+        return args, particle
 
-def test_particle_input_with_variadic_positional_arguments():
-    args = [5, 6, 7]
+    args = (5, 6, 7)
     particle = "p+"
-    expected = args.append(particle)
-    actual = function_with_positional_arguments(*args, particle=particle)
+    expected = (args, Particle(particle))
+
+    actual = function_with_var_positional_arguments(*args, particle=particle)
+
+    assert actual == expected
+
+
+@pytest.mark.xfail(reason="See issue #2150.")
+def test_particle_input_with_pos_and_var_positional_arguments():
+    """
+    Test that |particle_input| works with functions that accept
+    positional followed by variadic positional arguments.
+    """
+
+    @particle_input
+    def function_with_pos_and_var_positional_arguments(
+        a, *args, particle: ParticleLike = None
+    ):
+        return args, particle
+
+    a = 1
+    args = (5, 6, 7)
+    particle = "p+"
+    expected = (a, args, Particle(particle))
+    actual = function_with_pos_and_var_positional_arguments(a, *args, particle=particle)
     assert actual == expected

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -654,3 +654,16 @@ def test_particle_input_warning_for_float_z_mean():
     Z = result.charge / const.e.si
 
     assert u.isclose(Z, z_mean)
+
+
+@particle_input
+def function_with_positional_arguments(*args, particle: ParticleLike = None):
+    return args, particle
+
+
+def test_particle_input_with_variadic_positional_arguments():
+    args = [5, 6, 7]
+    particle = "p+"
+    expected = args.append(particle)
+    actual = function_with_positional_arguments(*args, particle=particle)
+    assert actual == expected


### PR DESCRIPTION
## Description

This PR enables `@particle_input` to decorate functions with a signature like:

```python
@particle_input
def f(*args, particle: ParticleLike = "p+"):
    ...
```

This fix does not extend to functions where there are positional arguments prior to variadic positional arguments, and instead adds an xfailing test for this.

This PR also does some minor refactoring of `@particle_input` (including how it processes arguments) and updates some docstrings.

## Motivation and context

I ran into this problem again when coming back to #1029, since I'm considering adding a signature that uses this pattern. 

I can't think of a straightforward way to address the case where there are positional arguments before variadic positional arguments, so I decided to not address that here and instead do an incremental change.

## Related issues

This is a partial fix of #2150.