### PR TITLE
Increase minimum version of voila to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "requests >= 2.27.1",
   "scipy >= 1.7.0",
   "tqdm >= 4.60.0",
-  "voila >= 0.3.3",
+  "voila >= 0.5.0",
   "wrapt >= 1.12.1",
   "xarray >= 2022.3.0",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -135,7 +135,7 @@ deps =
     requests == 2.27.1
     scipy == 1.7.0
     tqdm == 4.60.0
-    voila == 0.3.3
+    voila == 0.5.0
     wrapt == 1.12.1
     xarray == 2022.3.0
 setenv =


### PR DESCRIPTION
We just started getting an error related to lxml when we run our tests with minimum dependencies for Python 3.9 on Windows.  It appeared that lxml was needed by voila, so I tried bumping the minimum version of voila, which seems to have fixed it.