### PR TITLE
Annotate dunder methods using `autotyping` and change `NoReturn` annotations to `None`

### DIFF
--- a/changelog/2437.trivial.rst
+++ b/changelog/2437.trivial.rst
@@ -1,0 +1,2 @@
+Used ``autotyping`` to implement type hint annotations for special
+methods like ``__init__`` and ``__str__``.

--- a/changelog/2437.trivial.rst
+++ b/changelog/2437.trivial.rst
@@ -1,2 +1,3 @@
 Used ``autotyping`` to implement type hint annotations for special
-methods like ``__init__`` and ``__str__``.
+methods like ``__init__`` and ``__str__``, and changed ``-> typing.NoReturn``
+annotations to ``-> None``.

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,8 +3,8 @@ python_version = 3.9
 pretty = true
 exclude = (?x)(
           docs|
-          .run|
-          .tox
+          \.run|
+          \.tox
           )
 
 enable_error_code = ignore-without-code

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@ python_version = 3.9
 pretty = true
 exclude = (?x)(
           docs|
+          .run|
           .tox
           )
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -68,7 +68,7 @@ ignore_errors = true
 # remove the disabled error codes file-by-file.
 
 [mypy-plasmapy]
-disable_error_code = no-untyped-def,no-redef
+disable_error_code = no-untyped-def
 
 [mypy-plasmapy.analysis.fit_functions]
 disable_error_code = assignment,attr-defined,misc,name-match,no-any-return,no-untyped-call,no-untyped-def,type-arg
@@ -104,13 +104,13 @@ disable_error_code = arg-type,no-untyped-call,no-untyped-def
 disable_error_code = no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.analysis.time_series.excess_statistics]
-disable_error_code = no-untyped-call,no-untyped-def
+disable_error_code = no-untyped-call,no-untyped-def,var-annotated
 
 [mypy-plasmapy.analysis.time_series.running_moments]
 disable_error_code = name-match,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.analysis.time_series.tests.test_conditioanl_averaging]
-disable_error_code = no-untyped-call,no-untyped-def
+disable_error_code = no-untyped-def
 
 [mypy-plasmapy.analysis.time_series.tests.test_excess_statistics]
 disable_error_code = no-untyped-call,no-untyped-def
@@ -146,7 +146,7 @@ disable_error_code = attr-defined,no-untyped-call,no-untyped-def
 disable_error_code = arg-type,assignment,attr-defined,misc,no-untyped-call,no-untyped-def,type-arg
 
 [mypy-plasmapy.dispersion.analytical.mhd_waves_]
-disable_error_code = attr-defined,has-type,misc,no-any-return,no-untyped-call,no-untyped-def,syntax
+disable_error_code = attr-defined,has-type,misc,no-untyped-call,no-untyped-def,syntax
 
 [mypy-plasmapy.dispersion.analytical.stix_]
 disable_error_code = arg-type,assignment,attr-defined,call-overload,misc,no-untyped-call,no-untyped-def
@@ -338,7 +338,7 @@ disable_error_code = arg-type,no-untyped-def
 disable_error_code = arg-type,assignment,call-overload,no-any-return,no-untyped-def,return-value,syntax,type-arg,union-attr,var-annotated
 
 [mypy-plasmapy.particles._special_particles]
-disable_error_code = no-untyped-call,no-untyped-def,type-arg,var-annotated
+disable_error_code = type-arg,var-annotated
 
 [mypy-plasmapy.particles.atomic]
 disable_error_code = arg-type,assignment,misc,no-any-return,no-untyped-call,no-untyped-def,union-attr
@@ -395,10 +395,10 @@ disable_error_code = attr-defined,no-untyped-def
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.particles.tests.test_particle_class]
-disable_error_code = arg-type,attr-defined,misc,no-untyped-call,no-untyped-def
+disable_error_code = arg-type,attr-defined,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.particles.tests.test_particle_collections]
-disable_error_code = arg-type,misc,no-untyped-call,no-untyped-def
+disable_error_code = arg-type,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.particles.tests.test_pickling]
 disable_error_code = arg-type,no-untyped-def
@@ -418,20 +418,17 @@ disable_error_code = misc,name-match,no-any-return,no-untyped-call,no-untyped-de
 [mypy-plasmapy.plasma.plasma_base]
 disable_error_code = no-untyped-call,no-untyped-def,var-annotated
 
-[mypy-plasmapy.plasma.plasma_factory]
-disable_error_code = no-untyped-call
-
 [mypy-plasmapy.plasma.sources.openpmd_hdf5]
-disable_error_code = arg-type,misc,no-untyped-call,no-untyped-def
+disable_error_code = arg-type,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.plasma.sources.plasma3d]
-disable_error_code = no-untyped-call,no-untyped-def,type-arg
+disable_error_code = misc,no-untyped-call,no-untyped-def,type-arg
 
 [mypy-plasmapy.plasma.sources.plasmablob]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.plasma.sources.tests.test_openpmd_hdf5]
-disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def,type-arg
+disable_error_code = attr-defined,no-untyped-call,no-untyped-def,type-arg
 
 [mypy-plasmapy.plasma.sources.tests.test_plasma3d]
 disable_error_code = no-untyped-def
@@ -440,7 +437,7 @@ disable_error_code = no-untyped-def
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.plasma.tests.test_equilibria1d]
-disable_error_code = no-untyped-call,no-untyped-def
+disable_error_code = no-untyped-def
 
 [mypy-plasmapy.plasma.tests.test_grids]
 disable_error_code = abstract,no-untyped-call,no-untyped-def
@@ -461,13 +458,10 @@ disable_error_code = no-untyped-def
 disable_error_code = no-untyped-def
 
 [mypy-plasmapy.simulation.particletracker]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def,var-annotated
+disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def,var-annotated
 
 [mypy-plasmapy.simulation.tests.test_particletracker]
 disable_error_code = attr-defined,no-untyped-def
-
-[mypy-plasmapy.tests._helpers.exceptions]
-disable_error_code = misc
 
 [mypy-plasmapy.tests._helpers.tests.sample_functions]
 disable_error_code = misc,no-untyped-def,valid-type
@@ -488,13 +482,13 @@ disable_error_code = arg-type,no-untyped-def
 disable_error_code = no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.utils.calculator.widget_helpers]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def,union-attr,var-annotated
+disable_error_code = assignment,attr-defined,no-untyped-call,no-untyped-def,var-annotated
 
 [mypy-plasmapy.utils.code_repr]
 disable_error_code = arg-type,assignment,attr-defined,no-any-return,no-untyped-call,no-untyped-def,type-arg,union-attr
 
 [mypy-plasmapy.utils.data.downloader]
-disable_error_code = import-untyped,no-untyped-def
+disable_error_code = no-untyped-def
 
 [mypy-plasmapy.utils.data.tests.test_downloader]
 disable_error_code = no-untyped-call,no-untyped-def

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -38,7 +38,7 @@ class AbstractFitFunction(ABC):
         self,
         params: Optional[tuple[float, ...]] = None,
         param_errors: Optional[tuple[float, ...]] = None,
-    ):
+    ) -> None:
         """
         Parameters
         ----------
@@ -105,7 +105,7 @@ class AbstractFitFunction(ABC):
         return f"{self.__str__()} {self.__class__}"
 
     @abstractmethod
-    def __str__(self):
+    def __str__(self) -> str:
         ...
 
     @abstractmethod
@@ -803,7 +803,7 @@ class ExponentialPlusLinear(AbstractFitFunction):
         self,
         params: Optional[tuple[float, ...]] = None,
         param_errors: Optional[tuple[float, ...]] = None,
-    ):
+    ) -> None:
         self._exponential = Exponential()
         self._linear = Linear()
         super().__init__(params=params, param_errors=param_errors)
@@ -941,7 +941,7 @@ class ExponentialPlusOffset(AbstractFitFunction):
         self,
         params: Optional[tuple[float, ...]] = None,
         param_errors: Optional[tuple[float, ...]] = None,
-    ):
+    ) -> None:
         self._explin = ExponentialPlusLinear()
         super().__init__(params=params, param_errors=param_errors)
 

--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -65,7 +65,7 @@ class NonZeroDivergence(NullPointError):  # noqa: N818
        change in future releases.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             "The divergence constraint does not hold for the provided magnetic field."
         )
@@ -94,7 +94,7 @@ class Point:
        change in future releases.
     """
 
-    def __init__(self, loc):
+    def __init__(self, loc) -> None:
         self._loc = loc
 
     def get_loc(self):
@@ -116,7 +116,7 @@ class NullPoint(Point):
        change in future releases.
     """
 
-    def __init__(self, null_loc, classification):
+    def __init__(self, null_loc, classification) -> None:
         super().__init__(null_loc)
         self._classification = classification
 

--- a/plasmapy/analysis/time_series/conditional_averaging.py
+++ b/plasmapy/analysis/time_series/conditional_averaging.py
@@ -107,7 +107,7 @@ class ConditionalEvents:
         length_of_return=None,
         distance=0,
         remove_non_max_peaks=False,
-    ):
+    ) -> None:
         self._check_for_value_errors(
             distance,
             signal,

--- a/plasmapy/analysis/time_series/excess_statistics.py
+++ b/plasmapy/analysis/time_series/excess_statistics.py
@@ -54,7 +54,7 @@ class ExcessStatistics:
     [0.5, 0.0, 0]
     """
 
-    def __init__(self, signal, thresholds, time_step):
+    def __init__(self, signal, thresholds, time_step) -> None:
         if time_step <= 0:
             raise ValueError("time_step must be positive")
 

--- a/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
@@ -65,7 +65,7 @@ class Layer:
         mass_density: Optional[u.Quantity[u.kg / u.m**3]] = None,
         active: bool = True,
         name: str = "",
-    ):
+    ) -> None:
         self.thickness = thickness
         self.energy_axis = energy_axis
         self.active = active
@@ -112,7 +112,7 @@ class Stack:
 
     """
 
-    def __init__(self, layers: list[Layer]):
+    def __init__(self, layers: list[Layer]) -> None:
         self._layers = layers
         self._energy_bands = None
 

--- a/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -130,7 +130,7 @@ class Tracker:
         detector: u.Quantity[u.m],
         detector_hdir=None,
         verbose=True,
-    ):
+    ) -> None:
         # self.grid is the grid object
         if isinstance(grids, AbstractGrid):
             self.grids = [

--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -85,7 +85,7 @@ class Characteristic:
     """
 
     @validate_quantities(bias={"can_be_inf": False}, current={"can_be_inf": False})
-    def __init__(self, bias: u.Quantity[u.V], current: u.Quantity[u.A]):
+    def __init__(self, bias: u.Quantity[u.V], current: u.Quantity[u.A]) -> None:
         _langmuir_futurewarning()
 
         self.bias = bias

--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -198,7 +198,7 @@ class DryCharacteristic(langmuir.Characteristic):
     unique values.
     """
 
-    def __init__(self, bias, current):
+    def __init__(self, bias, current) -> None:
         super().__init__(bias, current)
         self.bias = bias
         self.current = current

--- a/plasmapy/dispersion/analytical/mhd_waves_.py
+++ b/plasmapy/dispersion/analytical/mhd_waves_.py
@@ -46,7 +46,7 @@ class AbstractMHDWave(ABC):
         gamma: float = 5 / 3,
         mass_numb: Optional[Integral] = None,
         Z: Optional[Real] = None,
-    ):
+    ) -> None:
         # validate arguments
         for arg_name in ("B", "density", "T"):
             val = locals()[arg_name].squeeze()

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -333,7 +333,7 @@ class ClassicalTransport:
         mu=None,
         theta=None,
         coulomb_log_method="classical",
-    ):
+    ) -> None:
         # check the model
         self.model = model.lower()  # string inputs should be case-insensitive
         valid_models = ["braginskii", "spitzer", "spitzer-harm", "ji-held"]

--- a/plasmapy/formulary/collisions/frequencies.py
+++ b/plasmapy/formulary/collisions/frequencies.py
@@ -162,7 +162,7 @@ class SingleParticleCollisionFrequencies:
         T_b: u.Quantity[u.K],
         n_b: u.Quantity[u.m**-3],
         Coulomb_log,
-    ):
+    ) -> None:
         # Note: This class uses CGS units internally to coincide
         #       with our references.  Input is taken in MKS units and
         #       then converted as necessary. Output is in MKS units.
@@ -397,7 +397,7 @@ class MaxwellianCollisionFrequencies:
         T_b: u.Quantity[u.K],
         n_b: u.Quantity[u.m**-3],
         Coulomb_log: u.Quantity[u.dimensionless_unscaled],
-    ):
+    ) -> None:
         if (
             isinstance(v_drift, np.ndarray)
             and isinstance(T_a, np.ndarray)

--- a/plasmapy/formulary/magnetostatics.py
+++ b/plasmapy/formulary/magnetostatics.py
@@ -57,7 +57,7 @@ class MagneticDipole(MagnetoStatics):
     """
 
     @validate_quantities
-    def __init__(self, moment: u.Quantity[u.A * u.m**2], p0: u.Quantity[u.m]):
+    def __init__(self, moment: u.Quantity[u.A * u.m**2], p0: u.Quantity[u.m]) -> None:
         self.moment = moment.value
         self._moment_u = moment.unit
         self.p0 = p0.value
@@ -150,7 +150,7 @@ class GeneralWire(Wire):
     """
 
     @validate_quantities
-    def __init__(self, parametric_eq, t1, t2, current: u.Quantity[u.A]):
+    def __init__(self, parametric_eq, t1, t2, current: u.Quantity[u.A]) -> None:
         if callable(parametric_eq):
             self.parametric_eq = parametric_eq
         else:
@@ -270,7 +270,7 @@ class FiniteStraightWire(Wire):
     @validate_quantities
     def __init__(
         self, p1: u.Quantity[u.m], p2: u.Quantity[u.m], current: u.Quantity[u.A]
-    ):
+    ) -> None:
         self.p1 = p1.value
         self.p2 = p2.value
         self._p1_u = p1.unit
@@ -411,7 +411,9 @@ class InfiniteStraightWire(Wire):
     """
 
     @validate_quantities
-    def __init__(self, direction, p0: u.Quantity[u.m], current: u.Quantity[u.A]):
+    def __init__(
+        self, direction, p0: u.Quantity[u.m], current: u.Quantity[u.A]
+    ) -> None:
         self.direction = direction / np.linalg.norm(direction)
         self.p0 = p0.value
         self._p0_u = p0.unit
@@ -520,7 +522,7 @@ class CircularWire(Wire):
         radius: u.Quantity[u.m],
         current: u.Quantity[u.A],
         n=300,
-    ):
+    ) -> None:
         self.normal = normal / np.linalg.norm(normal)
         self.center = center.value
         self._center_u = center.unit

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -328,7 +328,7 @@ class RelativisticBody:
         Z: Optional[Integral] = None,
         mass_numb: Optional[Integral] = None,
         dtype: Optional[DTypeLike] = np.longdouble,
-    ):
+    ) -> None:
         self._particle = particle
 
         self._dtype = dtype

--- a/plasmapy/particles/_special_particles.py
+++ b/plasmapy/particles/_special_particles.py
@@ -42,7 +42,7 @@ class ParticleZoo:
     True
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         leptons = {"e-", "mu-", "tau-", "nu_e", "nu_mu", "nu_tau"}
         antileptons = {"e+", "mu+", "tau+", "anti_nu_e", "anti_nu_mu", "anti_nu_tau"}
         baryons = {"p+", "n"}

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -184,7 +184,7 @@ class _ParticleInput:
         exclude: Optional[Union[str, set, list, tuple]] = None,
         allow_custom_particles: bool = True,
         allow_particle_lists: bool = True,
-    ):
+    ) -> None:
         self._data = {}
         self.callable_ = callable_
         self.require = require

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -11,7 +11,7 @@ import wrapt
 from collections.abc import Callable, Iterable
 from inspect import BoundArguments
 from numbers import Integral, Real
-from typing import Any, NoReturn, Optional, Union
+from typing import Any, Optional, Union
 
 from plasmapy.particles._factory import _physical_particle_factory
 from plasmapy.particles.exceptions import (
@@ -331,7 +331,7 @@ class _ParticleInput:
         """
         return self._data["parameters_to_process"]
 
-    def verify_charge_categorization(self, particle) -> NoReturn:
+    def verify_charge_categorization(self, particle) -> None:
         """
         Raise an exception if the particle does not meet charge
         categorization criteria.
@@ -391,7 +391,7 @@ class _ParticleInput:
 
         return category_errmsg
 
-    def verify_particle_categorization(self, particle) -> NoReturn:
+    def verify_particle_categorization(self, particle) -> None:
         """
         Verify that the particle meets the categorization criteria.
 

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -86,7 +86,7 @@ class IonicLevel:
     @particle_input
     def __init__(
         self, ion: Particle, ionic_fraction=None, number_density=None, T_i=None
-    ):
+    ) -> None:
         try:
             self.ion = ion
             self.ionic_fraction = ionic_fraction
@@ -261,7 +261,7 @@ class IonizationState:
         kappa: Real = np.inf,
         n_elem: u.Quantity[u.m**-3] = np.nan * u.m**-3,
         tol: float = 1e-15,
-    ):
+    ) -> None:
         self._number_of_particles = particle.atomic_number + 1
 
         if particle.is_ion or particle.is_category(require=("uncharged", "element")):

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -10,7 +10,7 @@ import numpy as np
 import warnings
 
 from numbers import Integral, Real
-from typing import NoReturn, Optional
+from typing import Optional
 
 from plasmapy.particles.atomic import ionic_levels
 from plasmapy.particles.decorators import particle_input
@@ -510,7 +510,7 @@ class IonizationState:
         total = np.sum(self._ionic_fractions)
         return np.isclose(total, 1, atol=tol, rtol=0)
 
-    def normalize(self) -> NoReturn:
+    def normalize(self) -> None:
         """
         Normalize the ionization state distribution (if set) so that the
         sum of the ionic fractions becomes equal to one.

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -143,7 +143,7 @@ class IonizationStateCollection:
         n0: u.Quantity[u.m**-3] = np.nan * u.m**-3,
         tol: Real = 1e-15,
         kappa: Real = np.inf,
-    ):
+    ) -> None:
         set_abundances = True
         if isinstance(inputs, dict) and np.all(
             [isinstance(fracs, u.Quantity) for fracs in inputs.values()]

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -8,7 +8,7 @@ import astropy.units as u
 import numpy as np
 
 from numbers import Integral, Real
-from typing import NoReturn, Optional, Union
+from typing import Optional, Union
 
 from plasmapy.particles.atomic import atomic_number
 from plasmapy.particles.exceptions import (
@@ -918,7 +918,7 @@ class IonizationStateCollection:
             abundances=all_abundances,
         )
 
-    def summarize(self, minimum_ionic_fraction: Real = 0.01) -> NoReturn:
+    def summarize(self, minimum_ionic_fraction: Real = 0.01) -> None:
         """
         Print quicklook information.
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -166,7 +166,7 @@ class AbstractParticle(ABC):
             }
         }
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """
         Raise an `~plasmapy.particles.exceptions.ParticleError` because
         particles do not have a truth value.
@@ -581,7 +581,7 @@ class Particle(AbstractPhysicalParticle):
         *_,
         mass_numb: Optional[Integral] = None,
         Z: Optional[Integral] = None,
-    ):
+    ) -> None:
         # TODO: Remove the following block during or after the 0.9.0 release
 
         if _:
@@ -1886,7 +1886,7 @@ class DimensionlessParticle(AbstractParticle):
         mass: Optional[Real] = None,
         charge: Optional[Real] = None,
         symbol: Optional[str] = None,
-    ):
+    ) -> None:
         try:
             self.mass = mass
             self.charge = charge
@@ -2096,7 +2096,7 @@ class CustomParticle(AbstractPhysicalParticle):
         symbol: Optional[str] = None,
         *,
         Z: Optional[Real] = None,
-    ):
+    ) -> None:
         # TODO: py3.10 replace ifology with structural pattern matching
 
         if Z is not None and charge is not None:

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from numbers import Integral, Real
-from typing import NoReturn, Optional, TYPE_CHECKING, Union
+from typing import Optional, TYPE_CHECKING, Union
 
 from plasmapy.particles import _elements, _isotopes, _parsing, _special_particles
 from plasmapy.particles.exceptions import (
@@ -610,12 +610,12 @@ class Particle(AbstractPhysicalParticle):
 
         self.__name__ = self.__repr__()
 
-    def _initialize_attributes_and_categories(self) -> NoReturn:
+    def _initialize_attributes_and_categories(self) -> None:
         """Create empty collections for attributes and categories."""
         self._attributes = defaultdict(type(None))
         self._categories = set()
 
-    def _validate_inputs(self) -> NoReturn:
+    def _validate_inputs(self) -> None:
         """Raise appropriate exceptions when inputs are invalid."""
         argument, mass_numb, Z = self.__inputs
 
@@ -632,7 +632,7 @@ class Particle(AbstractPhysicalParticle):
         if Z is not None and not isinstance(Z, Integral):
             raise TypeError("Z is not an integer.")
 
-    def _store_particle_identity(self) -> NoReturn:
+    def _store_particle_identity(self) -> None:
         """Store the particle's symbol and identifying information."""
         self._validate_inputs()
         argument, mass_numb, Z = self.__inputs
@@ -642,7 +642,7 @@ class Particle(AbstractPhysicalParticle):
         else:
             self._store_identity_of_atom(argument)
 
-    def _store_identity_of_atom(self, argument) -> NoReturn:
+    def _store_identity_of_atom(self, argument) -> None:
         """
         Store the particle's symbol, element, isotope, ion, mass number,
         and charge number.
@@ -666,14 +666,14 @@ class Particle(AbstractPhysicalParticle):
         for key in information_about_atom:
             self._attributes[key] = information_about_atom[key]
 
-    def _assign_particle_attributes(self) -> NoReturn:
+    def _assign_particle_attributes(self) -> None:
         """Assign particle attributes and categories."""
         if self.symbol in _special_particles.data_about_special_particles:
             self._assign_special_particle_attributes()
         else:
             self._assign_atom_attributes()
 
-    def _assign_special_particle_attributes(self) -> NoReturn:
+    def _assign_special_particle_attributes(self) -> None:
         """Initialize special particles."""
         attributes = self._attributes
         categories = self._categories
@@ -720,7 +720,7 @@ class Particle(AbstractPhysicalParticle):
                 "mass number or charge number not equal to 1."
             )
 
-    def _assign_atom_attributes(self) -> NoReturn:
+    def _assign_atom_attributes(self) -> None:
         """Assign attributes and categories to elements, isotopes, and ions."""
         attributes = self._attributes
         categories = self._categories
@@ -776,7 +776,7 @@ class Particle(AbstractPhysicalParticle):
 
         categories.add(this_element["category"])
 
-    def _add_charge_information(self) -> NoReturn:
+    def _add_charge_information(self) -> None:
         """Assign attributes and categories related to charge information."""
         if self._attributes["charge number"] == 1:
             self._attributes["charge"] = const.e.si
@@ -788,7 +788,7 @@ class Particle(AbstractPhysicalParticle):
         elif self._attributes["charge number"] == 0:
             self._categories.add("uncharged")
 
-    def _add_half_life_information(self) -> NoReturn:
+    def _add_half_life_information(self) -> None:
         """Assign categories related to stability."""
         if self._attributes["half-life"] is not None:
             if isinstance(self._attributes["half-life"], str):

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -188,7 +188,7 @@ class ParticleList(collections.UserList):
 
         return new_particles
 
-    def __init__(self, particles: Optional[Iterable] = None):
+    def __init__(self, particles: Optional[Iterable] = None) -> None:
         self._data = self._list_of_particles_and_custom_particles(particles)
 
     @staticmethod

--- a/plasmapy/particles/serialization.py
+++ b/plasmapy/particles/serialization.py
@@ -34,7 +34,7 @@ class ParticleJSONDecoder(json.JSONDecoder):
         Any keyword accepted by `~json.JSONDecoder`.
     """
 
-    def __init__(self, *, object_hook=None, **kwargs):
+    def __init__(self, *, object_hook=None, **kwargs) -> None:
         if object_hook is None:
             object_hook = self.particle_hook
         json.JSONDecoder.__init__(self, object_hook=object_hook, **kwargs)

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -393,7 +393,7 @@ def test_class_stacked_decorator(outer_decorator, inner_decorator):
     class Sample:
         @outer_decorator
         @inner_decorator
-        def __init__(self, particle: ParticleLike):
+        def __init__(self, particle: ParticleLike) -> None:
             self.particle = particle
 
     result = Sample("p+")
@@ -411,7 +411,7 @@ def test_annotated_init():
 
     class HasAnnotatedInit:
         @particle_input(require="element")
-        def __init__(self, particle: ParticleLike, ionic_fractions=None):
+        def __init__(self, particle: ParticleLike, ionic_fractions=None) -> None:
             self.particle = particle
 
     x = HasAnnotatedInit("H-1", ionic_fractions=32)
@@ -451,7 +451,7 @@ def test_particle_input_with_validate_quantities(outer_decorator, inner_decorato
             self,
             particle: ParticleLike,
             T_e: u.Quantity[u.K] = None,
-        ):
+        ) -> None:
             self.particle = particle
             self.T_e = T_e
 
@@ -500,7 +500,7 @@ class ParameterNamesCase:
         particles_in_category,
         particles_not_in_category,
         exception,
-    ):
+    ) -> None:
         self.category = category
         self.function = function
         self.particles_in_category = particles_in_category

--- a/plasmapy/plasma/cylindrical_equilibria.py
+++ b/plasmapy/plasma/cylindrical_equilibria.py
@@ -26,7 +26,7 @@ class ForceFreeFluxRope:
     ejections (ICMEs).
     """
 
-    def __init__(self, B0, alpha):
+    def __init__(self, B0, alpha) -> None:
         self.B0 = B0
         self.alpha = alpha
 

--- a/plasmapy/plasma/equilibria1d.py
+++ b/plasmapy/plasma/equilibria1d.py
@@ -50,7 +50,7 @@ class HarrisSheet:
     <Quantity 1.8622... T>
     """
 
-    def __init__(self, B0, delta, P0=0 * u.Pa):
+    def __init__(self, B0, delta, P0=0 * u.Pa) -> None:
         self.B0 = B0
         self.delta = delta
         self.P0 = P0

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -76,7 +76,7 @@ class AbstractGrid(ABC):
 
     """
 
-    def __init__(self, *seeds, num=100, **kwargs):
+    def __init__(self, *seeds, num=100, **kwargs) -> None:
         # Initialize some variables
         self._interpolator = None
         self._is_uniform = None

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -75,7 +75,7 @@ class GenericPlasma(BasePlasma):
     methods declared in the `~plasmapy.plasma.plasma_base.BasePlasma`.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         pass
 
     # The definitions for the abstract methods declared in `BasePlasma`

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -1,4 +1,6 @@
 """Functionality for reading in HDF5 files following the OpenPMD standard."""
+from types import TracebackType
+from typing import Optional
 
 __all__ = ["HDF5Reader"]
 
@@ -53,7 +55,7 @@ class HDF5Reader(GenericPlasma):
         Any keyword accepted by `~plasmapy.plasma.plasma_base.GenericPlasma`.
     """
 
-    def __init__(self, hdf5, **kwargs):
+    def __init__(self, hdf5, **kwargs) -> None:
         super().__init__(**kwargs)
 
         if not Path(hdf5).is_file():
@@ -72,7 +74,12 @@ class HDF5Reader(GenericPlasma):
     def close(self):
         self.h5.close()
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ):
         self.h5.close()
 
     def _check_valid_openpmd_version(self):

--- a/plasmapy/plasma/sources/plasma3d.py
+++ b/plasmapy/plasma/sources/plasma3d.py
@@ -38,7 +38,7 @@ class Plasma3D(GenericPlasma):
     """
 
     @validate_quantities(domain_x=u.m, domain_y=u.m, domain_z=u.m)
-    def __init__(self, domain_x, domain_y, domain_z, **kwargs):
+    def __init__(self, domain_x, domain_y, domain_z, **kwargs) -> None:
         super().__init__(**kwargs)
 
         # Define domain sizes

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -22,7 +22,7 @@ class PlasmaBlob(GenericPlasma):
     """
 
     @validate_quantities(T_e=u.K, n_e=u.m**-3)
-    def __init__(self, T_e, n_e, Z=None, particle="p"):
+    def __init__(self, T_e, n_e, Z=None, particle="p") -> None:
         """
         Initialize plasma parameters.
         The most basic description is composition (ion), temperature,

--- a/plasmapy/simulation/abstractions.py
+++ b/plasmapy/simulation/abstractions.py
@@ -15,7 +15,6 @@ __all__ = [
 import astropy.units as u
 
 from abc import ABC, abstractmethod
-from typing import NoReturn
 
 
 class AbstractSimulation(ABC):
@@ -35,7 +34,7 @@ class AbstractSimulation(ABC):
         ...
 
     @abstractmethod
-    def initialize(self) -> NoReturn:
+    def initialize(self) -> None:
         """Prepare the simulation to be run."""
         ...
 
@@ -45,7 +44,7 @@ class AbstractSimulation(ABC):
         ...
 
     @abstractmethod
-    def finalize(self) -> NoReturn:
+    def finalize(self) -> None:
         """Perform the steps to close the simulation."""
         ...
 

--- a/plasmapy/simulation/particletracker.py
+++ b/plasmapy/simulation/particletracker.py
@@ -99,7 +99,7 @@ class ParticleTracker:
         dt=np.inf * u.s,
         nt=np.inf,
         integrator="explicit_boris",
-    ):
+    ) -> None:
         if np.isinf(dt) and np.isinf(nt):
             raise ValueError("Both dt and nt are infinite.")
 

--- a/plasmapy/tests/_helpers/tests/sample_functions.py
+++ b/plasmapy/tests/_helpers/tests/sample_functions.py
@@ -91,7 +91,7 @@ def return_none() -> None:
 class SampleClass1:
     """A sample class to be used for testing purposes."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         pass
 
     @classmethod
@@ -123,7 +123,7 @@ class SampleClass1:
 class SampleClass2:
     """A sample class to be used for testing purposes."""
 
-    def __init__(self, cls_arg1, cls_arg2, *, cls_kwarg1, cls_kwarg2):
+    def __init__(self, cls_arg1, cls_arg2, *, cls_kwarg1, cls_kwarg2) -> None:
         self.cls_arg1 = cls_arg1
         self.cls_arg2 = cls_arg2
         self.cls_kwarg1 = cls_kwarg1

--- a/plasmapy/tests/_helpers/tests/sample_functions.py
+++ b/plasmapy/tests/_helpers/tests/sample_functions.py
@@ -7,8 +7,6 @@ import astropy.units as u
 import numpy as np
 import warnings
 
-from typing import NoReturn
-
 
 class SampleException(Exception):  # noqa: N818
     """A sample exception to be used for testing purposes."""
@@ -51,7 +49,7 @@ def return_np_array(args) -> np.array:
     return np.array(args)
 
 
-def issue_warning() -> NoReturn:
+def issue_warning() -> None:
     """A sample function that issues a `SampleWarning`."""
 
     warnings.warn("warning message", SampleWarning)
@@ -114,7 +112,7 @@ class SampleClass1:
 
         raise SampleException("error message")
 
-    def issue_warning(self) -> NoReturn:
+    def issue_warning(self) -> None:
         """A sample method that issues a `SampleWarning`."""
 
         warnings.warn("warning message", SampleWarning)

--- a/plasmapy/utils/calculator/widget_helpers.py
+++ b/plasmapy/utils/calculator/widget_helpers.py
@@ -59,7 +59,9 @@ class _GenericWidget(abc.ABC):
         If the method `create_widget` is not implemented.
     """
 
-    def __init__(self, property_name, property_alias="", values_cont=values_container):
+    def __init__(
+        self, property_name, property_alias="", values_cont=values_container
+    ) -> None:
         self.property_name = property_name
         self.property_alias = property_alias or property_name
         self.widget = None
@@ -262,7 +264,7 @@ class _FloatBox(_GenericWidget):
         Maximum value the widget can take
     """
 
-    def __init__(self, property_name, min=-1e50, max=1e50):  # noqa: A002
+    def __init__(self, property_name, min=-1e50, max=1e50) -> None:  # noqa: A002
         super().__init__(property_name)
         self.min = min
         self.max = max
@@ -295,7 +297,7 @@ class _CheckBox(_GenericWidget):
         Name of the property the widget is associated with.
     """
 
-    def __init__(self, property_name):
+    def __init__(self, property_name) -> None:
         super().__init__(property_name)
 
     def create_widget(self):
@@ -321,7 +323,7 @@ class _ParticleBox(_GenericWidget):
         (particle_type in this case)
     """
 
-    def __init__(self, property_name, property_alias=None):
+    def __init__(self, property_name, property_alias=None) -> None:
         super().__init__(property_name, property_alias=property_alias)
 
     def edge_case_condition(self, value):
@@ -394,7 +396,7 @@ class _IonBox(_ParticleBox):
         Alias of the property the widget is associated with.
     """
 
-    def __init__(self, property_name, property_alias=None):
+    def __init__(self, property_name, property_alias=None) -> None:
         super().__init__(property_name, property_alias=property_alias)
 
     def try_change_value(self, value):
@@ -440,7 +442,9 @@ class _FunctionInfo:
         Reference to global dictionary of values to be passed to the function
     """
 
-    def __init__(self, module_name, function_name, values_cont=values_container):
+    def __init__(
+        self, module_name, function_name, values_cont=values_container
+    ) -> None:
         self.module = module_name
         self.fname = function_name
         self.fattr = getattr(importlib.import_module(module_name), function_name)

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -85,7 +85,7 @@ class BasicRegistrationFactory:
         default_widget_type=None,
         additional_validation_functions=None,
         registry=None,
-    ):
+    ) -> None:
         self.registry = {} if registry is None else registry
         if additional_validation_functions is None:
             additional_validation_functions = []

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -44,7 +44,7 @@ class CheckBase:
         specified checks on the input arguments of the wrapped function
     """
 
-    def __init__(self, checks_on_return=None, **checks):
+    def __init__(self, checks_on_return=None, **checks) -> None:
         self._checks = checks
         if checks_on_return is not None:
             self._checks["checks_on_return"] = checks_on_return
@@ -141,7 +141,7 @@ class CheckValues(CheckBase):
         self,
         checks_on_return: Optional[dict[str, bool]] = None,
         **checks: dict[str, bool],
-    ):
+    ) -> None:
         super().__init__(checks_on_return=checks_on_return, **checks)
 
     def __call__(self, f):
@@ -468,7 +468,7 @@ class CheckUnits(CheckBase):
         self,
         checks_on_return: Union[u.Unit, list[u.Unit], dict[str, Any]] = None,
         **checks: Union[u.Unit, list[u.Unit], dict[str, Any]],
-    ):
+    ) -> None:
         super().__init__(checks_on_return=checks_on_return, **checks)
 
     def __call__(self, f):

--- a/plasmapy/utils/decorators/tests/test_checks.py
+++ b/plasmapy/utils/decorators/tests/test_checks.py
@@ -612,7 +612,7 @@ class TestCheckUnits:
         # test on class method
         class Foo:
             @CheckUnits()
-            def __init__(self, y: u.cm):
+            def __init__(self, y: u.cm) -> None:
                 self.y = y
 
             @CheckUnits(x=u.cm)
@@ -1108,7 +1108,7 @@ class TestCheckValues:
         # test on class method
         class Foo:
             @CheckValues(y={"can_be_negative": True})
-            def __init__(self, y):
+            def __init__(self, y) -> None:
                 self.y = y
 
             @CheckValues(

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -456,7 +456,7 @@ class TestValidateQuantities:
         # test on class method
         class Foo:
             @ValidateQuantities()
-            def __init__(self, y: u.cm):
+            def __init__(self, y: u.cm) -> None:
                 self.y = y
 
             @ValidateQuantities(validations_on_return={"can_be_negative": False})
@@ -557,7 +557,7 @@ class TestValidateClassAttributes:
             x: Optional[int] = None,
             y: Optional[int] = None,
             z: Optional[int] = None,
-        ):
+        ) -> None:
             self.x = x
             self.y = y
             self.z = z

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -139,7 +139,9 @@ class ValidateQuantities(CheckUnits, CheckValues):
         https://docs.astropy.org/en/stable/units/equivalencies.html
     """
 
-    def __init__(self, validations_on_return=None, **validations: dict[str, Any]):
+    def __init__(
+        self, validations_on_return=None, **validations: dict[str, Any]
+    ) -> None:
         if "checks_on_return" in validations:
             raise TypeError(
                 "keyword argument 'checks_on_return' is not allowed, "

--- a/plasmapy/utils/tests/test_datatype_factory_base.py
+++ b/plasmapy/utils/tests/test_datatype_factory_base.py
@@ -41,7 +41,7 @@ from plasmapy.utils.datatype_factory_base import (
 
 
 class BaseWidget:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         pass
 
 


### PR DESCRIPTION
This PR uses [autotyping](https://github.com/JelleZijlstra/autotyping) to add type hint annotations to dunder methods like `__init__`, `__str__`, etc.

These are the commands I used in the top-level directory, after having temporarily added a config file as per the [autotyping usage guidelines](https://github.com/JelleZijlstra/autotyping#usage).

```bash
pip install autotyping
python -m libcst.tool codemod autotyping.AutotypeCommand plasmapy --annotate-magics
```

I automatically updated `mypy.ini` to reflect the necessary changes in per-file ignores, and `ruff` did some autoformatting too.

I also changed `NoReturn` to `None` for return annotations.

