### PR TITLE
Add a tox environment for running mypy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
           os: ubuntu-latest
           python: '3.11'
           toxenv: mypy
+          toxargs: --show-error-context --show-error-code-links --pretty
 
     steps:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,6 @@ jobs:
           os: ubuntu-latest
           python: '3.11'
           toxenv: mypy
-          toxargs: --show-error-context --show-error-code-links --pretty
 
     steps:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,11 @@ jobs:
           python: '3.11'
           toxenv: linters
 
+        - name: mypy
+          os: ubuntu-latest
+          python: '3.11'
+          toxenv: mypy
+
     steps:
 
     - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,11 +44,6 @@ jobs:
           python: '3.11'
           toxenv: linters
 
-        - name: mypy
-          os: ubuntu-latest
-          python: '3.11'
-          toxenv: mypy
-
     steps:
 
     - name: Checkout code

--- a/changelog/2431.trivial.rst
+++ b/changelog/2431.trivial.rst
@@ -1,2 +1,1 @@
-Added the mypy static type checker to PlasmaPy's suite of continuous
-integration checks.
+Added a tox environment for running mypy.

--- a/changelog/2431.trivial.rst
+++ b/changelog/2431.trivial.rst
@@ -1,0 +1,2 @@
+Added the mypy static type checker to PlasmaPy's suite of continuous
+integration checks.

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,8 @@
 python_version = 3.9
 pretty = true
 exclude = (?x)(
-          docs
+          docs|
+          .tox
           )
 
 enable_error_code = ignore-without-code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,19 +82,13 @@ docs = [
   "tox >= 4.4.0",
   "unidecode >= 1.3.6",
 ]
-# Some of these packages contain typing information for packages that
-# don't themselves contain type hints. We might want to move these from
-# the tests section and into the specific mypy environment.
 tests = [
   "hypothesis >= 6.35.1",
-  "pandas-stubs >= 1.5.0.221010",  # used by mypy
   "pre-commit >= 3.0.0",
   "pytest-regressions >= 2.3.1",
   "pytest-xdist >= 3.0.2",
   "tomli >= 2.0.1",
   "tox >= 4.3.1",
-  "types-requests >= 2.27.1",  # used by mypy
-  "types-tqdm >= 4.66.0.3",  # used by mypy
 ]
 [project.urls]
 Changelog = "https://docs.plasmapy.org/en/stable/whatsnew/index.html"

--- a/tox.ini
+++ b/tox.ini
@@ -153,3 +153,12 @@ basepython = python3.9
 extras =
 deps =
 commands = python -c 'import plasmapy'
+
+[testenv:mypy]
+deps =
+    mypy >= 1.8.0
+    pandas-stubs
+    types-requests
+    types-tqdm
+commands =
+    mypy plasmapy --show-error-context --show-error-code-links --pretty --install-types --non-interactive

--- a/tox.ini
+++ b/tox.ini
@@ -158,4 +158,4 @@ commands = python -c 'import plasmapy'
 deps =
     mypy >= 1.8.0
 commands =
-    mypy plasmapy --install-types --non-interactive --show-error-context --show-error-code-links --pretty
+    mypy plasmapy --install-types --non-interactive

--- a/tox.ini
+++ b/tox.ini
@@ -158,4 +158,4 @@ commands = python -c 'import plasmapy'
 deps =
     mypy >= 1.8.0
 commands =
-    mypy plasmapy --install-types --non-interactive
+    mypy plasmapy --install-types --non-interactive --show-error-context --show-error-code-links --pretty

--- a/tox.ini
+++ b/tox.ini
@@ -157,8 +157,5 @@ commands = python -c 'import plasmapy'
 [testenv:mypy]
 deps =
     mypy >= 1.8.0
-    pandas-stubs
-    types-requests
-    types-tqdm
 commands =
-    mypy plasmapy --show-error-context --show-error-code-links --pretty --install-types --non-interactive
+    mypy plasmapy --install-types --non-interactive


### PR DESCRIPTION
This PR adds a tox environment for running the mypy static type checking tool.  This tox environment will be added to our suite of continuous integration tests in #2432.

I am separating this PR out so that I can use this tox environment in other PRs, like #2429.

Related to #268. The motivation for using mypy is discussed in #2424.