### PR TITLE
Replace deprecated `typing.Callable` with `collections.abc.Callable`

### DIFF
--- a/docs/plasmapy_sphinx/autodoc/automodapi.py
+++ b/docs/plasmapy_sphinx/autodoc/automodapi.py
@@ -307,6 +307,7 @@ import sys
 import warnings
 
 from collections import OrderedDict
+from collections.abc import Callable
 from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
 from sphinx.application import Sphinx
@@ -322,7 +323,7 @@ except ImportError:
 from sphinx.ext.autodoc import bool_option, ModuleDocumenter
 from sphinx.locale import __
 from sphinx.util import logging
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from ..automodsumm.core import AutomodsummOptions, option_str_list
 from ..utils import default_grouping_info

--- a/docs/plasmapy_sphinx/automodsumm/core.py
+++ b/docs/plasmapy_sphinx/automodsumm/core.py
@@ -207,10 +207,11 @@ __all__ = [
 
 import os
 
+from collections.abc import Callable
 from importlib import import_module
 from sphinx.ext.autosummary import Autosummary
 from sphinx.util import logging
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from ..automodsumm.generate import GenDocsFromAutomodsumm
 from ..utils import default_grouping_info, find_mod_objs, get_custom_grouping_info

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -21,7 +21,7 @@ __all__ = [
 import numpy as np
 import warnings
 
-from typing import Callable
+from collections.abc import Callable
 
 # Declare Constants & global variables
 _EQUALITY_ATOL = 1e-10

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -15,8 +15,9 @@ import numbers
 import numpy as np
 import warnings
 
+from collections.abc import Callable
 from lmfit import Model
-from typing import Any, Callable, Optional, Union
+from typing import Any, Optional, Union
 
 from plasmapy.formulary import (
     permittivity_1D_Maxwellian_lite,

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -185,7 +185,7 @@ class _ParticleInput:
         allow_custom_particles: bool = True,
         allow_particle_lists: bool = True,
     ):
-        self._data: dict[str, Any] = {}
+        self._data = {}
         self.callable_ = callable_
         self.require = require
         self.any_of = any_of

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -43,7 +43,7 @@ _particle_input_annotations = (
 )
 
 
-def _get_annotations(callable_: Callable) -> dict[str, Any]:
+def _get_annotations(callable_: Callable):
     """
     Access the annotations of a callable.
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -8,10 +8,10 @@ import numpy as np
 import warnings
 import wrapt
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from inspect import BoundArguments
 from numbers import Integral, Real
-from typing import Any, Callable, NoReturn, Optional, Union
+from typing import Any, NoReturn, Optional, Union
 
 from plasmapy.particles._factory import _physical_particle_factory
 from plasmapy.particles.exceptions import (
@@ -43,7 +43,7 @@ _particle_input_annotations = (
 )
 
 
-def _get_annotations(callable_: Callable):
+def _get_annotations(callable_: Callable) -> dict[str, Any]:
     """
     Access the annotations of a callable.
 
@@ -185,7 +185,7 @@ class _ParticleInput:
         allow_custom_particles: bool = True,
         allow_particle_lists: bool = True,
     ):
-        self._data = {}
+        self._data: dict[str, Any] = {}
         self.callable_ = callable_
         self.require = require
         self.any_of = any_of

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -7,8 +7,8 @@ import collections
 import contextlib
 import numpy as np
 
-from collections.abc import Iterable, Sequence
-from typing import Callable, Optional, Union
+from collections.abc import Callable, Iterable, Sequence
+from typing import Optional, Union
 
 from plasmapy.particles.exceptions import InvalidParticleError
 from plasmapy.particles.particle_class import (

--- a/plasmapy/utils/_pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/_pytest_helpers/pytest_helpers.py
@@ -17,7 +17,8 @@ import numpy as np
 import pytest
 import warnings
 
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 
 from plasmapy.tests._helpers.exceptions import (
     InvalidTestError,

--- a/plasmapy/utils/code_repr.py
+++ b/plasmapy/utils/code_repr.py
@@ -6,8 +6,9 @@ import astropy.units as u
 import inspect
 import numpy as np
 
+from collections.abc import Callable
 from numbers import Integral
-from typing import Any, Callable, Optional, Union
+from typing import Any, Optional, Union
 
 
 def _code_repr_of_ndarray(array: np.ndarray, max_items=np.inf) -> str:

--- a/plasmapy/utils/decorators/lite_func.py
+++ b/plasmapy/utils/decorators/lite_func.py
@@ -7,8 +7,9 @@ __all__ = ["bind_lite_func"]
 import functools
 import inspect
 
+from collections.abc import Callable
 from numba.extending import is_jitted
-from typing import Callable, Optional
+from typing import Optional
 
 
 class _LiteFuncDict(dict):


### PR DESCRIPTION
Python's docs said that `typing.Callable` is a deprecated alias to `collections.abc.Callable`. This PR updates our usage of `typing.Callable`.