### PR TITLE
Use autotyping to add `-> None` return annotations

### DIFF
--- a/changelog/2439.trivial.rst
+++ b/changelog/2439.trivial.rst
@@ -1,0 +1,2 @@
+Used ``autotyping`` to add ``-> None`` return annotations to functions
+and methods with no ``return`` statement.

--- a/plasmapy/__init__.py
+++ b/plasmapy/__init__.py
@@ -71,7 +71,7 @@ __citation__ = (
 )
 
 
-def online_help(query: str):  # coverage: ignore
+def online_help(query: str) -> None:  # coverage: ignore
     """
     Open a search page in |PlasmaPy's documentation|, or another page
     that contains relevant online help.

--- a/plasmapy/analysis/swept_langmuir/tests/test_floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_floating_potential.py
@@ -18,7 +18,7 @@ from plasmapy.analysis.swept_langmuir.floating_potential import (
 from plasmapy.utils.exceptions import PlasmaPyWarning
 
 
-def test_floating_potential_namedtuple():
+def test_floating_potential_namedtuple() -> None:
     """
     Test structure of the namedtuple used to return computed floating potential
     data.
@@ -55,11 +55,11 @@ class TestFindFloatingPotential:
     _linear_p_sine_current = _linear_current + 1.2 * np.sin(1.2 * _voltage)
     _exp_current = -1.3 + 2.2 * np.exp(_voltage)
 
-    def test_alias(self):
+    def test_alias(self) -> None:
         """Test the associated alias(es) is(are) defined correctly."""
         assert find_vf_ is find_floating_potential
 
-    def test_call_of_check_sweep(self):
+    def test_call_of_check_sweep(self) -> None:
         """
         Test `find_floating_potential` appropriately calls
         `plasmapy.analysis.swept_langmuir.helpers.check_sweep` so we can relay on
@@ -163,7 +163,7 @@ class TestFindFloatingPotential:
             ),
         ],
     )
-    def test_raises(self, kwargs, _error):
+    def test_raises(self, kwargs, _error) -> None:
         """Test scenarios that raise `Exception`s."""
         with pytest.raises(_error):
             find_floating_potential(**kwargs)
@@ -208,7 +208,7 @@ class TestFindFloatingPotential:
             ),
         ],
     )
-    def test_warnings(self, kwargs, expected, _warning):
+    def test_warnings(self, kwargs, expected, _warning) -> None:
         """Test scenarios that issue warnings."""
         with pytest.warns(_warning):
             vf, extras = find_floating_potential(**kwargs)
@@ -244,7 +244,7 @@ class TestFindFloatingPotential:
             (None, "exponential", [slice(26, 28)], slice(20, 34)),
         ],
     )
-    def test_kwarg_min_points(self, min_points, fit_type, islands, indices):
+    def test_kwarg_min_points(self, min_points, fit_type, islands, indices) -> None:
         """
         Test functionality of keyword `min_points` and how it affects the
         size of the crossing-point island.
@@ -342,7 +342,7 @@ class TestFindFloatingPotential:
             ),
         ],
     )
-    def test_island_finding(self, kwargs, expected):
+    def test_island_finding(self, kwargs, expected) -> None:
         """
         Test scenarios related to the identification of crossing-point islands.
         """
@@ -364,7 +364,7 @@ class TestFindFloatingPotential:
                 assert rtn_val == val
 
     @pytest.mark.parametrize(("m", "b"), [(2.0, 0.0), (1.33, -0.1), (0.5, -0.1)])
-    def test_perfect_linear(self, m, b):
+    def test_perfect_linear(self, m, b) -> None:
         """Test calculated fit parameters on a few perfectly linear cases."""
         voltage = self._voltage
         current = m * voltage + b
@@ -388,7 +388,7 @@ class TestFindFloatingPotential:
         ("a", "alpha", "b"),
         [(1.0, 0.2, -0.2), (2.7, 0.2, -10.0), (6.0, 0.6, -10.0)],
     )
-    def test_perfect_exponential(self, a, alpha, b):
+    def test_perfect_exponential(self, a, alpha, b) -> None:
         """Test calculated fit parameters on a few perfectly exponential cases."""
         voltage = self._voltage
         current = a * np.exp(alpha * voltage) + b

--- a/plasmapy/analysis/swept_langmuir/tests/test_helpers.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_helpers.py
@@ -165,7 +165,7 @@ from plasmapy.analysis.swept_langmuir.helpers import check_sweep
         ),
     ],
 )
-def test_check_sweep(voltage, current, kwargs, with_context, expected):
+def test_check_sweep(voltage, current, kwargs, with_context, expected) -> None:
     """Test functionality of `plasmapy.analysis.swept_langmuir.helpers.check_sweep`."""
     with with_context:
         rtn_voltage, rtn_current = check_sweep(

--- a/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
+++ b/plasmapy/analysis/swept_langmuir/tests/test_ion_saturation_current.py
@@ -16,7 +16,7 @@ from plasmapy.analysis.swept_langmuir.ion_saturation_current import (
 )
 
 
-def test_ion_saturation_current_namedtuple():
+def test_ion_saturation_current_namedtuple() -> None:
     """
     Test structure of the namedtuple used to return the computed ion saturation
     current data.
@@ -66,7 +66,7 @@ class TestFindIonSaturationCurrent:
     _linear_p_sine_current = _linear_current + 1.2 * np.sin(1.2 * _voltage)
     _exp_current = -1.3 + 2.2 * np.exp(_voltage)
 
-    def test_alias(self):
+    def test_alias(self) -> None:
         """Test the associated alias(es) is(are) defined correctly."""
         assert find_isat_ is find_ion_saturation_current
 
@@ -123,7 +123,7 @@ class TestFindIonSaturationCurrent:
             ),
         ],
     )
-    def test_raises(self, kwargs, _error):
+    def test_raises(self, kwargs, _error) -> None:
         """Test scenarios that raise exceptions."""
         with pytest.raises(_error):
             find_ion_saturation_current(**kwargs)
@@ -259,7 +259,7 @@ class TestFindIonSaturationCurrent:
             ),
         ],
     )
-    def test_analytical_fits(self, kwargs, expected):
+    def test_analytical_fits(self, kwargs, expected) -> None:
         """Test functionality on analytical traces."""
         isat, extras = find_ion_saturation_current(**kwargs)
 
@@ -275,7 +275,7 @@ class TestFindIonSaturationCurrent:
         assert extras.fitted_indices == expected[1].fitted_indices
 
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-    def test_on_pace_data(self):
+    def test_on_pace_data(self) -> None:
         """
         Test functionality on D. Pace data.
 

--- a/plasmapy/analysis/tests/test_fit_functions.py
+++ b/plasmapy/analysis/tests/test_fit_functions.py
@@ -24,7 +24,7 @@ class TestAbstractFitFunction:
 
     ff_class = ffuncs.AbstractFitFunction
 
-    def test_is_abc(self):
+    def test_is_abc(self) -> None:
         """Test `AbstractFitFunction` is an abstract base class."""
         assert issubclass(self.ff_class, ABC)
 
@@ -44,7 +44,7 @@ class TestAbstractFitFunction:
             ("root_solve", False),
         ],
     )
-    def test_methods(self, name, isproperty):
+    def test_methods(self, name, isproperty) -> None:
         """Test for required methods and properties."""
         assert hasattr(self.ff_class, name)
 
@@ -55,7 +55,7 @@ class TestAbstractFitFunction:
         "name",
         ["__str__", "func", "func_err", "latex_str"],
     )
-    def test_abstractmethods(self, name):
+    def test_abstractmethods(self, name) -> None:
         """Test for required abstract methods."""
         assert name in self.ff_class.__abstractmethods__
 
@@ -91,15 +91,15 @@ class BaseFFTests(ABC):
         """
         ...
 
-    def test_inheritance(self):
+    def test_inheritance(self) -> None:
         """Test inheritance from `AbstractFitFunction`."""
         assert issubclass(self.ff_class, self.abc)
 
-    def test_iscallable(self):
+    def test_iscallable(self) -> None:
         """Test instantiated fit function is callable."""
         assert callable(self.ff_class())
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """Test __repr__."""
         ff_obj = self.ff_class()
         assert ff_obj.__repr__() == f"{ff_obj.__str__()} {ff_obj.__class__}"
@@ -121,7 +121,7 @@ class BaseFFTests(ABC):
             ("root_solve", False),
         ],
     )
-    def test_methods(self, name, isproperty):
+    def test_methods(self, name, isproperty) -> None:
         """Test attribute/method/property existence."""
         assert hasattr(self.ff_class, name)
 
@@ -143,7 +143,7 @@ class BaseFFTests(ABC):
             ("__str__", "_test__str__"),
         ],
     )
-    def test_abstractmethod_values(self, name, value_ref_name):
+    def test_abstractmethod_values(self, name, value_ref_name) -> None:
         """Test value of all abstract methods, except `func` and `func_err`."""
         ff_obj = self.ff_class()
 
@@ -173,7 +173,7 @@ class BaseFFTests(ABC):
             (None, "default+", pytest.raises(ValueError)),
         ],
     )
-    def test_instantiation(self, params, param_errors, with_condition):
+    def test_instantiation(self, params, param_errors, with_condition) -> None:
         """Test behavior of fit function class instantiation."""
         if params == "default":
             params = self._test_params
@@ -205,7 +205,7 @@ class BaseFFTests(ABC):
             else:
                 assert ff_obj.param_errors == ff_obj.FitParamTuple(*param_errors)
 
-    def test_param_namedtuple(self):
+    def test_param_namedtuple(self) -> None:
         """
         Test that the namedtuple used for `params` and `param_errors` is
         constructed correctly.
@@ -216,7 +216,7 @@ class BaseFFTests(ABC):
         for name in ff_obj.param_names:
             assert hasattr(ff_obj.FitParamTuple, name)
 
-    def test_param_names(self):
+    def test_param_names(self) -> None:
         """Test attribute `param_names` is defined correctly."""
         ff_obj = self.ff_class()
         assert isinstance(ff_obj.param_names, tuple)
@@ -232,7 +232,7 @@ class BaseFFTests(ABC):
             ([3], 10, pytest.raises(ValueError)),
         ],
     )
-    def test_params_setting(self, params, extra, with_condition):
+    def test_params_setting(self, params, extra, with_condition) -> None:
         """Tests for property setting of attribute `params`."""
         ff_obj = self.ff_class()
 
@@ -254,7 +254,7 @@ class BaseFFTests(ABC):
             ([3], 10, pytest.raises(ValueError)),
         ],
     )
-    def test_param_errors_setting(self, param_errors, extra, with_condition):
+    def test_param_errors_setting(self, param_errors, extra, with_condition) -> None:
         """Tests for property setting of attribute `param_errors`."""
         ff_obj = self.ff_class()
 
@@ -278,7 +278,7 @@ class BaseFFTests(ABC):
             (5, "hello", pytest.raises(TypeError)),
         ],
     )
-    def test_func(self, x, replace_a_param, with_condition):
+    def test_func(self, x, replace_a_param, with_condition) -> None:
         """Test the `func` method."""
         ff_obj = self.ff_class()
 
@@ -308,7 +308,7 @@ class BaseFFTests(ABC):
             (5, {"x_err": [0.1, 0.1]}, pytest.raises(ValueError)),
         ],
     )
-    def test_func_err(self, x, kwargs, with_condition):
+    def test_func_err(self, x, kwargs, with_condition) -> None:
         """Test the `func_err` method."""
         params = self._test_params
         param_errors = self._test_param_errors
@@ -347,7 +347,7 @@ class BaseFFTests(ABC):
             (5, {"x_err": [1, 2], "reterr": True}, pytest.raises(ValueError)),
         ],
     )
-    def test_call(self, x, kwargs, with_condition):
+    def test_call(self, x, kwargs, with_condition) -> None:
         """Test __call__ behavior."""
         params = self._test_params
         param_errors = self._test_param_errors
@@ -377,7 +377,7 @@ class BaseFFTests(ABC):
     def test_root_solve(self):
         ...
 
-    def test_curve_fit(self):
+    def test_curve_fit(self) -> None:
         """Test the `curve_fit` method."""
         ff_obj = self.ff_class()
 
@@ -433,7 +433,7 @@ class TestFFExponential(BaseFFTests):
 
         return np.abs(y) * np.sqrt(err)
 
-    def test_root_solve(self):
+    def test_root_solve(self) -> None:
         ff_obj = self.ff_class(params=(1, 1), param_errors=(0, 0))
         root, err = ff_obj.root_solve()
         assert np.isnan(root)
@@ -479,7 +479,7 @@ class TestFFExponentialPlusLinear(BaseFFTests):
 
         return np.sqrt(err)
 
-    def test_root_solve(self):
+    def test_root_solve(self) -> None:
         ff_obj = self.ff_class(params=(5.0, 0.5, 1.0, 5.0), param_errors=(0, 0, 0, 0))
         root, err = ff_obj.root_solve(-5)
         assert np.isclose(root, -5.345338)
@@ -521,7 +521,7 @@ class TestFFExponentialPlusOffset(BaseFFTests):
 
         return np.sqrt(err)
 
-    def test_root_solve(self):
+    def test_root_solve(self) -> None:
         ff_obj = self.ff_class(params=(3.0, 0.5, -5.0), param_errors=(0, 0, 0))
         root, err = ff_obj.root_solve()
         assert root == np.log(5.0 / 3.0) / 0.5
@@ -578,7 +578,9 @@ class TestFFLinear(BaseFFTests):
             ((0.0, 1.0), (0.1, 0.1), np.nan, np.nan, pytest.warns(RuntimeWarning)),
         ],
     )
-    def test_root_solve(self, params, param_errors, root, root_err, conditional):
+    def test_root_solve(
+        self, params, param_errors, root, root_err, conditional
+    ) -> None:
         with conditional:
             ff_obj = self.ff_class(params=params, param_errors=param_errors)
             results = ff_obj.root_solve()

--- a/plasmapy/analysis/tests/test_nullpoint.py
+++ b/plasmapy/analysis/tests/test_nullpoint.py
@@ -53,7 +53,7 @@ def vspace_func_7(x, y, z):
     return [(y - 5.5) * (y + 5.5), (z - 5.5), (x - 5.5)]
 
 
-def test_trilinear_coeff_cal():
+def test_trilinear_coeff_cal() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.trilinear_coeff_cal`."""
     vspace_args = {
         "x_range": [0, 10],
@@ -75,12 +75,12 @@ def test_trilinear_coeff_cal():
     ]
 
     @pytest.mark.parametrize(("kwargs", "expected"), test_trilinear_coeff_cal_values)
-    def test_trilinear_coeff_cal_vals(kwargs, expected):
+    def test_trilinear_coeff_cal_vals(kwargs, expected) -> None:
         r"""Test expected values."""
         assert _trilinear_coeff_cal(**kwargs) == expected
 
 
-def test_trilinear_jacobian():
+def test_trilinear_jacobian() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.trilinear_jacobian`."""
     vspace_args = {
         "x_range": [0, 10],
@@ -97,7 +97,7 @@ def test_trilinear_jacobian():
     assert np.allclose(mtrx, exact_mtrx, atol=_EQUALITY_ATOL)
 
 
-def test_trilinear_approx():
+def test_trilinear_approx() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.trilinear_approx`."""
     vspace2_args = {
         "x_range": [0, 10],
@@ -159,7 +159,7 @@ class Test_reduction:
     ]
 
     @pytest.mark.parametrize(("kwargs", "expected"), test_reduction_values)
-    def test_reduction_vals(self, kwargs, expected):
+    def test_reduction_vals(self, kwargs, expected) -> None:
         r"""Test expected values."""
         assert _reduction(**kwargs) == expected
 
@@ -184,7 +184,7 @@ class Test_trilinear_analysis:
     ]
 
     @pytest.mark.parametrize(("kwargs", "expected"), test_trilinear_analysis_values)
-    def test_trilinear_analysis_vals(self, kwargs, expected):
+    def test_trilinear_analysis_vals(self, kwargs, expected) -> None:
         r"""Test expected values."""
         assert _trilinear_analysis(**kwargs) == expected
 
@@ -200,7 +200,7 @@ class Test_bilinear_root:
     ]
 
     @pytest.mark.parametrize(("kwargs", "expected"), test_bilinear_root_values)
-    def test_bilinear_root_vals(self, kwargs, expected):
+    def test_bilinear_root_vals(self, kwargs, expected) -> None:
         r"""Test expected values."""
         x1, y1 = _bilinear_root(**kwargs)[0]
         x2, y2 = _bilinear_root(**kwargs)[1]
@@ -230,7 +230,7 @@ class Test_locate_null_point:
     ]
 
     @pytest.mark.parametrize(("kwargs", "expected"), test_locate_null_point_values)
-    def test_locate_null_point_vals(self, kwargs, expected):
+    def test_locate_null_point_vals(self, kwargs, expected) -> None:
         r"""Test expected values."""
         assert np.isclose(
             _locate_null_point(**kwargs).reshape(1, 3), expected, atol=_EQUALITY_ATOL
@@ -238,7 +238,7 @@ class Test_locate_null_point:
 
 
 @pytest.mark.slow()
-def test_null_point_find1():
+def test_null_point_find1() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Uniform grid
     nullpoint_args = {
@@ -255,7 +255,7 @@ def test_null_point_find1():
 
 
 @pytest.mark.slow()
-def test_null_point_find2():
+def test_null_point_find2() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Non-uniform grid
     vspace_args = {
@@ -271,7 +271,7 @@ def test_null_point_find2():
     assert np.isclose(loc2, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
 
 
-def test_null_point_find3():
+def test_null_point_find3() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Vector values passed by hand
     nullpoint3_args = {
@@ -289,7 +289,7 @@ def test_null_point_find3():
 
 
 @pytest.mark.slow()
-def test_null_point_find4():
+def test_null_point_find4() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Two null points
     nullpoint4_args = {
@@ -312,7 +312,7 @@ def test_null_point_find4():
     "ignore::plasmapy.analysis.nullpoint.MultipleNullPointWarning"
 )
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_null_point_find5():
+def test_null_point_find5() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Many null points because a y vector dimension is zero
     nullpoint5_args = {
@@ -345,7 +345,7 @@ def test_null_point_find5():
 @pytest.mark.filterwarnings(
     "ignore::plasmapy.analysis.nullpoint.MultipleNullPointWarning"
 )
-def test_null_point_find6():
+def test_null_point_find6() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Many null points; All vector dimensions zero
     nullpoint6_args = {
@@ -360,7 +360,7 @@ def test_null_point_find6():
 
 
 @pytest.mark.slow()
-def test_null_point_find7():
+def test_null_point_find7() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # No null points, discriminant less than zero
     nullpoint7_args = {
@@ -375,7 +375,7 @@ def test_null_point_find7():
 
 
 @pytest.mark.slow()
-def test_null_point_find8():
+def test_null_point_find8() -> None:
     r"""Test `~plasmapy.analysis.nullpoint.null_point_find`."""
     # Non-linear field
     nullpoint8_args = {
@@ -462,12 +462,12 @@ class Test_classify_null_point:
     ]
 
     @pytest.mark.parametrize(("kwargs", "expected"), test_classify_null_point_values)
-    def test_classify_null_point_vals(self, kwargs, expected):
+    def test_classify_null_point_vals(self, kwargs, expected) -> None:
         r"""Test expected values."""
         assert uniform_null_point_find(**kwargs)[0].classification == expected
 
 
-def test_null_point_find9():
+def test_null_point_find9() -> None:
     """Testing a magnetic field that violates the divergence constraint"""
     nullpoint9_args = {
         "x_range": [-0.1, 0.1],
@@ -486,7 +486,7 @@ def test_null_point_find9():
     "ignore::plasmapy.analysis.nullpoint.MultipleNullPointWarning"
 )
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_null_point_find10():
+def test_null_point_find10() -> None:
     nullpoint10_args = {
         "x_range": [-0.1, 0.1],
         "y_range": [-0.1, 0.1],
@@ -512,7 +512,7 @@ def test_null_point_find10():
     "ignore::plasmapy.analysis.nullpoint.MultipleNullPointWarning"
 )
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_null_point_find11():
+def test_null_point_find11() -> None:
     nullpoint10_args = {
         "x_range": [-0.1, 0.1],
         "y_range": [-0.1, 0.1],

--- a/plasmapy/analysis/time_series/excess_statistics.py
+++ b/plasmapy/analysis/time_series/excess_statistics.py
@@ -70,7 +70,7 @@ class ExcessStatistics:
 
         self._calculate_excess_statistics(signal, thresholds, time_step)
 
-    def _calculate_excess_statistics(self, signal, thresholds, time_step):
+    def _calculate_excess_statistics(self, signal, thresholds, time_step) -> None:
         for threshold in thresholds:
             indices_above_threshold = np.where(np.array(signal) > threshold)[0]
 

--- a/plasmapy/analysis/time_series/tests/test_conditioanl_averaging.py
+++ b/plasmapy/analysis/time_series/tests/test_conditioanl_averaging.py
@@ -47,7 +47,7 @@ def test_ConditionalEvents_Errors(
     length_of_return,
     distance,
     exception,
-):
+) -> None:
     """Test whether exception is risen"""
     with pytest.raises(exception):
         ConditionalEvents(
@@ -228,7 +228,7 @@ def test_ConditionalEvents_class(
     length_of_return,
     distance,
     expected,
-):
+) -> None:
     """Tests for ConditionalEvents class"""
     cond_events = ConditionalEvents(
         signal,
@@ -311,7 +311,7 @@ def test_peak_not_max_value(
     distance,
     remove_non_max_peaks,
     expected,
-):
+) -> None:
     """Tests for ConditionalEvents class"""
     cond_events = ConditionalEvents(
         signal,

--- a/plasmapy/analysis/time_series/tests/test_excess_statistics.py
+++ b/plasmapy/analysis/time_series/tests/test_excess_statistics.py
@@ -83,7 +83,7 @@ from plasmapy.analysis.time_series.excess_statistics import ExcessStatistics
         ),
     ],
 )
-def test_ExcessStatistics(signal, thresholds, time_step, pdf, bins, expected):
+def test_ExcessStatistics(signal, thresholds, time_step, pdf, bins, expected) -> None:
     """Test ExcessStatistics class"""
     excess_stats = ExcessStatistics(signal, thresholds, time_step)
     assert excess_stats.total_time_above_threshold == expected[0]
@@ -100,7 +100,9 @@ def test_ExcessStatistics(signal, thresholds, time_step, pdf, bins, expected):
     ("signal", "thresholds", "time_step", "bins", "exception"),
     [([1, 2], 1, -1, 32, ValueError), ([1, 2], 1, 1, 1.5, TypeError)],
 )
-def test_ExcessStatistics_exception(signal, thresholds, time_step, bins, exception):
+def test_ExcessStatistics_exception(
+    signal, thresholds, time_step, bins, exception
+) -> None:
     """Test whether exception is risen"""
     with pytest.raises(exception):
         tmp = ExcessStatistics(signal, thresholds, time_step)

--- a/plasmapy/analysis/time_series/tests/test_running_moments.py
+++ b/plasmapy/analysis/time_series/tests/test_running_moments.py
@@ -16,14 +16,14 @@ from plasmapy.analysis.time_series.running_moments import running_mean, running_
         (np.array([-0.5, -0.0, 0.5, 1.0, 1.5]), 2, [0.5]),
     ],
 )
-def test_running_mean(signal, radius, expected):
+def test_running_mean(signal, radius, expected) -> None:
     """Test running_mean function"""
     result = running_mean(signal=signal, radius=radius)
     assert np.allclose(result, expected)
 
 
 @pytest.mark.parametrize(("signal", "radius"), [([1, 2], 1), ([1, 2, 3, 4], 1.2)])
-def test_running_mean_exception(signal, radius):
+def test_running_mean_exception(signal, radius) -> None:
     """Test whether exception is risen"""
     with pytest.raises((ValueError, TypeError)):
         running_mean(signal, radius)
@@ -46,7 +46,7 @@ def test_running_mean_exception(signal, radius):
         ([1, 2, 3, 2, 1] * u.eV, 1, 4, [1, 2, 3, 4, 5], ([3] * u.eV, [3])),
     ],
 )
-def test_running_moment(signal, radius, moment, time, expected):
+def test_running_moment(signal, radius, moment, time, expected) -> None:
     """Test running_moment_function"""
     result = running_moment(signal, radius, moment, time)
     assert np.allclose(result, expected)
@@ -61,7 +61,7 @@ def test_running_moment(signal, radius, moment, time, expected):
         ([1, 2, 3, 4, 5], 1, 2, [1, 2, 3, 4]),
     ],
 )
-def test_running_moment_exception(signal, radius, moment, time):
+def test_running_moment_exception(signal, radius, moment, time) -> None:
     """Test whether exception is risen"""
     with pytest.raises(ValueError):
         running_moment(signal, radius, moment, time)

--- a/plasmapy/conftest.py
+++ b/plasmapy/conftest.py
@@ -11,7 +11,7 @@ else:
         matplotlib.use("Agg")
 
 
-def pytest_configure(config):  # coverage: ignore
+def pytest_configure(config) -> None:  # coverage: ignore
     """Adds @pytest.mark.slow annotation for marking slow tests for optional skipping."""
     config.addinivalue_line(
         "markers",

--- a/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -301,7 +301,7 @@ class Tracker:
 
         return np.max(theta)
 
-    def _log(self, msg):
+    def _log(self, msg) -> None:
         if self.verbose:
             # We'll need to switch from print() to using logging library
             print(msg)  # noqa: T201
@@ -579,7 +579,7 @@ class Tracker:
         max_theta=None,
         particle: Particle = Particle("p+"),  # noqa: B008
         distribution="monte-carlo",
-    ):
+    ) -> None:
         r"""
         Generates the angular distributions about the Z-axis, then
         rotates those distributions to align with the source-to-detector axis.
@@ -804,7 +804,7 @@ class Tracker:
         # with the largest gridstep
         return np.where(dt == np.inf, np.max(gridstep), dt)
 
-    def _coast_to_grid(self):
+    def _coast_to_grid(self) -> None:
         r"""
         Coasts all particles to the timestep when the first particle should
         be entering the grid. Doing in this in one step (rather than pushing
@@ -862,7 +862,7 @@ class Tracker:
 
         return x
 
-    def _remove_deflected_particles(self):
+    def _remove_deflected_particles(self) -> None:
         r"""
         Removes any particles that have been deflected away from the detector
         plane (eg. those that will never hit the grid).
@@ -898,7 +898,7 @@ class Tracker:
                 RuntimeWarning,
             )
 
-    def _push(self):
+    def _push(self) -> None:
         r"""
         Advance particles using an implementation of the time-centered
         Boris algorithm.
@@ -1284,7 +1284,7 @@ class Tracker:
             "v0": v0,
         }
 
-    def save_results(self, path):
+    def save_results(self, path) -> None:
         """
         Save the simulations results :attr:`results_dict` to a `numpy`
         ``.npz`` file format (see `numpy.lib.format`) using `numpy.savez`.

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_detector_stacks.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_detector_stacks.py
@@ -48,7 +48,7 @@ def hdv2_stack(tmp_path):
     return Stack(layers)
 
 
-def test_create_layer_with_different_stopping_powers(tmp_path):
+def test_create_layer_with_different_stopping_powers(tmp_path) -> None:
     """
     Tests the input validation for creating a Layer with either the linear
     stopping power or the mass stopping power.
@@ -81,22 +81,22 @@ def test_create_layer_with_different_stopping_powers(tmp_path):
         Layer(100 * u.um, eaxis, mass_stopping_power, mass_density=None)
 
 
-def test_film_stack_num_layers(hdv2_stack):
+def test_film_stack_num_layers(hdv2_stack) -> None:
     # Test num_layers property
     assert hdv2_stack.num_layers == 21
 
 
-def test_film_stack_num_active(hdv2_stack):
+def test_film_stack_num_active(hdv2_stack) -> None:
     # Test num_active property
     assert hdv2_stack.num_active == 10
 
 
-def test_film_stack_thickness(hdv2_stack):
+def test_film_stack_thickness(hdv2_stack) -> None:
     # Test thickness property
     assert np.isclose(hdv2_stack.thickness.to(u.mm).value, 1.19)
 
 
-def test_film_stack_deposition_curves(hdv2_stack):
+def test_film_stack_deposition_curves(hdv2_stack) -> None:
     energies = np.arange(1, 60, 1) * u.MeV
     deposition_curves = hdv2_stack.deposition_curves(energies, return_only_active=False)
 
@@ -106,7 +106,7 @@ def test_film_stack_deposition_curves(hdv2_stack):
     ), "The integral over all layers for each particle species is not unity."
 
 
-def test_film_stack_energy_bands_active(hdv2_stack):
+def test_film_stack_energy_bands_active(hdv2_stack) -> None:
     # Test energy bands
     ebands = hdv2_stack.energy_bands([0.1, 60] * u.MeV, 0.1 * u.MeV, dx=1 * u.um)
 
@@ -116,7 +116,7 @@ def test_film_stack_energy_bands_active(hdv2_stack):
     assert np.allclose(ebands.to(u.MeV).value[:5, :], expected, atol=0.15)
 
 
-def test_film_stack_energy_bands_inum_active(hdv2_stack):
+def test_film_stack_energy_bands_inum_active(hdv2_stack) -> None:
     # Test including inum_active layers
     ebands = hdv2_stack.energy_bands(
         [0.1, 60] * u.MeV, 0.1 * u.MeV, dx=1 * u.um, return_only_active=False

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -133,7 +133,7 @@ def _test_grid(  # noqa: C901, PLR0912
 
 @pytest.mark.slow()
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_multiple_grids():
+def test_multiple_grids() -> None:
     """
     Test that a case with two grids runs.
 
@@ -235,7 +235,7 @@ def run_mesh_example(
 
 
 @pytest.mark.slow()
-def test_1D_deflections():
+def test_1D_deflections() -> None:
     # Check B-deflection
     hax, lineout = run_1D_example("constant_bz")
     loc = hax[np.argmax(lineout)]
@@ -248,7 +248,7 @@ def test_1D_deflections():
 
 
 @pytest.mark.slow()
-def test_coordinate_systems():
+def test_coordinate_systems() -> None:
     """
     Check that specifying the same point in different coordinate systems
     ends up with identical source and detector vectors.
@@ -278,7 +278,7 @@ def test_coordinate_systems():
 
 
 @pytest.mark.slow()
-def test_input_validation():
+def test_input_validation() -> None:
     """
     Intentionally raise a number of errors.
     """
@@ -359,7 +359,7 @@ def test_input_validation():
 
 
 @pytest.mark.slow()
-def test_init():
+def test_init() -> None:
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
     # Cartesian
@@ -386,7 +386,7 @@ def test_init():
 
 
 @pytest.mark.slow()
-def test_create_particles():
+def test_create_particles() -> None:
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
     # Cartesian
@@ -406,7 +406,7 @@ def test_create_particles():
 
 
 @pytest.mark.slow()
-def test_load_particles():
+def test_load_particles() -> None:
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
     # Cartesian
@@ -438,7 +438,7 @@ def test_load_particles():
 
 
 @pytest.mark.slow()
-def test_run_options():
+def test_run_options() -> None:
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
 
     # Cartesian
@@ -533,12 +533,12 @@ class TestSyntheticRadiograph:
             ((tracker_obj_not_simulated,), {}, RuntimeError),
         ],
     )
-    def test_raises(self, args, kwargs, _raises):
+    def test_raises(self, args, kwargs, _raises) -> None:
         """Test scenarios the raise an Exception."""
         with pytest.raises(_raises):
             cpr.synthetic_radiograph(*args, **kwargs)
 
-    def test_warns(self):
+    def test_warns(self) -> None:
         """
         Test warning when less than half the particles reach the detector plane.
         """
@@ -582,7 +582,7 @@ class TestSyntheticRadiograph:
             ),
         ],
     )
-    def test_intensity_histogram(self, args, kwargs, expected):
+    def test_intensity_histogram(self, args, kwargs, expected) -> None:
         """Test several valid use cases."""
         results = cpr.synthetic_radiograph(*args, **kwargs)
 
@@ -607,7 +607,7 @@ class TestSyntheticRadiograph:
         assert histogram.shape == expected["bins"]
 
     @pytest.mark.filterwarnings("ignore:divide by zero:RuntimeWarning")
-    def test_optical_density_histogram(self):
+    def test_optical_density_histogram(self) -> None:
         """
         Test the optical density calculation is correct and stuffed
         with numpy.inf when the intensity is zero.
@@ -635,7 +635,7 @@ class TestSyntheticRadiograph:
 
 
 @pytest.mark.slow()
-def test_saving_output(tmp_path):
+def test_saving_output(tmp_path) -> None:
     """Test behavior of Tracker.save_results."""
 
     sim = create_tracker_obj()
@@ -665,7 +665,7 @@ def test_saving_output(tmp_path):
     "case",
     ["creating particles", "loading particles", "adding a wire mesh"],
 )
-def test_cannot_modify_simulation_after_running(case):
+def test_cannot_modify_simulation_after_running(case) -> None:
     """
     Test that a Tracker objection can not be modified after it is
     run (Tracker.run).
@@ -692,7 +692,7 @@ def test_cannot_modify_simulation_after_running(case):
 
 
 @pytest.mark.slow()
-def test_gaussian_sphere_analytical_comparison():
+def test_gaussian_sphere_analytical_comparison() -> None:
     """
     Run a known example problem and compare it to a theoretical
     model for small deflections.
@@ -788,7 +788,7 @@ def test_gaussian_sphere_analytical_comparison():
 
 
 @pytest.mark.slow()
-def test_add_wire_mesh():
+def test_add_wire_mesh() -> None:
     # ************************************************************
     # Test various input configurations
     # ************************************************************
@@ -901,7 +901,7 @@ def test_add_wire_mesh():
 
 @pytest.mark.slow()
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_multiple_grids2():
+def test_multiple_grids2() -> None:
     """
     Test that a case with two grids runs.
     TODO: automate test by including two fields with some obvious analytical

--- a/plasmapy/diagnostics/langmuir.py
+++ b/plasmapy/diagnostics/langmuir.py
@@ -115,7 +115,7 @@ class Characteristic:
         b.current += other.current
         return b
 
-    def sort(self):
+    def sort(self) -> None:
         r"""Sort the characteristic by ascending bias."""
 
         _sort = self.bias.argsort()
@@ -196,7 +196,7 @@ class Characteristic:
                 ymax + padding * (ymax - ymin),
             ] * u.A
 
-    def plot(self):
+    def plot(self) -> None:
         r"""Plot the characteristic in matplotlib."""
         import matplotlib.pyplot as plt
 

--- a/plasmapy/diagnostics/tests/test_langmuir.py
+++ b/plasmapy/diagnostics/tests/test_langmuir.py
@@ -24,7 +24,7 @@ class Test__fitting_functions:
     T0 = 3
     Delta_T = 15
 
-    def test_fit_func_lin(self):
+    def test_fit_func_lin(self) -> None:
         r"""Test linear fitting function"""
 
         value = langmuir._fit_func_lin(self.x, self.x0, self.y0, self.c0)
@@ -36,7 +36,7 @@ class Test__fitting_functions:
         )
         assert value == expect_value, errStr
 
-    def test_fit_func_lin_inverse(self):
+    def test_fit_func_lin_inverse(self) -> None:
         r"""Test linear fitting function with inverse slope"""
 
         value = langmuir._fit_func_lin_inverse(self.x, self.x0, self.y0, self.T0)
@@ -49,7 +49,7 @@ class Test__fitting_functions:
         )
         assert np.allclose(value, expect_value), errStr
 
-    def test_fit_func_double_lin_inverse(self):
+    def test_fit_func_double_lin_inverse(self) -> None:
         r"""Test double linear fitting function with inverse slope and an offset
         for use in fitting a bi-Maxwellian electron current growth region"""
 
@@ -83,7 +83,7 @@ class Test__characteristic_errors:
 
     current_arr2 = np.random.rand(N) * u.A  # noqa: NPY002
 
-    def test_invalid_dimensions(self):
+    def test_invalid_dimensions(self) -> None:
         r"""Test 2D arrays work with Characteristic class"""
 
         # `Characteristic.get_unique_bias` runs during initialization
@@ -91,19 +91,19 @@ class Test__characteristic_errors:
         with pytest.warns(FutureWarning):
             langmuir.Characteristic(self.bias_2darr, self.current_2darr)
 
-    def test_infinite_I(self):
+    def test_infinite_I(self) -> None:
         r"""Test error upon an infinite current value"""
 
         with pytest.raises(ValueError):
             langmuir.Characteristic(bias_arr, self.current_infarr)
 
-    def test_infinite_U(self):
+    def test_infinite_U(self) -> None:
         r"""Test error upon an infinite bias value"""
 
         with pytest.raises(ValueError):
             langmuir.Characteristic(self.bias_infarr, current_arr)
 
-    def test_unequal_arrays(self):
+    def test_unequal_arrays(self) -> None:
         r"""Test errors upon unequal array lengths"""
 
         with pytest.raises(ValueError):
@@ -114,7 +114,7 @@ class Test__characteristic_errors:
             with pytest.warns(FutureWarning):
                 langmuir.Characteristic(bias_arr, self.current_longarr)
 
-    def test_addition(self):
+    def test_addition(self) -> None:
         r"""Test addition of characteristic objects"""
 
         with pytest.warns(FutureWarning):
@@ -127,7 +127,7 @@ class Test__characteristic_errors:
         errStr = "Addition of characteristic objects is not behaving as it should."
         assert (a.current + b.current == ab_sum.current).all(), errStr
 
-    def test_subtraction(self):
+    def test_subtraction(self) -> None:
         r"""Test addition of characteristic objects"""
 
         with pytest.warns(FutureWarning):
@@ -198,7 +198,7 @@ class DryCharacteristic(langmuir.Characteristic):
     unique values.
     """
 
-    def __init__(self, bias, current):
+    def __init__(self, bias, current) -> None:
         super().__init__(bias, current)
         self.bias = bias
         self.current = current
@@ -218,26 +218,26 @@ class Test__Characteristic_inherited_methods:
 
     bias_duplicates_arr = np.array((1, 2) * int(N / 2)) * u.V
 
-    def test_invalid_bias_dimensions(self):
+    def test_invalid_bias_dimensions(self) -> None:
         r"""Test error on non-1D bias array"""
         with pytest.raises(ValueError):
             with pytest.warns(FutureWarning):
                 DryCharacteristic(self.bias_2darr, current_arr)
 
-    def test_invalid_current_dimensions(self):
+    def test_invalid_current_dimensions(self) -> None:
         r"""Test error on non-1d current array"""
         with pytest.raises(ValueError):
             with pytest.warns(FutureWarning):
                 DryCharacteristic(bias_arr, self.current_2darr)
 
-    def test_bias_and_current_length_mismatch(self):
+    def test_bias_and_current_length_mismatch(self) -> None:
         r"""Test error on non-1d bias and current arrays"""
 
         with pytest.raises(ValueError):
             with pytest.warns(FutureWarning):
                 DryCharacteristic(self.bias_4length_arr, self.current_5length_arr)
 
-    def test_duplicate_bias_values(self):
+    def test_duplicate_bias_values(self) -> None:
         r"""Test error on bias array containing duplicate values"""
 
         with pytest.raises(ValueError):
@@ -245,7 +245,7 @@ class Test__Characteristic_inherited_methods:
                 DryCharacteristic(self.bias_duplicates_arr, current_arr)
 
     @staticmethod
-    def test_inplace_unique_bias():
+    def test_inplace_unique_bias() -> None:
         r"""Test new Characteristic instance being returned"""
 
         with pytest.warns(FutureWarning):
@@ -256,7 +256,7 @@ class Test__Characteristic_inherited_methods:
         assert isinstance(new_char, langmuir.Characteristic)
 
     @staticmethod
-    def test_getpadded_limit(characteristic):
+    def test_getpadded_limit(characteristic) -> None:
         r"""Test padding limit on Characteristic instance"""
 
         char = characteristic
@@ -271,7 +271,7 @@ class Test__swept_probe_analysis:
     r"""Test the swept_probe_analysis function in langmuir.py"""
 
     @staticmethod
-    def test_nan_area():
+    def test_nan_area() -> None:
         r"""Test error upon NaN area"""
 
         with pytest.raises(ValueError):
@@ -281,7 +281,7 @@ class Test__swept_probe_analysis:
                 )
 
     @staticmethod
-    def test_unit_conversion_error():
+    def test_unit_conversion_error() -> None:
         r"""Test error upon incorrect probe area unit"""
 
         with pytest.raises(u.UnitTypeError):
@@ -289,7 +289,7 @@ class Test__swept_probe_analysis:
                 langmuir.swept_probe_analysis(characteristic, 1 * u.cm, "Ar-40 1+")
 
     @staticmethod
-    def test_negative_area():
+    def test_negative_area() -> None:
         r"""Test error upon negative probe area"""
 
         with pytest.raises(ValueError):
@@ -298,7 +298,7 @@ class Test__swept_probe_analysis:
 
     @staticmethod
     @pytest.mark.parametrize("bimaxwellian", [True, False])
-    def test_ordering_invariance(bimaxwellian, characteristic_simulated):
+    def test_ordering_invariance(bimaxwellian, characteristic_simulated) -> None:
         r"""Test invariance to ordering of the bias and current values"""
 
         with pytest.warns(FutureWarning):
@@ -322,7 +322,7 @@ class Test__swept_probe_analysis:
             assert (sim_result[key] == sim_result_shuffled[key]).all(), errStr
 
 
-def test_get_floating_potential_with_return_arg(characteristic):
+def test_get_floating_potential_with_return_arg(characteristic) -> None:
     r"""Test floating potential and the return argument"""
 
     with pytest.warns(FutureWarning):
@@ -332,7 +332,7 @@ def test_get_floating_potential_with_return_arg(characteristic):
     assert np.allclose((potential.to(u.V).value, arg), (0.12203823, 5))
 
 
-def test_get_ion_density_OML_without_return_fit(characteristic):
+def test_get_ion_density_OML_without_return_fit(characteristic) -> None:
     r"""Test ion density without returning the fit value"""
 
     with pytest.warns(FutureWarning):
@@ -342,7 +342,7 @@ def test_get_ion_density_OML_without_return_fit(characteristic):
     assert np.isclose(density.value, 385344135.12064785)
 
 
-def test_get_EEDF():
+def test_get_EEDF() -> None:
     """Test the obtained EEDF"""
 
     with pytest.warns(FutureWarning):

--- a/plasmapy/diagnostics/tests/test_thomson.py
+++ b/plasmapy/diagnostics/tests/test_thomson.py
@@ -188,7 +188,7 @@ def single_species_collective_spectrum(single_species_collective_args):
 
 
 @pytest.mark.slow()
-def test_single_species_collective_spectrum(single_species_collective_spectrum):
+def test_single_species_collective_spectrum(single_species_collective_spectrum) -> None:
     """
     Compares the generated spectrum to previously determined values
     """
@@ -217,7 +217,7 @@ def test_single_species_collective_spectrum(single_species_collective_spectrum):
 
 
 @pytest.mark.slow()
-def test_spectral_density_minimal_arguments(single_species_collective_args):
+def test_spectral_density_minimal_arguments(single_species_collective_args) -> None:
     """
     Check that spectral density runs with minimal arguments
     """
@@ -242,7 +242,7 @@ def test_spectral_density_minimal_arguments(single_species_collective_args):
     alpha, Skw = thomson.spectral_density(*args, **kwargs)
 
 
-def test_single_species_collective_lite(single_species_collective_args):
+def test_single_species_collective_lite(single_species_collective_args) -> None:
     # Make a copy of the input args
     args_fixture_copy = copy.copy(single_species_collective_args)
     args, kwargs = spectral_density_args_kwargs(single_species_collective_args)
@@ -257,7 +257,9 @@ def test_single_species_collective_lite(single_species_collective_args):
     assert np.allclose(Skw1.to(u.s / u.rad).value, Skw2)
 
 
-def test_spectral_density_lite_minimal_arguments(single_species_collective_args):
+def test_spectral_density_lite_minimal_arguments(
+    single_species_collective_args,
+) -> None:
     lite_kwargs = args_to_lite_args(single_species_collective_args)
     args, kwargs = spectral_density_args_kwargs(lite_kwargs)
 
@@ -300,14 +302,14 @@ def multiple_species_collective_args():
     return kwargs
 
 
-def test_efract_sum_error(single_species_collective_args):
+def test_efract_sum_error(single_species_collective_args) -> None:
     args, kwargs = spectral_density_args_kwargs(single_species_collective_args)
     kwargs["efract"] = np.array([2.0])  # Sum is not 1
     with pytest.raises(ValueError):
         alpha, Skw = thomson.spectral_density(*args, **kwargs)
 
 
-def test_ifract_sum_error(single_species_collective_args):
+def test_ifract_sum_error(single_species_collective_args) -> None:
     args, kwargs = spectral_density_args_kwargs(single_species_collective_args)
     kwargs["ifract"] = np.array([0.5, 1.2])  # Sum is not 1
     with pytest.raises(ValueError):
@@ -331,7 +333,9 @@ def multiple_species_collective_spectrum(multiple_species_collective_args):
     return (alpha, wavelengths, Skw)
 
 
-def test_multiple_species_collective_spectrum(multiple_species_collective_spectrum):
+def test_multiple_species_collective_spectrum(
+    multiple_species_collective_spectrum,
+) -> None:
     """
     Compares the generated spectrum to previously determined values
     """
@@ -408,7 +412,9 @@ def single_species_non_collective_spectrum(single_species_non_collective_args):
 
 
 @pytest.mark.slow()
-def test_single_species_non_collective_spectrum(single_species_non_collective_spectrum):
+def test_single_species_non_collective_spectrum(
+    single_species_non_collective_spectrum,
+) -> None:
     """
     Compares the generated spectrum to previously determined values
     """
@@ -512,7 +518,7 @@ def test_single_species_non_collective_spectrum(single_species_non_collective_sp
 )
 def test_spectral_density_input_errors(
     kwargs, error, msg, single_species_collective_args
-):
+) -> None:
     """
     Validate errors with invalid argument and keyword arguments in
     spectral_density
@@ -541,7 +547,7 @@ def test_spectral_density_input_errors(
 
 
 @pytest.mark.slow()
-def test_split_populations():
+def test_split_populations() -> None:
     """
     Make sure that splitting a single population of ions or electrons
     into two identical halves returns the same result.
@@ -601,7 +607,7 @@ def test_split_populations():
     assert np.all(deviation < 1e-6), "Failed split populations test"
 
 
-def test_thomson_with_instrument_function(single_species_collective_args):
+def test_thomson_with_instrument_function(single_species_collective_args) -> None:
     """
     Generates an example Thomson scattering spectrum with an instrument
     function applied
@@ -626,7 +632,7 @@ def test_thomson_with_instrument_function(single_species_collective_args):
 def test_thomson_with_invalid_instrument_function(
     instr_func,
     single_species_collective_args,
-):
+) -> None:
     """
     Verifies that an exception is raised if the provided instrument function
     is invalid.
@@ -639,7 +645,7 @@ def test_thomson_with_invalid_instrument_function(
         alpha, Skw_with = thomson.spectral_density(*args, **kwargs)
 
 
-def test_param_to_array_fcns():
+def test_param_to_array_fcns() -> None:
     """
     Tests a few low-level routines used to convert lmfit scalar parameters
     into array input for `spectral_density` based on a naming convention
@@ -679,7 +685,7 @@ def run_fit(  # noqa: C901
     require_redchi=1,
     # If false, don't perform the actual fit but instead just create the Model
     run_fit=True,
-):
+) -> None:
     """
     Take a Parameters object, generate some synthetic data near it,
     perturb the initial values, then try a fit.
@@ -1033,7 +1039,7 @@ def noncollective_single_species_settings_params():
 
 
 @pytest.mark.slow()
-def test_fit_epw_single_species(epw_single_species_settings_params):
+def test_fit_epw_single_species(epw_single_species_settings_params) -> None:
     wavelengths, params, settings = spectral_density_model_settings_params(
         epw_single_species_settings_params
     )
@@ -1042,7 +1048,7 @@ def test_fit_epw_single_species(epw_single_species_settings_params):
 
 
 @pytest.mark.slow()
-def test_fit_epw_multi_species(epw_multi_species_settings_params):
+def test_fit_epw_multi_species(epw_multi_species_settings_params) -> None:
     wavelengths, params, settings = spectral_density_model_settings_params(
         epw_multi_species_settings_params
     )
@@ -1051,7 +1057,7 @@ def test_fit_epw_multi_species(epw_multi_species_settings_params):
 
 
 @pytest.mark.slow()
-def test_fit_iaw_single_species(iaw_single_species_settings_params):
+def test_fit_iaw_single_species(iaw_single_species_settings_params) -> None:
     wavelengths, params, settings = spectral_density_model_settings_params(
         iaw_single_species_settings_params
     )
@@ -1061,7 +1067,7 @@ def test_fit_iaw_single_species(iaw_single_species_settings_params):
 
 @pytest.mark.slow()
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_fit_iaw_instr_func(iaw_single_species_settings_params):
+def test_fit_iaw_instr_func(iaw_single_species_settings_params) -> None:
     """
     Tests fitting with an instrument function
     """
@@ -1076,7 +1082,7 @@ def test_fit_iaw_instr_func(iaw_single_species_settings_params):
 
 
 @pytest.mark.slow()
-def test_fit_iaw_multi_species(iaw_multi_species_settings_params):
+def test_fit_iaw_multi_species(iaw_multi_species_settings_params) -> None:
     wavelengths, params, settings = spectral_density_model_settings_params(
         iaw_multi_species_settings_params
     )
@@ -1085,7 +1091,9 @@ def test_fit_iaw_multi_species(iaw_multi_species_settings_params):
 
 
 @pytest.mark.slow()
-def test_fit_noncollective_single_species(noncollective_single_species_settings_params):
+def test_fit_noncollective_single_species(
+    noncollective_single_species_settings_params,
+) -> None:
     wavelengths, params, settings = spectral_density_model_settings_params(
         noncollective_single_species_settings_params
     )
@@ -1095,7 +1103,7 @@ def test_fit_noncollective_single_species(noncollective_single_species_settings_
 
 @pytest.mark.slow()
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_fit_with_instr_func(epw_single_species_settings_params):
+def test_fit_with_instr_func(epw_single_species_settings_params) -> None:
     """
 
     Check that fitting works with an instrument function.
@@ -1128,7 +1136,9 @@ def test_fit_with_instr_func(epw_single_species_settings_params):
 
 
 @pytest.mark.parametrize("instr_func", invalid_instr_func_list)
-def test_fit_with_invalid_instr_func(instr_func, iaw_single_species_settings_params):
+def test_fit_with_invalid_instr_func(
+    instr_func, iaw_single_species_settings_params
+) -> None:
     """
     Verifies that an exception is raised if the provided instrument function
     is invalid.
@@ -1144,7 +1154,7 @@ def test_fit_with_invalid_instr_func(instr_func, iaw_single_species_settings_par
 
 
 @pytest.mark.slow()
-def test_fit_with_minimal_parameters():
+def test_fit_with_minimal_parameters() -> None:
     # Create example data for fitting
     probe_wavelength = 532 * u.nm
     probe_vec = np.array([1, 0, 0])
@@ -1281,7 +1291,9 @@ def test_fit_with_minimal_parameters():
         ),
     ],
 )
-def test_model_input_validation(control, error, msg, iaw_multi_species_settings_params):
+def test_model_input_validation(
+    control, error, msg, iaw_multi_species_settings_params
+) -> None:
     kwargs = iaw_multi_species_settings_params
     # We'll need to switch from print() to using logging library
     print(list(control.keys()))  # noqa: T201

--- a/plasmapy/dispersion/analytical/tests/test_mhd_wave_class.py
+++ b/plasmapy/dispersion/analytical/tests/test_mhd_wave_class.py
@@ -42,7 +42,7 @@ class TestMHDWave:
             ({**kwargs_plasma_cold, "gamma": "wrong type"}, TypeError),
         ],
     )
-    def test_raises_init(self, kwargs, error):
+    def test_raises_init(self, kwargs, error) -> None:
         """Test scenarios that raise an exception."""
         with pytest.raises(error):
             mhd_waves(**kwargs)
@@ -62,7 +62,7 @@ class TestMHDWave:
         ],
     )
     @pytest.mark.parametrize("mode", range(3))
-    def test_raises_angular_frequency(self, kwargs, error, mode):
+    def test_raises_angular_frequency(self, kwargs, error, mode) -> None:
         """Test scenarios that raise an exception."""
         with pytest.raises(error):
             sample_waves[mode].angular_frequency(**kwargs)
@@ -81,7 +81,7 @@ class TestMHDWave:
         ],
     )
     @pytest.mark.parametrize("mode", range(3))
-    def test_warns(self, kwargs_wave, error, mode):
+    def test_warns(self, kwargs_wave, error, mode) -> None:
         """Test scenarios the issue a `Warning`."""
         with pytest.warns(error):
             sample_waves[mode].angular_frequency(**kwargs_wave)
@@ -89,7 +89,7 @@ class TestMHDWave:
     @pytest.mark.parametrize("B", [1e-3, 1e-2])
     @pytest.mark.parametrize("density", [1e16, 1e-11 * u.kg])
     @pytest.mark.parametrize("T", [0, 1e5, 1e6])
-    def test_angular_frequency_limiting_vals(self, B, density, T):
+    def test_angular_frequency_limiting_vals(self, B, density, T) -> None:
         """Test limiting values of the angular frequencies and phase velocities"""
         waves = mhd_waves(B * u.T, density * u.m**-3, "p+", T=T * u.K)
         v_a = waves[0].alfven_speed
@@ -122,7 +122,7 @@ class TestMHDWave:
             ),
         ],
     )
-    def test_angular_frequency_return_structure(self, kwargs, expected):
+    def test_angular_frequency_return_structure(self, kwargs, expected) -> None:
         assert isinstance(sample_waves, tuple)
 
         for mode in range(3):
@@ -134,7 +134,7 @@ class TestMHDWave:
     @pytest.mark.parametrize("B", [1e-3, 1e-2])
     @pytest.mark.parametrize("density", [1e16, 1e-11 * u.kg])
     @pytest.mark.parametrize("T", [0, 1e5, 1e6])
-    def test_group_velocity_vals(self, B, density, T):
+    def test_group_velocity_vals(self, B, density, T) -> None:
         """Test limiting values of the group velocities"""
         waves = mhd_waves(B * u.T, density * u.m**-3, "p+", T=T * u.K)
 

--- a/plasmapy/dispersion/analytical/tests/test_stix_.py
+++ b/plasmapy/dispersion/analytical/tests/test_stix_.py
@@ -80,7 +80,7 @@ class TestStix:
             ),
         ],
     )
-    def test_raises(self, kwargs, _error):
+    def test_raises(self, kwargs, _error) -> None:
         with pytest.raises(_error):
             stix(**kwargs)
 
@@ -133,7 +133,7 @@ class TestStix:
         ],
     )
     @pytest.mark.filterwarnings("ignore::astropy.units.UnitsWarning")
-    def test_return_structure(self, kwargs, expected):
+    def test_return_structure(self, kwargs, expected) -> None:
         k = stix(**kwargs)
 
         assert isinstance(k, u.Quantity)
@@ -234,7 +234,7 @@ class TestStix:
             ),
         ],
     )
-    def test_vals_stix_figs(self, kwargs, expected):
+    def test_vals_stix_figs(self, kwargs, expected) -> None:
         ion = kwargs["ions"][0]
 
         mu = ion.mass / Particle("e-").mass
@@ -301,7 +301,7 @@ class TestStix:
             },
         ],
     )
-    def test_vals_theta_zero(self, kwargs):
+    def test_vals_theta_zero(self, kwargs) -> None:
         """
         Test on the known solutions for theta = 0,
         see Stix ch. 1 eqn 37.
@@ -354,7 +354,7 @@ class TestStix:
             },
         ],
     )
-    def test_vals_theta_90deg(self, kwargs):
+    def test_vals_theta_90deg(self, kwargs) -> None:
         """
         Test on the known solutions for theta = pi/2,
         see Stix ch. 1 eqn 38.

--- a/plasmapy/dispersion/analytical/tests/test_two_fluid_.py
+++ b/plasmapy/dispersion/analytical/tests/test_two_fluid_.py
@@ -63,7 +63,7 @@ class TestTwoFluid:
             ({**_kwargs_single_valued, "gamma_i": "wrong type"}, TypeError),
         ],
     )
-    def test_raises(self, kwargs, _error):
+    def test_raises(self, kwargs, _error) -> None:
         """Test scenarios that raise an `Exception`."""
         with pytest.raises(_error):
             two_fluid(**kwargs)
@@ -86,7 +86,7 @@ class TestTwoFluid:
             ),
         ],
     )
-    def test_warns(self, kwargs, _warning):
+    def test_warns(self, kwargs, _warning) -> None:
         """Test scenarios the issue a `Warning`."""
         with pytest.warns(_warning):
             two_fluid(**kwargs)
@@ -108,7 +108,7 @@ class TestTwoFluid:
             ),
         ],
     )
-    def test_on_bellan2012_vals(self, kwargs, expected):
+    def test_on_bellan2012_vals(self, kwargs, expected) -> None:
         """
         Test calculated values based on Figure 1 of Bellan 2012
         (DOI: https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2012JA017856).
@@ -165,7 +165,7 @@ class TestTwoFluid:
             ),
         ],
     )
-    def test_return_structure(self, kwargs, expected):
+    def test_return_structure(self, kwargs, expected) -> None:
         """Test the structure of the returned values."""
         ws = two_fluid(**kwargs)
 

--- a/plasmapy/dispersion/numerical/tests/test_hollweg_.py
+++ b/plasmapy/dispersion/numerical/tests/test_hollweg_.py
@@ -62,7 +62,7 @@ class TestHollweg:
             ({**_kwargs_single_valued, "gamma_i": "wrong type"}, TypeError),
         ],
     )
-    def test_raises(self, kwargs, _error):
+    def test_raises(self, kwargs, _error) -> None:
         """Test scenarios that raise an `Exception`."""
         with pytest.raises(_error):
             hollweg(**kwargs)
@@ -111,7 +111,7 @@ class TestHollweg:
             ),
         ],
     )
-    def test_warning(self, kwargs, _warning):
+    def test_warning(self, kwargs, _warning) -> None:
         """Test scenarios that raise a `Warning`."""
         with pytest.warns(_warning):
             hollweg(**kwargs)
@@ -190,7 +190,7 @@ class TestHollweg:
     )
     @pytest.mark.filterwarnings("ignore::astropy.units.UnitsWarning")
     @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
-    def test_handle_k_theta_arrays(self, kwargs, expected):
+    def test_handle_k_theta_arrays(self, kwargs, expected) -> None:
         """Test scenarios involving k and theta arrays."""
         ws = hollweg(**kwargs)
         for mode, val in ws.items():
@@ -266,7 +266,7 @@ class TestHollweg:
         ],
     )
     @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
-    def test_hollweg1999_vals(self, kwargs, expected, desired_beta):
+    def test_hollweg1999_vals(self, kwargs, expected, desired_beta) -> None:
         """
         Test calculated values based on Figure 2 of Hollweg1999
         (DOI: https://doi.org/10.1029/1998JA900132) using eqn 3 of
@@ -328,7 +328,7 @@ class TestHollweg:
         ],
     )
     @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
-    def test_Z_override(self, kwargs, expected):
+    def test_Z_override(self, kwargs, expected) -> None:
         """Test overriding behavior of kw 'Z'."""
         ws = hollweg(**kwargs)
         ws_expected = hollweg(**expected)
@@ -365,7 +365,7 @@ class TestHollweg:
             ),
         ],
     )
-    def test_return_structure(self, kwargs, expected):
+    def test_return_structure(self, kwargs, expected) -> None:
         """Test the structure of the returned values."""
         ws = hollweg(**kwargs)
 

--- a/plasmapy/dispersion/numerical/tests/test_kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/tests/test_kinetic_alfven_.py
@@ -58,7 +58,7 @@ class TestKinetic_Alfven:
             ({**_kwargs_single_valued, "Z": "wrong type"}, TypeError),
         ],
     )
-    def test_raises(self, kwargs, _error):
+    def test_raises(self, kwargs, _error) -> None:
         """Test scenarios that raise an `Exception`."""
         with pytest.raises(_error):
             kinetic_alfven(**kwargs)
@@ -90,7 +90,7 @@ class TestKinetic_Alfven:
         ],
     )
     @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
-    def test_return_structure(self, kwargs, expected):
+    def test_return_structure(self, kwargs, expected) -> None:
         """Test the structure of the returned values."""
         ws = kinetic_alfven(**kwargs)
 
@@ -145,7 +145,7 @@ class TestKinetic_Alfven:
             ),
         ],
     )
-    def test_warning(self, kwargs, _warning):
+    def test_warning(self, kwargs, _warning) -> None:
         """Test scenarios that raise a `Warning`."""
         with pytest.warns(_warning):
             kinetic_alfven(**kwargs)

--- a/plasmapy/dispersion/tests/test_dispersion_functions.py
+++ b/plasmapy/dispersion/tests/test_dispersion_functions.py
@@ -43,7 +43,7 @@ class TestPlasmaDispersionFunction:
     """Test class for `plasmapy.dispersion.plasma_dispersion_func`."""
 
     @pytest.mark.parametrize(("w", "expected"), plasma_dispersion_func_table)
-    def test_plasma_dispersion_func(self, w, expected):
+    def test_plasma_dispersion_func(self, w, expected) -> None:
         r"""Test plasma_dispersion_func against tabulated results and
         known symmetry properties."""
 
@@ -61,7 +61,7 @@ class TestPlasmaDispersionFunction:
 
     @given(complex_numbers(allow_infinity=False, allow_nan=False, max_magnitude=20))
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-    def test_plasma_dispersion_func_symmetry(self, w):
+    def test_plasma_dispersion_func_symmetry(self, w) -> None:
         r"""Test plasma_dispersion_func against its symmetry properties"""
 
         # The two symmetry properties of the plasma dispersion function
@@ -149,7 +149,7 @@ class TestPlasmaDispersionFunction:
             f"{Z_of_w_array - Z_power_series}\n"
         )
 
-    def test_plasma_dispersion_func_roots(self):
+    def test_plasma_dispersion_func_roots(self) -> None:
         """Test roots of the plasma dispersion function."""
 
         # The first five roots of the plasma dispersion function are given
@@ -178,7 +178,7 @@ class TestPlasmaDispersionFunction:
 
     @pytest.mark.parametrize(("w", "expected_error"), plasma_disp_func_errors_table)
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-    def test_plasma_dispersion_func_errors(self, w, expected_error):
+    def test_plasma_dispersion_func_errors(self, w, expected_error) -> None:
         """Test errors that should be raised by plasma_dispersion_func."""
 
         with pytest.raises(expected_error, match=r".*plasma_dispersion_func.*"):
@@ -208,7 +208,7 @@ class TestPlasmaDispersionFunctionDeriv:
     """Test class for `plasmapy.dispersion.plasma_dispersion_func_deriv`."""
 
     @pytest.mark.parametrize(("w", "expected"), plasma_disp_deriv_table)
-    def test_plasma_dispersion_func_deriv(self, w, expected):
+    def test_plasma_dispersion_func_deriv(self, w, expected) -> None:
         r"""Test plasma_dispersion_func_deriv against tabulated results"""
 
         # The tabulated results are taken from Fried & Conte (1961)
@@ -225,7 +225,7 @@ class TestPlasmaDispersionFunctionDeriv:
 
     @given(complex_numbers(allow_infinity=True, allow_nan=False))
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-    def test_plasma_dispersion_func_deriv_characterization(self, w):
+    def test_plasma_dispersion_func_deriv_characterization(self, w) -> None:
         r"""Test plasma_dispersion_func_deriv against an exact relationship."""
 
         # The exact analytical relationship comes from the bottom of
@@ -249,7 +249,7 @@ class TestPlasmaDispersionFunctionDeriv:
 
     @pytest.mark.parametrize(("w", "expected_error"), plasma_disp_func_errors_table)
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-    def test_plasma_dispersion_deriv_errors(self, w, expected_error):
+    def test_plasma_dispersion_deriv_errors(self, w, expected_error) -> None:
         """Test errors that should be raised by plasma_dispersion_func_deriv."""
 
         with pytest.raises(expected_error, match=r".*plasma_dispersion_func_deriv.*"):

--- a/plasmapy/formulary/collisions/helio/tests/test_collisional_analysis.py
+++ b/plasmapy/formulary/collisions/helio/tests/test_collisional_analysis.py
@@ -110,6 +110,6 @@ class Testcollisional_thermalization:
     )
     @pytest.mark.slow()
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-    def test_raises(self, kwargs, _error):
+    def test_raises(self, kwargs, _error) -> None:
         with pytest.raises(_error):
             temp_ratio(**kwargs)

--- a/plasmapy/formulary/collisions/tests/test_coulomb.py
+++ b/plasmapy/formulary/collisions/tests/test_coulomb.py
@@ -20,7 +20,7 @@ from plasmapy.utils.exceptions import (
 
 class Test_Coulomb_logarithm:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.temperature1 = 10 * 11604 * u.K
         cls.T_arr = np.array([1, 2]) * u.eV
@@ -78,13 +78,13 @@ class Test_Coulomb_logarithm:
             {"method": "GMS-6", "z_mean": 1.0 * u.dimensionless_unscaled},
         ],
     )
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             Coulomb_logarithm, insert_some_nans, insert_all_nans, kwargs
         )
 
-    def test_unknown_method(self):
+    def test_unknown_method(self) -> None:
         """Test that function will raise ValueError on non-existent method"""
         with pytest.raises(ValueError):
             Coulomb_logarithm(
@@ -94,7 +94,7 @@ class Test_Coulomb_logarithm:
                 method="welcome our new microsoft overlords",
             )
 
-    def test_handle_invalid_V(self):
+    def test_handle_invalid_V(self) -> None:
         """Test that V default, V = None, and V = np.nan all give the same result"""
         with pytest.warns(CouplingWarning):
             methodVal_0 = Coulomb_logarithm(
@@ -120,7 +120,7 @@ class Test_Coulomb_logarithm:
         assert_quantity_allclose(methodVal_0, methodVal_1)
         assert_quantity_allclose(methodVal_0, methodVal_2)
 
-    def test_handle_zero_V(self):
+    def test_handle_zero_V(self) -> None:
         """Test that V == 0 returns a PhysicsError"""
         with pytest.raises(PhysicsError):
             Coulomb_logarithm(
@@ -131,7 +131,7 @@ class Test_Coulomb_logarithm:
                 V=0 * u.m / u.s,
             )
 
-    def test_handle_V_arraysizes(self):
+    def test_handle_V_arraysizes(self) -> None:
         """Test that different sized V input array gets handled by _boilerplate"""
         with pytest.warns(CouplingWarning):
             methodVal_0 = Coulomb_logarithm(
@@ -158,7 +158,7 @@ class Test_Coulomb_logarithm:
         assert_quantity_allclose(methodVal_0[0], methodVal_2[0])
         assert_quantity_allclose(methodVal_1[1], methodVal_2[1])
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         with pytest.warns(CouplingWarning):
             lnLambda = Coulomb_logarithm(
                 self.temperature1, self.density2, self.particles
@@ -168,7 +168,7 @@ class Test_Coulomb_logarithm:
             )
         assert lnLambda == lnLambdaRev
 
-    def test_Chen_Q_machine(self):
+    def test_Chen_Q_machine(self) -> None:
         """
         Tests whether Coulomb logarithm gives value consistent with
         Chen's Introduction to Plasma Physics and Controlled Fusion
@@ -189,7 +189,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_Chen_lab(self):
+    def test_Chen_lab(self) -> None:
         """
         Tests whether Coulomb logarithm gives value consistent with
         Chen's Introduction to Plasma Physics and Controlled Fusion
@@ -210,7 +210,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_Chen_torus(self):
+    def test_Chen_torus(self) -> None:
         """
         Tests whether Coulomb logarithm gives value consistent with
         Chen's Introduction to Plasma Physics and Controlled Fusion
@@ -231,7 +231,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_Chen_fusion(self):
+    def test_Chen_fusion(self) -> None:
         """
         Tests whether Coulomb logarithm gives value consistent with
         Chen's Introduction to Plasma Physics and Controlled Fusion
@@ -253,7 +253,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_Chen_laser(self):
+    def test_Chen_laser(self) -> None:
         """
         Tests whether Coulomb logarithm gives value consistent with
         Chen's Introduction to Plasma Physics and Controlled Fusion
@@ -275,7 +275,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_ls_min_interp(self):
+    def test_ls_min_interp(self) -> None:
         """
         Test for first version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -296,7 +296,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS1(self):
+    def test_GMS1(self) -> None:
         """
         Test for first version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -317,7 +317,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_ls_min_interp_negative(self):
+    def test_ls_min_interp_negative(self) -> None:
         """
         Test for first version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks for when
@@ -333,7 +333,7 @@ class Test_Coulomb_logarithm:
                 method="ls_min_interp",
             )
 
-    def test_GMS1_negative(self):
+    def test_GMS1_negative(self) -> None:
         """
         Test for first version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks for when
@@ -349,7 +349,7 @@ class Test_Coulomb_logarithm:
                 method="GMS-1",
             )
 
-    def test_ls_full_interp(self):
+    def test_ls_full_interp(self) -> None:
         """
         Test for second version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -370,7 +370,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS2(self):
+    def test_GMS2(self) -> None:
         """
         Test for second version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -391,7 +391,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_ls_full_interp_negative(self):
+    def test_ls_full_interp_negative(self) -> None:
         """
         Test for second version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks for when
@@ -407,7 +407,7 @@ class Test_Coulomb_logarithm:
                 method="ls_full_interp",
             )
 
-    def test_GMS2_negative(self):
+    def test_GMS2_negative(self) -> None:
         """
         Test for second version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks for when
@@ -423,7 +423,7 @@ class Test_Coulomb_logarithm:
                 method="GMS-2",
             )
 
-    def test_ls_clamp_mininterp(self):
+    def test_ls_clamp_mininterp(self) -> None:
         """
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -444,7 +444,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS3(self):
+    def test_GMS3(self) -> None:
         """
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -465,7 +465,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_ls_clamp_mininterp_negative(self):
+    def test_ls_clamp_mininterp_negative(self) -> None:
         """
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -490,7 +490,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS3_negative(self):
+    def test_GMS3_negative(self) -> None:
         """
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -513,7 +513,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_ls_clamp_mininterp_non_scalar_density(self):
+    def test_ls_clamp_mininterp_non_scalar_density(self) -> None:
         """
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -538,7 +538,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue.all(), errStr
 
-    def test_GMS3_non_scalar_density(self):
+    def test_GMS3_non_scalar_density(self) -> None:
         """
         Test for third version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -561,7 +561,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue.all(), errStr
 
-    def test_hls_min_interp(self):
+    def test_hls_min_interp(self) -> None:
         """
         Test for fourth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -582,7 +582,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS4(self):
+    def test_GMS4(self) -> None:
         """
         Test for fourth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -603,7 +603,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_hls_min_interp_negative(self):
+    def test_hls_min_interp_negative(self) -> None:
         """
         Test for fourth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -628,7 +628,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS4_negative(self):
+    def test_GMS4_negative(self) -> None:
         """
         Test for fourth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -651,7 +651,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_hls_max_interp(self):
+    def test_hls_max_interp(self) -> None:
         """
         Test for fifth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -672,7 +672,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS5(self):
+    def test_GMS5(self) -> None:
         """
         Test for fifth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -693,7 +693,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_hls_max_interp_negative(self):
+    def test_hls_max_interp_negative(self) -> None:
         """
         Test for fifth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -718,7 +718,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS5_negative(self):
+    def test_GMS5_negative(self) -> None:
         """
         Test for fifth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -741,7 +741,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_hls_full_interp(self):
+    def test_hls_full_interp(self) -> None:
         """
         Test for sixth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -762,7 +762,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS6(self):
+    def test_GMS6(self) -> None:
         """
         Test for sixth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002).
@@ -783,7 +783,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_hls_full_interp_negative(self):
+    def test_hls_full_interp_negative(self) -> None:
         """
         Test for sixth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -808,7 +808,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_GMS6_negative(self):
+    def test_GMS6_negative(self) -> None:
         """
         Test for sixth version of Coulomb logarithm from Gericke,
         Murillo, and Schlanges PRE (2002). This checks whether
@@ -831,7 +831,7 @@ class Test_Coulomb_logarithm:
         )
         assert testTrue, errStr
 
-    def test_ls_full_interp_zmean_error(self):
+    def test_ls_full_interp_zmean_error(self) -> None:
         """
         Tests whether ls_full_interp raises z_mean error when a z_mean is not
         provided.
@@ -844,7 +844,7 @@ class Test_Coulomb_logarithm:
                 method="ls_full_interp",
             )
 
-    def test_GMS2_zmean_error(self):
+    def test_GMS2_zmean_error(self) -> None:
         """
         Tests whether GMS-2 raises z_mean error when a z_mean is not
         provided.
@@ -854,7 +854,7 @@ class Test_Coulomb_logarithm:
                 self.temperature2, self.density2, self.particles, method="GMS-2"
             )
 
-    def test_hls_max_interp_zmean_error(self):
+    def test_hls_max_interp_zmean_error(self) -> None:
         """
         Tests whether hls_max_interp raises z_mean error when a z_mean is not
         provided.
@@ -867,7 +867,7 @@ class Test_Coulomb_logarithm:
                 method="hls_max_interp",
             )
 
-    def test_GMS5_zmean_error(self):
+    def test_GMS5_zmean_error(self) -> None:
         """
         Tests whether GMS-5 raises z_mean error when a z_mean is not
         provided.
@@ -877,7 +877,7 @@ class Test_Coulomb_logarithm:
                 self.temperature2, self.density2, self.particles, method="GMS-5"
             )
 
-    def test_hls_full_interp_zmean_error(self):
+    def test_hls_full_interp_zmean_error(self) -> None:
         """
         Tests whether hls_full_interp raises z_mean error when a z_mean is not
         provided.
@@ -890,7 +890,7 @@ class Test_Coulomb_logarithm:
                 method="hls_full_interp",
             )
 
-    def test_GMS6_zmean_error(self):
+    def test_GMS6_zmean_error(self) -> None:
         """
         Tests whether GMS-6 raises z_mean error when a z_mean is not
         provided.
@@ -900,17 +900,17 @@ class Test_Coulomb_logarithm:
                 self.temperature2, self.density2, self.particles, method="GMS-6"
             )
 
-    def test_relativity_warn(self):
+    def test_relativity_warn(self) -> None:
         """Tests whether relativity warning is raised at high velocity."""
         with pytest.warns(RelativityWarning):
             Coulomb_logarithm(1e5 * u.K, 1 * u.m**-3, ("e", "p"), V=0.9 * c)
 
-    def test_relativity_error(self):
+    def test_relativity_error(self) -> None:
         """Tests whether relativity error is raised at light speed."""
         with pytest.raises(RelativityError):
             Coulomb_logarithm(1e5 * u.K, 1 * u.m**-3, ("e", "p"), V=1.1 * c)
 
-    def test_unit_conversion_error(self):
+    def test_unit_conversion_error(self) -> None:
         """
         Tests whether unit conversion error is raised when arguments
         are given with incorrect units.
@@ -920,14 +920,14 @@ class Test_Coulomb_logarithm:
                 1e5 * u.g, 1 * u.m**-3, ("e", "p"), V=29979245 * u.m / u.s
             )
 
-    def test_single_particle_error(self):
+    def test_single_particle_error(self) -> None:
         """
         Tests whether an error is raised if only a single particle is given.
         """
         with pytest.raises(ValueError):
             Coulomb_logarithm(1 * u.K, 5 * u.m**-3, "e")
 
-    def test_invalid_particle_error(self):
+    def test_invalid_particle_error(self) -> None:
         """
         Tests whether an error is raised when an invalid particle name
         is given.

--- a/plasmapy/formulary/collisions/tests/test_dimensionless.py
+++ b/plasmapy/formulary/collisions/tests/test_dimensionless.py
@@ -12,7 +12,7 @@ from plasmapy.utils.exceptions import CouplingWarning, PhysicsWarning
 
 class Test_coupling_parameter:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 11604 * u.K
         cls.n_e = 1e21 * u.cm**-3
@@ -23,12 +23,12 @@ class Test_coupling_parameter:
         cls.True_zmean = 10.689750083758698
         cls.True_quantum = 0.3334662805238162
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         result = coupling_parameter(self.T, self.n_e, self.particles)
         resultRev = coupling_parameter(self.T, self.n_e, self.particles[::-1])
         assert result == resultRev
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test for known value.
         """
@@ -44,7 +44,7 @@ class Test_coupling_parameter:
         errStr = f"Coupling parameter should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -65,7 +65,7 @@ class Test_coupling_parameter:
         )
         assert testTrue, errStr
 
-    def test_zmean(self):
+    def test_zmean(self) -> None:
         """
         Test value obtained when arbitrary z_mean is passed
         """
@@ -92,13 +92,13 @@ class Test_coupling_parameter:
             {"method": "quantum"},
         ],
     )
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             coupling_parameter, insert_some_nans, insert_all_nans, kwargs
         )
 
-    def test_quantum(self):
+    def test_quantum(self) -> None:
         """
         Testing quantum method for coupling parameter.
         """
@@ -111,7 +111,7 @@ class Test_coupling_parameter:
         )
         assert testTrue, errStr
 
-    def test_kwarg_method_error(self):
+    def test_kwarg_method_error(self) -> None:
         """Testing kwarg `method` fails is not 'classical' or 'quantum'"""
         with pytest.raises(ValueError):
             coupling_parameter(self.T, self.n_e, self.particles, method="not a method")
@@ -119,7 +119,7 @@ class Test_coupling_parameter:
 
 class Test_Knudsen_number:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.length = 1 * u.nm
         cls.T = 11604 * u.K
@@ -129,7 +129,7 @@ class Test_Knudsen_number:
         cls.V = 1e4 * u.km / u.s
         cls.True1 = 440.4757187793204
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         with pytest.warns(CouplingWarning):
             result = Knudsen_number(self.length, self.T, self.n_e, self.particles)
             resultRev = Knudsen_number(
@@ -137,7 +137,7 @@ class Test_Knudsen_number:
             )
         assert result == resultRev
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test for known value.
         """
@@ -155,7 +155,7 @@ class Test_Knudsen_number:
         errStr = f"Knudsen number should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -180,6 +180,6 @@ class Test_Knudsen_number:
 
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(Knudsen_number, insert_some_nans, insert_all_nans, {})

--- a/plasmapy/formulary/collisions/tests/test_frequencies.py
+++ b/plasmapy/formulary/collisions/tests/test_frequencies.py
@@ -77,7 +77,7 @@ class TestSingleParticleCollisionFrequencies:
             ("Coulomb_log", u.dimensionless_unscaled),
         ],
     )
-    def test_units(self, attribute_to_test, expected_attribute_units):
+    def test_units(self, attribute_to_test, expected_attribute_units) -> None:
         """Test the return units"""
 
         assert getattr(
@@ -95,7 +95,7 @@ class TestSingleParticleCollisionFrequencies:
             "Lorentz_collision_frequency",
         ],
     )
-    def test_conversion_consistency(self, attribute_to_test):
+    def test_conversion_consistency(self, attribute_to_test) -> None:
         """
         Test that a consistent value is computed for attributes
         regardless of argument units.
@@ -381,7 +381,7 @@ class TestSingleParticleCollisionFrequencies:
         limit_type,
         constructor_arguments,
         constructor_keyword_arguments,
-    ):
+    ) -> None:
         """Test the return values"""
 
         value_test_case = SingleParticleCollisionFrequencies(
@@ -442,7 +442,7 @@ class TestSingleParticleCollisionFrequencies:
     )
     def test_init_errors(
         self, expected_error, constructor_arguments, constructor_keyword_arguments
-    ):
+    ) -> None:
         """Test errors raised in the __init__ function body"""
 
         with pytest.raises(expected_error):
@@ -471,7 +471,7 @@ class TestSingleParticleCollisionFrequencies:
             },
         ],
     )
-    def test_handle_ndarrays(self, constructor_keyword_arguments):
+    def test_handle_ndarrays(self, constructor_keyword_arguments) -> None:
         """Test for ability to handle numpy array quantities"""
 
         SingleParticleCollisionFrequencies(**constructor_keyword_arguments)
@@ -522,7 +522,7 @@ class TestMaxwellianCollisionFrequencies:
     )
     def test_init_errors(
         self, expected_error, constructor_arguments, constructor_keyword_arguments
-    ):
+    ) -> None:
         """Test errors raised in the __init__ function body"""
 
         with pytest.raises(expected_error):
@@ -603,7 +603,7 @@ class TestMaxwellianCollisionFrequencies:
         constructor_arguments,
         constructor_keyword_arguments,
         attribute_name,
-    ):
+    ) -> None:
         """Test errors raised in attribute bodies"""
 
         test_case = MaxwellianCollisionFrequencies(
@@ -647,7 +647,7 @@ class TestMaxwellianCollisionFrequencies:
     @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.RelativityWarning")
     def test_fundamental_frequency_values(
         self, frequency_to_test, constructor_keyword_arguments
-    ):
+    ) -> None:
         value_test_case = MaxwellianCollisionFrequencies(
             **constructor_keyword_arguments
         )
@@ -665,7 +665,7 @@ class TestMaxwellianCollisionFrequencies:
 
 class Test_collision_frequency:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 11604 * u.K
         cls.n = 1e17 * u.cm**-3
@@ -679,13 +679,13 @@ class Test_collision_frequency:
         cls.True_protons = 44450104815.91857
         cls.True_zmean = 1346828153985.4646
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         with pytest.warns(CouplingWarning):
             result = collision_frequency(self.T, self.n, self.particles)
             resultRev = collision_frequency(self.T, self.n, self.particles[::-1])
         assert result == resultRev
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test for known value.
         """
@@ -702,7 +702,7 @@ class Test_collision_frequency:
         errStr = f"Collision frequency should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -734,13 +734,13 @@ class Test_collision_frequency:
             {"particles": ("p", "p")},
         ],
     )
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             collision_frequency, insert_some_nans, insert_all_nans, kwargs
         )
 
-    def test_electrons(self):
+    def test_electrons(self) -> None:
         """
         Testing collision frequency between electrons.
         """
@@ -762,7 +762,7 @@ class Test_collision_frequency:
         )
         assert testTrue, errStr
 
-    def test_protons(self):
+    def test_protons(self) -> None:
         """
         Testing collision frequency between protons (ions).
         """
@@ -784,7 +784,7 @@ class Test_collision_frequency:
         )
         assert testTrue, errStr
 
-    def test_zmean(self):
+    def test_zmean(self) -> None:
         """
         Test collisional frequency function when given arbitrary z_mean.
         """
@@ -804,7 +804,7 @@ class Test_collision_frequency:
 
 class Test_fundamental_electron_collision_freq:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T_arr = np.array([1, 2]) * u.eV
         cls.n_arr = np.array([1e20, 2e20]) * u.cm**-3
@@ -814,7 +814,7 @@ class Test_fundamental_electron_collision_freq:
     # TODO: array coulomb log
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             fundamental_electron_collision_freq, insert_some_nans, insert_all_nans, {}
@@ -823,7 +823,7 @@ class Test_fundamental_electron_collision_freq:
 
 class Test_fundamental_ion_collision_freq:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T_arr = np.array([1, 2]) * u.eV
         cls.n_arr = np.array([1e20, 2e20]) * u.cm**-3
@@ -833,7 +833,7 @@ class Test_fundamental_ion_collision_freq:
     # TODO: array coulomb log
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             fundamental_ion_collision_freq, insert_some_nans, insert_all_nans, {}

--- a/plasmapy/formulary/collisions/tests/test_lengths.py
+++ b/plasmapy/formulary/collisions/tests/test_lengths.py
@@ -9,19 +9,19 @@ from plasmapy.utils.exceptions import CouplingWarning, PhysicsWarning
 
 class Test_impact_parameter_perp:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 11604 * u.K
         cls.particles = ("e", "p")
         cls.V = 1e4 * u.km / u.s
         cls.True1 = 7.200146594293746e-10
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         result = lengths.impact_parameter_perp(self.T, self.particles)
         resultRev = lengths.impact_parameter_perp(self.T, self.particles[::-1])
         assert result == resultRev
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test for known value.
         """
@@ -36,7 +36,7 @@ class Test_impact_parameter_perp:
         )
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -54,7 +54,7 @@ class Test_impact_parameter_perp:
 
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             lengths.impact_parameter_perp, insert_some_nans, insert_all_nans, {}
@@ -68,7 +68,7 @@ class Test_impact_parameter_perp:
 
 class Test_impact_parameter:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 11604 * u.K
         cls.T_arr = np.array([1, 2]) * u.eV
@@ -79,12 +79,12 @@ class Test_impact_parameter:
         cls.V = 1e4 * u.km / u.s
         cls.True1 = np.array([7.200146594293746e-10, 2.3507660003984624e-08])
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         result = lengths.impact_parameter(self.T, self.n_e, self.particles)
         resultRev = lengths.impact_parameter(self.T, self.n_e, self.particles[::-1])
         assert result == resultRev
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test for known value.
         """
@@ -102,7 +102,7 @@ class Test_impact_parameter:
         errStr = f"Impact parameters should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -125,7 +125,7 @@ class Test_impact_parameter:
         )
         assert testTrue, errStr
 
-    def test_bad_method(self):
+    def test_bad_method(self) -> None:
         """Testing failure when invalid method is passed."""
         with pytest.raises(ValueError):
             lengths.impact_parameter(
@@ -151,7 +151,7 @@ class Test_impact_parameter:
             {"method": "GMS-6", "z_mean": 1.0 * u.dimensionless_unscaled},
         ],
     )
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans, kwargs) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             lengths.impact_parameter, insert_some_nans, insert_all_nans, kwargs
@@ -170,7 +170,7 @@ class Test_impact_parameter:
             ((2, 3, 5, 4, 2), (2, 3, 5, 4, 2)),
         ],
     )
-    def test_extend_output_for_array_input(self, n_e_shape, T_shape):
+    def test_extend_output_for_array_input(self, n_e_shape, T_shape) -> None:
         """
         Test to verify that if either/or T and n_e are arrays, the
         resulting bmin and bmax have the correct shapes.
@@ -194,7 +194,7 @@ class Test_impact_parameter:
 
 class Test_mean_free_path:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 11604 * u.K
         cls.n_e = 1e17 * u.cm**-3
@@ -203,13 +203,13 @@ class Test_mean_free_path:
         cls.V = 1e4 * u.km / u.s
         cls.True1 = 4.4047571877932046e-07
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         with pytest.warns(CouplingWarning):
             result = lengths.mean_free_path(self.T, self.n_e, self.particles)
             resultRev = lengths.mean_free_path(self.T, self.n_e, self.particles[::-1])
         assert result == resultRev
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test for known value.
         """
@@ -226,7 +226,7 @@ class Test_mean_free_path:
         errStr = f"Mean free path should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -250,7 +250,7 @@ class Test_mean_free_path:
 
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             lengths.mean_free_path, insert_some_nans, insert_all_nans, {}

--- a/plasmapy/formulary/collisions/tests/test_misc.py
+++ b/plasmapy/formulary/collisions/tests/test_misc.py
@@ -10,7 +10,7 @@ from plasmapy.utils.exceptions import CouplingWarning, PhysicsWarning
 
 class Test_Spitzer_resistivity:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 11604 * u.K
         cls.n = 1e12 * u.cm**-3
@@ -20,12 +20,12 @@ class Test_Spitzer_resistivity:
         cls.True1 = 1.2665402649805445e-3
         cls.True_zmean = 0.00020264644239688712
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         result = Spitzer_resistivity(self.T, self.n, self.particles)
         resultRev = Spitzer_resistivity(self.T, self.n, self.particles[::-1])
         assert result == resultRev
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test for known value.
         """
@@ -41,7 +41,7 @@ class Test_Spitzer_resistivity:
         errStr = f"Spitzer resistivity should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -62,7 +62,7 @@ class Test_Spitzer_resistivity:
         )
         assert testTrue, errStr
 
-    def test_zmean(self):
+    def test_zmean(self) -> None:
         """Testing Spitzer when z_mean is passed."""
         methodVal = Spitzer_resistivity(
             self.T,
@@ -79,7 +79,7 @@ class Test_Spitzer_resistivity:
     # TODO: vector z_mean
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(
             Spitzer_resistivity, insert_some_nans, insert_all_nans, {}
@@ -88,7 +88,7 @@ class Test_Spitzer_resistivity:
 
 class Test_mobility:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 11604 * u.K
         cls.n_e = 1e17 * u.cm**-3
@@ -98,13 +98,13 @@ class Test_mobility:
         cls.True1 = 0.13066090887074902
         cls.True_zmean = 0.32665227217687254
 
-    def test_symmetry(self):
+    def test_symmetry(self) -> None:
         with pytest.warns(CouplingWarning):
             result = mobility(self.T, self.n_e, self.particles)
             resultRev = mobility(self.T, self.n_e, self.particles[::-1])
         assert result == resultRev
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test for known value.
         """
@@ -121,7 +121,7 @@ class Test_mobility:
         errStr = f"Mobility should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -143,7 +143,7 @@ class Test_mobility:
         )
         assert testTrue, errStr
 
-    def test_zmean(self):
+    def test_zmean(self) -> None:
         """Testing mobility when z_mean is passed."""
         with pytest.warns(exceptions.PhysicsWarning, match="strong coupling effects"):
             methodVal = mobility(
@@ -161,6 +161,6 @@ class Test_mobility:
     # TODO: vector z_mean
     @pytest.mark.parametrize("insert_some_nans", [[], ["V"]])
     @pytest.mark.parametrize("insert_all_nans", [[], ["V"]])
-    def test_handle_nparrays(self, insert_some_nans, insert_all_nans):
+    def test_handle_nparrays(self, insert_some_nans, insert_all_nans) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(mobility, insert_some_nans, insert_all_nans, {})

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -278,7 +278,9 @@ def gyroradius(  # noqa: C901
             Vperp[~isfinite_Vperp] = rbody.velocity
         return Vperp
 
-    def _warn_if_lorentz_factor_and_relativistic(isfinite_lorentzfactor, relativistic):
+    def _warn_if_lorentz_factor_and_relativistic(
+        isfinite_lorentzfactor, relativistic
+    ) -> None:
         if np.any(isfinite_lorentzfactor) and relativistic:
             warnings.warn(
                 "lorentzfactor is given along with Vperp or T, will lead "

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -297,7 +297,7 @@ class RelativisticBody:
 
     def _store_velocity_like_argument(
         self, speed_like_input: dict[str, Union[u.Quantity, Real]]
-    ):
+    ) -> None:
         """
         Take the velocity-like argument and store it via the setter for
         the corresponding attribute.
@@ -328,7 +328,7 @@ class RelativisticBody:
         Z: Optional[Integral] = None,
         mass_numb: Optional[Integral] = None,
         dtype: Optional[DTypeLike] = np.longdouble,
-    ):
+    ) -> None:
         self._particle = particle
 
         self._dtype = dtype
@@ -476,21 +476,21 @@ class RelativisticBody:
 
     @kinetic_energy.setter
     @validate_quantities(E_K={"can_be_negative": False})
-    def kinetic_energy(self, E_K: u.Quantity[u.J]):
+    def kinetic_energy(self, E_K: u.Quantity[u.J]) -> None:
         self.total_energy = E_K + self.mass_energy
 
     @total_energy.setter
     @validate_quantities(E_tot={"can_be_negative": False})
-    def total_energy(self, E_tot: u.Quantity[u.J]):
+    def total_energy(self, E_tot: u.Quantity[u.J]) -> None:
         self._momentum = np.sqrt(E_tot**2 - self.mass_energy**2) / c
 
     @v_over_c.setter
-    def v_over_c(self, v_over_c_: Real):
+    def v_over_c(self, v_over_c_: Real) -> None:
         self.velocity = v_over_c_ * c
 
     @velocity.setter
     @validate_quantities
-    def velocity(self, V: u.Quantity[u.m / u.s]):
+    def velocity(self, V: u.Quantity[u.m / u.s]) -> None:
         self._momentum = (Lorentz_factor(V) * self.mass * V).to(u.kg * u.m / u.s)
 
     @lorentz_factor.setter
@@ -513,7 +513,7 @@ class RelativisticBody:
 
     @momentum.setter
     @validate_quantities
-    def momentum(self, p: u.Quantity[u.kg * u.m / u.s]):
+    def momentum(self, p: u.Quantity[u.kg * u.m / u.s]) -> None:
         self._momentum = p.to(u.kg * u.m / u.s)
 
     def __eq__(self, other) -> bool:

--- a/plasmapy/formulary/tests/test_densities.py
+++ b/plasmapy/formulary/tests/test_densities.py
@@ -20,12 +20,12 @@ class TestCriticalDensity:
         """Get the critical density for the example frequency"""
         return critical_density(self.omega)
 
-    def test_units(self, n_c):
+    def test_units(self, n_c) -> None:
         """Test the return units"""
 
         assert n_c.unit.is_equivalent(u.m**-3)
 
-    def test_value(self, n_c):
+    def test_value(self, n_c) -> None:
         """
         Compare the calculated critical density with the expected value.
 
@@ -56,7 +56,7 @@ class Test_mass_density:
             ),
         ],
     )
-    def test_raises(self, args, kwargs, conditional):
+    def test_raises(self, args, kwargs, conditional) -> None:
         with conditional:
             mass_density(*args, **kwargs)
 
@@ -82,9 +82,9 @@ class Test_mass_density:
             ),
         ],
     )
-    def test_values(self, args, kwargs, expected):
+    def test_values(self, args, kwargs, expected) -> None:
         assert np.isclose(mass_density(*args, **kwargs), expected)
 
-    def test_handle_nparrays(self):
+    def test_handle_nparrays(self) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(mass_density)

--- a/plasmapy/formulary/tests/test_dielectric.py
+++ b/plasmapy/formulary/tests/test_dielectric.py
@@ -26,7 +26,7 @@ three_species = ["e", "D+", "H+"]
 
 
 class Test_ColdPlasmaPermittivity:
-    def test_proton_electron_plasma(self):
+    def test_proton_electron_plasma(self) -> None:
         """
         Test proton-electron plasma against the (approximate)
         analytical formulas
@@ -71,7 +71,7 @@ class Test_ColdPlasmaPermittivity:
         assert rotating_tuple_result.plasma is P
         assert isinstance(rotating_tuple_result, RotatingTensorElements)
 
-    def test_three_species(self):
+    def test_three_species(self) -> None:
         """
         Test with three species (2 ions): D plasma with 5%H minority fraction
         """
@@ -81,7 +81,7 @@ class Test_ColdPlasmaPermittivity:
         assert np.isclose(D, 13408.99181054283)
         assert np.isclose(P, -10524167.9)
 
-    def test_SD_to_LR_relationships(self):
+    def test_SD_to_LR_relationships(self) -> None:
         """
         Test the relationships between (S, D, P) notation in Stix basis and
         (L, R, P) notation in the rotating basis, ie test:
@@ -98,7 +98,7 @@ class Test_ColdPlasmaPermittivity:
         assert np.isclose(S, (R + L) / 2)
         assert np.isclose(D, (R - L) / 2)
 
-    def test_numpy_array_workflow(self):
+    def test_numpy_array_workflow(self) -> None:
         """
         As per @jhillairet at:
         https://github.com/PlasmaPy/PlasmaPy/issues/539#issuecomment-425337810
@@ -139,12 +139,12 @@ class Test_permittivity_1D_Maxwellian:
         ("bound_name", "bound_attr"),
         [("lite", permittivity_1D_Maxwellian_lite)],
     )
-    def test_lite_function_binding(self, bound_name, bound_attr):
+    def test_lite_function_binding(self, bound_name, bound_attr) -> None:
         """Test expected attributes are bound correctly."""
         assert hasattr(permittivity_1D_Maxwellian, bound_name)
         assert getattr(permittivity_1D_Maxwellian, bound_name) is bound_attr
 
-    def test_lite_function_marking(self):
+    def test_lite_function_marking(self) -> None:
         """
         Test permittivity_1D_Maxwellian is marked as having a Lite-Function.
         """
@@ -162,7 +162,7 @@ class Test_permittivity_1D_Maxwellian:
             assert origin == bound_origin
 
     @pytest.mark.parametrize(("kwargs", "expected"), cases)
-    def test_known(self, kwargs, expected):
+    def test_known(self, kwargs, expected) -> None:
         """
         Tests permittivity_1D_Maxwellian for expected value.
         """
@@ -176,7 +176,7 @@ class Test_permittivity_1D_Maxwellian:
         )
 
     @pytest.mark.parametrize(("kwargs", "expected"), cases)
-    def test_fail(self, kwargs, expected):
+    def test_fail(self, kwargs, expected) -> None:
         """
         Tests if `test_known` would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -199,7 +199,7 @@ class Test_permittivity_1D_Maxwellian_lite:
     @pytest.mark.parametrize(
         ("kwargs", "expected"), Test_permittivity_1D_Maxwellian.cases
     )
-    def test_normal_vs_lite_values(self, kwargs, expected):  # noqa: ARG002
+    def test_normal_vs_lite_values(self, kwargs, expected) -> None:  # noqa: ARG002
         """
         Test that `permittivity_1D_Maxwellian_lite` and
         `permittivity_1D_Maxwellian` calculate the same values.

--- a/plasmapy/formulary/tests/test_dimensionless.py
+++ b/plasmapy/formulary/tests/test_dimensionless.py
@@ -40,17 +40,17 @@ T_e = 1e6 * u.K
         (Rm_, Mag_Reynolds),
     ],
 )
-def test_aliases(alias, parent):
+def test_aliases(alias, parent) -> None:
     """Test all aliases defined in dimensionless.py"""
     assert alias is parent
 
 
-def test_beta_dimensionless():
+def test_beta_dimensionless() -> None:
     # Check that beta is dimensionless
     float(beta(T, n, B))
 
 
-def test_beta_nan():
+def test_beta_nan() -> None:
     # Check that nans are passed through properly
     B = np.array([1, np.nan]) * u.T
     n = np.array([1, 1]) * u.cm**-3
@@ -60,7 +60,7 @@ def test_beta_nan():
     assert out[1].unit == u.dimensionless_unscaled
 
 
-def test_Reynolds_number():
+def test_Reynolds_number() -> None:
     r"""Test Reynolds_number in dimensionless.py"""
     rho = 1490 * u.kg / u.m**3
     U = 0.1 * u.m / u.s
@@ -78,7 +78,7 @@ def test_Reynolds_number():
         Reynolds_number(rho, 4 * u.kg, L, mu)
 
 
-def test_Mag_Reynolds():
+def test_Mag_Reynolds() -> None:
     r"""Test Mag_Reynolds in dimensionless.py"""
 
     sigma = 1e8 * u.S / u.m
@@ -96,7 +96,7 @@ def test_Mag_Reynolds():
         Mag_Reynolds(2.2 * u.kg, L, sigma)
 
 
-def test_Debye_number():
+def test_Debye_number() -> None:
     r"""Test the Debye_number function in dimensionless.py."""
 
     assert Debye_number(T_e, n_e).unit.is_equivalent(u.dimensionless_unscaled)
@@ -135,7 +135,7 @@ def test_Debye_number():
     assert_can_handle_nparray(Debye_number)
 
 
-def test_Hall_parameter():
+def test_Hall_parameter() -> None:
     r"""Test Hall_parameter in dimensionless.py"""
 
     ion = Particle("He-4 +1")
@@ -169,7 +169,7 @@ def test_Hall_parameter():
         Hall_parameter(1e10 * u.m**-3, 5.8e3 * u.eV, 2.3 * u.T, ion, particle)
 
 
-def test_Lundquist_number():
+def test_Lundquist_number() -> None:
     r"""Test the Lundquist_number function in dimensionless.py."""
     L = 0.05 * u.m
     rho = 1490 * u.kg / u.m**3

--- a/plasmapy/formulary/tests/test_distribution.py
+++ b/plasmapy/formulary/tests/test_distribution.py
@@ -22,7 +22,7 @@ from plasmapy.formulary.speeds import kappa_thermal_speed, thermal_speed
 
 class Test_Maxwellian_1D:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T_e = 30000 * u.K
         cls.v = 1e5 * u.m / u.s
@@ -37,7 +37,7 @@ class Test_Maxwellian_1D:
         cls.vTh = thermal_speed(cls.T_e, particle=cls.particle, method="most_probable")
         cls.distFuncTrue = 5.851627151617136e-07
 
-    def test_max_noDrift(self):
+    def test_max_noDrift(self) -> None:
         """
         Checks maximum value of distribution function is in expected place,
         when there is no drift applied.
@@ -47,7 +47,7 @@ class Test_Maxwellian_1D:
         ).argmax()
         assert np.isclose(self.v_vect[max_index].value, 0.0)
 
-    def test_max_drift(self):
+    def test_max_drift(self) -> None:
         """
         Checks maximum value of distribution function is in expected place,
         when there is drift applied.
@@ -57,7 +57,7 @@ class Test_Maxwellian_1D:
         ).argmax()
         assert np.isclose(self.v_vect[max_index].value, self.v_drift.value)
 
-    def test_norm(self):
+    def test_norm(self) -> None:
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
@@ -80,7 +80,7 @@ class Test_Maxwellian_1D:
         exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
-    def test_std(self):
+    def test_std(self) -> None:
         """
         Tests standard deviation of function?
         """
@@ -93,7 +93,7 @@ class Test_Maxwellian_1D:
         T_distri = (std**2 / k_B * m_e).to(u.K)
         assert np.isclose(T_distri.value, self.T_e.value)
 
-    def test_units_no_vTh(self):
+    def test_units_no_vTh(self) -> None:
         """
         Tests distribution function with units, but not passing vTh.
         """
@@ -108,7 +108,7 @@ class Test_Maxwellian_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_units_vTh(self):
+    def test_units_vTh(self) -> None:
         """
         Tests distribution function with units and passing vTh.
         """
@@ -123,7 +123,7 @@ class Test_Maxwellian_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_unitless_no_vTh(self):
+    def test_unitless_no_vTh(self) -> None:
         """
         Tests distribution function without units, and not passing vTh.
         """
@@ -139,7 +139,7 @@ class Test_Maxwellian_1D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_unitless_vTh(self):
+    def test_unitless_vTh(self) -> None:
         """
         Tests distribution function without units, and with passing vTh.
         """
@@ -159,7 +159,7 @@ class Test_Maxwellian_1D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_zero_drift_units(self):
+    def test_zero_drift_units(self) -> None:
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
@@ -179,7 +179,7 @@ class Test_Maxwellian_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_value_drift_units(self):
+    def test_value_drift_units(self) -> None:
         """
         Testing vdrifts with values
         """
@@ -194,7 +194,7 @@ class Test_Maxwellian_1D:
         errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
-    def test_no_units(self):
+    def test_no_units(self) -> None:
         """
         Test resulting error from using incorrect units parameter
         """
@@ -210,7 +210,7 @@ class Test_Maxwellian_1D:
 
 class Test_Maxwellian_speed_1D:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 1.0 * u.eV
         cls.particle = "H+"
@@ -222,7 +222,7 @@ class Test_Maxwellian_speed_1D:
         cls.distFuncTrue = 1.72940389716217e-27
         cls.distFuncDrift = 2 * (cls.vTh**2 * np.pi) ** (-1 / 2)
 
-    def test_norm(self):
+    def test_norm(self) -> None:
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
@@ -234,7 +234,7 @@ class Test_Maxwellian_speed_1D:
         exceptStr = "Integral of distribution function should be 1."
         assert np.isclose(integ.value, 1), exceptStr
 
-    def test_units_no_vTh(self):
+    def test_units_no_vTh(self) -> None:
         """
         Tests distribution function with units, but not passing vTh.
         """
@@ -249,7 +249,7 @@ class Test_Maxwellian_speed_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_units_vTh(self):
+    def test_units_vTh(self) -> None:
         """
         Tests distribution function with units and passing vTh.
         """
@@ -264,7 +264,7 @@ class Test_Maxwellian_speed_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_unitless_no_vTh(self):
+    def test_unitless_no_vTh(self) -> None:
         """
         Tests distribution function without units, and not passing vTh.
         """
@@ -280,7 +280,7 @@ class Test_Maxwellian_speed_1D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_unitless_vTh(self):
+    def test_unitless_vTh(self) -> None:
         """
         Tests distribution function without units, and with passing vTh.
         """
@@ -300,7 +300,7 @@ class Test_Maxwellian_speed_1D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_zero_drift_units(self):
+    def test_zero_drift_units(self) -> None:
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
@@ -320,7 +320,7 @@ class Test_Maxwellian_speed_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_value_drift_units(self):
+    def test_value_drift_units(self) -> None:
         """
         Testing vdrifts with values
         """
@@ -336,7 +336,7 @@ class Test_Maxwellian_speed_1D:
             distFunc.value, self.distFuncDrift.value, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_no_units(self):
+    def test_no_units(self) -> None:
         """
         Test resulting error from using incorrect units parameter
         """
@@ -352,7 +352,7 @@ class Test_Maxwellian_speed_1D:
 
 class Test_Maxwellian_velocity_2D:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 1.0 * u.eV
         cls.particle = "H+"
@@ -366,7 +366,7 @@ class Test_Maxwellian_velocity_2D:
         cls.vy_drift2 = 1e5 * u.m / u.s
         cls.distFuncTrue = 7.477094598799251e-55
 
-    def test_norm(self):
+    def test_norm(self) -> None:
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
@@ -391,7 +391,7 @@ class Test_Maxwellian_velocity_2D:
         exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
-    def test_units_no_vTh(self):
+    def test_units_no_vTh(self) -> None:
         """
         Tests distribution function with units, but not passing vTh.
         """
@@ -406,7 +406,7 @@ class Test_Maxwellian_velocity_2D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_units_vTh(self):
+    def test_units_vTh(self) -> None:
         """
         Tests distribution function with units and passing vTh.
         """
@@ -426,7 +426,7 @@ class Test_Maxwellian_velocity_2D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_unitless_no_vTh(self):
+    def test_unitless_no_vTh(self) -> None:
         """
         Tests distribution function without units, and not passing vTh.
         """
@@ -446,7 +446,7 @@ class Test_Maxwellian_velocity_2D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_unitless_vTh(self):
+    def test_unitless_vTh(self) -> None:
         """
         Tests distribution function without units, and with passing vTh.
         """
@@ -467,7 +467,7 @@ class Test_Maxwellian_velocity_2D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_zero_drift_units(self):
+    def test_zero_drift_units(self) -> None:
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
@@ -489,7 +489,7 @@ class Test_Maxwellian_velocity_2D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_value_drift_units(self):
+    def test_value_drift_units(self) -> None:
         """
         Testing vdrifts with values
         """
@@ -506,7 +506,7 @@ class Test_Maxwellian_velocity_2D:
         errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
-    def test_no_units(self):
+    def test_no_units(self) -> None:
         """
         Test resulting error from using incorrect units parameter
         """
@@ -525,7 +525,7 @@ class Test_Maxwellian_velocity_2D:
 @pytest.mark.slow()
 class Test_Maxwellian_speed_2D:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 1.0 * u.eV
         cls.particle = "H+"
@@ -536,7 +536,7 @@ class Test_Maxwellian_speed_2D:
         cls.v_drift2 = 1e5 * u.m / u.s
         cls.distFuncTrue = 2.2148166449365907e-26
 
-    def test_norm(self):
+    def test_norm(self) -> None:
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
@@ -548,7 +548,7 @@ class Test_Maxwellian_speed_2D:
         exceptStr = "Integral of distribution function should be 1."
         assert np.isclose(integ.value, 1), exceptStr
 
-    def test_units_no_vTh(self):
+    def test_units_no_vTh(self) -> None:
         """
         Tests distribution function with units, but not passing vTh.
         """
@@ -563,7 +563,7 @@ class Test_Maxwellian_speed_2D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_units_vTh(self):
+    def test_units_vTh(self) -> None:
         """
         Tests distribution function with units and passing vTh.
         """
@@ -578,7 +578,7 @@ class Test_Maxwellian_speed_2D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_unitless_no_vTh(self):
+    def test_unitless_no_vTh(self) -> None:
         """
         Tests distribution function without units, and not passing vTh.
         """
@@ -594,7 +594,7 @@ class Test_Maxwellian_speed_2D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_unitless_vTh(self):
+    def test_unitless_vTh(self) -> None:
         """
         Tests distribution function without units, and with passing vTh.
         """
@@ -614,7 +614,7 @@ class Test_Maxwellian_speed_2D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_zero_drift_units(self):
+    def test_zero_drift_units(self) -> None:
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
@@ -634,7 +634,7 @@ class Test_Maxwellian_speed_2D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_value_drift_units(self):
+    def test_value_drift_units(self) -> None:
         """
         Testing vdrifts with values
         """
@@ -647,7 +647,7 @@ class Test_Maxwellian_speed_2D:
                 units="units",
             )
 
-    def test_no_units(self):
+    def test_no_units(self) -> None:
         """
         Test resulting error from using incorrect units parameter
         """
@@ -664,7 +664,7 @@ class Test_Maxwellian_speed_2D:
 @pytest.mark.slow()
 class Test_Maxwellian_velocity_3D:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 1.0 * u.eV
         cls.particle = "H+"
@@ -681,7 +681,7 @@ class Test_Maxwellian_velocity_3D:
         cls.vz_drift2 = 1e5 * u.m / u.s
         cls.distFuncTrue = 6.465458269306909e-82
 
-    def test_norm(self):
+    def test_norm(self) -> None:
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
@@ -708,7 +708,7 @@ class Test_Maxwellian_velocity_3D:
         exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
-    def test_units_no_vTh(self):
+    def test_units_no_vTh(self) -> None:
         """
         Tests distribution function with units, but not passing vTh.
         """
@@ -728,7 +728,7 @@ class Test_Maxwellian_velocity_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_units_vTh(self):
+    def test_units_vTh(self) -> None:
         """
         Tests distribution function with units and passing vTh.
         """
@@ -749,7 +749,7 @@ class Test_Maxwellian_velocity_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_unitless_no_vTh(self):
+    def test_unitless_no_vTh(self) -> None:
         """
         Tests distribution function without units, and not passing vTh.
         """
@@ -770,7 +770,7 @@ class Test_Maxwellian_velocity_3D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_unitless_vTh(self):
+    def test_unitless_vTh(self) -> None:
         """
         Tests distribution function without units, and with passing vTh.
         """
@@ -792,7 +792,7 @@ class Test_Maxwellian_velocity_3D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_zero_drift_units(self):
+    def test_zero_drift_units(self) -> None:
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
@@ -816,7 +816,7 @@ class Test_Maxwellian_velocity_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_value_drift_units(self):
+    def test_value_drift_units(self) -> None:
         """
         Testing vdrifts with values
         """
@@ -835,7 +835,7 @@ class Test_Maxwellian_velocity_3D:
         errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
-    def test_no_units(self):
+    def test_no_units(self) -> None:
         """
         Test resulting error from using incorrect units parameter
         """
@@ -855,7 +855,7 @@ class Test_Maxwellian_velocity_3D:
 
 class Test_Maxwellian_speed_3D:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 1.0 * u.eV
         cls.particle = "H+"
@@ -866,7 +866,7 @@ class Test_Maxwellian_speed_3D:
         cls.v_drift2 = 1e5 * u.m / u.s
         cls.distFuncTrue = 1.8057567503860518e-25
 
-    def test_norm(self):
+    def test_norm(self) -> None:
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
@@ -878,7 +878,7 @@ class Test_Maxwellian_speed_3D:
         exceptStr = "Integral of distribution function should be 1."
         assert np.isclose(integ.value, 1), exceptStr
 
-    def test_units_no_vTh(self):
+    def test_units_no_vTh(self) -> None:
         """
         Tests distribution function with units, but not passing vTh.
         """
@@ -893,7 +893,7 @@ class Test_Maxwellian_speed_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_units_vTh(self):
+    def test_units_vTh(self) -> None:
         """
         Tests distribution function with units and passing vTh.
         """
@@ -908,7 +908,7 @@ class Test_Maxwellian_speed_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_unitless_no_vTh(self):
+    def test_unitless_no_vTh(self) -> None:
         """
         Tests distribution function without units, and not passing vTh.
         """
@@ -924,7 +924,7 @@ class Test_Maxwellian_speed_3D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_unitless_vTh(self):
+    def test_unitless_vTh(self) -> None:
         """
         Tests distribution function without units, and with passing vTh.
         """
@@ -944,7 +944,7 @@ class Test_Maxwellian_speed_3D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_zero_drift_units(self):
+    def test_zero_drift_units(self) -> None:
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
@@ -964,7 +964,7 @@ class Test_Maxwellian_speed_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_value_drift_units(self):
+    def test_value_drift_units(self) -> None:
         """
         Testing vdrifts with values
         """
@@ -977,7 +977,7 @@ class Test_Maxwellian_speed_3D:
                 units="units",
             )
 
-    def test_no_units(self):
+    def test_no_units(self) -> None:
         """
         Test resulting error from using incorrect units parameter
         """
@@ -993,7 +993,7 @@ class Test_Maxwellian_speed_3D:
 
 class Test_kappa_velocity_1D:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T_e = 30000 * u.K
         cls.kappa = 4
@@ -1010,7 +1010,7 @@ class Test_kappa_velocity_1D:
         cls.vTh = kappa_thermal_speed(cls.T_e, kappa=cls.kappa, particle=cls.particle)
         cls.distFuncTrue = 6.637935187755855e-07
 
-    def test_invalid_kappa(self):
+    def test_invalid_kappa(self) -> None:
         """
         Checks if function raises error when kappa <= 3/2 is passed as an
         argument.
@@ -1024,7 +1024,7 @@ class Test_kappa_velocity_1D:
                 units="units",
             )
 
-    def test_max_noDrift(self):
+    def test_max_noDrift(self) -> None:
         """
         Checks maximum value of distribution function is in expected place,
         when there is no drift applied.
@@ -1038,7 +1038,7 @@ class Test_kappa_velocity_1D:
         ).argmax()
         assert np.isclose(self.v_vect[max_index].value, 0.0)
 
-    def test_max_drift(self):
+    def test_max_drift(self) -> None:
         """
         Checks maximum value of distribution function is in expected place,
         when there is drift applied.
@@ -1055,7 +1055,7 @@ class Test_kappa_velocity_1D:
     # TODO: Need to add a test to see if the kappa distribution goes to a
     # Maxwellian in the limit of large κ
 
-    def test_norm(self):
+    def test_norm(self) -> None:
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
@@ -1078,7 +1078,7 @@ class Test_kappa_velocity_1D:
         exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
-    def test_std(self):
+    def test_std(self) -> None:
         """
         Tests standard deviation of function?
         """
@@ -1093,7 +1093,7 @@ class Test_kappa_velocity_1D:
         T_distri = (std**2 / k_B * m_e).to(u.K)
         assert np.isclose(T_distri.value, self.T_e.value)
 
-    def test_units_no_vTh(self):
+    def test_units_no_vTh(self) -> None:
         """
         Tests distribution function with units, but not passing vTh.
         """
@@ -1112,7 +1112,7 @@ class Test_kappa_velocity_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_units_vTh(self):
+    def test_units_vTh(self) -> None:
         """
         Tests distribution function with units and passing vTh.
         """
@@ -1132,7 +1132,7 @@ class Test_kappa_velocity_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_unitless_no_vTh(self):
+    def test_unitless_no_vTh(self) -> None:
         """
         Tests distribution function without units, and not passing vTh.
         """
@@ -1152,7 +1152,7 @@ class Test_kappa_velocity_1D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_unitless_vTh(self):
+    def test_unitless_vTh(self) -> None:
         """
         Tests distribution function without units, and with passing vTh.
         """
@@ -1173,7 +1173,7 @@ class Test_kappa_velocity_1D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_zero_drift_units(self):
+    def test_zero_drift_units(self) -> None:
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
@@ -1194,7 +1194,7 @@ class Test_kappa_velocity_1D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_value_drift_units(self):
+    def test_value_drift_units(self) -> None:
         """
         Testing vdrifts with values
         """
@@ -1210,7 +1210,7 @@ class Test_kappa_velocity_1D:
         errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
-    def test_no_units(self):
+    def test_no_units(self) -> None:
         """
         Test resulting error from using incorrect units parameter
         """
@@ -1228,7 +1228,7 @@ class Test_kappa_velocity_1D:
 @pytest.mark.slow()
 class Test_kappa_velocity_3D:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T = 1.0 * u.eV
         cls.kappa = 4
@@ -1247,7 +1247,7 @@ class Test_kappa_velocity_3D:
         cls.vz_drift2 = 1e5 * u.m / u.s
         cls.distFuncTrue = 1.1847914288918793e-22
 
-    def test_invalid_kappa(self):
+    def test_invalid_kappa(self) -> None:
         """
         Checks if function raises error when kappa <= 3/2 is passed as an
         argument.
@@ -1298,7 +1298,7 @@ class Test_kappa_velocity_3D:
     #
     #        return
 
-    def test_norm(self):
+    def test_norm(self) -> None:
         """
         Tests whether distribution function is normalized, and integrates to 1.
         """
@@ -1325,7 +1325,7 @@ class Test_kappa_velocity_3D:
         exceptStr = "Integral of distribution function should be 1 and not {integVal}."
         assert np.isclose(integVal, 1, rtol=1e-3, atol=0.0), exceptStr
 
-    def test_units_no_vTh(self):
+    def test_units_no_vTh(self) -> None:
         """
         Tests distribution function with units, but not passing vTh.
         """
@@ -1346,7 +1346,7 @@ class Test_kappa_velocity_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_units_vTh(self):
+    def test_units_vTh(self) -> None:
         """
         Tests distribution function with units and passing vTh.
         """
@@ -1368,7 +1368,7 @@ class Test_kappa_velocity_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_unitless_no_vTh(self):
+    def test_unitless_no_vTh(self) -> None:
         """
         Tests distribution function without units, and not passing vTh.
         """
@@ -1390,7 +1390,7 @@ class Test_kappa_velocity_3D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_unitless_vTh(self):
+    def test_unitless_vTh(self) -> None:
         """
         Tests distribution function without units, and with passing vTh.
         """
@@ -1413,7 +1413,7 @@ class Test_kappa_velocity_3D:
         )
         assert np.isclose(distFunc, self.distFuncTrue, rtol=1e-5, atol=0.0), errStr
 
-    def test_zero_drift_units(self):
+    def test_zero_drift_units(self) -> None:
         """
         Testing inputting drift equal to 0 with units. These should just
         get passed and not have extra units applied to them.
@@ -1438,7 +1438,7 @@ class Test_kappa_velocity_3D:
             distFunc.value, self.distFuncTrue, rtol=1e-5, atol=0.0
         ), errStr
 
-    def test_value_drift_units(self):
+    def test_value_drift_units(self) -> None:
         """
         Testing vdrifts with values
         """
@@ -1458,7 +1458,7 @@ class Test_kappa_velocity_3D:
         errStr = f"Distribution function should be {testVal} and not {distFunc}."
         assert np.isclose(distFunc.value, testVal, rtol=1e-5, atol=0.0), errStr
 
-    def test_no_units(self):
+    def test_no_units(self) -> None:
         """
         Test resulting error from using incorrect units parameter
         """

--- a/plasmapy/formulary/tests/test_drifts.py
+++ b/plasmapy/formulary/tests/test_drifts.py
@@ -11,7 +11,7 @@ class Test_diamagnetic_drift:
     q = 1 * u.C
     n = 1 / u.m**3
 
-    def test_isothermal_plasma(self):
+    def test_isothermal_plasma(self) -> None:
         r"""
         Cylindrical & isothermal plasma in Fig 3.4 of Chen.
         """
@@ -25,13 +25,13 @@ class Test_diamagnetic_drift:
             np.linalg.norm(result), T / self.q / np.linalg.norm(B) / u.m
         )
 
-    def test_diamagnetic_drift_1d_arrays(self):
+    def test_diamagnetic_drift_1d_arrays(self) -> None:
         dp = u.Quantity([1, 0, 0], unit=u.N / u.m**3)
         B = u.Quantity([0, -1, 0], unit=u.T)
         result = drifts.diamagnetic_drift(2 * dp, 3 * B, self.n, self.q)
         assert_quantity_allclose(result, (2 / 3) * u.Quantity([0, 0, 1], u.m / u.s))
 
-    def test_diamagnetic_drift_2d_array(self):
+    def test_diamagnetic_drift_2d_array(self) -> None:
         dp = u.Quantity([[1, 0, 0], [1, 0, 0], [1, 0, 0]], unit=u.N / u.m**3)
         B = -u.Quantity([[0, 1, 0], [0, 1, 0], [0, 1, 0]], unit=u.T)
 
@@ -41,7 +41,7 @@ class Test_diamagnetic_drift:
             (2 / 3) * u.Quantity([[0, 0, 1], [0, 0, 1], [0, 0, 1]], unit=u.m / u.s),
         )
 
-    def test_diamagnetic_drift_3d_array(self):
+    def test_diamagnetic_drift_3d_array(self) -> None:
         dp = u.Quantity([[[1, 0, 0]]], unit=u.N / u.m**3)
         B = u.Quantity([[[0, -1, 0]]], unit=u.T)
 
@@ -50,7 +50,7 @@ class Test_diamagnetic_drift:
             result, (2 / 3) * u.Quantity([[[0, 0, 1]]], unit=u.m / u.s)
         )
 
-    def test_nonsensical_units(self):
+    def test_nonsensical_units(self) -> None:
         dp = u.Quantity([[1, 0, 0], [1, 0, 0], [1, 0, 0]], unit=u.C)
         B = u.Quantity([[0, 1, 0], [0, 1, 0], [0, 1, 0]], unit=u.kg)
         q = 1 * u.C
@@ -59,18 +59,18 @@ class Test_diamagnetic_drift:
         with pytest.raises(u.UnitTypeError):
             drifts.diamagnetic_drift(dp, B, n, q)
 
-    def test_alias(self):
+    def test_alias(self) -> None:
         assert drifts.vd_ is drifts.diamagnetic_drift
 
 
 class Test_ExB_drift:
-    def test_E_x_B_1d_arrays(self):
+    def test_E_x_B_1d_arrays(self) -> None:
         E = u.Quantity([1, 0, 0], unit=u.V / u.m)
         B = u.Quantity([0, 1, 0], unit=u.T)
         result = drifts.ExB_drift(2 * E, 3 * B)
         assert_quantity_allclose(result, (2 / 3) * u.Quantity([0, 0, 1], u.m / u.s))
 
-    def test_ExB_2d_array(self):
+    def test_ExB_2d_array(self) -> None:
         E = u.Quantity([[1, 0, 0], [1, 0, 0], [1, 0, 0]], unit=u.V / u.m)
         B = u.Quantity([[0, 1, 0], [0, 1, 0], [0, 1, 0]], unit=u.T)
 
@@ -80,14 +80,14 @@ class Test_ExB_drift:
             (2 / 3) * u.Quantity([[0, 0, 1], [0, 0, 1], [0, 0, 1]], unit=u.m / u.s),
         )
 
-    def test_nonsensical_units(self):
+    def test_nonsensical_units(self) -> None:
         E = u.Quantity([[1, 0, 0], [1, 0, 0], [1, 0, 0]], unit=u.mm)
         B = u.Quantity([[0, 1, 0], [0, 1, 0], [0, 1, 0]], unit=u.kg)
 
         with pytest.raises(u.UnitTypeError):
             drifts.ExB_drift(E, B)
 
-    def test_ExB_3d_array(self):
+    def test_ExB_3d_array(self) -> None:
         E = u.Quantity([[[1, 0, 0]]], unit=u.V / u.m)
         B = u.Quantity([[[0, 1, 0]]], unit=u.T)
 
@@ -96,19 +96,19 @@ class Test_ExB_drift:
             result, (2 / 3) * u.Quantity([[[0, 0, 1]]], unit=u.m / u.s)
         )
 
-    def test_alias(self):
+    def test_alias(self) -> None:
         assert drifts.veb_ is drifts.ExB_drift
 
 
 class Test_force_drift:
-    def test_force_x_B_1d_arrays(self):
+    def test_force_x_B_1d_arrays(self) -> None:
         F = u.Quantity([1, 0, 0], unit=u.N)
         B = u.Quantity([0, 1, 0], unit=u.T)
         q = 1 * u.C
         result = drifts.force_drift(2 * F, 3 * B, q)
         assert_quantity_allclose(result, (2 / 3) * u.Quantity([0, 0, 1], u.m / u.s))
 
-    def test_force_B_2d_array(self):
+    def test_force_B_2d_array(self) -> None:
         F = u.Quantity([[1, 0, 0], [1, 0, 0], [1, 0, 0]], unit=u.N)
         B = u.Quantity([[0, 1, 0], [0, 1, 0], [0, 1, 0]], unit=u.T)
         q = 1 * u.C
@@ -119,7 +119,7 @@ class Test_force_drift:
             (2 / 3) * u.Quantity([[0, 0, 1], [0, 0, 1], [0, 0, 1]], unit=u.m / u.s),
         )
 
-    def test_force_B_3d_array(self):
+    def test_force_B_3d_array(self) -> None:
         F = u.Quantity([[[1, 0, 0]]], unit=u.N)
         B = u.Quantity([[[0, 1, 0]]], unit=u.T)
         q = 1 * u.C
@@ -129,7 +129,7 @@ class Test_force_drift:
             result, (2 / 3) * u.Quantity([[[0, 0, 1]]], unit=u.m / u.s)
         )
 
-    def test_nonsensical_units(self):
+    def test_nonsensical_units(self) -> None:
         F = u.Quantity([[1, 0, 0], [1, 0, 0], [1, 0, 0]], unit=u.mm)
         B = u.Quantity([[0, 1, 0], [0, 1, 0], [0, 1, 0]], unit=u.kg)
         q = 1 * u.C
@@ -137,5 +137,5 @@ class Test_force_drift:
         with pytest.raises(u.UnitTypeError):
             drifts.force_drift(F, B, q)
 
-    def test_alias(self):
+    def test_alias(self) -> None:
         assert drifts.vfd_ is drifts.force_drift

--- a/plasmapy/formulary/tests/test_fermi_integral.py
+++ b/plasmapy/formulary/tests/test_fermi_integral.py
@@ -10,7 +10,7 @@ from plasmapy.formulary.mathematics import Fermi_integral
 
 class Test_Fermi_integral:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initialize parameters for tests."""
         cls.arg1 = 3.889780
         cls.True1 = 6.272518847136373 - 8.673617379884035e-19j
@@ -25,7 +25,7 @@ class Test_Fermi_integral:
             ]
         )
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Test Fermi_integral for expected value.
         """
@@ -34,7 +34,7 @@ class Test_Fermi_integral:
         errStr = f"Fermi integral value should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Test if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -48,14 +48,14 @@ class Test_Fermi_integral:
         )
         assert testTrue, errStr
 
-    def test_array(self):
+    def test_array(self) -> None:
         """Test Fermi_integral where argument is an array of inputs."""
         methodVals = Fermi_integral(self.args, self.order1)
         testTrue = np.allclose(methodVals, self.Trues, rtol=1e-16, atol=0.0)
         errStr = f"Fermi integral value should be {self.Trues} and not {methodVals}."
         assert testTrue, errStr
 
-    def test_invalid_type(self):
+    def test_invalid_type(self) -> None:
         """
         Test whether `TypeError` is raised when an invalid argument
         type is passed to `~plasmapy.mathematics.Fermi_integral`.

--- a/plasmapy/formulary/tests/test_frequencies.py
+++ b/plasmapy/formulary/tests/test_frequencies.py
@@ -35,12 +35,12 @@ B_nanarr = np.array([0.001, np.nan]) * u.T
         (wuh_, upper_hybrid_frequency),
     ],
 )
-def test_aliases(alias, parent):
+def test_aliases(alias, parent) -> None:
     """Test all aliases defined in frequencies.py"""
     assert alias is parent
 
 
-def test_gyrofrequency():
+def test_gyrofrequency() -> None:
     r"""Test the gyrofrequency function in frequencies.py."""
 
     assert gyrofrequency(B, "e-").unit.is_equivalent(u.rad / u.s)
@@ -120,7 +120,7 @@ def test_gyrofrequency():
     assert_can_handle_nparray(gyrofrequency, kwargs={"signed": False})
 
 
-def test_lower_hybrid_frequency():
+def test_lower_hybrid_frequency() -> None:
     r"""Test the lower_hybrid_frequency function in frequencies.py."""
 
     ion = "He-4 1+"
@@ -155,7 +155,7 @@ def test_lower_hybrid_frequency():
     assert_can_handle_nparray(lower_hybrid_frequency)
 
 
-def test_upper_hybrid_frequency():
+def test_upper_hybrid_frequency() -> None:
     r"""Test the upper_hybrid_frequency function in frequencies.py."""
 
     omega_uh = upper_hybrid_frequency(B, n_e=n_e)
@@ -188,7 +188,7 @@ def test_upper_hybrid_frequency():
     assert_can_handle_nparray(upper_hybrid_frequency)
 
 
-def test_Buchsbaum_frequency():
+def test_Buchsbaum_frequency() -> None:
     r"""Test the Buchsbaum_frequency function in frequencies.py."""
 
     with pytest.raises(InvalidParticleError):

--- a/plasmapy/formulary/tests/test_ionization.py
+++ b/plasmapy/formulary/tests/test_ionization.py
@@ -5,7 +5,7 @@ import pytest
 from plasmapy.formulary.ionization import ionization_balance, Saha, Z_bal_
 
 
-def test_ionization_balance():
+def test_ionization_balance() -> None:
     n = 1e19 * u.m**-3
     T_e = 5000 * u.K
 
@@ -23,7 +23,7 @@ def test_ionization_balance():
         ionization_balance(2e19 * u.kg, T_e)
 
 
-def test_Saha():
+def test_Saha() -> None:
     g_j = 2
     g_k = 1
     n_e = 1e19 * u.m**-3

--- a/plasmapy/formulary/tests/test_lengths.py
+++ b/plasmapy/formulary/tests/test_lengths.py
@@ -39,7 +39,7 @@ V_nanarr = np.array([25, np.nan]) * u.m / u.s
 mu = m_p.to(u.u).value
 
 
-def test_Debye_length():
+def test_Debye_length() -> None:
     r"""Test the Debye_length function in lengths.py."""
 
     assert Debye_length(T_e, n_e).unit.is_equivalent(u.m)
@@ -123,7 +123,7 @@ class TestGyroradius:
             ),
         ],
     )
-    def test_raises(self, args, kwargs, _error):
+    def test_raises(self, args, kwargs, _error) -> None:
         """Test scenarios that raise an exception."""
 
         with warnings.catch_warnings(), pytest.raises(_error):
@@ -156,7 +156,7 @@ class TestGyroradius:
             ),
         ],
     )
-    def test_nan_values(self, args, kwargs, nan_mask):
+    def test_nan_values(self, args, kwargs, nan_mask) -> None:
         if nan_mask is None:
             assert np.all(np.isnan(gyroradius(*args, **kwargs)))
         else:
@@ -285,7 +285,7 @@ class TestGyroradius:
         ],
     )
     @pytest.mark.filterwarnings("ignore::UserWarning")
-    def test_values(self, args, kwargs, expected, atol):
+    def test_values(self, args, kwargs, expected, atol) -> None:
         if atol is None:
             atol = 1e-8
 
@@ -310,13 +310,13 @@ class TestGyroradius:
             ((1.1, "e-"), {"T": 1.2 * u.K}, 3.11737236e-08 * u.m, u.UnitsWarning),
         ],
     )
-    def test_warns(self, args, kwargs, expected, _warns):
+    def test_warns(self, args, kwargs, expected, _warns) -> None:
         with pytest.warns(_warns):
             rc = gyroradius(*args, **kwargs)
             if expected is not None:
                 assert np.allclose(rc, expected)
 
-    def test_keeps_arguments_unchanged(self):
+    def test_keeps_arguments_unchanged(self) -> None:
         Vperp1 = u.Quantity([np.nan, 1], unit=u.m / u.s)
         Vperp2 = Vperp1.copy()
         T = u.Quantity([1, np.nan], unit=u.K)
@@ -325,7 +325,7 @@ class TestGyroradius:
 
         assert_quantity_allclose(Vperp1, Vperp2)
 
-    def test_correct_thermal_speed_used(self):
+    def test_correct_thermal_speed_used(self) -> None:
         """
         Test the correct version of thermal_speed is used when
         temperature is given.
@@ -341,7 +341,7 @@ class TestGyroradius:
         )
 
 
-def test_inertial_length():
+def test_inertial_length() -> None:
     r"""Test the inertial_length function in lengths.py."""
 
     assert inertial_length(n_i, particle="p").unit.is_equivalent(u.m)
@@ -401,6 +401,6 @@ def test_inertial_length():
         (rhoc_, gyroradius),
     ],
 )
-def test_aliases(alias, parent):
+def test_aliases(alias, parent) -> None:
     """Test all aliases defined in lengths.py"""
     assert alias is parent

--- a/plasmapy/formulary/tests/test_magnetostatics.py
+++ b/plasmapy/formulary/tests/test_magnetostatics.py
@@ -17,11 +17,11 @@ mu0_4pi = constants.mu0 / 4 / np.pi
 
 
 class Test_MagneticDipole:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.moment = np.array([0, 0, 1]) * u.A * u.m * u.m
         self.p0 = np.array([0, 0, 0]) * u.m
 
-    def test_value1(self):
+    def test_value1(self) -> None:
         """Test a known solution"""
         p = np.array([1, 0, 0])
         B1 = MagneticDipole(self.moment, self.p0).magnetic_field(p)
@@ -29,7 +29,7 @@ class Test_MagneticDipole:
         assert np.all(np.isclose(B1.value, B1_expected.value))
         assert B1.unit == u.T
 
-    def test_value2(self):
+    def test_value2(self) -> None:
         """Test a known solution"""
         p = np.array([0, 0, 1])
         B2 = MagneticDipole(self.moment, self.p0).magnetic_field(p)
@@ -40,14 +40,14 @@ class Test_MagneticDipole:
     @pytest.mark.skipif(
         astropy.__version__ < "5.3.0", reason="change in unit representation"
     )
-    def test_repr(self):
+    def test_repr(self) -> None:
         """Test __repr__ function"""
         B1 = MagneticDipole(self.moment, self.p0)
         assert repr(B1) == r"MagneticDipole(moment=[0. 0. 1.]m2 A, p0=[0. 0. 0.]m)"
 
 
 class Test_GeneralWire:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.cw = CircularWire(
             np.array([0, 0, 1]), np.array([0, 0, 0]) * u.m, 1 * u.m, 1 * u.A
         )
@@ -55,12 +55,12 @@ class Test_GeneralWire:
         p2 = np.array([0.0, 0.0, 1.0]) * u.m
         self.fw = FiniteStraightWire(p1, p2, 1 * u.A)
 
-    def test_not_callable(self):
+    def test_not_callable(self) -> None:
         """Test that `GeneralWire` raises `TypeError` if its first argument is not callable"""
         with pytest.raises(TypeError):
             GeneralWire("wire", 0, 1, 1 * u.A)
 
-    def test_close_cw(self):
+    def test_close_cw(self) -> None:
         """Test if the GeneralWire is close to the CircularWire it converted from"""
         gw_cw = self.cw.to_GeneralWire()
         p = np.array([0, 0, 0])
@@ -70,7 +70,7 @@ class Test_GeneralWire:
         assert np.all(np.isclose(B_cw.value, B_gw_cw.value))
         assert B_cw.unit == B_gw_cw.unit
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """Test __repr__ function"""
         gw_cw = self.cw.to_GeneralWire()
         # round numbers to avoid calculation accuracy mismatch
@@ -81,7 +81,7 @@ class Test_GeneralWire:
             == r"GeneralWire(parametric_eq=curve, t1=-3.1516, t2=3.1516, current=1.0A)"
         )
 
-    def test_close_fw(self):
+    def test_close_fw(self) -> None:
         """Test if the GeneralWire is close to the FiniteWire it converted from"""
         gw_fw = self.fw.to_GeneralWire()
         p = np.array([1, 0, 0])
@@ -91,24 +91,24 @@ class Test_GeneralWire:
         assert np.all(np.isclose(B_fw.value, B_gw_fw.value))
         assert B_fw.unit == B_gw_fw.unit
 
-    def test_value_error(self):
+    def test_value_error(self) -> None:
         """Test GeneralWire raise ValueError when argument t1>t2"""
         with pytest.raises(ValueError):
             GeneralWire(lambda t: [0, 0, t], 2, 1, 1.0 * u.A)
 
 
 class Test_FiniteStraightWire:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.p1 = np.array([0.0, 0.0, -1.0]) * u.m
         self.p2 = np.array([0.0, 0.0, 1.0]) * u.m
         self.current = 1 * u.A
 
-    def test_same_point(self):
+    def test_same_point(self) -> None:
         """Test that `FiniteStraightWire` raises `ValueError` if p1 == p2"""
         with pytest.raises(ValueError):
             FiniteStraightWire(self.p1, self.p1, self.current)
 
-    def test_value1(self):
+    def test_value1(self) -> None:
         """Test a known solution"""
         fw = FiniteStraightWire(self.p1, self.p2, self.current)
         B1 = fw.magnetic_field([1, 0, 0])
@@ -116,7 +116,7 @@ class Test_FiniteStraightWire:
         assert np.all(np.isclose(B1.value, B1_expected.value))
         assert B1.unit == u.T
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """Test __repr__ function"""
         fw = FiniteStraightWire(self.p1, self.p2, self.current)
         assert (
@@ -126,12 +126,12 @@ class Test_FiniteStraightWire:
 
 
 class Test_InfiniteStraightWire:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.direction = np.array([0, 1, 0])
         self.p0 = np.array([0, 0, 0]) * u.m
         self.current = 1 * u.A
 
-    def test_value1(self):
+    def test_value1(self) -> None:
         """Test a known solution"""
         iw = InfiniteStraightWire(self.direction, self.p0, self.current)
         B1 = iw.magnetic_field([1, 0, 0])
@@ -139,7 +139,7 @@ class Test_InfiniteStraightWire:
         assert np.all(np.isclose(B1.value, B1_expected.value))
         assert B1.unit == u.T
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """Test __repr__ function"""
         iw = InfiniteStraightWire(self.direction, self.p0, self.current)
         assert (
@@ -149,19 +149,19 @@ class Test_InfiniteStraightWire:
 
 
 class Test_CircularWire:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.normalz = np.array([0, 0, 1])
         self.normalx = np.array([1, 0, 0])
         self.center = np.array([0, 0, 0]) * u.m
         self.radius = 1 * u.m
         self.current = 1 * u.A
 
-    def test_negative_radius(self):
+    def test_negative_radius(self) -> None:
         """Test that `FiniteStraightWire` raises `ValueError` if radius < 0"""
         with pytest.raises(ValueError):
             CircularWire(self.normalz, self.center, -1.0 * u.m, self.current)
 
-    def test_value1(self):
+    def test_value1(self) -> None:
         """Test a known solution"""
         cw = CircularWire(self.normalz, self.center, self.radius, self.current)
         B1 = cw.magnetic_field([0, 0, 1])
@@ -169,7 +169,7 @@ class Test_CircularWire:
         assert np.all(np.isclose(B1.value, B1_expected.value))
         assert B1.unit == u.T
 
-    def test_value2(self):
+    def test_value2(self) -> None:
         """Test a known solution"""
         cw = CircularWire(self.normalx, self.center, self.radius, self.current)
         B2 = cw.magnetic_field([1, 0, 0])
@@ -177,7 +177,7 @@ class Test_CircularWire:
         assert np.all(np.isclose(B2.value, B2_expected.value))
         assert B2.unit == u.T
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """Test __repr__ function"""
         cw = CircularWire(self.normalz, self.center, self.radius, self.current)
         assert (

--- a/plasmapy/formulary/tests/test_mathematics.py
+++ b/plasmapy/formulary/tests/test_mathematics.py
@@ -24,7 +24,7 @@ from plasmapy.formulary import mathematics
         (np.array([1, 0, 0]), np.array([-1, 0, 0]), -np.identity(3)),
     ],
 )
-def test_rot_a_to_b(a, b, correct):
+def test_rot_a_to_b(a, b, correct) -> None:
     R = mathematics.rot_a_to_b(a, b)
     np.testing.assert_allclose(R, correct, atol=1e-6)
 
@@ -40,6 +40,6 @@ def test_rot_a_to_b(a, b, correct):
         (np.array([1, 0]), np.array([1, 0]), ValueError),
     ],
 )
-def test_rot_a_to_b_raises(a, b, _raises):
+def test_rot_a_to_b_raises(a, b, _raises) -> None:
     with pytest.raises(_raises):
         mathematics.rot_a_to_b(a, b)

--- a/plasmapy/formulary/tests/test_misc.py
+++ b/plasmapy/formulary/tests/test_misc.py
@@ -36,19 +36,19 @@ T_e = 1e6 * u.K
         (pth_, thermal_pressure),
     ],
 )
-def test_aliases(alias, parent):
+def test_aliases(alias, parent) -> None:
     """Test all aliases defined in misc.py"""
     assert alias is parent
 
 
-def test_thermal_pressure():
+def test_thermal_pressure() -> None:
     assert thermal_pressure(T_e, n_i).unit.is_equivalent(u.Pa)
 
     # TODO: may be array issues with arg "mass"
     assert_can_handle_nparray(thermal_pressure)
 
 
-def test_magnetic_pressure():
+def test_magnetic_pressure() -> None:
     r"""Test the magnetic_pressure function in misc.py."""
 
     assert magnetic_pressure(B_arr).unit.is_equivalent(u.Pa)
@@ -82,7 +82,7 @@ def test_magnetic_pressure():
     assert_can_handle_nparray(magnetic_pressure)
 
 
-def test_magnetic_energy_density():
+def test_magnetic_energy_density() -> None:
     r"""Test the magnetic_energy_density function in misc.py."""
 
     assert magnetic_energy_density(B_arr).unit.is_equivalent(u.J / u.m**3)
@@ -122,7 +122,7 @@ def test_magnetic_energy_density():
     assert_can_handle_nparray(magnetic_energy_density)
 
 
-def test_Bohm_diffusion():
+def test_Bohm_diffusion() -> None:
     r"""Test Mag_Reynolds in dimensionless.py"""
 
     T_e = 5000 * u.K

--- a/plasmapy/formulary/tests/test_plasma_frequency.py
+++ b/plasmapy/formulary/tests/test_plasma_frequency.py
@@ -23,7 +23,7 @@ from plasmapy.utils._pytest_helpers import assert_can_handle_nparray
     ("alias", "parent"),
     [(wp_, plasma_frequency)],
 )
-def test_aliases(alias, parent):
+def test_aliases(alias, parent) -> None:
     assert alias is parent
 
 
@@ -39,12 +39,12 @@ class TestPlasmaFrequency:
         ("bound_name", "bound_attr"),
         [("lite", plasma_frequency_lite)],
     )
-    def test_lite_function_binding(self, bound_name, bound_attr):
+    def test_lite_function_binding(self, bound_name, bound_attr) -> None:
         """Test expected attributes are bound correctly."""
         assert hasattr(plasma_frequency, bound_name)
         assert getattr(plasma_frequency, bound_name) is bound_attr
 
-    def test_lite_function_marking(self):
+    def test_lite_function_marking(self) -> None:
         """
         Test plasma_frequency is marked as having a Lite-Function.
         """
@@ -71,7 +71,7 @@ class TestPlasmaFrequency:
             ),
         ],
     )
-    def test_raises(self, args, kwargs, _error):
+    def test_raises(self, args, kwargs, _error) -> None:
         """
         Test scenarios that cause plasma_frequency to raise an
         Exception.
@@ -91,7 +91,7 @@ class TestPlasmaFrequency:
             ((1e19, "p"), {}, u.UnitsWarning, plasma_frequency(1e19 * u.m**-3, "p")),
         ],
     )
-    def test_warns(self, args, kwargs, _warning, expected):
+    def test_warns(self, args, kwargs, _warning, expected) -> None:
         """
         Test scenarios the cause plasma_frequency to issue a warning.
         """
@@ -118,7 +118,7 @@ class TestPlasmaFrequency:
             ((m_p.to(u.u).value * u.cm**-3,), {"particle": "p"}, 1.32e3, 1e-2),
         ],
     )
-    def test_values(self, args, kwargs, expected, rtol):
+    def test_values(self, args, kwargs, expected, rtol) -> None:
         """Test various expected values."""
         wp = plasma_frequency(*args, **kwargs)
 
@@ -130,7 +130,7 @@ class TestPlasmaFrequency:
         ("args", "kwargs"),
         [((1 * u.cm**-3, "N+"), {}), ((1e12 * u.cm**-3,), {"particle": "p"})],
     )
-    def test_to_hz(self, args, kwargs):
+    def test_to_hz(self, args, kwargs) -> None:
         """Test behavior of the ``to_hz`` keyword."""
         wp = plasma_frequency(*args, **kwargs)
         fp = plasma_frequency(*args, to_hz=True, **kwargs)
@@ -139,17 +139,17 @@ class TestPlasmaFrequency:
         assert fp.unit == u.Hz
         assert fp.value == wp.value / (2.0 * np.pi)
 
-    def test_nans(self):
+    def test_nans(self) -> None:
         assert np.isnan(plasma_frequency(np.nan * u.m**-3, "e-"))
 
-    def test_can_handle_numpy_arrays(self):
+    def test_can_handle_numpy_arrays(self) -> None:
         assert_can_handle_nparray(plasma_frequency)
 
 
 class TestPlasmaFrequencyLite:
     """Test class for `plasma_frequency_lite`."""
 
-    def test_is_jitted(self):
+    def test_is_jitted(self) -> None:
         """Ensure `plasmapy_frequency_lite` was jitted by `numba`."""
         assert is_jitted(plasma_frequency_lite)
 
@@ -161,7 +161,7 @@ class TestPlasmaFrequencyLite:
             {"n": 1e11 * u.cm**-3, "particle": "He", "Z": 0.8},
         ],
     )
-    def test_normal_vs_lite_values(self, inputs):
+    def test_normal_vs_lite_values(self, inputs) -> None:
         """
         Test that plasma_frequency and plasma_frequency_lite calculate
         the same values.

--- a/plasmapy/formulary/tests/test_quantum.py
+++ b/plasmapy/formulary/tests/test_quantum.py
@@ -21,7 +21,7 @@ from plasmapy.particles.exceptions import InvalidParticleError
 from plasmapy.utils.exceptions import RelativityError
 
 
-def test_deBroglie_wavelength():
+def test_deBroglie_wavelength() -> None:
     dbwavelength1 = deBroglie_wavelength(2e7 * u.cm / u.s, "e")
     assert np.isclose(dbwavelength1.value, 3.628845222852886e-11)
     assert dbwavelength1.unit == u.m
@@ -64,12 +64,12 @@ def test_deBroglie_wavelength():
         ({"V": 8 * u.m / u.s, "particle": "invalid particle"}, InvalidParticleError),
     ],
 )
-def test_deBroglie_exceptions(kwargs, exception):
+def test_deBroglie_exceptions(kwargs, exception) -> None:
     with pytest.raises(exception):
         deBroglie_wavelength(**kwargs)
 
 
-def test_deBroglie_warning():
+def test_deBroglie_warning() -> None:
     with pytest.warns(u.UnitsWarning):
         deBroglie_wavelength(0.79450719277, "Be-7 1+")
 
@@ -82,7 +82,7 @@ n_e = 1e23 * u.cm**-3
 # add tests for different astropy units (random fuzzing method?)
 
 
-def test_thermal_deBroglie_wavelength():
+def test_thermal_deBroglie_wavelength() -> None:
     r"""Test the thermal_deBroglie_wavelength function in quantum.py."""
     lambda_dbTh = thermal_deBroglie_wavelength(T_e)
     # true value at 1 eV
@@ -104,7 +104,7 @@ def test_thermal_deBroglie_wavelength():
         thermal_deBroglie_wavelength(T_e=-1 * u.eV)
 
 
-def test_Fermi_energy():
+def test_Fermi_energy() -> None:
     r"""Test the Fermi_energy function in quantum.py."""
     energy_F = Fermi_energy(n_e)
     # true value at 1e23 cm-3
@@ -123,7 +123,7 @@ def test_Fermi_energy():
         Fermi_energy(n_e=-1 * u.m**-3)
 
 
-def test_Thomas_Fermi_length():
+def test_Thomas_Fermi_length() -> None:
     r"""Test the Thomas_Fermi_length function in quantum.py."""
     lambda_TF = Thomas_Fermi_length(n_e)
     # true value at 1e23 cm-3
@@ -143,7 +143,7 @@ def test_Thomas_Fermi_length():
         Thomas_Fermi_length(n_e=-1 * u.m**-3)
 
 
-def test_Wigner_Seitz_radius():
+def test_Wigner_Seitz_radius() -> None:
     """
     Checks Wigner-Seitz radius for a known value.
     """
@@ -167,7 +167,7 @@ class TestChemicalPotential:
 
     @staticmethod
     @pytest.mark.parametrize(*value_test_parameters)
-    def test_return_value(n_e, T, expected_value):
+    def test_return_value(n_e, T, expected_value) -> None:
         """
         Tests chemical_potential for expected value.
         """
@@ -181,7 +181,7 @@ class TestChemicalPotential:
 
     @staticmethod
     @pytest.mark.parametrize(*value_test_parameters)
-    def test_fail1(n_e, T, expected_value):
+    def test_fail1(n_e, T, expected_value) -> None:
         """
         Tests if test_return_value would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -200,13 +200,13 @@ class TestChemicalPotential:
 
 class Test__chemical_potential_interp:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.n_e = 1e23 * u.cm**-3
         cls.T = 11604 * u.K
         cls.True1 = 7.741254037813922
 
-    def test_known1(self):
+    def test_known1(self) -> None:
         """
         Tests Fermi_integral for expected value.
         """
@@ -215,7 +215,7 @@ class Test__chemical_potential_interp:
         errStr = f"Chemical potential value should be {self.True1} and not {methodVal}."
         assert testTrue, errStr
 
-    def test_fail1(self):
+    def test_fail1(self) -> None:
         """
         Tests if test_known1() would fail if we slightly adjusted the
         value comparison by some quantity close to numerical error.
@@ -230,7 +230,7 @@ class Test__chemical_potential_interp:
         assert testTrue, errStr
 
 
-def test_quantum_aliases():
+def test_quantum_aliases() -> None:
     r"""Test all aliases defined in quantum.py"""
 
     assert Ef_ is Fermi_energy
@@ -241,7 +241,7 @@ def test_quantum_aliases():
 class TestQuantumTheta:
     """Test the quantum_theta function in quantum.py."""
 
-    def test_units(self):
+    def test_units(self) -> None:
         """Test the return units"""
 
         theta = quantum_theta(1 * u.eV, 1e26 * u.m**-3)
@@ -257,7 +257,7 @@ class TestQuantumTheta:
             (1 * u.K, 1e26 * u.m**-3, 1.09690e-3),  # Specify temperature in Kelvin
         ],
     )
-    def test_value(self, T, n_e, expected_theta):
+    def test_value(self, T, n_e, expected_theta) -> None:
         """Compare the calculated theta with the expected value."""
 
         theta = quantum_theta(T, n_e)

--- a/plasmapy/formulary/tests/test_radiation.py
+++ b/plasmapy/formulary/tests/test_radiation.py
@@ -6,7 +6,7 @@ from plasmapy.formulary.radiation import thermal_bremsstrahlung
 from plasmapy.utils.exceptions import PhysicsError
 
 
-def test_thermal_bremsstrahlung():
+def test_thermal_bremsstrahlung() -> None:
     # Test correct spectrum created
     frequencies = (10 ** np.arange(15, 16, 0.01)) / u.s
     ne, Te = 1e22 * u.cm**-3, 1e2 * u.eV

--- a/plasmapy/formulary/tests/test_relativity.py
+++ b/plasmapy/formulary/tests/test_relativity.py
@@ -31,7 +31,7 @@ from plasmapy.utils.exceptions import RelativityError
         ([np.nan, 0, c.si.value] * u.m / u.s, [-np.nan, 1, np.inf]),
     ],
 )
-def test_Lorentz_factor(speed, expected):
+def test_Lorentz_factor(speed, expected) -> None:
     actual = Lorentz_factor(V=speed)
     assert u.allclose(actual, expected, equal_nan=True, rtol=1e-7)
 
@@ -46,7 +46,7 @@ def test_Lorentz_factor(speed, expected):
         (299792458 * u.kg / u.s, u.UnitTypeError),
     ],
 )
-def test_Lorentz_factor_exceptions(speed, exception):
+def test_Lorentz_factor_exceptions(speed, exception) -> None:
     with pytest.raises(exception):
         Lorentz_factor(speed)
 
@@ -54,7 +54,7 @@ def test_Lorentz_factor_exceptions(speed, exception):
 @pytest.mark.parametrize(
     ("speed", "warning"), [(2.2, u.UnitsWarning), (np.nan, u.UnitsWarning)]
 )
-def test_Lorentz_factor_warnings(speed, warning):
+def test_Lorentz_factor_warnings(speed, warning) -> None:
     with pytest.warns(warning):
         Lorentz_factor(speed)
 
@@ -74,7 +74,7 @@ def test_Lorentz_factor_warnings(speed, warning):
         ([1, 2] * u.Mm / u.s, [1e-15, 1e-16] * u.kg, [89.87601788, 8.98775179] * u.J),
     ],
 )
-def test_relativistic_energy(velocity, mass, expected):
+def test_relativistic_energy(velocity, mass, expected) -> None:
     actual = relativistic_energy(particle=mass, V=velocity)
     assert u.allclose(actual, expected, rtol=1e-6, atol=1e-6 * u.J, equal_nan=True)
     assert expected.unit == u.J
@@ -88,7 +88,7 @@ def test_relativistic_energy(velocity, mass, expected):
         (0 * c, -1 * u.kg, InvalidParticleError),
     ],
 )
-def test_relativistic_energy_exceptions(velocity, mass, exception):
+def test_relativistic_energy_exceptions(velocity, mass, exception) -> None:
     with pytest.raises(exception):
         relativistic_energy(V=velocity, particle=mass)
 
@@ -99,7 +99,7 @@ def test_relativistic_energy_exceptions(velocity, mass, exception):
         (2.2, 5 * u.kg, u.UnitsWarning),
     ],
 )
-def test_relativistic_energy_warnings(velocity, mass, warning):
+def test_relativistic_energy_warnings(velocity, mass, warning) -> None:
     with pytest.warns(warning):
         relativistic_energy(V=velocity, particle=mass)
 
@@ -116,7 +116,7 @@ proton_at_half_c_inputs = [
 
 @pytest.mark.parametrize(("attribute", "expected"), proton_at_half_c_inputs)
 @pytest.mark.parametrize(("parameter", "argument"), proton_at_half_c_inputs)
-def test_relativistic_body(parameter, argument, attribute, expected):
+def test_relativistic_body(parameter, argument, attribute, expected) -> None:
     """
     Test that when we create `RelativisticBody` instances for each of
     the different velocity-like arguments, that each of the resulting
@@ -136,7 +136,9 @@ def test_relativistic_body(parameter, argument, attribute, expected):
 
 @pytest.mark.parametrize(("attr_to_set", "set_value"), proton_at_half_c_inputs)
 @pytest.mark.parametrize(("attr_to_test", "expected"), proton_at_half_c_inputs)
-def test_relativistic_body_setters(attr_to_set, set_value, attr_to_test, expected):
+def test_relativistic_body_setters(
+    attr_to_set, set_value, attr_to_test, expected
+) -> None:
     """Test setting RelativisticBody attributes."""
     relativistic_body = RelativisticBody(proton, v_over_c=0.1)
     setattr(relativistic_body, attr_to_set, set_value)
@@ -151,7 +153,7 @@ def test_relativistic_body_setters(attr_to_set, set_value, attr_to_test, expecte
 
 
 @pytest.mark.parametrize("particle", [electron, proton])
-def test_relativistic_body_mass_energy(particle):
+def test_relativistic_body_mass_energy(particle) -> None:
     """Test `RelativisticBody.mass_energy`."""
     relativistic_body = RelativisticBody(particle, v_over_c=0)
     expected = particle.mass * c**2
@@ -178,7 +180,7 @@ def test_relativistic_body_mass_energy(particle):
         ({"lorentz_factor": 3 * u.m / u.s}, u.UnitConversionError),
     ],
 )
-def test_relativistic_body_init_exceptions(kwargs, exception):
+def test_relativistic_body_init_exceptions(kwargs, exception) -> None:
     """
     Test that `RelativisticBody` raises the appropriate exceptions
     during instantiation.
@@ -187,7 +189,7 @@ def test_relativistic_body_init_exceptions(kwargs, exception):
         RelativisticBody(proton, **kwargs)
 
 
-def test_relativistic_body_equality():
+def test_relativistic_body_equality() -> None:
     """Test that a `RelativisticBody` instance equals itself."""
     relativistic_body = RelativisticBody(particle=proton, v_over_c=0.34)
     assert relativistic_body == relativistic_body  # noqa: PLR0124
@@ -201,12 +203,12 @@ def test_relativistic_body_equality():
         (RelativisticBody("p+", V=c / 2), "different type"),
     ],
 )
-def test_relativistic_body_inequalities(this, that):
+def test_relativistic_body_inequalities(this, that) -> None:
     """Test the inequality properties of `RelativisticBody`."""
     assert this != that
 
 
-def test_relativistic_body_inequality_with_different_velocities():
+def test_relativistic_body_inequality_with_different_velocities() -> None:
     """
     Test that `RelativisticBody` instances are not equal when the
     velocity provided to them is different.
@@ -216,7 +218,7 @@ def test_relativistic_body_inequality_with_different_velocities():
     assert slower_body != faster_body
 
 
-def test_relativistic_body_inequality_with_different_particles():
+def test_relativistic_body_inequality_with_different_particles() -> None:
     """
     Test that `RelativisticBody` instances are not equal when the
     particles are different.
@@ -237,7 +239,7 @@ def test_relativistic_body_inequality_with_different_particles():
         "kinetic_energy",
     ],
 )
-def test_relativistic_body_defined_using_mass(attr):
+def test_relativistic_body_defined_using_mass(attr) -> None:
     """Test that a RelativisticBody can be provided a mass as the particle."""
     V = c / 2
 
@@ -251,7 +253,7 @@ def test_relativistic_body_defined_using_mass(attr):
 
 
 @pytest.mark.xfail(reason="RelativisticBody does not yet accept nan velocities")
-def test_relativistic_body_nan_velocity():
+def test_relativistic_body_nan_velocity() -> None:
     """
     Test that RelativisticBody can be created with no velocity defined,
     and then have the velocity be nan.
@@ -260,7 +262,7 @@ def test_relativistic_body_nan_velocity():
     assert np.isnan(relativistic_body.velocity)
 
 
-def test_relativistic_body_for_custom_particle():
+def test_relativistic_body_for_custom_particle() -> None:
     """Test that `RelativisticBody` can be created using a `CustomParticle`."""
     mass = 1e-27 * u.kg
     custom_particle = CustomParticle(mass=mass)
@@ -271,7 +273,7 @@ def test_relativistic_body_for_custom_particle():
     assert u.isclose(relativistic_custom_particle.lorentz_factor, 1, rtol=1e-9)
 
 
-def test_relativistic_body_with_particle_list():
+def test_relativistic_body_with_particle_list() -> None:
     """
     Test that `RelativisticBody` can be instantiated with multiple
     particles.
@@ -281,7 +283,7 @@ def test_relativistic_body_with_particle_list():
     np.testing.assert_allclose(relativistic_particles.lorentz_factor, 1)
 
 
-def test_relativistic_body_with_multiple_velocities():
+def test_relativistic_body_with_multiple_velocities() -> None:
     """
     Test that `RelativisticBody` can be instantiated with an array of
     velocities.
@@ -293,7 +295,7 @@ def test_relativistic_body_with_multiple_velocities():
     )
 
 
-def test_relativistic_body_with_multiple_particles_and_velocities():
+def test_relativistic_body_with_multiple_particles_and_velocities() -> None:
     """
     Test that `RelativisticBody` can be instantiated with multiple
     particles and multiple velocities.
@@ -305,7 +307,7 @@ def test_relativistic_body_with_multiple_particles_and_velocities():
 
 
 @pytest.mark.parametrize("function", [repr, str])
-def test_relativistic_body_into_string(function):
+def test_relativistic_body_into_string(function) -> None:
     """Test that `repr` and `str` work on RelativisticBody."""
     relativistic_body = RelativisticBody("p+", V=5.0 * u.m / u.s)
     expected = "RelativisticBody(p+, 5.0 m / s)"

--- a/plasmapy/formulary/tests/test_speeds.py
+++ b/plasmapy/formulary/tests/test_speeds.py
@@ -35,7 +35,7 @@ T_negarr = np.array([1e6, -5151.0]) * u.K
         (cs_, ion_sound_speed),
     ],
 )
-def test_aliases(alias, parent):
+def test_aliases(alias, parent) -> None:
     """Test all aliases defined in speeds.py"""
     assert alias is parent
 
@@ -74,7 +74,7 @@ class TestAlfvenSpeed:
             ),
         ],
     )
-    def test_raises(self, args, kwargs, _error):
+    def test_raises(self, args, kwargs, _error) -> None:
         """Test scenarios that raise exceptions or warnings."""
         with pytest.raises(_error):
             Alfven_speed(*args, **kwargs)
@@ -106,7 +106,7 @@ class TestAlfvenSpeed:
             ((0.5, 1.0e18 * u.m**-3), {"ion": "He+"}, 5471032.81, {}, u.UnitsWarning),
         ],
     )
-    def test_warns(self, args, kwargs, expected, isclose_kw, _warning):
+    def test_warns(self, args, kwargs, expected, isclose_kw, _warning) -> None:
         """Test scenarios that issue warnings"""
         with pytest.warns(_warning):
             val = Alfven_speed(*args, **kwargs)
@@ -179,7 +179,7 @@ class TestAlfvenSpeed:
             ),
         ],
     )
-    def test_values(self, args, kwargs, expected, isclose_kw):
+    def test_values(self, args, kwargs, expected, isclose_kw) -> None:
         """Test expected values."""
         assert np.allclose(Alfven_speed(*args, **kwargs), expected, **isclose_kw)
 
@@ -202,7 +202,7 @@ class TestAlfvenSpeed:
             ),
         ],
     )
-    def test_nan_values(self, args, kwargs, nan_mask):
+    def test_nan_values(self, args, kwargs, nan_mask) -> None:
         """Input scenarios that lead to `numpy.nan` values being returned."""
         val = Alfven_speed(*args, **kwargs)
         if np.isscalar(val.value):
@@ -212,7 +212,7 @@ class TestAlfvenSpeed:
             assert np.all(nan_arr[nan_mask])
             assert np.all(np.logical_not(nan_arr[np.logical_not(nan_mask)]))
 
-    def test_handle_nparrays(self):
+    def test_handle_nparrays(self) -> None:
         """Test for ability to handle numpy array quantities"""
         assert_can_handle_nparray(Alfven_speed)
 
@@ -305,7 +305,7 @@ class Test_Ion_Sound_Speed:
             ),  # testing for user input Z
         ],
     )
-    def test_values(self, args, kwargs, expected, isclose_kw):
+    def test_values(self, args, kwargs, expected, isclose_kw) -> None:
         assert np.isclose(ion_sound_speed(*args, **kwargs), expected, **isclose_kw)
 
     # case when Z=1 is assumed
@@ -330,7 +330,7 @@ class Test_Ion_Sound_Speed:
             ),
         ],
     )
-    def test_warns(self, kwargs1, kwargs2, _warning):
+    def test_warns(self, kwargs1, kwargs2, _warning) -> None:
         with pytest.warns(_warning):
             val = ion_sound_speed(**kwargs1)
             if kwargs2 != {}:
@@ -414,7 +414,7 @@ class Test_Ion_Sound_Speed:
             ),
         ],
     )
-    def test_raises(self, args, kwargs, _error):
+    def test_raises(self, args, kwargs, _error) -> None:
         with pytest.raises(_error):
             ion_sound_speed(*args, **kwargs)
 
@@ -425,8 +425,8 @@ class Test_Ion_Sound_Speed:
             ({"T_e": T_nanarr, "T_i": 0 * u.K, "n_e": n_e, "k": k_1, "ion": "p"}),
         ],
     )
-    def test_nan_values(self, kwargs):
+    def test_nan_values(self, kwargs) -> None:
         np.isnan(ion_sound_speed(**kwargs)[1])
 
-    def test_handle_nparrays(self):
+    def test_handle_nparrays(self) -> None:
         assert_can_handle_nparray(ion_sound_speed)

--- a/plasmapy/formulary/tests/test_thermal_speed.py
+++ b/plasmapy/formulary/tests/test_thermal_speed.py
@@ -34,7 +34,7 @@ from plasmapy.utils.exceptions import RelativityError, RelativityWarning
     ("alias", "parent"),
     [(vth_, thermal_speed), (vth_kappa_, kappa_thermal_speed)],
 )
-def test_aliases(alias, parent):
+def test_aliases(alias, parent) -> None:
     assert alias is parent
 
 
@@ -54,7 +54,7 @@ class TestThermalSpeedCoefficients:
             (1, 2, ValueError),
         ],
     )
-    def test_raises(self, ndim, method, _error):
+    def test_raises(self, ndim, method, _error) -> None:
         """Test scenarios that raise exceptions."""
         with pytest.raises(_error):
             thermal_speed_coefficients(ndim=ndim, method=method)
@@ -76,7 +76,7 @@ class TestThermalSpeedCoefficients:
             (3, "nrl", 1),
         ],
     )
-    def test_values(self, ndim, method, expected):
+    def test_values(self, ndim, method, expected) -> None:
         """Test that the correct values are returned."""
         val = thermal_speed_coefficients(ndim=ndim, method=method)
         assert np.isclose(val, expected)
@@ -103,12 +103,12 @@ class TestThermalSpeed:
             ("coefficients", thermal_speed_coefficients),
         ],
     )
-    def test_lite_function_binding(self, bound_name, bound_attr):
+    def test_lite_function_binding(self, bound_name, bound_attr) -> None:
         """Test expected attributes are bound correctly."""
         assert hasattr(thermal_speed, bound_name)
         assert getattr(thermal_speed, bound_name) is bound_attr
 
-    def test_lite_function_marking(self):
+    def test_lite_function_marking(self) -> None:
         """
         Test thermal_speed is marked as having a Lite-Function.
         """
@@ -232,7 +232,7 @@ class TestThermalSpeed:
             ),
         ],
     )
-    def test_values(self, args, kwargs, expected):
+    def test_values(self, args, kwargs, expected) -> None:
         """Test scenarios with known calculated values."""
         vth = thermal_speed(*args, **kwargs)
         assert np.allclose(vth.value, expected)
@@ -251,7 +251,7 @@ class TestThermalSpeed:
             ((1e6 * u.K, "e-"), {"ndim": 4}, ValueError),
         ],
     )
-    def test_raises(self, args, kwargs, _error):
+    def test_raises(self, args, kwargs, _error) -> None:
         """Test scenarios that cause an `Exception` to be raised."""
         with pytest.raises(_error):
             thermal_speed(*args, **kwargs)
@@ -270,7 +270,7 @@ class TestThermalSpeed:
             ((1e6, "p"), {}, u.UnitsWarning, thermal_speed(1e6 * u.K, "p")),
         ],
     )
-    def test_warns(self, args, kwargs, _warning, expected):
+    def test_warns(self, args, kwargs, _warning, expected) -> None:
         """Test scenarios where `thermal_speed` issues warnings."""
         with pytest.warns(_warning):
             vth = thermal_speed(*args, **kwargs)
@@ -279,21 +279,21 @@ class TestThermalSpeed:
             if expected is not None:
                 assert vth == expected
 
-    def test_electron_vs_proton(self):
+    def test_electron_vs_proton(self) -> None:
         """
         Ensure the electron thermal speed is larger that the proton
         thermal speed for the same parameters.
         """
         assert thermal_speed(1e6 * u.K, "e-") > thermal_speed(1e6 * u.K, "p")
 
-    def test_can_handle_numpy_arrays(self):
+    def test_can_handle_numpy_arrays(self) -> None:
         assert_can_handle_nparray(thermal_speed)
 
 
 class TestThermalSpeedLite:
     """Test class for `thermal_speed_lite`."""
 
-    def test_is_jitted(self):
+    def test_is_jitted(self) -> None:
         """Ensure `thermal_speed_lite` was jitted by `numba`."""
         assert is_jitted(thermal_speed_lite)
 
@@ -316,7 +316,7 @@ class TestThermalSpeedLite:
             {"T": 1 * u.eV, "particle": Particle("Ar+"), "method": "rms", "ndim": 3},
         ],
     )
-    def test_normal_vs_lite_values(self, inputs):
+    def test_normal_vs_lite_values(self, inputs) -> None:
         """
         Test that thermal_speed and thermal_speed_lite calculate the same values
         for the same inputs.
@@ -337,7 +337,7 @@ class TestThermalSpeedLite:
 # test class for kappa_thermal_speed() function:
 class Test_kappa_thermal_speed:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T_e = 5 * u.eV
         cls.kappaInvalid = 3 / 2
@@ -347,7 +347,7 @@ class Test_kappa_thermal_speed:
         cls.rms1True = 37905.474322612165
         cls.mean1True = 34922.98563039583
 
-    def test_invalid_kappa(self):
+    def test_invalid_kappa(self) -> None:
         """
         Checks if function raises error when kappa <= 3/2 is passed as an
         argument.
@@ -355,7 +355,7 @@ class Test_kappa_thermal_speed:
         with pytest.raises(ValueError):
             kappa_thermal_speed(self.T_e, self.kappaInvalid, particle=self.particle)
 
-    def test_invalid_method(self):
+    def test_invalid_method(self) -> None:
         """
         Checks if function raises error when invalid method is passed as an
         argument.
@@ -365,7 +365,7 @@ class Test_kappa_thermal_speed:
                 self.T_e, self.kappa, particle=self.particle, method="invalid"
             )
 
-    def test_probable1(self):
+    def test_probable1(self) -> None:
         """
         Tests if expected value is returned for a set of regular inputs.
         """
@@ -378,7 +378,7 @@ class Test_kappa_thermal_speed:
         )
         assert np.isclose(known1.value, self.probable1True, rtol=1e-8, atol=0.0), errstr
 
-    def test_rms1(self):
+    def test_rms1(self) -> None:
         """
         Tests if expected value is returned for a set of regular inputs.
         """
@@ -391,7 +391,7 @@ class Test_kappa_thermal_speed:
         )
         assert np.isclose(known1.value, self.rms1True, rtol=1e-8, atol=0.0), errstr
 
-    def test_mean1(self):
+    def test_mean1(self) -> None:
         """
         Tests if expected value is returned for a set of regular inputs.
         """
@@ -404,7 +404,7 @@ class Test_kappa_thermal_speed:
         )
         assert np.isclose(known1.value, self.mean1True, rtol=1e-8, atol=0.0), errstr
 
-    def test_handle_nparrays(self, kwargs=None):
+    def test_handle_nparrays(self, kwargs=None) -> None:
         """Test for ability to handle numpy array quantities"""
         if kwargs is None:
             kwargs = {"kappa": 2}

--- a/plasmapy/formulary/tests/test_transport.py
+++ b/plasmapy/formulary/tests/test_transport.py
@@ -52,7 +52,7 @@ def count_decimal_places(digits):
 @pytest.mark.slow()
 class Test_classical_transport:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Set up some initial values for tests"""
         cls.T_e = 1000 * u.eV
         cls.n_e = 2e13 / u.cm**3
@@ -109,7 +109,7 @@ class Test_classical_transport:
 
             cls.all_variables = cls.ct.all_variables
 
-    def test_spitzer_vs_formulary(self):
+    def test_spitzer_vs_formulary(self) -> None:
         """Spitzer resistivity should agree with approx. in NRL formulary"""
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
@@ -140,7 +140,7 @@ class Test_classical_transport:
             )
         assert testTrue, errStr
 
-    def test_resistivity_units(self):
+    def test_resistivity_units(self) -> None:
         """Output should be a Quantity with units of Ohm m"""
         with pytest.warns(RelativityWarning):
             testTrue = self.ct.resistivity.unit == u.Ohm * u.m
@@ -150,7 +150,7 @@ class Test_classical_transport:
             )
         assert testTrue, errStr
 
-    def test_thermoelectric_conductivity_units(self):
+    def test_thermoelectric_conductivity_units(self) -> None:
         """Output should be a Quantity with units of dimensionless"""
         testTrue = self.ct.thermoelectric_conductivity.unit == u.m / u.m
         errStr = (
@@ -159,7 +159,7 @@ class Test_classical_transport:
         )
         assert testTrue, errStr
 
-    def test_ion_thermal_conductivity_units(self):
+    def test_ion_thermal_conductivity_units(self) -> None:
         """Output should be Quantity with units of W / (m K)"""
         testTrue = self.ct.ion_thermal_conductivity.unit == u.W / u.m / u.K
         errStr = (
@@ -169,7 +169,7 @@ class Test_classical_transport:
         )
         assert testTrue, errStr
 
-    def test_electron_thermal_conductivity_units(self):
+    def test_electron_thermal_conductivity_units(self) -> None:
         """Output should be Quantity with units of W / (m K)"""
         with pytest.warns(RelativityWarning):
             testTrue = self.ct.electron_thermal_conductivity.unit == u.W / u.m / u.K
@@ -180,7 +180,7 @@ class Test_classical_transport:
             )
         assert testTrue, errStr
 
-    def test_ion_viscosity_units(self):
+    def test_ion_viscosity_units(self) -> None:
         """Output should be Quantity with units of Pa s"""
         testTrue = self.ct.ion_viscosity.unit == u.Pa * u.s
         errStr = (
@@ -189,7 +189,7 @@ class Test_classical_transport:
         )
         assert testTrue, errStr
 
-    def test_electron_viscosity_units(self):
+    def test_electron_viscosity_units(self) -> None:
         """Output should be Quantity with units of Pa s"""
         with pytest.warns(RelativityWarning):
             testTrue = self.ct.electron_viscosity.unit == u.Pa * u.s
@@ -199,7 +199,7 @@ class Test_classical_transport:
             )
         assert testTrue, errStr
 
-    def test_particle_mass(self):
+    def test_particle_mass(self) -> None:
         """Should raise ValueError if particle mass not found"""
         with pytest.raises(ValueError):
             ClassicalTransport(
@@ -211,7 +211,7 @@ class Test_classical_transport:
                 Z=1,
             )
 
-    def test_particle_charge_state(self):
+    def test_particle_charge_state(self) -> None:
         """Should raise ValueError if particle charge state not found"""
         with pytest.raises(InvalidParticleError):
             ClassicalTransport(
@@ -223,7 +223,7 @@ class Test_classical_transport:
                 m_i=m_p,
             )
 
-    def test_Z_checks(self):
+    def test_Z_checks(self) -> None:
         """Should raise ValueError if Z is negative"""
         with pytest.raises(ValueError):
             ClassicalTransport(
@@ -235,7 +235,7 @@ class Test_classical_transport:
                 Z=-1,
             )
 
-    def test_coulomb_log_warnings(self):
+    def test_coulomb_log_warnings(self) -> None:
         """Should warn CouplingWarning if coulomb log is near 1"""
         with pytest.warns(CouplingWarning):
             ClassicalTransport(
@@ -257,7 +257,7 @@ class Test_classical_transport:
                 coulomb_log_ei=1.3,
             )
 
-    def test_coulomb_log_errors(self):
+    def test_coulomb_log_errors(self) -> None:
         """Should raise PhysicsError if coulomb log is < 1"""
         with pytest.raises(PhysicsError), pytest.warns(CouplingWarning):
             ClassicalTransport(
@@ -279,7 +279,7 @@ class Test_classical_transport:
                 coulomb_log_ei=0.3,
             )
 
-    def test_coulomb_log_calc(self):
+    def test_coulomb_log_calc(self) -> None:
         """If no coulomb logs are input, they should be calculated"""
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
@@ -302,7 +302,7 @@ class Test_classical_transport:
         )
         assert testTrue, errStr
 
-    def test_hall_calc(self):
+    def test_hall_calc(self) -> None:
         """If no hall parameters are input, they should be calculated"""
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
@@ -327,7 +327,7 @@ class Test_classical_transport:
         errStr = f"Electron hall parameter should be {hall_e} and not {ct2.hall_e}."
         assert testTrue, errStr
 
-    def test_invalid_model(self):
+    def test_invalid_model(self) -> None:
         with pytest.raises(ValueError):
             ClassicalTransport(
                 T_e=self.T_e,
@@ -338,7 +338,7 @@ class Test_classical_transport:
                 model="standard",
             )
 
-    def test_invalid_field(self):
+    def test_invalid_field(self) -> None:
         with pytest.raises(ValueError):
             ClassicalTransport(
                 T_e=self.T_e,
@@ -349,7 +349,7 @@ class Test_classical_transport:
                 field_orientation="to the left",
             )
 
-    def test_precalculated_parameters(self):
+    def test_precalculated_parameters(self) -> None:
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
                 T_e=self.T_e,
@@ -379,7 +379,9 @@ class Test_classical_transport:
             ("spitzer", "resistivity", "all", 2),
         ],
     )
-    def test_number_of_returns(self, model, attr_name, field_orientation, expected):
+    def test_number_of_returns(
+        self, model, attr_name, field_orientation, expected
+    ) -> None:
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
                 T_e=self.T_e,
@@ -407,7 +409,7 @@ class Test_classical_transport:
             ("braginskii", 2.78349687e-8 * u.Ohm * u.m),
         ],
     )
-    def test_resistivity_by_model(self, model, expected):
+    def test_resistivity_by_model(self, model, expected) -> None:
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
                 T_e=self.T_e,
@@ -432,7 +434,7 @@ class Test_classical_transport:
             ("braginskii", 0.711084 * u.s / u.s),
         ],
     )
-    def test_thermoelectric_conductivity_by_model(self, model, expected):
+    def test_thermoelectric_conductivity_by_model(self, model, expected) -> None:
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
                 T_e=self.T_e,
@@ -465,7 +467,7 @@ class Test_classical_transport:
             ),
         ],
     )
-    def test_electron_viscosity_by_model(self, model, expected):
+    def test_electron_viscosity_by_model(self, model, expected) -> None:
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
                 T_e=self.T_e,
@@ -497,7 +499,7 @@ class Test_classical_transport:
             ),
         ],
     )
-    def test_ion_viscosity_by_model(self, model, expected):
+    def test_ion_viscosity_by_model(self, model, expected) -> None:
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
                 T_e=self.T_e,
@@ -522,7 +524,7 @@ class Test_classical_transport:
             ("braginskii", 5016895.3386957785 * u.W / (u.K * u.m)),
         ],
     )
-    def test_electron_thermal_conductivity_by_model(self, model, expected):
+    def test_electron_thermal_conductivity_by_model(self, model, expected) -> None:
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
                 T_e=self.T_e,
@@ -551,7 +553,7 @@ class Test_classical_transport:
             ("braginskii", 133052.21732349042 * u.W / (u.K * u.m)),
         ],
     )
-    def test_ion_thermal_conductivity_by_model(self, model, expected):
+    def test_ion_thermal_conductivity_by_model(self, model, expected) -> None:
         with pytest.warns(RelativityWarning):
             ct2 = ClassicalTransport(
                 T_e=self.T_e,
@@ -602,7 +604,7 @@ class Test_classical_transport:
             ],
         }.items(),
     )
-    def test_dictionary(self, key, expected):
+    def test_dictionary(self, key, expected) -> None:
         calculated = self.all_variables[key]
         testTrue = np.allclose(expected, calculated.si.value)
         errStr = (
@@ -610,7 +612,7 @@ class Test_classical_transport:
         )
         assert testTrue, errStr
 
-    def test_resistivity_wrapper(self):
+    def test_resistivity_wrapper(self) -> None:
         with pytest.warns(RelativityWarning):
             assert_quantity_allclose(
                 resistivity(
@@ -629,7 +631,7 @@ class Test_classical_transport:
                 self.ct_wrapper.resistivity,
             )
 
-    def test_thermoelectric_conductivity_wrapper(self):
+    def test_thermoelectric_conductivity_wrapper(self) -> None:
         with pytest.warns(RelativityWarning):
             val1 = thermoelectric_conductivity(
                 T_e=self.T_e,
@@ -647,7 +649,7 @@ class Test_classical_transport:
             val2 = self.ct_wrapper.thermoelectric_conductivity
             assert_quantity_allclose(val1, val2)
 
-    def test_ion_thermal_conductivity_wrapper(self):
+    def test_ion_thermal_conductivity_wrapper(self) -> None:
         with pytest.warns(RelativityWarning):
             wrapped = ion_thermal_conductivity(
                 T_e=self.T_e,
@@ -664,7 +666,7 @@ class Test_classical_transport:
             )
             assert_quantity_allclose(wrapped, self.ct_wrapper.ion_thermal_conductivity)
 
-    def test_electron_thermal_conductivity_wrapper(self):
+    def test_electron_thermal_conductivity_wrapper(self) -> None:
         with pytest.warns(RelativityWarning):
             wrapped = electron_thermal_conductivity(
                 T_e=self.T_e,
@@ -683,7 +685,7 @@ class Test_classical_transport:
                 wrapped, self.ct_wrapper.electron_thermal_conductivity
             )
 
-    def test_ion_viscosity_wrapper(self):
+    def test_ion_viscosity_wrapper(self) -> None:
         with pytest.warns(RelativityWarning):
             assert_quantity_allclose(
                 ion_viscosity(
@@ -702,7 +704,7 @@ class Test_classical_transport:
                 self.ct_wrapper.ion_viscosity,
             )
 
-    def test_electron_viscosity_wrapper(self):
+    def test_electron_viscosity_wrapper(self) -> None:
         with pytest.warns(RelativityWarning):
             assert_quantity_allclose(
                 electron_viscosity(
@@ -723,25 +725,25 @@ class Test_classical_transport:
 
 
 @pytest.mark.parametrize("particle", ["e", "p"])
-def test_nondim_thermal_conductivity_unrecognized_model(particle):
+def test_nondim_thermal_conductivity_unrecognized_model(particle) -> None:
     with pytest.raises(ValueError):
         _nondim_thermal_conductivity(
             1, 1, particle, "standard model is best model", "parallel"
         )
 
 
-def test_nondim_resistivity_unrecognized_model():
+def test_nondim_resistivity_unrecognized_model() -> None:
     with pytest.raises(ValueError):
         _nondim_resistivity(1, 1, "e", "SURPRISE SUPERSYMMETRY", "parallel")
 
 
-def test_nondim_te_conductivity_unrecognized_model():
+def test_nondim_te_conductivity_unrecognized_model() -> None:
     with pytest.raises(ValueError):
         _nondim_te_conductivity(1, 1, "e", "this is not a model", "parallel")
 
 
 @pytest.mark.parametrize("particle", ["e", "p"])
-def test_nondim_viscosity_unrecognized_model(particle):
+def test_nondim_viscosity_unrecognized_model(particle) -> None:
     with pytest.raises(ValueError):
         _nondim_viscosity(1, 1, particle, "not a model", "parallel")
 
@@ -749,7 +751,7 @@ def test_nondim_viscosity_unrecognized_model(particle):
 # test class for _nondim_tc_e_braginskii function:
 class Test__nondim_tc_e_braginskii:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Set up some initial values for tests"""
         cls.big_hall = 1000
         cls.small_hall = 0
@@ -765,7 +767,7 @@ class Test__nondim_tc_e_braginskii:
             (np.inf, "par", 12.5),  # eq (2.12), table 1
         ],
     )
-    def test_known_values_par(self, Z, field_orientation, expected):
+    def test_known_values_par(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         kappa_e_hat = _nondim_tc_e_braginskii(self.big_hall, Z, field_orientation)
         assert np.isclose(kappa_e_hat, expected, atol=1e-1)
@@ -781,20 +783,20 @@ class Test__nondim_tc_e_braginskii:
             (np.inf, "perp", 3.2),  # eq (2.13),table 1
         ],
     )
-    def test_known_values_perp(self, Z, field_orientation, expected):
+    def test_known_values_perp(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         kappa_e_hat = _nondim_tc_e_braginskii(self.big_hall, Z, field_orientation)
         assert np.isclose(kappa_e_hat * self.big_hall**2, expected, atol=1e-1)
 
     @pytest.mark.parametrize("Z", [1, 2, 3, 4, np.inf])
-    def test_unmagnetized(self, Z):
+    def test_unmagnetized(self, Z) -> None:
         """Confirm perp -> par as B -> 0"""
         kappa_e_hat_par = _nondim_tc_e_braginskii(self.small_hall, Z, "par")
         kappa_e_hat_perp = _nondim_tc_e_braginskii(self.small_hall, Z, "perp")
         assert np.isclose(kappa_e_hat_par, kappa_e_hat_perp, rtol=1e-3)
 
     @pytest.mark.parametrize("Z", [1, 4])
-    def test_cross_vs_ji_held(self, Z):
+    def test_cross_vs_ji_held(self, Z) -> None:
         """Cross should roughly agree with ji-held"""
         kappa_e_hat_cross_brag = _nondim_tc_e_braginskii(self.big_hall, Z, "cross")
         kappa_e_hat_cross_jh = _nondim_tc_e_ji_held(self.big_hall, Z, "cross")
@@ -809,30 +811,30 @@ class Test__nondim_tc_e_braginskii:
 # test class for _nondim_tc_i_braginskii function:
 class Test__nondim_tc_i_braginskii:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Set up some initial values for tests"""
         cls.big_hall = 1000
         cls.small_hall = 0
 
-    def test_known_values_par(self):
+    def test_known_values_par(self) -> None:
         """Check some known values"""
         kappa_i_hat = _nondim_tc_i_braginskii(self.big_hall, field_orientation="par")
         expected = 3.9  # Braginskii '65 eq (2.15)
         assert np.isclose(kappa_i_hat, expected, atol=1e-1)
 
-    def test_known_values_perp(self):
+    def test_known_values_perp(self) -> None:
         """Check some known values"""
         kappa_i_hat = _nondim_tc_i_braginskii(self.big_hall, field_orientation="perp")
         expected = 2.0  # Braginskii '65 eq (2.16)
         assert np.isclose(kappa_i_hat * self.big_hall**2, expected, atol=1e-1)
 
-    def test_unmagnetized(self):
+    def test_unmagnetized(self) -> None:
         """Confirm perp -> par as B -> 0"""
         kappa_i_hat_par = _nondim_tc_i_braginskii(self.small_hall, "par")
         kappa_i_hat_perp = _nondim_tc_i_braginskii(self.small_hall, "perp")
         assert np.isclose(kappa_i_hat_par, kappa_i_hat_perp, rtol=1e-3)
 
-    def test_cross_vs_ji_held_K2(self):
+    def test_cross_vs_ji_held_K2(self) -> None:
         """Confirm cross agrees with ji-held model when K=2"""
         kappa_i_hat_brag = _nondim_tc_i_braginskii(self.big_hall, "cross")
         kappa_i_hat_jh = _nondim_tc_i_ji_held(self.big_hall, 1, 0, 100, "cross", K=2)
@@ -842,7 +844,7 @@ class Test__nondim_tc_i_braginskii:
 # test class for _nondim_tec_braginskii function:
 class Test__nondim_tec_braginskii:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Set up some initial values for tests"""
         cls.big_hall = 1000
         cls.small_hall = 0
@@ -858,20 +860,20 @@ class Test__nondim_tec_braginskii:
             (np.inf, "par", 1.5),  # eq (2.9),table 1
         ],
     )
-    def test_known_values_par(self, Z, field_orientation, expected):
+    def test_known_values_par(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         beta_hat = _nondim_tec_braginskii(self.big_hall, Z, field_orientation)
         assert np.isclose(beta_hat, expected, atol=1e-1)
 
     @pytest.mark.parametrize("Z", [1, 2, 3, 4, np.inf])
-    def test_unmagnetized(self, Z):
+    def test_unmagnetized(self, Z) -> None:
         """Confirm perp -> par as B -> 0"""
         beta_hat_par = _nondim_tec_braginskii(self.small_hall, Z, "par")
         beta_hat_perp = _nondim_tec_braginskii(self.small_hall, Z, "perp")
         assert np.isclose(beta_hat_par, beta_hat_perp, rtol=1e-3)
 
     @pytest.mark.parametrize("Z", [1, 4])
-    def test_cross_vs_ji_held(self, Z):
+    def test_cross_vs_ji_held(self, Z) -> None:
         """Cross should roughly agree with ji-held"""
         beta_hat_cross_brag = _nondim_tec_braginskii(self.big_hall, Z, "cross")
         beta_hat_cross_jh = _nondim_tec_ji_held(self.big_hall, Z, "cross")
@@ -881,7 +883,7 @@ class Test__nondim_tec_braginskii:
 # test class for _nondim_resist_braginskii function:
 class Test__nondim_resist_braginskii:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Set up some initial values for tests"""
         cls.big_hall = 1000
         cls.small_hall = 0
@@ -897,20 +899,20 @@ class Test__nondim_resist_braginskii:
             (np.inf, "par", 0.29),  # eq (2.8),table 1
         ],
     )
-    def test_known_values_par(self, Z, field_orientation, expected):
+    def test_known_values_par(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         beta_hat = _nondim_resist_braginskii(self.big_hall, Z, field_orientation)
         assert np.isclose(beta_hat, expected, atol=1e-2)
 
     @pytest.mark.parametrize("Z", [1, 2, 3, 4, np.inf])
-    def test_unmagnetized(self, Z):
+    def test_unmagnetized(self, Z) -> None:
         """Confirm perp -> par as B -> 0"""
         alpha_hat_par = _nondim_resist_braginskii(self.small_hall, Z, "par")
         alpha_hat_perp = _nondim_resist_braginskii(self.small_hall, Z, "perp")
         assert np.isclose(alpha_hat_par, alpha_hat_perp, rtol=1e-3)
 
     @pytest.mark.parametrize("Z", [1, 4])
-    def test_cross_vs_ji_held(self, Z):
+    def test_cross_vs_ji_held(self, Z) -> None:
         """Cross should roughly agree with ji-held at hall 0.1"""
         alpha_hat_cross_brag = _nondim_resist_braginskii(0.1, Z, "cross")
         alpha_hat_cross_jh = _nondim_resist_ji_held(0.1, Z, "cross")
@@ -920,7 +922,7 @@ class Test__nondim_resist_braginskii:
 # test class for _nondim_visc_i_braginskii function:
 class Test__nondim_visc_i_braginskii:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Set up some initial values for tests"""
         cls.big_hall = 1000
         cls.small_hall = 0
@@ -930,13 +932,13 @@ class Test__nondim_visc_i_braginskii:
         ("expected", "power"),
         [(np.array((0.96, 0.3, 1.2, 0.5, 1.0)), np.array((0, 2, 2, 1, 1)))],
     )
-    def test_known_values(self, expected, power):
+    def test_known_values(self, expected, power) -> None:
         """Check some known values"""
         eta_i_hat = _nondim_visc_i_braginskii(self.big_hall)
         eta_i_hat_with_powers = eta_i_hat * self.big_hall**power
         assert np.allclose(eta_i_hat_with_powers, expected, atol=1e-2)
 
-    def test_vs_ji_held_K2(self):
+    def test_vs_ji_held_K2(self) -> None:
         """Confirm agreement with ji-held model when K=2"""
         eta_i_hat_brag = _nondim_visc_i_braginskii(self.big_hall)
         eta_i_hat_jh = _nondim_visc_i_ji_held(self.big_hall, 1, 0, 100, K=2)
@@ -947,7 +949,7 @@ class Test__nondim_visc_i_braginskii:
 # test class for _nondim_visc_e_braginskii function:
 class Test__nondim_visc_e_braginskii:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Set up some initial values for tests"""
         cls.big_hall = 1000
         cls.small_hall = 0
@@ -963,7 +965,7 @@ class Test__nondim_visc_e_braginskii:
             (1, 1.0, 4),  # eq (2.27)
         ],
     )
-    def test_known_values(self, Z, expected, idx):
+    def test_known_values(self, Z, expected, idx) -> None:
         """Check some known values"""
         beta_hat = _nondim_visc_e_braginskii(self.big_hall, Z)
         if idx == 0:
@@ -974,13 +976,13 @@ class Test__nondim_visc_e_braginskii:
             assert np.isclose(beta_hat[idx] * self.big_hall, expected, atol=1e-1)
 
 
-def test_fail__check_Z_nan():
+def test_fail__check_Z_nan() -> None:
     with pytest.raises(PhysicsError):
         _check_Z([1, 2, 3], 4)
 
 
 @pytest.mark.parametrize("Z", [1, 2, 4, 16, np.inf])
-def test__nondim_tc_e_spitzer(Z):
+def test__nondim_tc_e_spitzer(Z) -> None:
     """Test _nondim_tc_e_spitzer function"""
     kappa = _nondim_tc_e_spitzer(Z)
     if Z == 1:
@@ -999,7 +1001,7 @@ def test__nondim_tc_e_spitzer(Z):
 
 
 @pytest.mark.parametrize("Z", [1, 2, 4, 16, np.inf])
-def test__nondim_resist_spitzer(Z):
+def test__nondim_resist_spitzer(Z) -> None:
     """Test _nondim_resist_spitzer function"""
     alpha = _nondim_resist_spitzer(Z, "par")
     if Z == 1:
@@ -1015,7 +1017,7 @@ def test__nondim_resist_spitzer(Z):
 
 
 @pytest.mark.parametrize("Z", [1, 2, 4, 16, np.inf])
-def test__nondim_tec_spitzer(Z):
+def test__nondim_tec_spitzer(Z) -> None:
     """Test _nondim_tec_spitzer function"""
     beta = _nondim_tec_spitzer(Z)
     if Z == 1:
@@ -1072,7 +1074,7 @@ def test__nondim_tec_spitzer(Z):
         (500.8, 100, "cross", 0.004972),
     ],
 )
-def test__nondim_tc_e_ji_held(hall, Z, field_orientation, expected):
+def test__nondim_tc_e_ji_held(hall, Z, field_orientation, expected) -> None:
     """Test _nondim_tc_e_ji_held function"""
     kappa_hat = _nondim_tc_e_ji_held(hall, Z, field_orientation)
     kappa_check = expected
@@ -1128,7 +1130,7 @@ def test__nondim_tc_e_ji_held(hall, Z, field_orientation, expected):
         (629.8, 100, "cross", 0.002308),
     ],
 )
-def test__nondim_tec_ji_held(hall, Z, field_orientation, expected):
+def test__nondim_tec_ji_held(hall, Z, field_orientation, expected) -> None:
     """Test _nondim_tec_ji_held function"""
     beta_hat = _nondim_tec_ji_held(hall, Z, field_orientation)
     beta_check = expected
@@ -1179,7 +1181,7 @@ def test__nondim_tec_ji_held(hall, Z, field_orientation, expected):
         (7879, 100, "cross", 0.005652),
     ],
 )
-def test__nondim_resist_ji_held(hall, Z, field_orientation, expected):
+def test__nondim_resist_ji_held(hall, Z, field_orientation, expected) -> None:
     """Test _nondim_resist_ji_held function"""
     alpha_hat = _nondim_resist_ji_held(hall, Z, field_orientation)
     alpha_check = expected
@@ -1210,7 +1212,7 @@ def test__nondim_resist_ji_held(hall, Z, field_orientation, expected):
         (77.82, 1, 4, 0.01288),
     ],
 )
-def test__nondim_visc_e_ji_held(hall, Z, index, expected):
+def test__nondim_visc_e_ji_held(hall, Z, index, expected) -> None:
     """Test _nondim_visc_e_ji_held function"""
     alpha_hat = _nondim_visc_e_ji_held(hall, Z)
     alpha_check = expected
@@ -1242,7 +1244,7 @@ def test__nondim_visc_e_ji_held(hall, Z, index, expected):
         (77.11707, 1, 0, 100, "cross", 0.03235721),
     ],
 )
-def test__nondim_tc_i_ji_held(hall, Z, mu, theta, field_orientation, expected):
+def test__nondim_tc_i_ji_held(hall, Z, mu, theta, field_orientation, expected) -> None:
     """Test _nondim_tc_i_ji_held function"""
     kappa_hat = _nondim_tc_i_ji_held(hall, Z, mu, theta, field_orientation)
     kappa_check = expected
@@ -1270,7 +1272,7 @@ def test__nondim_tc_i_ji_held(hall, Z, mu, theta, field_orientation, expected):
         (80.42633, 1, 0, 100, 4, 0.01238144),
     ],
 )
-def test__nondim_visc_i_ji_held(hall, Z, mu, theta, index, expected):
+def test__nondim_visc_i_ji_held(hall, Z, mu, theta, index, expected) -> None:
     """Test _nondim_visc_i_ji_held function"""
     kappa_hat = _nondim_visc_i_ji_held(hall, Z, mu, theta)
     kappa_check = expected

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -205,7 +205,7 @@ class _ParticleInput:
         return self._data["callable"]
 
     @callable_.setter
-    def callable_(self, callable_: Callable):
+    def callable_(self, callable_: Callable) -> None:
         self._data["callable"] = callable_
         self._data["annotations"] = _get_annotations(callable_)
         self._data["parameters_to_process"] = self.find_parameters_to_process()
@@ -254,7 +254,7 @@ class _ParticleInput:
         return self._data["require"]
 
     @require.setter
-    def require(self, require_: Optional[Union[str, set, list, tuple]]):
+    def require(self, require_: Optional[Union[str, set, list, tuple]]) -> None:
         self._data["require"] = _make_into_set_or_none(require_)
 
     @property
@@ -269,7 +269,7 @@ class _ParticleInput:
         return self._data["any_of"]
 
     @any_of.setter
-    def any_of(self, any_of_: Optional[Union[str, set, list, tuple]]):
+    def any_of(self, any_of_: Optional[Union[str, set, list, tuple]]) -> None:
         self._data["any_of"] = _make_into_set_or_none(any_of_)
 
     @property
@@ -284,7 +284,7 @@ class _ParticleInput:
         return self._data["exclude"]
 
     @exclude.setter
-    def exclude(self, exclude_):
+    def exclude(self, exclude_) -> None:
         self._data["exclude"] = _make_into_set_or_none(exclude_)
 
     @property
@@ -300,7 +300,7 @@ class _ParticleInput:
         return self._data["allow_custom_particles"]
 
     @allow_custom_particles.setter
-    def allow_custom_particles(self, allow_custom_particles_: bool):
+    def allow_custom_particles(self, allow_custom_particles_: bool) -> None:
         self._data["allow_custom_particles"] = allow_custom_particles_
 
     @property
@@ -315,7 +315,7 @@ class _ParticleInput:
         return self._data["allow_particle_lists"]
 
     @allow_particle_lists.setter
-    def allow_particle_lists(self, allow_particle_lists_: bool):
+    def allow_particle_lists(self, allow_particle_lists_: bool) -> None:
         self._data["allow_particle_lists"] = allow_particle_lists_
 
     @property

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -150,7 +150,7 @@ class IonicLevel:
     @validate_quantities(
         n={"can_be_negative": False, "can_be_inf": False, "none_shall_pass": True},
     )
-    def number_density(self, n: u.Quantity[u.m**-3]):
+    def number_density(self, n: u.Quantity[u.m**-3]) -> None:
         self._number_density = np.nan * u.m**-3 if n is None else n
 
     @property
@@ -162,7 +162,7 @@ class IonicLevel:
     @validate_quantities(
         T={"can_be_negative": False, "can_be_inf": False, "none_shall_pass": True},
     )
-    def T_i(self, T: u.Quantity[u.K]):
+    def T_i(self, T: u.Quantity[u.K]) -> None:
         self._T_i = np.nan * u.K if T is None else T
 
 

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -2288,7 +2288,7 @@ class CustomParticle(AbstractPhysicalParticle):
         return (self.charge / const.e.si).value
 
     @charge_number.setter
-    def charge_number(self, Z: int):
+    def charge_number(self, Z: int) -> None:
         self._charge = Z * const.e.si
 
     @property

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -245,7 +245,7 @@ class ParticleList(collections.UserList):
             values = u.Quantity(values)
         return values
 
-    def append(self, particle: ParticleLike):
+    def append(self, particle: ParticleLike) -> None:
         """Append a particle to the end of the |ParticleList|."""
         if isinstance(particle, u.Quantity):
             particle = _turn_quantity_into_custom_particle(particle)
@@ -280,7 +280,7 @@ class ParticleList(collections.UserList):
         """
         return self._data
 
-    def extend(self, iterable: Iterable[ParticleLike]):
+    def extend(self, iterable: Iterable[ParticleLike]) -> None:
         """
         Extend the sequence by appending |particle-like| elements from
         ``iterable``.
@@ -306,7 +306,7 @@ class ParticleList(collections.UserList):
         """
         return self._get_particle_attribute("half_life", unit=u.s, default=np.nan * u.s)
 
-    def insert(self, index, particle: ParticleLike):
+    def insert(self, index, particle: ParticleLike) -> None:
         """Insert a particle before an index."""
         if isinstance(particle, u.Quantity):
             particle = _turn_quantity_into_custom_particle(particle)

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -240,24 +240,24 @@ table_functions_args_kwargs_output = [
     ("tested_function", "args", "kwargs", "expected_output"),
     table_functions_args_kwargs_output,
 )
-def test_functions_and_values(tested_function, args, kwargs, expected_output):
+def test_functions_and_values(tested_function, args, kwargs, expected_output) -> None:
     run_test(tested_function, args, kwargs, expected_output)
 
 
 class TestInvalidPeriodicElement:
-    def test_periodic_table_period(self):
+    def test_periodic_table_period(self) -> None:
         with pytest.raises(TypeError):
             periodic_table_period(("Ne", "Na"))
 
-    def test_periodic_table_block(self):
+    def test_periodic_table_block(self) -> None:
         with pytest.raises(TypeError):
             periodic_table_block(("N", "C", "F"))
 
-    def test_periodic_table_category(self):
+    def test_periodic_table_category(self) -> None:
         with pytest.raises(TypeError):
             periodic_table_category(["Rb", "He", "Li"])
 
-    def test_periodic_table_group(self):
+    def test_periodic_table_group(self) -> None:
         with pytest.raises(TypeError):
             periodic_table_group(("B", "Ti", "Ge"))
 
@@ -265,7 +265,7 @@ class TestInvalidPeriodicElement:
 # Next we have tests that do not fall nicely into equality comparisons.
 
 
-def test_standard_atomic_weight_value_between():
+def test_standard_atomic_weight_value_between() -> None:
     """Test that `standard_atomic_weight` returns approximately the
     correct value for phosphorus."""
     assert (
@@ -273,14 +273,14 @@ def test_standard_atomic_weight_value_between():
     ), "Incorrect standard atomic weight for phosphorus."
 
 
-def test_particle_mass_berkelium_249():
+def test_particle_mass_berkelium_249() -> None:
     """Test that `particle_mass` returns the correct value for Bk-249."""
     assert np.isclose(
         particle_mass("berkelium-249").to(u.u).value, 249.0749877
     ), "Incorrect isotope mass for berkelium."
 
 
-def test_particle_mass_for_hydrogen_with_no_mass_number():
+def test_particle_mass_for_hydrogen_with_no_mass_number() -> None:
     """Test that `particle_mass` does not return the proton mass when no
     mass number is specified for hydrogen.  In this case, the
     standard atomic weight should be used to account for the small
@@ -289,7 +289,7 @@ def test_particle_mass_for_hydrogen_with_no_mass_number():
     assert particle_mass("hydrogen", Z=1) > const.m_p
 
 
-def test_particle_mass_helium():
+def test_particle_mass_helium() -> None:
     """Test miscellaneous cases for `particle_mass`."""
     assert particle_mass("alpha") > particle_mass("He-3 2+")
 
@@ -321,7 +321,7 @@ equivalent_particle_mass_args = [
 @pytest.mark.parametrize(
     ("arg1", "kwargs1", "arg2", "kwargs2", "expected"), equivalent_particle_mass_args
 )
-def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected):
+def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected) -> None:
     """Test that `particle_mass` returns equivalent results for
     equivalent positional and keyword arguments."""
 
@@ -345,7 +345,7 @@ def test_particle_mass_equivalent_args(arg1, kwargs1, arg2, kwargs2, expected):
 
 
 @pytest.mark.slow()
-def test_known_common_stable_isotopes():
+def test_known_common_stable_isotopes() -> None:
     """Test that `known_isotopes`, `common_isotopes`, and
     `stable_isotopes` return the correct values for hydrogen."""
 
@@ -369,7 +369,7 @@ def test_known_common_stable_isotopes():
     )
 
 
-def test_half_life():
+def test_half_life() -> None:
     """Test that `half_life` returns the correct values for various
     isotopes."""
     assert np.isclose(
@@ -377,7 +377,7 @@ def test_half_life():
     ), "Incorrect half-life for tritium."
 
 
-def test_half_life_unstable_isotopes():
+def test_half_life_unstable_isotopes() -> None:
     """Test that `half_life` returns `None` and raises an exception for
     all isotopes that do not yet have half-life data."""
     for isotope in data_about_isotopes:
@@ -389,7 +389,7 @@ def test_half_life_unstable_isotopes():
                 half_life(isotope)
 
 
-def test_half_life_u_220():
+def test_half_life_u_220() -> None:
     """Test that `half_life` returns `None` and issues a warning for an
     isotope without half-life data."""
 
@@ -405,7 +405,7 @@ def test_half_life_u_220():
         )
 
 
-def test_known_common_stable_isotopes_cases():
+def test_known_common_stable_isotopes_cases() -> None:
     """Test that known_isotopes, common_isotopes, and stable_isotopes
     return certain isotopes that fall into these categories."""
     assert "H-1" in known_isotopes("H")
@@ -423,7 +423,7 @@ def test_known_common_stable_isotopes_cases():
 
 
 @pytest.mark.slow()
-def test_known_common_stable_isotopes_len():
+def test_known_common_stable_isotopes_len() -> None:
     """Test that `known_isotopes`, `common_isotopes`, and
     `stable_isotopes` each return a `list` of the expected length.
 
@@ -455,7 +455,7 @@ def test_known_common_stable_isotopes_len():
 
 
 @pytest.mark.parametrize("func", [common_isotopes, stable_isotopes, known_isotopes])
-def test_known_common_stable_isotopes_error(func):
+def test_known_common_stable_isotopes_error(func) -> None:
     """Test that `known_isotopes`, `common_isotopes`, and
     `stable_isotopes` raise an `~plasmapy.utils.InvalidElementError` for
     neutrons."""
@@ -464,7 +464,7 @@ def test_known_common_stable_isotopes_error(func):
         pytest.fail(f"{func} is not raising a ElementError for neutrons.")
 
 
-def test_isotopic_abundance():
+def test_isotopic_abundance() -> None:
     """Test that `isotopic_abundance` returns the appropriate values or
     raises appropriate errors for various isotopes."""
     assert isotopic_abundance("H", 1) == isotopic_abundance("protium")
@@ -501,7 +501,7 @@ isotopic_abundance_sum_table = (
 
 
 @pytest.mark.parametrize(("element", "isotopes"), isotopic_abundance_sum_table)
-def test_isotopic_abundances_sum(element, isotopes):
+def test_isotopic_abundances_sum(element, isotopes) -> None:
     """Test that the sum of isotopic abundances for each element with
     isotopic abundances is one."""
     sum_of_iso_abund = sum(isotopic_abundance(isotope) for isotope in isotopes)
@@ -511,15 +511,15 @@ def test_isotopic_abundances_sum(element, isotopes):
 
 
 class TestReducedMassInput:
-    def test_incorrect_units(self):
+    def test_incorrect_units(self) -> None:
         with pytest.raises(InvalidParticleError):
             reduced_mass("N", 6e-26 * u.l)
 
-    def test_missing_atomic_data(self):
+    def test_missing_atomic_data(self) -> None:
         assert u.isclose(reduced_mass("Og", "H"), np.nan * u.kg, equal_nan=True)
 
 
-def test_ion_list_example():
+def test_ion_list_example() -> None:
     ions = ionic_levels("He-4")
     np.testing.assert_equal(ions.charge_number, [0, 1, 2])
     assert ions.symbols == ["He-4 0+", "He-4 1+", "He-4 2+"]
@@ -534,7 +534,7 @@ def test_ion_list_example():
         ("C", 3, 5, [3, 4, 5]),
     ],
 )
-def test_ion_list(particle, min_charge, max_charge, expected_charge_numbers):
+def test_ion_list(particle, min_charge, max_charge, expected_charge_numbers) -> None:
     """Test that inputs to ionic_levels are interpreted correctly."""
     particle = Particle(particle)
     ions = ionic_levels(particle, min_charge, max_charge)
@@ -547,7 +547,7 @@ def test_ion_list(particle, min_charge, max_charge, expected_charge_numbers):
 @pytest.mark.parametrize(
     ("element", "min_charge", "max_charge"), [("Li", 0, 4), ("Li", 3, 2)]
 )
-def test_invalid_inputs_to_ion_list(element, min_charge, max_charge):
+def test_invalid_inputs_to_ion_list(element, min_charge, max_charge) -> None:
     with pytest.raises(ChargeError):
         ionic_levels(element, min_charge, max_charge)
 
@@ -568,11 +568,11 @@ str_electron_table = [
 
 
 @pytest.mark.parametrize(("particle", "electron"), str_electron_table)
-def test_is_electron(particle, electron):
+def test_is_electron(particle, electron) -> None:
     assert _is_electron(particle) == electron
 
 
-def test_ionic_levels_example():
+def test_ionic_levels_example() -> None:
     """
     Test that `ionic_levels` can be used to create a |ParticleList|
     containing all the ions for a particular element.
@@ -591,7 +591,7 @@ def test_ionic_levels_example():
         ("C", 3, 5, [3, 4, 5]),
     ],
 )
-def test_ion_list2(particle, min_charge, max_charge, expected_charge_numbers):
+def test_ion_list2(particle, min_charge, max_charge, expected_charge_numbers) -> None:
     """Test that inputs to ionic_levels are interpreted correctly."""
     particle = Particle(particle)
     ions = ionic_levels(particle, min_charge, max_charge)
@@ -604,6 +604,6 @@ def test_ion_list2(particle, min_charge, max_charge, expected_charge_numbers):
 @pytest.mark.parametrize(
     ("element", "min_charge", "max_charge"), [("Li", 0, 4), ("Li", 3, 2)]
 )
-def test_invalid_inputs_to_ion_list2(element, min_charge, max_charge):
+def test_invalid_inputs_to_ion_list2(element, min_charge, max_charge) -> None:
     with pytest.raises(ChargeError):
         ionic_levels(element, min_charge, max_charge)

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -86,7 +86,7 @@ particle_input_simple_table = [
     ],
 )
 @pytest.mark.parametrize(("args", "kwargs", "symbol"), particle_input_simple_table)
-def test_particle_input_simple(func, args, kwargs, symbol):
+def test_particle_input_simple(func, args, kwargs, symbol) -> None:
     """
     Test that simple functions decorated by particle_input correctly
     return the correct Particle object.
@@ -127,7 +127,7 @@ particle_input_error_table = [
 @pytest.mark.parametrize(
     ("func", "kwargs", "expected_error"), particle_input_error_table
 )
-def test_particle_input_errors(func, kwargs, expected_error):
+def test_particle_input_errors(func, kwargs, expected_error) -> None:
     """
     Test that functions decorated with `@particle_input` raise the
     expected errors.
@@ -153,7 +153,7 @@ class ClassWithDecoratedMethods:
 
 
 @pytest.mark.parametrize("symbol", ["muon", "He 2+"])
-def test_particle_input_classes(symbol):
+def test_particle_input_classes(symbol) -> None:
     """Test that @particle_input works for instance methods."""
     expected = Particle(symbol)
     instance = ClassWithDecoratedMethods()
@@ -167,14 +167,14 @@ def test_particle_input_classes(symbol):
     assert result_parens == result_noparens == expected
 
 
-def test_no_annotations_exception():
+def test_no_annotations_exception() -> None:
     """
     Test that a function decorated with @particle_input that has no
     annotated arguments will raise a ParticleError.
     """
 
     @particle_input
-    def function_with_no_annotations():
+    def function_with_no_annotations() -> None:
         pass
 
     with pytest.raises(ParticleError):
@@ -182,7 +182,9 @@ def test_no_annotations_exception():
 
 
 @particle_input
-def ambiguous_keywords(p1: ParticleLike, p2: ParticleLike, Z=None, mass_numb=None):
+def ambiguous_keywords(
+    p1: ParticleLike, p2: ParticleLike, Z=None, mass_numb=None
+) -> None:
     """
     A trivial function with two annotated arguments plus the keyword
     arguments ``Z`` and ``mass_numb``.
@@ -197,7 +199,7 @@ ambiguous_arguments = [
 
 
 @pytest.mark.parametrize(("args", "kwargs"), ambiguous_arguments)
-def test_function_with_ambiguity(args, kwargs):
+def test_function_with_ambiguity(args, kwargs) -> None:
     """
     Test that a function decorated with particle_input that has two
     annotated arguments along with `Z` and `mass_numb` raises an
@@ -208,7 +210,7 @@ def test_function_with_ambiguity(args, kwargs):
         ambiguous_keywords(*args, **kwargs)
 
 
-def test_optional_particle():
+def test_optional_particle() -> None:
     particle = "He"
 
     @particle_input
@@ -262,7 +264,7 @@ categorization_particle_exception = [
 @pytest.mark.parametrize(
     ("categorization", "particle", "exception"), categorization_particle_exception
 )
-def test_decorator_categories(categorization, particle, exception):
+def test_decorator_categories(categorization, particle, exception) -> None:
     """
     Test that the ``require``, ``any_of``, and ``exclude`` categories
     lead to a |ParticleError| being raised when an inputted particle
@@ -285,7 +287,7 @@ def test_decorator_categories(categorization, particle, exception):
         decorated_function(particle)
 
 
-def test_optional_particle_annotation_parameter():
+def test_optional_particle_annotation_parameter() -> None:
     """
     Tests the `Optional[Particle]` annotation argument in a function
     decorated by `@particle_input` such that the annotated argument allows
@@ -316,7 +318,7 @@ decorator_pairs = [
 
 
 @pytest.mark.parametrize(("decorator1", "decorator2"), decorator_pairs)
-def test_stacking_decorators(decorator1, decorator2):
+def test_stacking_decorators(decorator1, decorator2) -> None:
     """
     Test that particle_input and validate_quantities can be stacked in
     either order with or without parentheses.
@@ -336,7 +338,7 @@ def test_stacking_decorators(decorator1, decorator2):
 
 
 @pytest.mark.parametrize(("decorator1", "decorator2"), decorator_pairs)
-def test_preserving_signature_with_stacked_decorators(decorator1, decorator2):
+def test_preserving_signature_with_stacked_decorators(decorator1, decorator2) -> None:
     """
     Test that |particle_input| & |validate_quantities| preserve the
     function signature after being stacked.
@@ -351,7 +353,7 @@ def test_preserving_signature_with_stacked_decorators(decorator1, decorator2):
     assert undecorated_signature == decorated_signature_1_2 == decorated_signature_2_1
 
 
-def test_annotated_classmethod():
+def test_annotated_classmethod() -> None:
     """
     Test that `particle_input` behaves as expected for a method that is
     decorated with `classmethod`.
@@ -369,7 +371,7 @@ def test_annotated_classmethod():
 
 @pytest.mark.parametrize("outer_decorator", [particle_input, particle_input()])
 @pytest.mark.parametrize("inner_decorator", [particle_input, particle_input()])
-def test_self_stacked_decorator(outer_decorator, inner_decorator):
+def test_self_stacked_decorator(outer_decorator, inner_decorator) -> None:
     """Test that particle_input can be stacked with itself."""
 
     @outer_decorator
@@ -384,7 +386,7 @@ def test_self_stacked_decorator(outer_decorator, inner_decorator):
 
 @pytest.mark.parametrize("outer_decorator", [particle_input, particle_input()])
 @pytest.mark.parametrize("inner_decorator", [particle_input, particle_input()])
-def test_class_stacked_decorator(outer_decorator, inner_decorator):
+def test_class_stacked_decorator(outer_decorator, inner_decorator) -> None:
     """
     Test that particle_input can be stacked with itself for an
     instance method.
@@ -393,7 +395,7 @@ def test_class_stacked_decorator(outer_decorator, inner_decorator):
     class Sample:
         @outer_decorator
         @inner_decorator
-        def __init__(self, particle: ParticleLike):
+        def __init__(self, particle: ParticleLike) -> None:
             self.particle = particle
 
     result = Sample("p+")
@@ -406,12 +408,12 @@ validate_quantities_ = validate_quantities(
 )
 
 
-def test_annotated_init():
+def test_annotated_init() -> None:
     """Test that `particle_input` can decorate an __init__ method."""
 
     class HasAnnotatedInit:
         @particle_input(require="element")
-        def __init__(self, particle: ParticleLike, ionic_fractions=None):
+        def __init__(self, particle: ParticleLike, ionic_fractions=None) -> None:
             self.particle = particle
 
     x = HasAnnotatedInit("H-1", ionic_fractions=32)
@@ -441,7 +443,9 @@ def test_annotated_init():
         ),
     ],
 )
-def test_particle_input_with_validate_quantities(outer_decorator, inner_decorator):
+def test_particle_input_with_validate_quantities(
+    outer_decorator, inner_decorator
+) -> None:
     """Test that particle_input can be stacked with validate_quantities."""
 
     class C:
@@ -451,7 +455,7 @@ def test_particle_input_with_validate_quantities(outer_decorator, inner_decorato
             self,
             particle: ParticleLike,
             T_e: u.Quantity[u.K] = None,
-        ):
+        ) -> None:
             self.particle = particle
             self.T_e = T_e
 
@@ -476,7 +480,7 @@ kwargs_to_decorator_and_args = [
 @pytest.mark.parametrize(
     ("kwargs_to_particle_input", "arg"), kwargs_to_decorator_and_args
 )
-def test_particle_input_verification(kwargs_to_particle_input, arg):
+def test_particle_input_verification(kwargs_to_particle_input, arg) -> None:
     """Test the allow_custom_particles keyword argument to particle_input."""
 
     @particle_input(**kwargs_to_particle_input)
@@ -500,7 +504,7 @@ class ParameterNamesCase:
         particles_in_category,
         particles_not_in_category,
         exception,
-    ):
+    ) -> None:
         self.category = category
         self.function = function
         self.particles_in_category = particles_in_category
@@ -560,7 +564,7 @@ class TestParticleInputParameterNames:
     categories.
     """
 
-    def test_individual_particles_not_in_category(self, case):
+    def test_individual_particles_not_in_category(self, case) -> None:
         """
         Test that the appropriate exception is raised when the function
         is provided with individual particles that are not in the
@@ -570,7 +574,7 @@ class TestParticleInputParameterNames:
             with pytest.raises(case.exception):
                 case.function(particle)
 
-    def test_particle_list_not_in_category(self, case):
+    def test_particle_list_not_in_category(self, case) -> None:
         """
         Test that the appropriate exception is raised when the function
         is provided with multiple particles at once that are all not in
@@ -579,7 +583,7 @@ class TestParticleInputParameterNames:
         with pytest.raises(case.exception):
             case.function(case.particles_not_in_category)
 
-    def test_particle_list_some_in_category(self, case):
+    def test_particle_list_some_in_category(self, case) -> None:
         """
         Test that the appropriate exception is raised when the function
         is provided with multiple particles at once, of which some are
@@ -591,7 +595,7 @@ class TestParticleInputParameterNames:
     # If "ionic_level" gets added as a particle category, then add
     # assertions to the following test using is_category.
 
-    def test_individual_particles_all_in_category(self, case):
+    def test_individual_particles_all_in_category(self, case) -> None:
         """
         Test that no exception is raised when the function is provided
         with individual particles that are all in the category.
@@ -599,7 +603,7 @@ class TestParticleInputParameterNames:
         for particle in case.particles_in_category:
             case.function(particle)
 
-    def test_particle_list_all_in_category(self, case):
+    def test_particle_list_all_in_category(self, case) -> None:
         """
         Test that no exception is raised when the function is provided
         with multiple particles at once which are all in the category.
@@ -607,7 +611,7 @@ class TestParticleInputParameterNames:
         case.function(case.particles_in_category)
 
 
-def test_custom_particle_for_parameter_named_ion():
+def test_custom_particle_for_parameter_named_ion() -> None:
     """
     Test that a positively charged CustomParticle is treated as a valid
     ion when the parameter is named ``ion``.
@@ -617,7 +621,7 @@ def test_custom_particle_for_parameter_named_ion():
     assert result == custom_ion
 
 
-def test_creating_mean_particle_for_parameter_named_ion():
+def test_creating_mean_particle_for_parameter_named_ion() -> None:
     Z = 1.3
     ion = get_ion(ion="He", Z=Z)
     assert u.isclose(ion.charge, Z * const.e.si)
@@ -629,7 +633,7 @@ def return_particle(particle: ParticleLike, Z=None, mass_numb=None):
     return particle
 
 
-def test_particle_input_warning_for_integer_z_mean():
+def test_particle_input_warning_for_integer_z_mean() -> None:
     """
     Test that if a function decorated by `particle_input` is passed
     an integer called `z_mean`, then `z_mean` becomes `Z` and a warning
@@ -640,7 +644,7 @@ def test_particle_input_warning_for_integer_z_mean():
     assert result == "p+"
 
 
-def test_particle_input_warning_for_float_z_mean():
+def test_particle_input_warning_for_float_z_mean() -> None:
     """
     Test that if a function decorated by `particle_input` is passed
     a float called `z_mean`, then `z_mean` becomes `Z` and a warning
@@ -656,7 +660,7 @@ def test_particle_input_warning_for_float_z_mean():
     assert u.isclose(Z, z_mean)
 
 
-def test_particle_input_with_var_positional_arguments():
+def test_particle_input_with_var_positional_arguments() -> None:
     """
     Test that |particle_input| works with functions that accept
     variadic positional arguments and keyword arguments.
@@ -676,7 +680,7 @@ def test_particle_input_with_var_positional_arguments():
 
 
 @pytest.mark.xfail(reason="See issue #2150.")
-def test_particle_input_with_pos_and_var_positional_arguments():
+def test_particle_input_with_pos_and_var_positional_arguments() -> None:
     """
     Test that |particle_input| works with functions that accept
     positional followed by variadic positional arguments.

--- a/plasmapy/particles/tests/test_exceptions.py
+++ b/plasmapy/particles/tests/test_exceptions.py
@@ -201,7 +201,9 @@ tests_for_exceptions = {
     list(tests_for_exceptions.values()),
     ids=list(tests_for_exceptions.keys()),
 )
-def test_named_tests_for_exceptions(tested_object, args, kwargs, expected_exception):
+def test_named_tests_for_exceptions(
+    tested_object, args, kwargs, expected_exception
+) -> None:
     """
     Test that appropriate exceptions are raised for inappropriate inputs
     to `IonizationState` or `IonizationStateCollection`
@@ -1025,7 +1027,7 @@ type_error_tests = [
     ("tested_object", "args", "kwargs", "expected"),
     tests_from_nuclear + tests_from_atomic + particle_error_tests + type_error_tests,
 )
-def test_unnamed_tests_exceptions(tested_object, args, kwargs, expected):
+def test_unnamed_tests_exceptions(tested_object, args, kwargs, expected) -> None:
     """
     Test that appropriate exceptions are raised for inappropriate inputs
     to different functions.

--- a/plasmapy/particles/tests/test_factory.py
+++ b/plasmapy/particles/tests/test_factory.py
@@ -49,7 +49,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(("args", "kwargs", "expected"), test_cases)
-def test_physical_particle_factory(args, kwargs, expected):
+def test_physical_particle_factory(args, kwargs, expected) -> None:
     result = _physical_particle_factory(*args, **kwargs)
     assert result == expected
     assert type(result) == type(expected)
@@ -66,12 +66,12 @@ test_cases_for_exceptions = [
 
 
 @pytest.mark.parametrize(("args", "kwargs", "expected"), test_cases_for_exceptions)
-def test_particle_factory_exceptions(args, kwargs, expected):
+def test_particle_factory_exceptions(args, kwargs, expected) -> None:
     with pytest.raises(expected):
         _physical_particle_factory(*args, **kwargs)
 
 
-def test_particle_factory_custom_particle_with_none_kwargs():
+def test_particle_factory_custom_particle_with_none_kwargs() -> None:
     """
     Test that when `_physical_particle_factory` is provided with a
     `CustomParticle` along with ``Z=None`` and ``mass_numb=None`` as

--- a/plasmapy/particles/tests/test_ionization_collection.py
+++ b/plasmapy/particles/tests/test_ionization_collection.py
@@ -21,7 +21,7 @@ from plasmapy.particles.exceptions import InvalidIsotopeError, ParticleError
 
 def check_abundances_consistency(
     abundances: dict[str, Real], log_abundances: dict[str, Real]
-):
+) -> None:
     """
     Test that a set of abundances is consistent with a set of the base
     10 logarithm of abundances.
@@ -110,11 +110,11 @@ test_names = tests.keys()
 @pytest.mark.slow()
 class TestIonizationStateCollection:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         cls.instances = {}
 
     @pytest.mark.parametrize("test_name", test_names)
-    def test_instantiation(self, test_name):
+    def test_instantiation(self, test_name) -> None:
         try:
             self.instances[test_name] = IonizationStateCollection(**tests[test_name])
         except Exception:  # noqa: BLE001
@@ -123,19 +123,19 @@ class TestIonizationStateCollection:
             )
 
     @pytest.mark.parametrize("test_name", test_names)
-    def test_no_exceptions_from_str(self, test_name):
+    def test_no_exceptions_from_str(self, test_name) -> None:
         self.instances[test_name].__str__()
 
     @pytest.mark.parametrize("test_name", test_names)
-    def test_no_exceptions_from_repr(self, test_name):
+    def test_no_exceptions_from_repr(self, test_name) -> None:
         self.instances[test_name].__repr__()
 
     @pytest.mark.parametrize("test_name", test_names)
-    def test_no_exceptions_from_info(self, test_name):
+    def test_no_exceptions_from_info(self, test_name) -> None:
         self.instances[test_name].summarize()
 
     @pytest.mark.parametrize("test_name", test_names)
-    def test_simple_equality(self, test_name):
+    def test_simple_equality(self, test_name) -> None:
         """Test that __eq__ is not extremely broken."""
         a = IonizationStateCollection(**tests[test_name])
         b = IonizationStateCollection(**tests[test_name])
@@ -154,7 +154,7 @@ class TestIonizationStateCollection:
             if isinstance(tests[test_name]["inputs"], dict)
         ],
     )
-    def test_that_particles_were_set_correctly(self, test_name):
+    def test_that_particles_were_set_correctly(self, test_name) -> None:
         input_particles = tests[test_name]["inputs"].keys()
         particles = [Particle(input_particle) for input_particle in input_particles]
         expected_particles = {p.symbol for p in particles}
@@ -167,7 +167,7 @@ class TestIonizationStateCollection:
         )
 
     @pytest.mark.parametrize("test_name", has_attribute("abundances", tests))
-    def test_that_abundances_kwarg_sets_abundances(self, test_name):
+    def test_that_abundances_kwarg_sets_abundances(self, test_name) -> None:
         try:
             actual_abundances = self.instances[test_name].abundances
         except Exception:  # noqa: BLE001
@@ -185,7 +185,7 @@ class TestIonizationStateCollection:
             )
 
     @pytest.mark.parametrize("test_name", test_names)
-    def test_that_elements_and_isotopes_are_sorted(self, test_name):
+    def test_that_elements_and_isotopes_are_sorted(self, test_name) -> None:
         elements = self.instances[test_name].base_particles
         before_sorting = []
         for element in elements:
@@ -287,7 +287,7 @@ class TestIonizationStateCollection:
                 )
 
     @pytest.mark.parametrize("test_name", test_names)
-    def test_getitem_element_intcharge(self, test_name):
+    def test_getitem_element_intcharge(self, test_name) -> None:
         instance = self.instances[test_name]
         for particle in instance.base_particles:
             for int_charge in range(atomic_number(particle) + 1):
@@ -309,7 +309,7 @@ class TestIonizationStateCollection:
             if isinstance(tests[test_name]["inputs"], dict)
         ],
     )
-    def test_normalization(self, test_name):
+    def test_normalization(self, test_name) -> None:
         instance = self.instances[test_name]
         instance.normalize()
         not_normalized_elements = []
@@ -329,7 +329,7 @@ class TestIonizationStateCollection:
             )
 
 
-def test_abundances_consistency():
+def test_abundances_consistency() -> None:
     """Test that ``abundances`` and ``log_abundances`` are consistent."""
 
     inputs = {"H": [1, 0], "He": [1, 0, 0]}
@@ -358,7 +358,7 @@ class TestIonizationStateCollectionItemAssignment:
     """
 
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         cls.states = IonizationStateCollection(
             {"H": [0.9, 0.1], "He": [0.5, 0.4999, 1e-4]}
         )
@@ -372,7 +372,7 @@ class TestIonizationStateCollectionItemAssignment:
             ("He", [0.89, 0.1, 0.01]),
         ],
     )
-    def test_setitem(self, element, new_states):
+    def test_setitem(self, element, new_states) -> None:
         """Test item assignment in an IonizationStateCollection instance."""
         try:
             self.states[element] = new_states
@@ -400,14 +400,16 @@ class TestIonizationStateCollectionItemAssignment:
             (KeyError, KeyError, KeyError),
         ],
     )
-    def test_setitem_errors(self, base_particle, new_states, expected_exception):
+    def test_setitem_errors(
+        self, base_particle, new_states, expected_exception
+    ) -> None:
         with pytest.raises(expected_exception):
             self.states[base_particle] = new_states
 
 
 class TestIonizationStateCollectionDensities:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         cls.initial_ionfracs = {
             "H": np.array([0.87, 0.13]),
             "He": np.array([0.24, 0.37, 0.39]),
@@ -425,7 +427,7 @@ class TestIonizationStateCollectionDensities:
             cls.initial_ionfracs, abundances=cls.abundances, n0=cls.n
         )
 
-    def test_electron_density(self):
+    def test_electron_density(self) -> None:
         assert np.isclose(
             self.states.n_e.value, self.expected_electron_density.value
         ), (
@@ -435,7 +437,7 @@ class TestIonizationStateCollectionDensities:
         )
 
     @pytest.mark.parametrize("elem", ["H", "He"])
-    def test_number_densities(self, elem):
+    def test_number_densities(self, elem) -> None:
         assert np.allclose(
             self.states.number_densities[elem].value,
             self.expected_densities[elem].value,
@@ -448,13 +450,13 @@ class TestIonizationStateCollectionDensities:
 
 class TestIonizationStateCollectionAttributes:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         cls.elements = ["H", "He", "Li", "Fe"]
         cls.instance = IonizationStateCollection(cls.elements)
         cls.new_n = 5.153 * u.cm**-3
 
     @pytest.mark.parametrize("uninitialized_attribute", ["T_e", "n0", "n_e"])
-    def test_attribute_defaults_to_nan(self, uninitialized_attribute):
+    def test_attribute_defaults_to_nan(self, uninitialized_attribute) -> None:
         command = f"self.instance.{uninitialized_attribute}"
         default_value = eval(command)  # noqa: PGH001, S307
         assert np.isnan(default_value), (
@@ -462,7 +464,7 @@ class TestIonizationStateCollectionAttributes:
             f"instead defaults to {default_value}."
         )
 
-    def test_kappa_defaults_to_inf(self):
+    def test_kappa_defaults_to_inf(self) -> None:
         assert np.isinf(
             self.instance.kappa
         ), "kappa does not default to a value of inf."
@@ -470,7 +472,7 @@ class TestIonizationStateCollectionAttributes:
     @pytest.mark.parametrize(
         "uninitialized_attribute", ["number_densities", "ionic_fractions"]
     )
-    def test_attribute_defaults_to_dict_of_nans(self, uninitialized_attribute):
+    def test_attribute_defaults_to_dict_of_nans(self, uninitialized_attribute) -> None:
         command = f"self.instance.{uninitialized_attribute}"
         default_value = eval(command)  # noqa: PGH001, S307
         assert (
@@ -487,7 +489,7 @@ class TestIonizationStateCollectionAttributes:
     @pytest.mark.parametrize(
         "uninitialized_attribute", ["abundances", "log_abundances"]
     )
-    def test_abundances_default_to_nans(self, uninitialized_attribute):
+    def test_abundances_default_to_nans(self, uninitialized_attribute) -> None:
         command = f"self.instance.{uninitialized_attribute}"
         default_value = eval(command)  # noqa: PGH001, S307
         for element in self.elements:
@@ -519,7 +521,9 @@ class TestIonizationStateCollectionAttributes:
             ("ionic_fractions", {"H": [1.0, 0.0]}, ParticleError),
         ],
     )
-    def test_attribute_exceptions(self, attribute, invalid_value, expected_exception):
+    def test_attribute_exceptions(
+        self, attribute, invalid_value, expected_exception
+    ) -> None:
         command = f"self.instance.{attribute} = {invalid_value}"
         errmsg = f"No {expected_exception} was raised for command\n\n: {command}"
 
@@ -527,7 +531,7 @@ class TestIonizationStateCollectionAttributes:
             exec(command)  # noqa: S102
             pytest.fail(errmsg)
 
-    def test_setting_ionic_fractions_for_single_element(self):
+    def test_setting_ionic_fractions_for_single_element(self) -> None:
         """
         Test that __setitem__ correctly sets new ionic fractions when
         used for just H, while not changing the ionic fractions for He
@@ -561,7 +565,9 @@ class TestIonizationStateCollectionAttributes:
             ("He", [1.01, -0.02, 0.01], ValueError),
         ],
     )
-    def test_setting_invalid_ionfracs(self, key, invalid_fracs, expected_exception):
+    def test_setting_invalid_ionfracs(
+        self, key, invalid_fracs, expected_exception
+    ) -> None:
         errmsg = (
             f"No {expected_exception} is raised when trying to assign "
             f"{invalid_fracs} to {key} in an IonizationStateCollection instance."
@@ -570,12 +576,12 @@ class TestIonizationStateCollectionAttributes:
             self.instance[key] = invalid_fracs
             pytest.fail(errmsg)
 
-    def test_setting_incomplete_abundances(self):
+    def test_setting_incomplete_abundances(self) -> None:
         new_abundances = {"H": 1, "He": 0.1, "Fe": 1e-5, "Au": 1e-8}  # missing lithium
         with pytest.raises(ParticleError):
             self.instance.abundances = new_abundances
 
-    def test_setting_abundances(self):
+    def test_setting_abundances(self) -> None:
         new_abundances = {"H": 1, "He": 0.1, "Li": 1e-4, "Fe": 1e-5, "Au": 1e-8}
 
         log_new_abundances = {
@@ -613,12 +619,12 @@ class TestIonizationStateCollectionAttributes:
             ("Fe", slice(3, 7)),
         ],
     )
-    def test_invalid_indices(self, invalid_indices):
+    def test_invalid_indices(self, invalid_indices) -> None:
         with pytest.raises(IndexError):
             self.instance[invalid_indices]
 
     @pytest.mark.parametrize("index", ["H", "Fe"])
-    def test_getitem_one_index(self, index):
+    def test_getitem_one_index(self, index) -> None:
         instance = self.instance
         result = instance[index]
 
@@ -635,7 +641,7 @@ class TestIonizationStateCollectionAttributes:
         assert result == expected
 
     @pytest.mark.parametrize("indices", [("H", 1), ("Fe", 6)])
-    def test_getitem_two_indices(self, indices):
+    def test_getitem_two_indices(self, indices) -> None:
         instance = self.instance
         result = instance[indices]
 
@@ -656,7 +662,7 @@ class TestIonizationStateCollectionAttributes:
 
         assert result.ionic_symbol == particle_symbol(particle, Z=charge_number)
 
-    def test_setting_n(self):
+    def test_setting_n(self) -> None:
         try:
             self.instance.n0 = self.new_n
         except Exception:  # noqa: BLE001
@@ -666,7 +672,7 @@ class TestIonizationStateCollectionAttributes:
         if self.instance.n0.unit != u.m**-3:
             pytest.fail("Incorrect units for new number density.")
 
-    def test_resetting_valid_densities(self):
+    def test_resetting_valid_densities(self) -> None:
         """
         Test that item assignment can be used to set number densities
         that preserve the total element number density.
@@ -690,7 +696,7 @@ class TestIonizationStateCollectionAttributes:
             self.instance.number_densities[element], valid_number_densities
         ), "Item assignment of valid number densities did not yield correct number densities."
 
-    def test_resetting_invalid_densities(self):
+    def test_resetting_invalid_densities(self) -> None:
         """
         Test that item assignment with number densities that would
         change the total element number density raises an exception.
@@ -701,25 +707,25 @@ class TestIonizationStateCollectionAttributes:
         with pytest.raises(ValueError):
             self.instance[element] = invalid_number_densities
 
-    def test_elemental_abundances_not_quantities(self):
+    def test_elemental_abundances_not_quantities(self) -> None:
         for element in self.instance.base_particles:
             assert not isinstance(self.instance.abundances[element], u.Quantity)
 
     @pytest.mark.parametrize("element", ["H", "He", "Fe"])
-    def test_ionic_fractions_not_quantities(self, element):
+    def test_ionic_fractions_not_quantities(self, element) -> None:
         ionic_fractions = self.instance.ionic_fractions[element]
         if isinstance(ionic_fractions, u.Quantity):
             pytest.fail(
                 f"The ionic fractions of {element} are a Quantity but should not be."
             )
 
-    def test_that_iron_ionic_fractions_are_still_undefined(self):
+    def test_that_iron_ionic_fractions_are_still_undefined(self) -> None:
         assert "Fe" in self.instance.ionic_fractions
         iron_fractions = self.instance.ionic_fractions["Fe"]
         assert len(iron_fractions) == atomic_number("Fe") + 1
         assert np.all(np.isnan(iron_fractions))
 
-    def test_base_particles(self):
+    def test_base_particles(self) -> None:
         """
         Test that the original base particles remain as the base
         particles after performing a bunch of operations that should not
@@ -727,7 +733,7 @@ class TestIonizationStateCollectionAttributes:
         """
         assert self.instance.base_particles == self.elements
 
-    def test_base_particles_equal_ionic_fraction_particles(self):
+    def test_base_particles_equal_ionic_fraction_particles(self) -> None:
         assert self.instance.base_particles == list(
             self.instance.ionic_fractions.keys()
         )
@@ -741,7 +747,7 @@ class TestIonizationStateCollectionDensityEqualities:
     """
 
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         # Create arguments to IonizationStateCollection that are all consistent
         # with each other.
 
@@ -775,7 +781,7 @@ class TestIonizationStateCollectionDensityEqualities:
         }
 
     @pytest.mark.parametrize("test_key", ["ndens1", "ndens2"])
-    def test_number_densities_defined(self, test_key):
+    def test_number_densities_defined(self, test_key) -> None:
         number_densities = self.instances[test_key].number_densities
         for base_particle in self.instances[test_key].base_particles:
             assert not np.any(np.isnan(number_densities[base_particle])), (
@@ -784,7 +790,7 @@ class TestIonizationStateCollectionDensityEqualities:
             )
 
     @pytest.mark.parametrize("test_key", ["no_ndens3", "no_ndens4", "no_ndens5"])
-    def test_number_densities_undefined(self, test_key):
+    def test_number_densities_undefined(self, test_key) -> None:
         number_densities = self.instances[test_key].number_densities
         for base_particle in self.instances[test_key].base_particles:
             assert np.all(np.isnan(number_densities[base_particle])), (
@@ -798,7 +804,7 @@ class TestIonizationStateCollectionDensityEqualities:
             ["ndens1", "ndens2", "no_ndens3", "no_ndens4", "no_ndens5"], repeat=2
         ),
     )
-    def test_equality(self, this, that):
+    def test_equality(self, this, that) -> None:
         """
         Test that the IonizationStateCollection instances that should provide
         ``number_densities`` are all equal to each other.  Test that the
@@ -820,18 +826,18 @@ class TestIonizationStateCollectionDensityEqualities:
             pytest.fail(f"Cases {this} and {that} should be {descriptor} but are not.")
 
 
-def test_number_density_assignment():
+def test_number_density_assignment() -> None:
     instance = IonizationStateCollection(["H", "He"])
     number_densities = [2, 3, 5] * u.m**-3
     instance["He"] = number_densities
 
 
-def test_len():
+def test_len() -> None:
     ionization_states = IonizationStateCollection(["H", "He"])
     assert len(ionization_states) == 2
 
 
-def test_iteration_with_nested_iterator():
+def test_iteration_with_nested_iterator() -> None:
     ionization_states = IonizationStateCollection(["H", "He"])
 
     i = 0
@@ -843,7 +849,7 @@ def test_iteration_with_nested_iterator():
     assert i == 4
 
 
-def test_two_isotopes_of_same_element():
+def test_two_isotopes_of_same_element() -> None:
     IonizationStateCollection(["H-1", "D"])
 
 
@@ -869,7 +875,7 @@ def test_average_ion_consistency(
     use_rms_mass,
     use_rms_charge,
     physical_type,
-):
+) -> None:
     """
     Make sure that the average ions returned from equivalent `IonizationState`
     and `IonizationStateCollection` instances are consistent with each other.
@@ -907,7 +913,7 @@ def test_comparison_to_equivalent_particle_list(
     physical_property,
     use_rms,  # noqa: ARG001
     include_neutrals,
-):
+) -> None:
     """
     Test that `IonizationState.average_ion` gives consistent results with
     `ParticleList.average_particle` when the ratios of different particles
@@ -940,7 +946,7 @@ def test_comparison_to_equivalent_particle_list(
     assert_quantity_allclose(actual_average_quantity, expected_average_quantity)
 
 
-def test_average_particle_exception():
+def test_average_particle_exception() -> None:
     """
     Test that `IonizationStateCollection.average_ion` raises the
     appropriate exception when abundances are undefined and there is more
@@ -952,12 +958,12 @@ def test_average_particle_exception():
         ionization_states.average_ion()
 
 
-def test_inequality_with_different_type():
+def test_inequality_with_different_type() -> None:
     ionization_states = IonizationStateCollection({"H": [1, 0], "He": [1, 0, 0]})
     assert ionization_states != "different type"
 
 
-def test_inequality_with_different_base_particles():
+def test_inequality_with_different_base_particles() -> None:
     instance1 = IonizationStateCollection({"H": [1, 0], "He": [1, 0, 0]})
     instance2 = IonizationStateCollection({"H": [1, 0], "Li": [1, 0, 0, 0]})
     assert instance1 != instance2

--- a/plasmapy/particles/tests/test_ionization_state.py
+++ b/plasmapy/particles/tests/test_ionization_state.py
@@ -29,7 +29,7 @@ ionic_fraction_table = [
 @pytest.mark.parametrize(
     ("ion", "ionic_fraction", "number_density"), ionic_fraction_table
 )
-def test_ionic_level_attributes(ion, ionic_fraction, number_density):
+def test_ionic_level_attributes(ion, ionic_fraction, number_density) -> None:
     instance = IonicLevel(
         ion=ion, ionic_fraction=ionic_fraction, number_density=number_density
     )
@@ -51,7 +51,7 @@ def test_ionic_level_attributes(ion, ionic_fraction, number_density):
     ("invalid_fraction", "expected_exception"),
     [(-1e-9, ParticleError), (1.00000000001, ParticleError), ("...", ParticleError)],
 )
-def test_ionic_level_invalid_inputs(invalid_fraction, expected_exception):
+def test_ionic_level_invalid_inputs(invalid_fraction, expected_exception) -> None:
     """
     Test that IonicLevel raises exceptions when the ionic fraction
     is out of the interval [0,1] or otherwise invalid.
@@ -61,7 +61,7 @@ def test_ionic_level_invalid_inputs(invalid_fraction, expected_exception):
 
 
 @pytest.mark.parametrize("invalid_particle", ["H", "e-", "Fe-56"])
-def test_ionic_level_invalid_particles(invalid_particle):
+def test_ionic_level_invalid_particles(invalid_particle) -> None:
     """
     Test that `~plasmapy.particles.IonicLevel` raises the appropriate
     exception when passed a particle that isn't a neutral or ion.
@@ -71,7 +71,7 @@ def test_ionic_level_invalid_particles(invalid_particle):
 
 
 @pytest.mark.parametrize(("ion1", "ion2"), [("Fe-56 6+", "Fe-56 5+"), ("H 1+", "D 1+")])
-def test_ionic_level_comparison_with_different_ions(ion1, ion2):
+def test_ionic_level_comparison_with_different_ions(ion1, ion2) -> None:
     """
     Test that a `TypeError` is raised when an `IonicLevel` object
     is compared to an `IonicLevel` object of a different ion.
@@ -84,12 +84,12 @@ def test_ionic_level_comparison_with_different_ions(ion1, ion2):
     assert ionic_fraction_1 != ionic_fraction_2
 
 
-def test_ionic_level_inequality_with_different_type():
+def test_ionic_level_inequality_with_different_type() -> None:
     instance = IonicLevel("H 1+", 0.3)
     assert instance != "different type"
 
 
-def test_ionization_state_ion_input_error():
+def test_ionization_state_ion_input_error() -> None:
     """
     Test that `~plasmapy.particles.IonizationState` raises the appropriate
     exception when an ion is the base particle and ionic fractions are
@@ -143,7 +143,7 @@ def test_ionization_state(request):
     return IonizationState(**request.param)
 
 
-def test_charge_numbers(test_ionization_state):
+def test_charge_numbers(test_ionization_state) -> None:
     """
     Test that an `IonizationState` instance has the correct charge
     numbers.
@@ -152,7 +152,7 @@ def test_charge_numbers(test_ionization_state):
     assert np.allclose(test_ionization_state.charge_numbers, expected_charge_numbers)
 
 
-def test_equal_to_itself(He_ionization_state):
+def test_equal_to_itself(He_ionization_state) -> None:
     """
     Test that `IonizationState.__eq__` returns `True for two identical
     `IonizationState` instances.
@@ -161,7 +161,7 @@ def test_equal_to_itself(He_ionization_state):
 
 
 @pytest.mark.parametrize(("tolerance", "output"), [(1e-8, True), (1e-9001, False)])
-def test_equal_to_within_tolerance(tolerance, output):
+def test_equal_to_within_tolerance(tolerance, output) -> None:
     """
     Test that `IonizationState.__eq__` returns `True` for two
     `IonizationState` instances that differ within the inputted
@@ -174,7 +174,7 @@ def test_equal_to_within_tolerance(tolerance, output):
     assert (H == H_acceptable_error) == output
 
 
-def test_equality_no_more_exception(test_ionization_state, He_ionization_state):
+def test_equality_no_more_exception(test_ionization_state, He_ionization_state) -> None:
     """
     Test that comparisons of `IonizationState` instances for
     different elements does not fail.
@@ -184,7 +184,7 @@ def test_equality_no_more_exception(test_ionization_state, He_ionization_state):
     assert test_ionization_state != He_ionization_state
 
 
-def test_iteration(test_ionization_state):
+def test_iteration(test_ionization_state) -> None:
     """Test that `IonizationState` instances iterate impeccably."""
     states = list(test_ionization_state)
 
@@ -232,7 +232,7 @@ def test_iteration(test_ionization_state):
         pytest.fail(errmsg)
 
 
-def test_normalization():
+def test_normalization() -> None:
     """
     Test that `_is_normalized` returns `False` when there is an
     error greater than the tolerance, and `True` after normalizing.
@@ -243,7 +243,7 @@ def test_normalization():
     assert H._is_normalized(tol=1e-15)
 
 
-def test_identifications(test_ionization_state):
+def test_identifications(test_ionization_state) -> None:
     """
     Test that the identification attributes for test
     `IonizationState` instances match the expected values from the
@@ -276,7 +276,7 @@ def test_identifications(test_ionization_state):
     )
 
 
-def test_as_particle_list(test_ionization_state):
+def test_as_particle_list(test_ionization_state) -> None:
     """
     Test that `IonizationState` returns the correct `Particle`
     instances.
@@ -288,7 +288,7 @@ def test_as_particle_list(test_ionization_state):
     assert expected_particles == actual_particles
 
 
-def test_getitem(test_ionization_state):
+def test_getitem(test_ionization_state) -> None:
     """
     Test that `IonizationState.__getitem__` returns the same value
     when using equivalent keys (charge number, particle symbol, and
@@ -342,7 +342,7 @@ def He_ionization_state():
 
 
 @pytest.mark.parametrize("index", [-1, 4, "Li"])
-def test_indexing_error(He_ionization_state, index):
+def test_indexing_error(He_ionization_state, index) -> None:
     """
     Test that an `IonizationState` instance cannot be indexed
     outside of the bounds of allowed charge numbers.
@@ -351,18 +351,18 @@ def test_indexing_error(He_ionization_state, index):
         He_ionization_state[index]
 
 
-def test_inequality_with_different_type(He_ionization_state):
+def test_inequality_with_different_type(He_ionization_state) -> None:
     assert He_ionization_state != "different type"
 
 
 @pytest.mark.parametrize("tol", [-1e-16, 1.0000001])
-def test_invalid_tolerances(He_ionization_state, tol):
+def test_invalid_tolerances(He_ionization_state, tol) -> None:
     """Test that invalid tolerances raise appropriate errors."""
     with pytest.raises(ValueError):
         He_ionization_state.tol = tol
 
 
-def test_State_equality_and_getitem(He_ionization_state):
+def test_State_equality_and_getitem(He_ionization_state) -> None:
     charge = 2
     symbol = "He 2+"
     result_from_charge = He_ionization_state[charge]
@@ -374,7 +374,7 @@ ions = ["Fe 6+", "p", "He-4 0+", "triton", "alpha", "Ne +0"]
 
 
 @pytest.mark.parametrize("ion", ions)
-def test_IonizationState_ionfracs_from_ion_input(ion):
+def test_IonizationState_ionfracs_from_ion_input(ion) -> None:
     ionization_state = IonizationState(ion)
     ion_particle = Particle(ion)
     actual_ionic_fractions = ionization_state.ionic_fractions
@@ -393,7 +393,7 @@ def test_IonizationState_ionfracs_from_ion_input(ion):
 
 
 @pytest.mark.parametrize("ion", ions)
-def test_IonizationState_base_particles_from_ion_input(ion):
+def test_IonizationState_base_particles_from_ion_input(ion) -> None:
     """
     Test that supplying an ion to IonizationState will result in the
     base particle being the corresponding isotope or ion and that the
@@ -442,7 +442,7 @@ def instance():
 
 
 @pytest.mark.parametrize("key", expected_properties)
-def test_IonizationState_attributes(instance, key):
+def test_IonizationState_attributes(instance, key) -> None:
     """
     Test a specific case that the `IonizationState` attributes are
     working as expected.
@@ -462,12 +462,12 @@ def test_IonizationState_attributes(instance, key):
             assert np.allclose(expected, actual)
 
 
-def test_IonizationState_methods(instance):
+def test_IonizationState_methods(instance) -> None:
     assert instance._is_normalized()
     assert str(instance) == "<IonizationState instance for He-4>"
 
 
-def test_IonizationState_ion_temperatures(instance):
+def test_IonizationState_ion_temperatures(instance) -> None:
     for ionic_level in instance:
         assert instance.T_e == ionic_level.T_i
 
@@ -475,7 +475,7 @@ def test_IonizationState_ion_temperatures(instance):
 @pytest.mark.xfail(
     reason="IonizationState currently does not store IonicLevels, but generates them on the fly!"
 )
-def test_IonizationState_ion_temperature_persistence(instance):
+def test_IonizationState_ion_temperature_persistence(instance) -> None:
     instance[0].T_i += 1 * u.K
     assert instance[0].T_i - instance.T_e == (1 * u.K)
 
@@ -490,11 +490,11 @@ def test_IonizationState_ion_temperature_persistence(instance):
         u.Quantity([1000, 1000, 10000], u.K),
     ],
 )
-def test_set_T_i(instance, T_i):
+def test_set_T_i(instance, T_i) -> None:
     instance.T_i = T_i
 
 
-def test_default_T_i_is_T_e(instance):
+def test_default_T_i_is_T_e(instance) -> None:
     T_i = instance.T_i
     assert_quantity_allclose(T_i, instance.T_e)
     assert len(T_i) == 3
@@ -517,20 +517,20 @@ def test_default_T_i_is_T_e(instance):
         ),
     ],
 )
-def test_set_T_i_with_errors(instance, T_i, expectation):
+def test_set_T_i_with_errors(instance, T_i, expectation) -> None:
     with expectation:
         instance.T_i = T_i
 
 
-def test_slicing(instance):
+def test_slicing(instance) -> None:
     instance[1:]
 
 
-def test_len(instance):
+def test_len(instance) -> None:
     assert len(instance) == 3
 
 
-def test_nans():
+def test_nans() -> None:
     """
     Test that when no ionic fractions or temperature are inputted,
     the result is an array full of `~numpy.nan` of the right size.
@@ -547,7 +547,7 @@ def test_nans():
     )
 
 
-def test_setting_ionic_fractions():
+def test_setting_ionic_fractions() -> None:
     """
     Test the setter for the ``ionic_fractions`` attribute on
     `~plasmapy.particles.IonizationState`.
@@ -561,7 +561,7 @@ def test_setting_ionic_fractions():
 class Test_IonizationStateNumberDensitiesSetter:
     """Test that setting IonizationState.number_densities works correctly."""
 
-    def setup_class(self):
+    def setup_class(self) -> None:
         self.element = "H"
         self.valid_number_densities = u.Quantity([0.1, 0.2], unit=u.m**-3)
         self.expected_n_elem = np.sum(self.valid_number_densities)
@@ -575,7 +575,7 @@ class Test_IonizationStateNumberDensitiesSetter:
                 "Unable to instantiate IonizationState with no ionic fractions."
             )
 
-    def test_setting_number_densities(self):
+    def test_setting_number_densities(self) -> None:
         try:
             self.instance.number_densities = self.valid_number_densities
         except Exception:  # noqa: BLE001
@@ -592,7 +592,7 @@ class Test_IonizationStateNumberDensitiesSetter:
             f"value of {self.valid_number_densities}."
         )
 
-    def test_ionic_fractions(self):
+    def test_ionic_fractions(self) -> None:
         assert np.allclose(
             self.instance.ionic_fractions, self.expected_ionic_fractions
         ), (
@@ -600,47 +600,47 @@ class Test_IonizationStateNumberDensitiesSetter:
             "correctly after the number densities were set."
         )
 
-    def test_n_elem(self):
+    def test_n_elem(self) -> None:
         assert u.quantity.allclose(self.instance.n_elem, self.expected_n_elem), (
             "IonizationState.n_elem not set correctly after "
             "number_densities was set."
         )
 
-    def test_n_e(self):
+    def test_n_e(self) -> None:
         assert u.quantity.allclose(
             self.instance.n_e, self.valid_number_densities[1]
         ), "IonizationState.n_e not set correctly after number_densities was set."
 
-    def test_that_negative_density_raises_error(self):
+    def test_that_negative_density_raises_error(self) -> None:
         with pytest.raises(ParticleError, match="cannot be negative"):
             self.instance.number_densities = u.Quantity([-0.1, 0.2], unit=u.m**-3)
 
-    def test_incorrect_number_of_charge_states_error(self):
+    def test_incorrect_number_of_charge_states_error(self) -> None:
         with pytest.raises(ParticleError, match="Incorrect number of charge states"):
             self.instance.number_densities = u.Quantity([0.1, 0.2, 0.3], unit=u.m**-3)
 
-    def test_incorrect_units_error(self):
+    def test_incorrect_units_error(self) -> None:
         with pytest.raises(u.UnitsError):
             self.instance.number_densities = u.Quantity([0.1, 0.2], unit=u.kg)
 
     # The following two tests are not related to setting the
     # number_densities attribute, but are helpful to test anyway.
 
-    def test_T_e_isnan_when_not_set(self):
+    def test_T_e_isnan_when_not_set(self) -> None:
         assert np.isnan(self.instance.T_e)
 
-    def test_kappa_isinf_when_not_set(self):
+    def test_kappa_isinf_when_not_set(self) -> None:
         assert np.isinf(self.instance.kappa)
 
 
-def test_iteration_with_nested_iterator():
+def test_iteration_with_nested_iterator() -> None:
     hydrogen = IonizationState("p+", n_elem=1e20 * u.m**-3, T_e=10 * u.eV)
 
     i = sum(1 for _, __ in itertools.product(hydrogen, hydrogen))
     assert i == 4
 
 
-def test_ionization_state_inequality_and_identity():
+def test_ionization_state_inequality_and_identity() -> None:
     deuterium_states = IonizationState("D+", n_elem=1e20 * u.m**-3, T_e=10 * u.eV)
     tritium_states = IonizationState("T+", n_elem=1e20 * u.m**-3, T_e=10 * u.eV)
     assert deuterium_states != tritium_states
@@ -659,7 +659,7 @@ particles_and_ionfracs = [
 
 @pytest.mark.parametrize("physical_property", physical_properties)
 @pytest.mark.parametrize(("base_particle", "ionic_fractions"), particles_and_ionfracs)
-def test_weighted_mean_ion(base_particle, ionic_fractions, physical_property):
+def test_weighted_mean_ion(base_particle, ionic_fractions, physical_property) -> None:
     """
     Test that `IonizationState.average_ion` gives a |CustomParticle|
     instance with the expected mass or charge when calculating the
@@ -676,7 +676,7 @@ def test_weighted_mean_ion(base_particle, ionic_fractions, physical_property):
 
 @pytest.mark.parametrize("physical_property", physical_properties)
 @pytest.mark.parametrize(("base_particle", "ionic_fractions"), particles_and_ionfracs)
-def test_weighted_rms_ion(base_particle, ionic_fractions, physical_property):
+def test_weighted_rms_ion(base_particle, ionic_fractions, physical_property) -> None:
     """
     Test that `IonizationState.average_ion` gives a |CustomParticle|
     instances with the expected mass or charge when calculating the
@@ -694,7 +694,7 @@ def test_weighted_rms_ion(base_particle, ionic_fractions, physical_property):
     assert_quantity_allclose(actual_rms_quantity, expected_rms_quantity)
 
 
-def test_exclude_neutrals_from_average_ion():
+def test_exclude_neutrals_from_average_ion() -> None:
     """
     Test that the `IonizationState.average_ion` method returns a
     |CustomParticle| that does not include neutrals in the averaging
@@ -711,7 +711,7 @@ def test_exclude_neutrals_from_average_ion():
 
 
 @pytest.mark.parametrize("physical_property", physical_properties)
-def test_comparison_to_equivalent_particle_list(physical_property):
+def test_comparison_to_equivalent_particle_list(physical_property) -> None:
     """
     Test that `IonizationState.average_ion` gives consistent results with
     `ParticleList.average_particle` when the ratios of different particles

--- a/plasmapy/particles/tests/test_nuclear.py
+++ b/plasmapy/particles/tests/test_nuclear.py
@@ -16,18 +16,18 @@ test_nuclear_equivalent_calls_table = [
 
 
 @pytest.mark.parametrize("test_inputs", test_nuclear_equivalent_calls_table)
-def test_nuclear_equivalent_calls(test_inputs):
+def test_nuclear_equivalent_calls(test_inputs) -> None:
     run_test_equivalent_calls(test_inputs)
 
 
-def test_nuclear_binding_energy_D_T():
+def test_nuclear_binding_energy_D_T() -> None:
     before = nuclear_binding_energy("D") + nuclear_binding_energy("T")
     after = nuclear_binding_energy("alpha")
     E_in_MeV = (after - before).to(u.MeV).value  # D + T --> alpha + n + E
     assert np.isclose(E_in_MeV, 17.58, rtol=0.01)
 
 
-def test_nuclear_reaction_energy():
+def test_nuclear_reaction_energy() -> None:
     reaction1 = "D + T --> alpha + n"
     reaction2 = "T + D -> n + alpha"
     released_energy1 = nuclear_reaction_energy(reaction1)
@@ -40,7 +40,7 @@ def test_nuclear_reaction_energy():
     nuclear_reaction_energy("neutron + antineutron --> neutron + antineutron")
 
 
-def test_nuclear_reaction_energy_triple_alpha():
+def test_nuclear_reaction_energy_triple_alpha() -> None:
     triple_alpha1 = "alpha + He-4 --> Be-8"
     triple_alpha2 = "Be-8 + alpha --> carbon-12"
     energy_triplealpha1 = nuclear_reaction_energy(triple_alpha1)
@@ -53,19 +53,19 @@ def test_nuclear_reaction_energy_triple_alpha():
     assert np.isclose(energy.to(u.keV).value, -91.8, atol=0.1)
 
 
-def test_nuclear_reaction_energy_alpha_decay():
+def test_nuclear_reaction_energy_alpha_decay() -> None:
     alpha_decay_example = "U-238 --> Th-234 + alpha"
     energy_alpha_decay = nuclear_reaction_energy(alpha_decay_example)
     assert np.isclose(energy_alpha_decay.to(u.MeV).value, 4.26975, atol=1e-5)
 
 
-def test_nuclear_reaction_energy_triple_alpha_r():
+def test_nuclear_reaction_energy_triple_alpha_r() -> None:
     triple_alpha1_r = "4*He-4 --> 2*Be-8"
     energy_triplealpha1_r = nuclear_reaction_energy(triple_alpha1_r)
     assert np.isclose(energy_triplealpha1_r.to(u.keV).value, -91.8 * 2, atol=0.1)
 
 
-def test_nuclear_reaction_energy_beta():
+def test_nuclear_reaction_energy_beta() -> None:
     energy1 = nuclear_reaction_energy(reactants=["n"], products=["p", "e-"])
     assert np.isclose(energy1.to(u.MeV).value, 0.78, atol=0.01)
     energy2 = nuclear_reaction_energy(reactants=["Mg-23"], products=["Na-23", "e+"])
@@ -90,13 +90,13 @@ nuclear_reaction_energy_kwargs_table = [
     ("reactants", "products", "expectedMeV", "tol"),
     nuclear_reaction_energy_kwargs_table,
 )
-def test_nuclear_reaction_energy_kwargs(reactants, products, expectedMeV, tol):
+def test_nuclear_reaction_energy_kwargs(reactants, products, expectedMeV, tol) -> None:
     energy = nuclear_reaction_energy(reactants=reactants, products=products).si
     expected = (expectedMeV * u.MeV).si
     assert np.isclose(expected.value, energy.value, atol=tol)
 
 
-def test_nuclear_reaction_energy2():
+def test_nuclear_reaction_energy2() -> None:
     reactants = ["D", "T"]
     products = ["alpha", "n"]
     expected = 17.6 * u.MeV
@@ -119,5 +119,5 @@ table_of_nuclear_tests = [
 @pytest.mark.parametrize(
     ("tested_object", "args", "kwargs", "expected_value"), table_of_nuclear_tests
 )
-def test_nuclear_table(tested_object, args, kwargs, expected_value):
+def test_nuclear_table(tested_object, args, kwargs, expected_value) -> None:
     run_test(tested_object, args, kwargs, expected_value, rtol=1e-3)

--- a/plasmapy/particles/tests/test_parsing.py
+++ b/plasmapy/particles/tests/test_parsing.py
@@ -49,7 +49,7 @@ aliases_and_symbols = [
 
 
 @pytest.mark.parametrize(("alias", "symbol"), aliases_and_symbols)
-def test_dealias_particle_aliases(alias, symbol):
+def test_dealias_particle_aliases(alias, symbol) -> None:
     """Test that _dealias_particle_aliases correctly takes in aliases and
     returns the corresponding symbols, and returns the original argument
     if the argument does not correspond to an alias."""
@@ -66,7 +66,7 @@ alias_dictionaries = [case_sensitive_aliases, case_insensitive_aliases]
 
 
 @pytest.mark.parametrize("alias_dict", alias_dictionaries)
-def test_alias_dict_properties(alias_dict):
+def test_alias_dict_properties(alias_dict) -> None:
     """Test properties of the alias dictionaries."""
 
     for key in alias_dict:
@@ -268,7 +268,7 @@ parse_check_table = [
 
 
 @pytest.mark.parametrize(("arg", "kwargs", "expected"), parse_check_table)
-def test_parse_and_check_atomic_input(arg, kwargs, expected):
+def test_parse_and_check_atomic_input(arg, kwargs, expected) -> None:
     result = parse_and_check_atomic_input(arg, **kwargs)
     assert result == expected, (
         "Error in _parse_and_check_atomic_input.\n"
@@ -317,7 +317,7 @@ invalid_particles_table = [
 
 
 @pytest.mark.parametrize(("arg", "kwargs"), invalid_particles_table)
-def test_parse_InvalidParticleErrors(arg, kwargs):
+def test_parse_InvalidParticleErrors(arg, kwargs) -> None:
     r"""Tests that _parse_and_check_atomic_input raises an
     InvalidParticleError when the input does not correspond
     to a real particle."""
@@ -330,7 +330,7 @@ def test_parse_InvalidParticleErrors(arg, kwargs):
         )
 
 
-def test_parse_InvalidElementErrors(particle):
+def test_parse_InvalidElementErrors(particle) -> None:
     r"""Tests that _parse_and_check_atomic_input raises an
     InvalidElementError when the input corresponds to a valid
     particle but not a valid element, isotope, or ion."""
@@ -356,7 +356,7 @@ atomic_warnings_table = [
 
 
 @pytest.mark.parametrize(("arg", "kwargs", "num_warnings"), atomic_warnings_table)
-def test_parse_AtomicWarnings(arg, kwargs, num_warnings):
+def test_parse_AtomicWarnings(arg, kwargs, num_warnings) -> None:
     r"""Tests that _parse_and_check_atomic_input issues an AtomicWarning
     under the required conditions."""
 
@@ -377,6 +377,6 @@ def test_parse_AtomicWarnings(arg, kwargs, num_warnings):
     )
 
 
-def test_Queen():
+def test_Queen() -> None:
     Queen = "Freddie Mercury (lead vocals, piano), Brian May (guitar, vocals), Roger Taylor (drums, vocals) and John Deacon (bass)"
     assert Particle("Freddie").element_name.capitalize() in Queen

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -577,7 +577,7 @@ equivalent_particles_table = [
 
 
 @pytest.mark.parametrize("equivalent_particles", equivalent_particles_table)
-def test_Particle_equivalent_cases(equivalent_particles):
+def test_Particle_equivalent_cases(equivalent_particles) -> None:
     """Test that all instances of a list of particles are equivalent."""
     run_test_equivalent_calls(Particle, *equivalent_particles)
 
@@ -624,7 +624,7 @@ test_Particle_error_table = [
 @pytest.mark.parametrize(
     ("args", "kwargs", "attribute", "exception"), test_Particle_error_table
 )
-def test_Particle_errors(args, kwargs, attribute, exception):
+def test_Particle_errors(args, kwargs, attribute, exception) -> None:
     """
     Test that the appropriate exceptions are raised during the creation
     and use of a `~plasmapy.particles.Particle` object.
@@ -649,7 +649,7 @@ test_Particle_warning_table = [
 @pytest.mark.parametrize(
     ("arg", "kwargs", "attribute", "warning"), test_Particle_warning_table
 )
-def test_Particle_warnings(arg, kwargs, attribute, warning):
+def test_Particle_warnings(arg, kwargs, attribute, warning) -> None:
     """
     Test that the appropriate warnings are issued during the creation
     and use of a `~plasmapy.particles.Particle` object.
@@ -664,7 +664,7 @@ def test_Particle_warnings(arg, kwargs, attribute, warning):
             )
 
 
-def test_Particle_cmp():
+def test_Particle_cmp() -> None:
     """Test ``__eq__`` and ``__ne__`` in the Particle class."""
     proton1 = Particle("p+")
     proton2 = Particle("proton")
@@ -679,7 +679,7 @@ def test_Particle_cmp():
 
 
 @pytest.mark.parametrize("particle", ["p+", "D+", "T+", "alpha"])
-def test_particle_equality_special_nuclides(particle):
+def test_particle_equality_special_nuclides(particle) -> None:
     particle_from_string = Particle(particle)
     particle_from_numbers = Particle(
         particle_from_string.element_name,
@@ -703,7 +703,7 @@ nuclide_mass_and_mass_equiv_table = [
 
 
 @pytest.mark.parametrize(("isotope", "ion"), nuclide_mass_and_mass_equiv_table)
-def test_particle_class_mass_nuclide_mass(isotope: str, ion: str):
+def test_particle_class_mass_nuclide_mass(isotope: str, ion: str) -> None:
     """
     Test that the ``mass`` and ``nuclide_mass`` attributes return
     equivalent values when appropriate.  The inputs should generally be
@@ -752,7 +752,7 @@ def test_particle_class_mass_nuclide_mass(isotope: str, ion: str):
 
 
 @pytest.mark.slow()
-def test_particle_half_life_string():
+def test_particle_half_life_string() -> None:
     """
     Find the first isotope where the half-life is stored as a string
     (because the uncertainties are too great), and tests that requesting
@@ -772,16 +772,16 @@ def test_particle_half_life_string():
 @pytest.mark.parametrize(
     ("p", "is_one"), [(Particle("e-"), True), (Particle("p+"), False)]
 )
-def test_particle_is_electron(p, is_one):
+def test_particle_is_electron(p, is_one) -> None:
     assert p.is_electron == is_one
 
 
-def test_particle_bool_error():
+def test_particle_bool_error() -> None:
     with pytest.raises(ParticleError):
         bool(Particle("e-"))
 
 
-def test_particle_inversion(particle_antiparticle_pair):
+def test_particle_inversion(particle_antiparticle_pair) -> None:
     """Test that particles have the correct antiparticles."""
     particle, antiparticle = particle_antiparticle_pair
     assert particle.antiparticle == antiparticle, (
@@ -790,7 +790,7 @@ def test_particle_inversion(particle_antiparticle_pair):
     )
 
 
-def test_antiparticle_inversion(particle_antiparticle_pair):
+def test_antiparticle_inversion(particle_antiparticle_pair) -> None:
     """Test that antiparticles have the correct antiparticles."""
     particle, antiparticle = particle_antiparticle_pair
     assert antiparticle.antiparticle == particle, (
@@ -799,7 +799,7 @@ def test_antiparticle_inversion(particle_antiparticle_pair):
     )
 
 
-def test_unary_operator_for_elements():
+def test_unary_operator_for_elements() -> None:
     with pytest.raises(ParticleError):
         Particle("C").antiparticle  # noqa: B018
 
@@ -810,7 +810,7 @@ class Test_antiparticle_properties_inversion:
     instances.
     """
 
-    def test_inverted_inversion(self, particle):
+    def test_inverted_inversion(self, particle) -> None:
         """
         Test that the antiparticle of the antiparticle of a particle is
         the original particle.
@@ -819,7 +819,7 @@ class Test_antiparticle_properties_inversion:
             particle == ~~particle
         ), f"~~{particle!r} equals {~~particle!r} instead of {particle!r}."
 
-    def test_opposite_charge(self, particle, opposite):
+    def test_opposite_charge(self, particle, opposite) -> None:
         """
         Test that a particle and its antiparticle have the opposite
         charge.
@@ -829,7 +829,7 @@ class Test_antiparticle_properties_inversion:
             f"opposites, as expected of a particle/antiparticle pair."
         )
 
-    def test_equal_mass(self, particle, opposite):
+    def test_equal_mass(self, particle, opposite) -> None:
         """
         Test that a particle and its antiparticle have the same mass.
         """
@@ -838,7 +838,7 @@ class Test_antiparticle_properties_inversion:
             f"as expected of a particle/antiparticle pair."
         )
 
-    def test_antiparticle_attribute_and_operator(self, particle):
+    def test_antiparticle_attribute_and_operator(self, particle) -> None:
         """
         Test that the Particle.antiparticle attribute returns the same
         value as the unary ~ (invert) operator acting on the same
@@ -852,7 +852,7 @@ class Test_antiparticle_properties_inversion:
 
 
 @pytest.mark.parametrize("arg", ["e-", "D+", "Fe 25+", "H-", "mu+"])
-def test_particleing_a_particle(arg):
+def test_particleing_a_particle(arg) -> None:
     """
     Test that Particle(arg) is equal to Particle(Particle(arg)), but is
     not the same object in memory.
@@ -943,7 +943,7 @@ customized_particle_tests = [
     ("cls", "kwargs", "attr", "expected"), customized_particle_tests
 )
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_custom_particles(cls, kwargs, attr, expected):
+def test_custom_particles(cls, kwargs, attr, expected) -> None:
     """Test the attributes of dimensionless and custom particles."""
     instance = cls(**kwargs)
     value = getattr(instance, attr)
@@ -963,7 +963,7 @@ def test_custom_particles(cls, kwargs, attr, expected):
         (DimensionlessParticle, "η", "η"),
     ],
 )
-def test_custom_particle_symbol(cls, symbol, expected):
+def test_custom_particle_symbol(cls, symbol, expected) -> None:
     instance = cls(symbol=symbol)
     assert instance.symbol == expected
 
@@ -976,7 +976,7 @@ custom_particle_categories_table = [
 
 
 @pytest.mark.parametrize(("kwargs", "expected"), custom_particle_categories_table)
-def test_custom_particle_categories(kwargs, expected):
+def test_custom_particle_categories(kwargs, expected) -> None:
     """Test that CustomParticle.categories behaves as expected."""
     custom_particle = CustomParticle(**kwargs)
     assert custom_particle.categories == expected
@@ -1003,7 +1003,7 @@ def test_custom_particle_is_category(
     kwargs_to_custom_particle,
     kwargs_to_is_category,
     expected,
-):
+) -> None:
     """Test that CustomParticle.is_category works as expected."""
     custom_particle = CustomParticle(**kwargs_to_custom_particle)
     actual = custom_particle.is_category(**kwargs_to_is_category)
@@ -1051,7 +1051,7 @@ custom_particle_errors = [
 
 
 @pytest.mark.parametrize(("cls", "kwargs", "exception"), custom_particle_errors)
-def test_customized_particles_errors(cls, kwargs, exception):
+def test_customized_particles_errors(cls, kwargs, exception) -> None:
     """
     Test that attempting to create invalid dimensionless or custom particles
     results in an InvalidParticleError.
@@ -1082,7 +1082,7 @@ customized_particle_repr_table = [
 @pytest.mark.parametrize(
     ("cls", "kwargs", "expected_repr"), customized_particle_repr_table
 )
-def test_customized_particle_repr(cls, kwargs, expected_repr):
+def test_customized_particle_repr(cls, kwargs, expected_repr) -> None:
     """Test the string representations of dimensionless and custom particles."""
     instance = cls(**kwargs)
     from_repr = repr(instance)
@@ -1099,7 +1099,7 @@ def test_customized_particle_repr(cls, kwargs, expected_repr):
 
 @pytest.mark.parametrize("cls", [CustomParticle, DimensionlessParticle])
 @pytest.mark.parametrize("not_a_str", [1, u.kg])
-def test_typeerror_redefining_symbol(cls, not_a_str):
+def test_typeerror_redefining_symbol(cls, not_a_str) -> None:
     """Test that the symbol attribute cannot be set to something besides a string"""
     instance = cls()
     with pytest.raises(TypeError):
@@ -1197,7 +1197,7 @@ custom_particles_from_json_tests = [
 )
 def test_custom_particles_from_json_string(
     cls, kwargs, json_string, expected_exception
-):
+) -> None:
     """Test the attributes of dimensionless and custom particles generated from
     JSON representation"""
     if expected_exception is None:
@@ -1228,7 +1228,9 @@ def test_custom_particles_from_json_string(
     ("cls", "kwargs", "json_string", "expected_exception"),
     custom_particles_from_json_tests,
 )
-def test_custom_particles_from_json_file(cls, kwargs, json_string, expected_exception):
+def test_custom_particles_from_json_file(
+    cls, kwargs, json_string, expected_exception
+) -> None:
     """Test the attributes of dimensionless and custom particles generated from
     JSON representation"""
     if expected_exception is None:
@@ -1296,7 +1298,9 @@ particles_from_json_tests = [
 @pytest.mark.parametrize(
     ("cls", "kwargs", "json_string", "expected_exception"), particles_from_json_tests
 )
-def test_particles_from_json_string(cls, kwargs, json_string, expected_exception):
+def test_particles_from_json_string(
+    cls, kwargs, json_string, expected_exception
+) -> None:
     """Test the attributes of Particle objects created from JSON representation."""
     if expected_exception is None:
         instance = cls(**kwargs)
@@ -1318,7 +1322,7 @@ def test_particles_from_json_string(cls, kwargs, json_string, expected_exception
 @pytest.mark.parametrize(
     ("cls", "kwargs", "json_string", "expected_exception"), particles_from_json_tests
 )
-def test_particles_from_json_file(cls, kwargs, json_string, expected_exception):
+def test_particles_from_json_file(cls, kwargs, json_string, expected_exception) -> None:
     """Test the attributes of Particle objects created from JSON representation."""
     if expected_exception is None:
         instance = cls(**kwargs)
@@ -1379,7 +1383,7 @@ particle_json_repr_table = [
 
 
 @pytest.mark.parametrize(("cls", "kwargs", "expected_repr"), particle_json_repr_table)
-def test_particle_to_json_string(cls, kwargs, expected_repr):
+def test_particle_to_json_string(cls, kwargs, expected_repr) -> None:
     """Test the JSON representations of normal, dimensionless and custom particles."""
     instance = cls(**kwargs)
     json_repr = instance.json_dumps()
@@ -1400,7 +1404,7 @@ def test_particle_to_json_string(cls, kwargs, expected_repr):
 
 
 @pytest.mark.parametrize(("cls", "kwargs", "expected_repr"), particle_json_repr_table)
-def test_particle_to_json_file(cls, kwargs, expected_repr):
+def test_particle_to_json_file(cls, kwargs, expected_repr) -> None:
     """Test the JSON representations of normal, dimensionless and custom particles."""
     instance = cls(**kwargs)
     test_file_object = io.StringIO("")
@@ -1423,7 +1427,7 @@ def test_particle_to_json_file(cls, kwargs, expected_repr):
     )
 
 
-def test_particle_is_category_valid_categories():
+def test_particle_is_category_valid_categories() -> None:
     """Test the location where valid categories may be accessed."""
     some_valid_categories = {
         "charged",
@@ -1440,7 +1444,7 @@ def test_particle_is_category_valid_categories():
     assert some_valid_categories.issubset(valid_categories)
 
 
-def test_CustomParticle_cmp():
+def test_CustomParticle_cmp() -> None:
     """Test ``__eq__`` and ``__ne__`` in the CustomParticle class."""
     particle1 = CustomParticle(2 * 126.90447 * u.u, 0 * u.C, "I2")
     particle2 = CustomParticle(2 * 126.90447 * u.u, 0 * u.C, "I2")
@@ -1463,7 +1467,7 @@ def test_CustomParticle_cmp():
         ("symbol", "😺"),
     ],
 )
-def test_CustomParticle_setters(attr, arg):
+def test_CustomParticle_setters(attr, arg) -> None:
     custom_particle = CustomParticle()
     setattr(custom_particle, attr, arg)
     output = getattr(custom_particle, attr)
@@ -1490,7 +1494,7 @@ test_molecule_table = [
         ([], {"symbol": "..."}, CustomParticle(symbol="...")),
     ],
 )
-def test_CustomParticle_from_quantities(args, kwargs, expected):
+def test_CustomParticle_from_quantities(args, kwargs, expected) -> None:
     actual = CustomParticle._from_quantities(*args, **kwargs)
     assert actual == expected
 
@@ -1503,13 +1507,13 @@ def test_CustomParticle_from_quantities(args, kwargs, expected):
         ([4 * u.kg, "invalid"], {}, InvalidParticleError),
     ],
 )
-def test_CustomParticle_from_quantities_errors(args, kwargs, exception):
+def test_CustomParticle_from_quantities_errors(args, kwargs, exception) -> None:
     with pytest.raises(exception):
         CustomParticle._from_quantities(*args, **kwargs)
 
 
 @pytest.mark.parametrize(("m", "Z", "symbol", "m_symbol", "m_Z"), test_molecule_table)
-def test_molecule(m, Z, symbol, m_symbol, m_Z):
+def test_molecule(m, Z, symbol, m_symbol, m_Z) -> None:
     """Test ``molecule`` function."""
     assert CustomParticle(m, Z, symbol) == molecule(m_symbol, m_Z)
 
@@ -1524,13 +1528,13 @@ test_molecule_error_table = [
 
 
 @pytest.mark.parametrize(("symbol", "Z"), test_molecule_error_table)
-def test_molecule_error(symbol, Z):
+def test_molecule_error(symbol, Z) -> None:
     """Test the error raised in case of a bad molecule symbol."""
     with pytest.raises(InvalidParticleError):
         molecule(symbol, Z)
 
 
-def test_molecule_other():
+def test_molecule_other() -> None:
     """Test fallback to |Particle| object and warning in case of redundant charge."""
     assert Particle("I") == molecule("I")
 
@@ -1540,25 +1544,25 @@ def test_molecule_other():
         )
 
 
-def test_undefined_charge():
+def test_undefined_charge() -> None:
     """Test that a particle with an undefined charge returns |nan| C."""
     H_particle = Particle("H")
     assert u.isclose(H_particle.charge, np.nan * u.C, equal_nan=True)
 
 
-def test_undefined_standard_atomic_weight():
+def test_undefined_standard_atomic_weight() -> None:
     """Test that a particle with an undefined standard atomic weight returns |nan| kg."""
     Pm_particle = Particle("Pm")
     assert u.isclose(Pm_particle.standard_atomic_weight, np.nan * u.kg, equal_nan=True)
 
 
-def test_undefined_mass():
+def test_undefined_mass() -> None:
     """Test that a particle with an undefined mass returns |nan| kg."""
     tau_neutrino_particle = Particle("tau neutrino")
     assert u.isclose(tau_neutrino_particle.mass, np.nan * u.kg, equal_nan=True)
 
 
-def test_undefined_mass_energy():
+def test_undefined_mass_energy() -> None:
     """Test that a particle with an undefined mass energy returns |nan| J."""
     nu_tau_particle = Particle("nu_tau")
     assert u.isclose(nu_tau_particle.mass_energy, np.nan * u.J, equal_nan=True)

--- a/plasmapy/particles/tests/test_particle_collections.py
+++ b/plasmapy/particles/tests/test_particle_collections.py
@@ -69,7 +69,7 @@ def _everything_is_particle_or_custom_particle(iterable):
         ([custom_particle, electron, "e-"]),
     ],
 )
-def test_particle_list_membership(args):
+def test_particle_list_membership(args) -> None:
     """
     Test that the particles in the `ParticleList` match the particles
     (or particle-like objects) that are passed to it.
@@ -82,7 +82,7 @@ def test_particle_list_membership(args):
 
 
 @pytest.mark.parametrize("attribute", attributes)
-def test_particle_list_attributes(attribute):
+def test_particle_list_attributes(attribute) -> None:
     """
     Test that the attributes of ParticleList correspond to the
     attributes of the listed particles.
@@ -99,7 +99,7 @@ def test_particle_list_attributes(attribute):
 
 
 @pytest.mark.parametrize("attribute", attributes)
-def test_particle_list_no_redefining_attributes(various_particles, attribute):
+def test_particle_list_no_redefining_attributes(various_particles, attribute) -> None:
     """
     Test that attributes of `ParticleList` cannot be manually redefined.
 
@@ -111,14 +111,14 @@ def test_particle_list_no_redefining_attributes(various_particles, attribute):
         various_particles.__setattr__(attribute, 42)
 
 
-def test_particle_list_len():
+def test_particle_list_len() -> None:
     """Test that using `len` on a `ParticleList` returns the expected number."""
     original_list = ["n", "p", "e-"]
     particle_list = ParticleList(original_list)
     assert len(particle_list) == len(original_list)
 
 
-def test_particle_list_append(various_particles):
+def test_particle_list_append(various_particles) -> None:
     """Test that a particle-like object can get appended to a `ParticleList`."""
     original_length = len(various_particles)
     various_particles.append("Li")
@@ -129,7 +129,7 @@ def test_particle_list_append(various_particles):
     assert various_particles.data[-1] is appended_item
 
 
-def test_particle_list_pop(various_particles):
+def test_particle_list_pop(various_particles) -> None:
     """Test that the last item in the `ParticleList` is removed when"""
     expected = various_particles[:-1]
     particle_that_should_be_removed = various_particles[-1]
@@ -138,7 +138,7 @@ def test_particle_list_pop(various_particles):
     assert removed_particle == particle_that_should_be_removed
 
 
-def test_particle_list_extend(various_particles):
+def test_particle_list_extend(various_particles) -> None:
     """
     Test that a `ParticleList` can be extended when provided with an
     iterable that yields particle-like objects.
@@ -149,14 +149,14 @@ def test_particle_list_extend(various_particles):
     assert various_particles[-3:] == new_particles
 
 
-def test_particle_list_extended_with_particle_list(various_particles):
+def test_particle_list_extended_with_particle_list(various_particles) -> None:
     """Test that a `ParticleList` can be extended with another `ParticleList`."""
     particle_list = ParticleList(["D", "T", CustomParticle()])
     various_particles.extend(particle_list)
     assert various_particles[-3:] == particle_list
 
 
-def test_particle_list_insert(various_particles):
+def test_particle_list_insert(various_particles) -> None:
     """Test insertion of particle-like objects into"""
     various_particles.insert(0, "tau neutrino")
     assert various_particles[0] == "tau neutrino"
@@ -166,7 +166,7 @@ def test_particle_list_insert(various_particles):
 invalid_particles = (0, "not a particle", DimensionlessParticle(), 5 * u.m)
 
 
-def test_particle_list_instantiate_with_invalid_particles():
+def test_particle_list_instantiate_with_invalid_particles() -> None:
     """
     Test that a `ParticleList` instance cannot be created when it is
     provided with invalid particles.
@@ -176,7 +176,9 @@ def test_particle_list_instantiate_with_invalid_particles():
 
 
 @pytest.mark.parametrize("invalid_particle", invalid_particles)
-def test_particle_list_append_invalid_particle(various_particles, invalid_particle):
+def test_particle_list_append_invalid_particle(
+    various_particles, invalid_particle
+) -> None:
     """
     Test that objects that are not particle-like cannot be appended to
     a `ParticleList` instance.
@@ -185,7 +187,7 @@ def test_particle_list_append_invalid_particle(various_particles, invalid_partic
         various_particles.append(invalid_particle)
 
 
-def test_particle_list_extend_with_invalid_particles(various_particles):
+def test_particle_list_extend_with_invalid_particles(various_particles) -> None:
     """
     Test that a `ParticleList` instance cannot be extended with any
     objects that are not particle-like.
@@ -195,7 +197,9 @@ def test_particle_list_extend_with_invalid_particles(various_particles):
 
 
 @pytest.mark.parametrize("invalid_particle", invalid_particles)
-def test_particle_list_insert_invalid_particle(various_particles, invalid_particle):
+def test_particle_list_insert_invalid_particle(
+    various_particles, invalid_particle
+) -> None:
     """
     Test that objects that are not particle-like cannot be inserted into
     a `ParticleList` instance.
@@ -204,7 +208,7 @@ def test_particle_list_insert_invalid_particle(various_particles, invalid_partic
         various_particles.insert(1, invalid_particle)
 
 
-def test_particle_list_sort_with_key_and_reverse():
+def test_particle_list_sort_with_key_and_reverse() -> None:
     """
     Test that a `ParticleList` instance can be sorted if a key is
     provided, and that the ``reverse`` keyword argument works too.
@@ -215,13 +219,13 @@ def test_particle_list_sort_with_key_and_reverse():
     assert particle_list.symbols == ["U", "Fe", "He", "H"]
 
 
-def test_particle_list_sort_without_key(various_particles):
+def test_particle_list_sort_without_key(various_particles) -> None:
     """Test that a `ParticleList` cannot be sorted if a key is not provided."""
     with pytest.raises(TypeError):
         various_particles.sort()
 
 
-def test_particle_list_dimensionless_particles():
+def test_particle_list_dimensionless_particles() -> None:
     """
     Test that a `ParticleList` cannot be instantiated with a
     `DimensionlessParticle`.
@@ -230,7 +234,7 @@ def test_particle_list_dimensionless_particles():
         ParticleList([DimensionlessParticle()])
 
 
-def test_particle_list_adding_particle_list(various_particles):
+def test_particle_list_adding_particle_list(various_particles) -> None:
     """Test that a `ParticleList` can be added to another `ParticleList`."""
     extra_particles = ParticleList(["H", "D", "T"])
     new_particles_list = various_particles + extra_particles
@@ -238,7 +242,7 @@ def test_particle_list_adding_particle_list(various_particles):
     assert isinstance(new_particles_list, ParticleList)
 
 
-def test_add_particle_list_and_particle(various_particles):
+def test_add_particle_list_and_particle(various_particles) -> None:
     """
     Test that a `ParticleList` can be added to a `Particle` on the right
     and then return a `ParticleList`.
@@ -249,7 +253,7 @@ def test_add_particle_list_and_particle(various_particles):
     assert isinstance(new_particle_list, ParticleList)
 
 
-def test_add_particle_and_particle_list(various_particles):
+def test_add_particle_and_particle_list(various_particles) -> None:
     """
     Test that a `Particle` can be added to a `ParticleList` on the right
     and then return a `ParticleList`.
@@ -260,7 +264,7 @@ def test_add_particle_and_particle_list(various_particles):
     assert isinstance(new_particle_list, ParticleList)
 
 
-def test_add_particle_and_particle_like():
+def test_add_particle_and_particle_like() -> None:
     """
     Test that a `Particle` can be added to a particle-like object on the
     right and then return a `ParticleList`.
@@ -271,7 +275,7 @@ def test_add_particle_and_particle_like():
     assert heavy_isotopes_of_hydrogen[1] == "T"
 
 
-def test_add_particle_like_and_particle():
+def test_add_particle_like_and_particle() -> None:
     """
     Test that a particle-like object on the left can be added to a
     `Particle` instance on the right and then return a `ParticleList`.
@@ -282,7 +286,7 @@ def test_add_particle_like_and_particle():
     assert heavy_isotopes_of_hydrogen[1] == "T"
 
 
-def test_particle_list_gt_as_nuclear_reaction_energy():
+def test_particle_list_gt_as_nuclear_reaction_energy() -> None:
     """
     Test that `ParticleList.__gt__` can be used to get the same result
     as `nuclear_reaction_energy`.
@@ -294,7 +298,7 @@ def test_particle_list_gt_as_nuclear_reaction_energy():
     assert u.allclose(expected_energy, actual_energy)
 
 
-def test_particle_gt_as_radioactive_decay():
+def test_particle_gt_as_radioactive_decay() -> None:
     """
     Test a nuclear reaction where a `Particle` instance is the sole
     reactant on the left side.
@@ -307,7 +311,7 @@ def test_particle_gt_as_radioactive_decay():
 
 @pytest.mark.parametrize("method", ["append", "__add__", "__radd__"])
 @pytest.mark.parametrize("invalid_particle", invalid_particles)
-def test_particle_list_invalid_ops(various_particles, invalid_particle, method):
+def test_particle_list_invalid_ops(various_particles, invalid_particle, method) -> None:
     """
     Test that operations with invalid particles raise the appropriate
     exceptions.
@@ -318,7 +322,7 @@ def test_particle_list_invalid_ops(various_particles, invalid_particle, method):
 
 @pytest.mark.parametrize("particle", [electron, CustomParticle()])
 @pytest.mark.parametrize("method", ["__mul__", "__rmul__"])
-def test_particle_multiplication(method, particle):
+def test_particle_multiplication(method, particle) -> None:
     """
     Test that multiplying a `Particle` or `CustomParticle` with an
     integer returns a `ParticleList` that contains the correct values.
@@ -356,7 +360,7 @@ def test_particle_multiplication(method, particle):
         ],
     ],
 )
-def test_particle_list_is_category(particles, args, kwargs, expected):
+def test_particle_list_is_category(particles, args, kwargs, expected) -> None:
     """
     Test that ``ParticleList.is_category()`` behaves as expected.
     """
@@ -364,7 +368,7 @@ def test_particle_list_is_category(particles, args, kwargs, expected):
     assert sample_list.is_category(*args, **kwargs) == expected
 
 
-def test_mean_particle():
+def test_mean_particle() -> None:
     """
     Test that ``ParticleList.average_particle()`` returns a particle with
     the mean mass and mean charge of a |ParticleList|.
@@ -378,7 +382,7 @@ def test_mean_particle():
     assert u.isclose(average_particle.charge, expected_charge, rtol=1e-14)
 
 
-def test_weighted_mean_particle():
+def test_weighted_mean_particle() -> None:
     """
     Test that ``ParticleList.average_particle()`` returns a particle with
     the weighted mean.
@@ -397,7 +401,7 @@ boolean_pairs = [(False, False), (True, False), (False, True), (True, True)]
 
 
 @pytest.mark.parametrize(("use_rms_charge", "use_rms_mass"), boolean_pairs)
-def test_root_mean_square_particle(use_rms_charge, use_rms_mass):
+def test_root_mean_square_particle(use_rms_charge, use_rms_mass) -> None:
     """
     Test that ``ParticleList.average_particle`` returns the mean or root
     mean square of the charge and mass, as appropriate.
@@ -435,7 +439,7 @@ def test_weighted_averages_of_particles(
     particle_multiplicities: dict[ParticleLike, int],
     use_rms_charge,
     use_rms_mass,
-):
+) -> None:
     """
     Compare the mass and charge of the average particle for two |ParticleList|
     instances.
@@ -487,7 +491,7 @@ def test_weighted_averages_of_particles(
         assert isinstance(weighted_mean_of_unique_particles, Particle)
 
 
-def test_particle_list_with_no_arguments():
+def test_particle_list_with_no_arguments() -> None:
     """Test that `ParticleList()` returns an empty `ParticleList`."""
     empty_particle_list = ParticleList()
     assert isinstance(empty_particle_list, ParticleList)
@@ -512,7 +516,7 @@ def test_particle_list_with_no_arguments():
         ),
     ),
 )
-def test_particle_list_from_quantity_array(quantities, expected):
+def test_particle_list_from_quantity_array(quantities, expected) -> None:
     """
     Test that ParticleList can accept a Quantity array of an appropriate
     physical type.

--- a/plasmapy/particles/tests/test_pickling.py
+++ b/plasmapy/particles/tests/test_pickling.py
@@ -29,7 +29,7 @@ class TestPickling:
             IonizationStateCollection({"H": [0.5, 0.5]}),
         ],
     )
-    def test_pickling(self, instance, tmp_path):
+    def test_pickling(self, instance, tmp_path) -> None:
         """
         Test that different objects contained within `plasmapy.particles`
         can be pickled and unpickled.

--- a/plasmapy/particles/tests/test_special_particles.py
+++ b/plasmapy/particles/tests/test_special_particles.py
@@ -1,7 +1,7 @@
 from plasmapy.particles._special_particles import data_about_special_particles
 
 
-def test_particle_antiparticle_pairs(particle_antiparticle_pair):
+def test_particle_antiparticle_pairs(particle_antiparticle_pair) -> None:
     """Test that particles and antiparticles have the same or exact
     opposite properties in the _Particles dictionary."""
     particle, antiparticle = (p.symbol for p in particle_antiparticle_pair)

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -28,7 +28,7 @@ class BasePlasma(ABC):
     # GenericPlasma subclass registry
     _registry = {}
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
         if hasattr(cls, "is_datasource_for"):
             cls._registry[cls] = cls.is_datasource_for

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -69,7 +69,7 @@ class HDF5Reader(GenericPlasma):
     def __enter__(self):
         return self.h5
 
-    def close(self):
+    def close(self) -> None:
         self.h5.close()
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/plasmapy/plasma/sources/plasma3d.py
+++ b/plasmapy/plasma/sources/plasma3d.py
@@ -182,7 +182,7 @@ class Plasma3D(GenericPlasma):
             else False
         )
 
-    def add_magnetostatic(self, *mstats: MagnetoStatics):
+    def add_magnetostatic(self, *mstats: MagnetoStatics) -> None:
         # for each MagnetoStatic argument
         prod = itertools.product(*[list(range(n)) for n in self.domain_shape])
         for mstat in mstats:

--- a/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
@@ -39,24 +39,24 @@ class TestOpenPMD2D:
     # https://github.com/openPMD/openPMD-example-datasets/blob/draft/example-2d.tar.gz
     # per the Creative Commons Zero v1.0 Universal license
 
-    def test_has_electric_field_with_units(self, h5_2d):
+    def test_has_electric_field_with_units(self, h5_2d) -> None:
         assert isinstance(h5_2d.electric_field.to(u.V / u.m), u.Quantity)
 
-    def test_correct_shape_electric_field(self, h5_2d):
+    def test_correct_shape_electric_field(self, h5_2d) -> None:
         assert h5_2d.electric_field.shape == (3, 51, 201)
 
-    def test_has_charge_density_with_units(self, h5_2d):
+    def test_has_charge_density_with_units(self, h5_2d) -> None:
         # this should simply pass without exception
         h5_2d.charge_density.to(u.C / u.m**3)
 
-    def test_correct_shape_charge_density(self, h5_2d):
+    def test_correct_shape_charge_density(self, h5_2d) -> None:
         assert h5_2d.charge_density.shape == (51, 201)
 
-    def test_has_magnetic_field(self, h5_2d):
+    def test_has_magnetic_field(self, h5_2d) -> None:
         with pytest.raises(AttributeError):
             h5_2d.magnetic_field  # noqa: B018
 
-    def test_has_electric_current(self, h5_2d):
+    def test_has_electric_current(self, h5_2d) -> None:
         with pytest.raises(AttributeError):
             h5_2d.electric_current  # noqa: B018
 
@@ -68,23 +68,23 @@ class TestOpenPMD3D:
     # https://github.com/openPMD/openPMD-example-datasets/blob/draft/example-3d.tar.gz
     # per the Creative Commons Zero v1.0 Universal license
 
-    def test_has_electric_field_with_units(self, h5_3d):
+    def test_has_electric_field_with_units(self, h5_3d) -> None:
         assert isinstance(h5_3d.electric_field.to(u.V / u.m), u.Quantity)
 
-    def test_correct_shape_electric_field(self, h5_3d):
+    def test_correct_shape_electric_field(self, h5_3d) -> None:
         assert h5_3d.electric_field.shape == (3, 26, 26, 201)
 
-    def test_has_charge_density_with_units(self, h5_3d):
+    def test_has_charge_density_with_units(self, h5_3d) -> None:
         assert isinstance(h5_3d.charge_density.to(u.C / u.m**3), u.Quantity)
 
-    def test_correct_shape_charge_density(self, h5_3d):
+    def test_correct_shape_charge_density(self, h5_3d) -> None:
         assert h5_3d.charge_density.shape == (26, 26, 201)
 
-    def test_has_magnetic_field(self, h5_3d):
+    def test_has_magnetic_field(self, h5_3d) -> None:
         with pytest.raises(AttributeError):
             h5_3d.magnetic_field  # noqa: B018
 
-    def test_has_electric_current(self, h5_3d):
+    def test_has_electric_current(self, h5_3d) -> None:
         with pytest.raises(AttributeError):
             h5_3d.electric_current  # noqa: B018
 
@@ -97,28 +97,28 @@ class TestOpenPMDThetaMode:
     # https://github.com/openPMD/openPMD-example-datasets/blob/draft/example-thetaMode.tar.gz
     # per the Creative Commons Zero v1.0 Universal license
 
-    def test_has_electric_field_with_units(self, h5_theta):
+    def test_has_electric_field_with_units(self, h5_theta) -> None:
         assert isinstance(h5_theta.electric_field.to(u.V / u.m), u.Quantity)
 
-    def test_correct_shape_electric_field(self, h5_theta):
+    def test_correct_shape_electric_field(self, h5_theta) -> None:
         assert h5_theta.electric_field.shape == (3, 3, 51, 201)
 
-    def test_has_charge_density_with_units(self, h5_theta):
+    def test_has_charge_density_with_units(self, h5_theta) -> None:
         assert isinstance(h5_theta.charge_density.to(u.C / u.m**3), u.Quantity)
 
-    def test_correct_shape_charge_density(self, h5_theta):
+    def test_correct_shape_charge_density(self, h5_theta) -> None:
         assert h5_theta.charge_density.shape == (3, 51, 201)
 
-    def test_has_magnetic_field_with_units(self, h5_theta):
+    def test_has_magnetic_field_with_units(self, h5_theta) -> None:
         assert isinstance(h5_theta.magnetic_field.to(u.T), u.Quantity)
 
-    def test_correct_shape_magnetic_field(self, h5_theta):
+    def test_correct_shape_magnetic_field(self, h5_theta) -> None:
         assert h5_theta.magnetic_field.shape == (3, 3, 51, 201)
 
-    def test_has_electric_current_with_units(self, h5_theta):
+    def test_has_electric_current_with_units(self, h5_theta) -> None:
         assert isinstance(h5_theta.electric_current.to(u.A * u.kg / u.m**3), u.Quantity)
 
-    def test_correct_shape_electric_current(self, h5_theta):
+    def test_correct_shape_electric_current(self, h5_theta) -> None:
         assert h5_theta.electric_current.shape == (3, 3, 51, 201)
 
 
@@ -132,21 +132,21 @@ units_test_table = [
 
 @pytest.mark.parametrize(("openPMD_dims", "expected"), units_test_table)
 @pytest.mark.slow()
-def test_fetch_units(openPMD_dims, expected: Union[tuple, list]):
+def test_fetch_units(openPMD_dims, expected: Union[tuple, list]) -> None:
     units = openpmd_hdf5._fetch_units(openPMD_dims)
     assert units == expected
 
 
-def test_unavailable_hdf5():
+def test_unavailable_hdf5() -> None:
     with pytest.raises(FileNotFoundError):
         openpmd_hdf5.HDF5Reader(hdf5="this_file_does_not_exist.h5")
 
 
-def test_non_openpmd_hdf5():
+def test_non_openpmd_hdf5() -> None:
     with pytest.raises(DataStandardError):
         openpmd_hdf5.HDF5Reader(hdf5=data_dir.joinpath("blank.h5"))
 
 
-def test_HDF5Reader(h5_2d):
+def test_HDF5Reader(h5_2d) -> None:
     assert isinstance(h5_2d, plasmapy.plasma.sources.HDF5Reader)
     assert isinstance(h5_2d, plasmapy.plasma.BasePlasma)

--- a/plasmapy/plasma/sources/tests/test_plasma3d.py
+++ b/plasmapy/plasma/sources/tests/test_plasma3d.py
@@ -13,7 +13,7 @@ from plasmapy.plasma.sources import plasma3d
         pytest.param((64, 64, 64), 262144, marks=pytest.mark.slow),  # 3D
     ],
 )
-def test_Plasma3D_setup(grid_dimensions, expected_size):
+def test_Plasma3D_setup(grid_dimensions, expected_size) -> None:
     r"""Function to test basic setup of the Plasma3D object.
 
     Tests that a Plasma3D object initiated with a particular
@@ -61,7 +61,7 @@ def test_Plasma3D_setup(grid_dimensions, expected_size):
 
 
 @pytest.mark.slow()
-def test_Plasma3D_derived_vars():
+def test_Plasma3D_derived_vars() -> None:
     r"""Function to test derived variables of the Plasma3D class.
 
     Tests the shapes, units and values of variables derived from core

--- a/plasmapy/plasma/sources/tests/test_plasmablob.py
+++ b/plasmapy/plasma/sources/tests/test_plasmablob.py
@@ -16,7 +16,7 @@ from plasmapy.utils.exceptions import CouplingWarning
         pytest.param((64, 64, 64), 262144, marks=pytest.mark.slow),  # 3D
     ],
 )
-def test_Plasma3D_setup(grid_dimensions, expected_size):
+def test_Plasma3D_setup(grid_dimensions, expected_size) -> None:
     r"""Function to test basic setup of the Plasma3D object.
 
     Tests that a Plasma3D object initiated with a particular
@@ -64,7 +64,7 @@ def test_Plasma3D_setup(grid_dimensions, expected_size):
 
 
 @pytest.mark.slow()
-def test_Plasma3D_derived_vars():
+def test_Plasma3D_derived_vars() -> None:
     r"""Function to test derived variables of the Plasma3D class.
 
     Tests the shapes, units and values of variables derived from core
@@ -107,7 +107,7 @@ def test_Plasma3D_derived_vars():
 
 
 @pytest.mark.slow()
-def test_Plasma3D_add_magnetostatics():
+def test_Plasma3D_add_magnetostatics() -> None:
     r"""Function to test add_magnetostatic function"""
     dipole = magnetostatics.MagneticDipole(
         np.array([0, 0, 1]) * u.A * u.m * u.m, np.array([0, 0, 0]) * u.m
@@ -129,7 +129,7 @@ def test_Plasma3D_add_magnetostatics():
 
 
 class Test_PlasmaBlobRegimes:
-    def test_intermediate_coupling(self):
+    def test_intermediate_coupling(self) -> None:
         r"""
         Method to test for coupling parameter for a plasma.
 
@@ -154,7 +154,7 @@ class Test_PlasmaBlobRegimes:
         errStr = f"Regime should be {expect_regime}, but got {regime} instead."
         assert testTrue, errStr
 
-    def test_strongly_coupled(self):
+    def test_strongly_coupled(self) -> None:
         r"""
         Method to test for coupling parameter for a plasma.
 
@@ -180,7 +180,7 @@ class Test_PlasmaBlobRegimes:
         errStr = f"Regime should be {expect_regime}, but got {regime} instead."
         assert testTrue, errStr
 
-    def test_weakly_coupled(self):
+    def test_weakly_coupled(self) -> None:
         r"""
         Method to test for coupling parameter for a plasma.
 
@@ -206,7 +206,7 @@ class Test_PlasmaBlobRegimes:
             regime, _ = blob.regimes()
         assert regime == expect_regime
 
-    def test_thermal_kinetic_energy_dominant(self):
+    def test_thermal_kinetic_energy_dominant(self) -> None:
         r"""
         Method to test for degeneracy parameter for a plasma.
 
@@ -234,7 +234,7 @@ class Test_PlasmaBlobRegimes:
         errStr = f"Regime should be {expect_regime}, but got {regime} instead."
         assert testTrue, errStr
 
-    def test_fermi_quantum_energy_dominant(self):
+    def test_fermi_quantum_energy_dominant(self) -> None:
         r"""
         Method to test for degeneracy parameter for a plasma.
 
@@ -260,7 +260,7 @@ class Test_PlasmaBlobRegimes:
         errStr = f"Regime should be {expect_regime}, but got {regime} instead."
         assert testTrue, errStr
 
-    def test_both_fermi_and_thermal_energy_important(self):
+    def test_both_fermi_and_thermal_energy_important(self) -> None:
         r"""
         Method to test for degeneracy parameter for a plasma.
 
@@ -291,7 +291,7 @@ class Test_PlasmaBlobRegimes:
 
 class Test_PlasmaBlob:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Initializing parameters for tests"""
         cls.T_e = 5 * 11e3 * u.K
         cls.n_e = 1e23 * u.cm**-3
@@ -303,7 +303,7 @@ class Test_PlasmaBlob:
         cls.couplingVal = 10.468374460435724
         cls.thetaVal = 0.6032979246923964
 
-    def test_invalid_particle(self):
+    def test_invalid_particle(self) -> None:
         """
         Checks if function raises error for invalid particle.
         """
@@ -312,7 +312,7 @@ class Test_PlasmaBlob:
                 T_e=self.T_e, n_e=self.n_e, Z=self.Z, particle="cupcakes"
             )
 
-    def test_electron_temperature(self):
+    def test_electron_temperature(self) -> None:
         """Testing if we get the same electron temperature we put in"""
         testTrue = self.T_e == self.blob.electron_temperature
         errStr = (
@@ -322,7 +322,7 @@ class Test_PlasmaBlob:
         )
         assert testTrue, errStr
 
-    def test_electron_density(self):
+    def test_electron_density(self) -> None:
         """Testing if we get the same electron density we put in"""
         testTrue = self.n_e == self.blob.electron_density
         errStr = (
@@ -332,7 +332,7 @@ class Test_PlasmaBlob:
         )
         assert testTrue, errStr
 
-    def test_ionization(self):
+    def test_ionization(self) -> None:
         """Testing if we get the same ionization we put in"""
         testTrue = self.Z == self.blob.ionization
         errStr = (
@@ -342,7 +342,7 @@ class Test_PlasmaBlob:
         )
         assert testTrue, errStr
 
-    def test_composition(self):
+    def test_composition(self) -> None:
         """Testing if we get the same composition (particle) we put in"""
         testTrue = self.particle == self.blob.composition
         errStr = (
@@ -352,7 +352,7 @@ class Test_PlasmaBlob:
         )
         assert testTrue, errStr
 
-    def test_coupling(self):
+    def test_coupling(self) -> None:
         """
         Tests if coupling  method value meets expected value.
         """
@@ -364,7 +364,7 @@ class Test_PlasmaBlob:
         testTrue = np.isclose(methodVal.value, self.couplingVal, rtol=1e-6, atol=0.0)
         assert testTrue, errStr
 
-    def test_quantum_theta(self):
+    def test_quantum_theta(self) -> None:
         """
         Tests if degeneracy parameter method value meets expected value.
         """

--- a/plasmapy/plasma/tests/test_equilibria1d.py
+++ b/plasmapy/plasma/tests/test_equilibria1d.py
@@ -5,7 +5,7 @@ from plasmapy.formulary import magnetic_pressure
 from plasmapy.plasma.equilibria1d import HarrisSheet
 
 
-def test_HarrisSheet():
+def test_HarrisSheet() -> None:
     B0 = 1 * u.T
     delta = 1 * u.m
     P0 = 0 * u.Pa
@@ -16,7 +16,7 @@ def test_HarrisSheet():
     ), "Magnetic field is supposed to be zero at y=0"
 
 
-def test_HarrisSheet_pressure_balance():
+def test_HarrisSheet_pressure_balance() -> None:
     B0 = 1 * u.T
     delta = 1 * u.m
     P0 = 0 * u.Pa
@@ -29,7 +29,7 @@ def test_HarrisSheet_pressure_balance():
     assert u.allclose(total_pressure, total_pressure[0], atol=1e-9 * u.Pa)
 
 
-def test_HarrisSheet_current_density():
+def test_HarrisSheet_current_density() -> None:
     B0 = 1 * u.T
     delta = 1 * u.m
     P0 = 0 * u.Pa
@@ -40,7 +40,7 @@ def test_HarrisSheet_current_density():
     assert u.allclose(J, correct_J, atol=1e-8 * u.A / u.m**2)
 
 
-def test_HarrisSheet_magnetic_field():
+def test_HarrisSheet_magnetic_field() -> None:
     B0 = 1 * u.T
     delta = 1 * u.m
     P0 = 0 * u.Pa
@@ -51,7 +51,7 @@ def test_HarrisSheet_magnetic_field():
     assert u.allclose(B, correct_B, atol=1e-9 * u.T)
 
 
-def test_HarrisSheet_limits():
+def test_HarrisSheet_limits() -> None:
     y = [-np.inf, np.inf] * u.m
     B0 = 1 * u.T
     delta = 1 * u.m

--- a/plasmapy/plasma/tests/test_grids.py
+++ b/plasmapy/plasma/tests/test_grids.py
@@ -152,7 +152,7 @@ create_args = [
 
 
 @pytest.mark.parametrize(("args", "kwargs", "shape", "error"), create_args)
-def test_AbstractGrid_creation(args, kwargs, shape, error):
+def test_AbstractGrid_creation(args, kwargs, shape, error) -> None:
     """
     Test the creation of AbstractGrids
 
@@ -177,7 +177,7 @@ def test_AbstractGrid_creation(args, kwargs, shape, error):
 @pytest.mark.filterwarnings(
     "ignore:.*MultiIndex.*:DeprecationWarning"
 )  # see issue 2319
-def test_print_summary(abstract_grid_uniform, abstract_grid_nonuniform):
+def test_print_summary(abstract_grid_uniform, abstract_grid_nonuniform) -> None:
     """
     Verify that both __str__ methods can be called without errors
     """
@@ -241,7 +241,7 @@ def test_AbstractGrid_uniform_attributes(
     type_in_iter,
     value,
     abstract_grid_uniform,
-):
+) -> None:
     """
     Tests that the attributes of AbstractGrid have the correct type and
     values for the fixture abstract_grid_uniform.
@@ -281,7 +281,7 @@ def test_AbstractGrid_nonuniform_attributes(
     type_in_iter,
     value,
     abstract_grid_nonuniform,
-):
+) -> None:
     """
     Tests that the attributes of AbstractGrid have the correct type and
     values for the fixture abstract_grid_uniform.
@@ -317,7 +317,7 @@ quantities = [
 
 
 @pytest.mark.skip("Not testable until cylindrical or spherical grids are implemented")
-def test_unit_attribute_error_case():
+def test_unit_attribute_error_case() -> None:
     """
     Verify that the unit attribute raises an exception if the units on all
     axes are not the same.
@@ -335,7 +335,7 @@ def test_unit_attribute_error_case():
 @pytest.mark.parametrize(("key", "value", "error", "warning", "match"), quantities)
 def test_AbstractGrid_add_quantities(
     abstract_grid_uniform, key, value, error, warning, match
-):
+) -> None:
     """
     Tests the add_quantities method of AbstractGrid
     """
@@ -382,7 +382,7 @@ req_q = [
 )
 def test_AbstractGrid_require_quantities(
     abstract_grid_uniform, required, replace_with_zeros, error, warning, match
-):
+) -> None:
     """
     Tests the AbstractGrid require_quantities method
     """
@@ -407,7 +407,7 @@ def test_AbstractGrid_require_quantities(
         assert all(k in abstract_grid_uniform.quantities for k in required)
 
 
-def test_AbstractGrid_indexing(abstract_grid_uniform):
+def test_AbstractGrid_indexing(abstract_grid_uniform) -> None:
     """
     Tests using indexing to directly get and set quantity array elements
     """
@@ -438,7 +438,7 @@ on_grid = [
 )  # see issue 2319
 def test_AbstractGrid_on_grid(
     abstract_grid_uniform, abstract_grid_nonuniform, fixture, pos, result
-):
+) -> None:
     # Select one of the grid fixtures
     grid = abstract_grid_uniform if fixture == "uniform" else abstract_grid_nonuniform
 
@@ -465,7 +465,7 @@ vector_intersect = [
 )  # see issue 2319
 def test_AbstractGrid_vector_intersects(
     abstract_grid_uniform, abstract_grid_nonuniform, fixture, p1, p2, result
-):
+) -> None:
     # Select one of the grid fixtures
     grid = abstract_grid_uniform if fixture == "uniform" else abstract_grid_nonuniform
 
@@ -521,7 +521,7 @@ create_args_uniform_cartesian = [
 @pytest.mark.parametrize(
     ("args", "kwargs", "shape", "error"), create_args_uniform_cartesian
 )
-def test_CartesianGrid_creation(args, kwargs, shape, error):
+def test_CartesianGrid_creation(args, kwargs, shape, error) -> None:
     # If no exception is expected, create the grid and check its shape
     if error is None:
         grid = grids.CartesianGrid(*args, **kwargs)
@@ -546,7 +546,9 @@ def test_CartesianGrid_creation(args, kwargs, shape, error):
         (np.array([2, -0.3, 0]) * u.cm, ["x"], np.array([np.nan]) * u.cm),
     ],
 )
-def test_uniform_cartesian_NN_interp(pos, quantities, expected, uniform_cartesian_grid):
+def test_uniform_cartesian_NN_interp(
+    pos, quantities, expected, uniform_cartesian_grid
+) -> None:
     """
     Test that the uniform Cartesian NN interpolator returns the correct values
     at various points to within the grid tolerance.
@@ -568,7 +570,7 @@ def test_uniform_cartesian_NN_interp(pos, quantities, expected, uniform_cartesia
 )
 def test_uniform_cartesian_NN_interp_errors(
     pos, quantities, error, uniform_cartesian_grid
-):
+) -> None:
     """
     Test that the uniform cartesian NN interpolator returns the expected
     errors.
@@ -578,7 +580,7 @@ def test_uniform_cartesian_NN_interp_errors(
         uniform_cartesian_grid.nearest_neighbor_interpolator(pos, *quantities)
 
 
-def test_uniform_cartesian_NN_interp_persistence(uniform_cartesian_grid):
+def test_uniform_cartesian_NN_interp_persistence(uniform_cartesian_grid) -> None:
     """
     Checks that the uniform Cartesian NN interpolator persistence feature
     performs correctly. Especially, this test ensures that changing the
@@ -669,7 +671,7 @@ create_args_nonuniform_cartesian = [
 @pytest.mark.parametrize(
     ("args", "kwargs", "shape", "error"), create_args_nonuniform_cartesian
 )
-def test_NonUniformCartesianGrid_creation(args, kwargs, shape, error):
+def test_NonUniformCartesianGrid_creation(args, kwargs, shape, error) -> None:
     # If no exception is expected, create the grid and check its shape
     if error is None:
         grid = grids.NonUniformCartesianGrid(*args, **kwargs)
@@ -700,7 +702,7 @@ def test_NonUniformCartesianGrid_creation(args, kwargs, shape, error):
 )  # see issue 2319
 def test_nonuniform_cartesian_NN_interp(
     pos, quantities, expected, nonuniform_cartesian_grid
-):
+) -> None:
     """
     Test that the uniform Cartesian NN interpolator returns the correct values
     at various points to within the grid tolerance.
@@ -718,7 +720,7 @@ def test_nonuniform_cartesian_NN_interp(
     "ignore:.*MultiIndex.*:DeprecationWarning"
 )  # see issue 2319
 @pytest.mark.slow()
-def test_nonuniform_cartesian_nearest_neighbor_interpolator():
+def test_nonuniform_cartesian_nearest_neighbor_interpolator() -> None:
     """
     Note that this test is running on a very small grid, because otherwise it is
     very slow.
@@ -784,7 +786,7 @@ def test_nonuniform_cartesian_nearest_neighbor_interpolator():
 )
 def test_volume_averaged_interpolator_at_several_positions(
     pos, what, expected, uniform_cartesian_grid
-):
+) -> None:
     pout = uniform_cartesian_grid.volume_averaged_interpolator(pos, *what)
     if len(what) == 1:
         assert np.allclose(pout, expected)
@@ -795,7 +797,7 @@ def test_volume_averaged_interpolator_at_several_positions(
             assert np.allclose(pout[ii], expected[ii])
 
 
-def test_volume_averaged_interpolator_missing_key(uniform_cartesian_grid):
+def test_volume_averaged_interpolator_missing_key(uniform_cartesian_grid) -> None:
     # Test quantity key not present in dataset
     pos = np.array([0.1, -0.3, 0.2]) * u.cm
     with pytest.raises(KeyError):
@@ -822,7 +824,7 @@ def test_volume_averaged_interpolator_missing_key(uniform_cartesian_grid):
 )
 def test_volume_averaged_interpolator_handle_out_of_bounds(
     pos, nan_mask, uniform_cartesian_grid
-):
+) -> None:
     # Contains out-of-bounds values (must handle NaNs correctly)
     pout = uniform_cartesian_grid.volume_averaged_interpolator(pos, "x")
     if nan_mask is None:
@@ -832,7 +834,7 @@ def test_volume_averaged_interpolator_handle_out_of_bounds(
         assert np.all(~np.isnan(pout.value[~nan_mask]))
 
 
-def test_volume_averaged_interpolator_persistence(uniform_cartesian_grid):
+def test_volume_averaged_interpolator_persistence(uniform_cartesian_grid) -> None:
     # Try running with persistence
     pos = np.array([[0.1, -0.3, 0], [0.1, -0.3, 0]]) * u.cm
     p1, p2 = uniform_cartesian_grid.volume_averaged_interpolator(
@@ -849,7 +851,7 @@ def test_volume_averaged_interpolator_persistence(uniform_cartesian_grid):
     assert p1.size == 1
 
 
-def test_volume_averaged_interpolator_known_solutions():
+def test_volume_averaged_interpolator_known_solutions() -> None:
     # Create a 4x4x4 test grid with positions -3, -1, 1, and 3 cm
     # Add a quantity that equals 0 when x=-3, 1 when x=-1,
     # 2 when x=1, and 3 when x= 3
@@ -873,7 +875,7 @@ def test_volume_averaged_interpolator_known_solutions():
     )
 
 
-def test_volume_averaged_interpolator_compare_NN_1D(uniform_cartesian_grid):
+def test_volume_averaged_interpolator_compare_NN_1D(uniform_cartesian_grid) -> None:
     # Create a low resolution test grid and check that the volume-avg
     # interpolator returns a higher resolution version
     npts = 150
@@ -898,7 +900,7 @@ def test_volume_averaged_interpolator_compare_NN_1D(uniform_cartesian_grid):
     assert va_error < nn_error
 
 
-def test_volume_averaged_interpolator_compare_NN_3D(uniform_cartesian_grid):
+def test_volume_averaged_interpolator_compare_NN_3D(uniform_cartesian_grid) -> None:
     # Do the same computation as the NN_1D test but in 3D
 
     npts = 150
@@ -933,7 +935,7 @@ def test_volume_averaged_interpolator_compare_NN_3D(uniform_cartesian_grid):
 @pytest.mark.filterwarnings(
     "ignore:.*MultiIndex.*:DeprecationWarning"
 )  # see issue 2319
-def test_NonUniformCartesianGrid():
+def test_NonUniformCartesianGrid() -> None:
     grid = grids.NonUniformCartesianGrid(-1 * u.cm, 1 * u.cm, num=10)
 
     pts0, pts1, pts2 = grid.grids
@@ -973,7 +975,7 @@ def test_NonUniformCartesianGrid():
         grids.NonUniformCartesianGrid(L0, L1, num=10)
 
 
-def debug_volume_avg_interpolator():
+def debug_volume_avg_interpolator() -> None:
     """
     Plot the comparison of the nearest neighbor interpolator and volume
     averaged interpolator for `~plasmapy.plasma.grids.CartesianGrid`.
@@ -1017,7 +1019,7 @@ def debug_volume_avg_interpolator():
     plt.xlim(-11, 11)
 
 
-def test_fast_nearest_neighbor_interpolate():
+def test_fast_nearest_neighbor_interpolate() -> None:
     """
     Confirms that the fast linear interpolator function is equivalent to
     the np.argmin(np.abs(x-y)) search method for ordered arrays

--- a/plasmapy/plasma/tests/test_lundquist.py
+++ b/plasmapy/plasma/tests/test_lundquist.py
@@ -3,7 +3,7 @@ import astropy.units as u
 from plasmapy.plasma import ForceFreeFluxRope
 
 
-def test_B_z():
+def test_B_z() -> None:
     B0 = 2 * u.T
     alpha = 3 * (1 / u.m)
     r = [0, 5] * u.m
@@ -12,7 +12,7 @@ def test_B_z():
     assert u.allclose(B_z, [B0, -0.028448945653561195 * u.T], atol=1e-9 * u.T)
 
 
-def test_B_theta():
+def test_B_theta() -> None:
     B0 = 2 * u.T
     alpha = 3 * (1 / u.m)
     r = [0, 5] * u.m
@@ -28,7 +28,7 @@ def test_B_theta():
     )
 
 
-def test_B_magnitude():
+def test_B_magnitude() -> None:
     B0 = 2 * u.T
     alpha = 3 * (1 / u.m)
     r = [0, 5] * u.m

--- a/plasmapy/plasma/tests/test_plasma_base.py
+++ b/plasmapy/plasma/tests/test_plasma_base.py
@@ -21,14 +21,14 @@ class IsNotDataSource(BasePlasma):
 
 
 class TestRegistrar:
-    def test_no_data_source(self):
+    def test_no_data_source(self) -> None:
         """
         NoDataSource class should not be registered since it has
         no method named ``is_datasource_for``.
         """
         assert not BasePlasma._registry.get(NoDataSource)
 
-    def test_is_data_source(self):
+    def test_is_data_source(self) -> None:
         """
         IsDataSource class should be registered since it has a
         method named ``is_datasource_for`` and must return True.
@@ -39,7 +39,7 @@ class TestRegistrar:
         # to not interfere with plasma factory tests
         del BasePlasma._registry[IsDataSource]
 
-    def test_is_not_data_source(self):
+    def test_is_not_data_source(self) -> None:
         """
         IsNotDataSource class should be registered since it has a
         method named ``is_datasource_for`` but must return False.
@@ -49,5 +49,5 @@ class TestRegistrar:
         del BasePlasma._registry[IsNotDataSource]
 
 
-def test_subclasses():
+def test_subclasses() -> None:
     assert issubclass(GenericPlasma, BasePlasma)

--- a/plasmapy/plasma/tests/test_plasma_factory.py
+++ b/plasmapy/plasma/tests/test_plasma_factory.py
@@ -15,12 +15,12 @@ def h5(request):
 
 
 class TestPlasma:
-    def test_patters(self):
+    def test_patters(self) -> None:
         # Input data whose specific subclass cannot be known
         generic = plasmapy.plasma.Plasma(blablobleh="spam")
         assert isinstance(generic, plasmapy.plasma.GenericPlasma)
 
-    def test_Plasma3D(self):
+    def test_Plasma3D(self) -> None:
         # Input data for Plasma3D
         three_dimensional = plasmapy.plasma.Plasma(
             domain_x=np.linspace(0, 1, 3) * u.m,
@@ -30,7 +30,7 @@ class TestPlasma:
         assert isinstance(three_dimensional, plasmapy.plasma.sources.Plasma3D)
         assert isinstance(three_dimensional, plasmapy.plasma.BasePlasma)
 
-    def test_PlasmaBlob(self):
+    def test_PlasmaBlob(self) -> None:
         # Input data for PlasmaBlob
         T_e = 25 * 15e3 * u.K
         n_e = 1e26 * u.cm**-3

--- a/plasmapy/utils/_pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/_pytest_helpers/pytest_helpers.py
@@ -633,7 +633,7 @@ def assert_can_handle_nparray(  # noqa: C901
     insert_some_nans=None,
     insert_all_nans=None,
     kwargs=None,
-):
+) -> None:
     """
     Test for ability to handle numpy array quantities.
 

--- a/plasmapy/utils/_pytest_helpers/tests/test_pytest_helpers.py
+++ b/plasmapy/utils/_pytest_helpers/tests/test_pytest_helpers.py
@@ -156,21 +156,21 @@ def test_run_test(f, args, kwargs, expected, whaterror):
         ) from spectacular_exception
 
 
-def test_run_test_rtol():
+def test_run_test_rtol() -> None:
     run_test(return_arg, 1.0, {}, 0.999999, rtol=1.1e-6)
 
 
-def test_run_test_rtol_failure():
+def test_run_test_rtol_failure() -> None:
     with pytest.raises(UnexpectedResultFail):
         run_test(return_arg, 1.0, {}, 0.999999, rtol=1e-7)
         pytest.fail("No exception raised for rtol test.")
 
 
-def test_run_test_atol():
+def test_run_test_atol() -> None:
     run_test(return_arg, 1.0, {}, 0.999999, atol=1.1e-6, rtol=0.0)
 
 
-def test_run_test_atol_failure():
+def test_run_test_atol_failure() -> None:
     with pytest.raises(UnexpectedResultFail):
         run_test(return_arg, (1.0,), {}, 0.999999, atol=1e-7)
         pytest.fail("No exception raised for atol test.")
@@ -194,7 +194,7 @@ inputs_table = [
 
 
 @pytest.mark.parametrize("inputs", inputs_table)
-def test_func(inputs):
+def test_func(inputs) -> None:
     """Test cases originally put in the docstring."""
     run_test(inputs)
 
@@ -257,7 +257,7 @@ def test_run_test_equivalent_calls(inputs, error):
             run_test_equivalent_calls(inputs)
 
 
-def test_run_test_equivalent_calls_types():
+def test_run_test_equivalent_calls_types() -> None:
     run_test_equivalent_calls(return_arg, 1, 1.0, require_same_type=False)
     with pytest.raises(UnexpectedResultFail):
         run_test_equivalent_calls(return_arg, 1, 1.0)

--- a/plasmapy/utils/calculator/__init__.py
+++ b/plasmapy/utils/calculator/__init__.py
@@ -18,7 +18,7 @@ and feedback: https://github.com/PlasmaPy/PlasmaPy/issues/new
 """
 
 
-def main():
+def main() -> None:
     """
     Stub function for command line tool that launches the plasma calculator notebook.
     """

--- a/plasmapy/utils/calculator/widget_helpers.py
+++ b/plasmapy/utils/calculator/widget_helpers.py
@@ -67,7 +67,7 @@ class _GenericWidget(abc.ABC):
         self.unit = None
         self.units_dropdown = None
 
-    def set_unit(self, unit):
+    def set_unit(self, unit) -> None:
         """
         Set unit for the value of widget, defaults to `None`.
 
@@ -100,7 +100,7 @@ class _GenericWidget(abc.ABC):
         """
         return self.units_dropdown
 
-    def set_place_holder(self, text):
+    def set_place_holder(self, text) -> None:
         """
         Set place holder text of the widget, defaults to empty string.
 
@@ -117,7 +117,7 @@ class _GenericWidget(abc.ABC):
         Virtual method to create widget.
         """
 
-    def post_creation(self):
+    def post_creation(self) -> None:
         """
         Default method that is called after widget creation.
         Attaches change listener to the widget.
@@ -125,7 +125,7 @@ class _GenericWidget(abc.ABC):
         self.set_place_holder("")
         self.widget.observe(self.handle_change, names="value")
 
-    def edge_case(self, value):  # noqa: B027
+    def edge_case(self, value) -> None:  # noqa: B027
         """
         Edge case handling for the widget. This is called within handle_change.
 
@@ -151,7 +151,7 @@ class _GenericWidget(abc.ABC):
         """
         return False
 
-    def try_change_value(self, value):
+    def try_change_value(self, value) -> None:
         """
         Set property_name in values_container to value.
 
@@ -162,7 +162,7 @@ class _GenericWidget(abc.ABC):
         """
         self.values_cont[self.property_name] = value
 
-    def display_error(self, value):  # noqa: ARG002
+    def display_error(self, value) -> None:  # noqa: ARG002
         """
         Handle invalid input provide realtime validation.
 
@@ -192,7 +192,7 @@ class _GenericWidget(abc.ABC):
         """
         return change.new * self.unit if self.unit else change.new
 
-    def attach_units_dropdown(self, options):
+    def attach_units_dropdown(self, options) -> None:
         """
         Special method that attaches dropdown widget to the input widget,
         and handles the change event of the dropdown widget.
@@ -207,7 +207,7 @@ class _GenericWidget(abc.ABC):
         )
         self.units_dropdown.observe(self.handle_dropdown_change, names="value")
 
-    def handle_dropdown_change(self, change):  # noqa: ARG002
+    def handle_dropdown_change(self, change) -> None:  # noqa: ARG002
         """
         Handle change event of the dropdown widget.
 
@@ -222,7 +222,7 @@ class _GenericWidget(abc.ABC):
                 self.values_cont[self.property_name].value * self.unit
             )
 
-    def handle_change(self, change):
+    def handle_change(self, change) -> None:
         """
         Handle change event of the widget, follows same process
         for all widgets.
@@ -267,7 +267,7 @@ class _FloatBox(_GenericWidget):
         self.min = min
         self.max = max
 
-    def create_widget(self, style=None):
+    def create_widget(self, style=None) -> None:
         """
         Implements create_widget. description_width is set to initial
         to make the widget as wide as possible.
@@ -298,7 +298,7 @@ class _CheckBox(_GenericWidget):
     def __init__(self, property_name):
         super().__init__(property_name)
 
-    def create_widget(self):
+    def create_widget(self) -> None:
         """
         Implements create_widget.
         """
@@ -340,7 +340,7 @@ class _ParticleBox(_GenericWidget):
         """
         return value is None or value == ""
 
-    def edge_case(self, value):  # noqa: ARG002
+    def edge_case(self, value) -> None:  # noqa: ARG002
         """
         Edge case to handle empty value of particle box
         resets the container value to `None`, and resets the error status.
@@ -349,7 +349,7 @@ class _ParticleBox(_GenericWidget):
         self.widget.description = ""
         self.widget.layout.border = ""
 
-    def try_change_value(self, value):
+    def try_change_value(self, value) -> None:
         """
         Set property_name in values_container to value,
         and resets the error status.
@@ -370,7 +370,7 @@ class _ParticleBox(_GenericWidget):
         self.widget.layout.border = ""
         self.widget.description = ""
 
-    def create_widget(self, style=None):
+    def create_widget(self, style=None) -> None:
         """
         Implements create_widget. description_width is set to initial
         to make the widget as wide as possible.
@@ -451,7 +451,7 @@ class _FunctionInfo:
         self.output_widget.layout.margin = EQUAL_SPACING_CONFIG
         self.output_widget.layout.padding = EQUAL_SPACING_CONFIG
 
-    def add_combo(self, spec_combo):
+    def add_combo(self, spec_combo) -> None:
         """
         Specify selective combination of parameters to be used in the function,
         This is the case for few functions where having all parameters doesn't yield
@@ -503,7 +503,7 @@ class _FunctionInfo:
             if arg in self.values_cont and self.values_cont[arg] is not None
         }
 
-    def error_message(self, spec):
+    def error_message(self, spec) -> None:
         """
         Generates an error message for the function when parameters are missing.
 
@@ -530,7 +530,7 @@ class _FunctionInfo:
 
         print(_colored_text(BLACK, "]"))  # noqa: T201
 
-    def process(self):
+    def process(self) -> None:
         """
         Processes the function based on signatures and spec_combo provided.
         Spec_combo is prioritized over the function signature.
@@ -583,7 +583,7 @@ def _create_label(label, color="black"):
     return widgets.HTML(f"<h3 style='margin:0px;{color_param}'>{label}<h3>")
 
 
-def _handle_button_click(event):
+def _handle_button_click(event) -> None:
     """
     Handles the click event of the calculate properties button.
     """
@@ -591,7 +591,7 @@ def _handle_button_click(event):
         fn.process()
 
 
-def _handle_clear_click(event):
+def _handle_clear_click(event) -> None:
     """
     Handles the click event of the clear properties button.
     Clears output of all functions.

--- a/plasmapy/utils/data/tests/test_downloader.py
+++ b/plasmapy/utils/data/tests/test_downloader.py
@@ -19,7 +19,7 @@ test_files = [
 
 
 @pytest.mark.parametrize(("filename", "expected"), test_files)
-def test_get_file(filename, expected, tmp_path):
+def test_get_file(filename, expected, tmp_path) -> None:
     """
     Test the get_file function
 
@@ -41,7 +41,7 @@ def test_get_file(filename, expected, tmp_path):
         downloader.get_file(filename, directory=tmp_path)
 
 
-def test_get_file_NIST_PSTAR_datafile(tmp_path):
+def test_get_file_NIST_PSTAR_datafile(tmp_path) -> None:
     """
     Test the get_file function on a NIST PSTAR datafile
 

--- a/plasmapy/utils/datatype_factory_base.py
+++ b/plasmapy/utils/datatype_factory_base.py
@@ -191,7 +191,7 @@ class BasicRegistrationFactory:
                     f"{WidgetType.__name__} found."
                 )
 
-    def unregister(self, WidgetType):
+    def unregister(self, WidgetType) -> None:
         """Remove a widget from the factory's registry."""
         self.registry.pop(WidgetType)
 

--- a/plasmapy/utils/decorators/tests/test_checks.py
+++ b/plasmapy/utils/decorators/tests/test_checks.py
@@ -35,10 +35,10 @@ class TestCheckBase:
     Test for decorator class :class:`~plasmapy.utils.decorators.checks.CheckBase`.
     """
 
-    def test_for_members(self):
+    def test_for_members(self) -> None:
         assert hasattr(CheckUnits, "checks")
 
-    def test_checks(self):
+    def test_checks(self) -> None:
         _cases = [
             {"input": (None, {"x": 1, "y": 2}), "output": {"x": 1, "y": 2}},
             {
@@ -82,10 +82,10 @@ class TestCheckUnits:
     def foo_with_none(x: u.Quantity, y: u.cm = None):  # noqa: ANN205
         return x.value + y.value
 
-    def test_inheritance(self):
+    def test_inheritance(self) -> None:
         assert issubclass(CheckUnits, CheckBase)
 
-    def test_cu_default_check_values(self):
+    def test_cu_default_check_values(self) -> None:
         """Test the default check dictionary for CheckUnits."""
         cu = CheckUnits()
         assert hasattr(cu, "_CheckUnits__check_defaults")
@@ -99,7 +99,7 @@ class TestCheckUnits:
         for key, val in _defaults:
             assert cu._CheckUnits__check_defaults[key] == val
 
-    def test_cu_method__flatten_equivalencies_list(self):
+    def test_cu_method__flatten_equivalencies_list(self) -> None:
         assert hasattr(CheckUnits, "_flatten_equivalencies_list")
 
         cu = CheckUnits()
@@ -107,7 +107,7 @@ class TestCheckUnits:
         for pair in pairs:
             assert cu._flatten_equivalencies_list(pair[0]) == pair[1]
 
-    def test_cu_method__condition_target_units(self):
+    def test_cu_method__condition_target_units(self) -> None:
         """Test method `CheckUnits._condition_target_units`."""
         assert hasattr(CheckUnits, "_condition_target_units")
 
@@ -126,7 +126,7 @@ class TestCheckUnits:
         with pytest.raises(ValueError):
             cu._condition_target_units(["five"])
 
-    def test_cu_method__normalize_equivalencies(self):
+    def test_cu_method__normalize_equivalencies(self) -> None:
         """Test method `CheckUnits._normalize_equivalencies`."""
         assert hasattr(CheckUnits, "_normalize_equivalencies")
 
@@ -179,7 +179,7 @@ class TestCheckUnits:
         with pytest.raises(ValueError):
             cu._normalize_equivalencies([("cm", u.cm)])
 
-    def test_cu_method__get_unit_checks(self):
+    def test_cu_method__get_unit_checks(self) -> None:
         """
         Test functionality/behavior of the method `_get_unit_checks` on `CheckUnits`.
         This method reviews the decorator `checks` arguments and wrapped function
@@ -429,7 +429,7 @@ class TestCheckUnits:
                         val = case["output"][arg_name][key]  # noqa: PLW2901
                     assert arg_checks[key] == val
 
-    def test_cu_method__check_unit(self):
+    def test_cu_method__check_unit(self) -> None:
         """
         Test functionality/behavior of the methods `_check_unit` and `_check_unit_core`
         on `CheckUnits`.  These methods do the actual checking of the argument units
@@ -553,7 +553,7 @@ class TestCheckUnits:
                 with pytest.raises(case["output"][3]):
                     cu._check_unit(arg, arg_name, arg_checks)
 
-    def test_cu_called_as_decorator(self):
+    def test_cu_called_as_decorator(self) -> None:
         """
         Test behavior of `CheckUnits.__call__` (i.e. used as a decorator).
         """
@@ -612,7 +612,7 @@ class TestCheckUnits:
         # test on class method
         class Foo:
             @CheckUnits()
-            def __init__(self, y: u.cm):
+            def __init__(self, y: u.cm) -> None:
                 self.y = y
 
             @CheckUnits(x=u.cm)
@@ -622,7 +622,7 @@ class TestCheckUnits:
         foo = Foo(10.0 * u.cm)
         assert foo.bar(-3 * u.cm) == 7 * u.cm
 
-    def test_cu_preserves_signature(self):
+    def test_cu_preserves_signature(self) -> None:
         """Test `CheckValues` preserves signature of wrapped function."""
         # I'd like to directly test the @preserve_signature is used (??)
 
@@ -635,7 +635,7 @@ class TestCheckUnits:
         side_effect=CheckUnits,
         autospec=True,
     )
-    def test_decorator_func_def(self, mock_cu_class):
+    def test_decorator_func_def(self, mock_cu_class) -> None:
         """
         Test that :func:`~plasmapy.utils.decorators.checks.check_units` is
         properly defined.
@@ -730,10 +730,10 @@ class TestCheckValues:
     def foo_stars(x, *args, y=3, **kwargs):
         return x + y
 
-    def test_inheritance(self):
+    def test_inheritance(self) -> None:
         assert issubclass(CheckValues, CheckBase)
 
-    def test_cv_default_check_values(self):
+    def test_cv_default_check_values(self) -> None:
         """Test the default check dictionary for CheckValues"""
         cv = CheckValues()
         assert hasattr(cv, "_CheckValues__check_defaults")
@@ -749,7 +749,7 @@ class TestCheckValues:
         for key, val in _defaults:
             assert cv._CheckValues__check_defaults[key] == val
 
-    def test_cv_method__get_value_checks(self):
+    def test_cv_method__get_value_checks(self) -> None:
         """
         Test functionality/behavior of the method `_get_value_checks` on `CheckValues`.
         This method reviews the decorator `checks` arguments to build a complete
@@ -856,7 +856,7 @@ class TestCheckValues:
 
                     assert arg_checks[key] == val
 
-    def test_cv_method__check_value(self):
+    def test_cv_method__check_value(self) -> None:
         """
         Test functionality/behavior of the `_check_value` method on `CheckValues`.
         This method does the actual checking of the argument values and should be
@@ -1037,7 +1037,7 @@ class TestCheckValues:
                 else:
                     assert cv._check_value(arg, arg_name, checks) is None
 
-    def test_cv_called_as_decorator(self):
+    def test_cv_called_as_decorator(self) -> None:
         """
         Test behavior of `CheckValues.__call__` (i.e. used as a decorator).
         """
@@ -1108,7 +1108,7 @@ class TestCheckValues:
         # test on class method
         class Foo:
             @CheckValues(y={"can_be_negative": True})
-            def __init__(self, y):
+            def __init__(self, y) -> None:
                 self.y = y
 
             @CheckValues(
@@ -1122,7 +1122,7 @@ class TestCheckValues:
         with pytest.raises(ValueError):
             foo.bar(1)
 
-    def test_cv_preserves_signature(self):
+    def test_cv_preserves_signature(self) -> None:
         """Test CheckValues preserves signature of wrapped function."""
         # I'd like to directly test the @preserve_signature is used (??)
 
@@ -1135,7 +1135,7 @@ class TestCheckValues:
         side_effect=CheckValues,
         autospec=True,
     )
-    def test_decorator_func_def(self, mock_cv_class):
+    def test_decorator_func_def(self, mock_cv_class) -> None:
         """
         Test that :func:`~plasmapy.utils.decorators.checks.check_values` is
         properly defined.
@@ -1250,25 +1250,25 @@ relativistic_warning_examples = [
 
 # Tests for _check_relativistic
 @pytest.mark.parametrize(("speed", "betafrac"), non_relativistic_speed_examples)
-def test__check_relativisitc_valid(speed, betafrac):
+def test__check_relativisitc_valid(speed, betafrac) -> None:
     _check_relativistic(speed, "f", betafrac=betafrac)
 
 
 @pytest.mark.parametrize(("speed", "betafrac", "error"), relativistic_error_examples)
-def test__check_relativistic_errors(speed, betafrac, error):
+def test__check_relativistic_errors(speed, betafrac, error) -> None:
     with pytest.raises(error):
         _check_relativistic(speed, "f", betafrac=betafrac)
 
 
 @pytest.mark.parametrize(("speed", "betafrac"), relativistic_warning_examples)
-def test__check_relativistic_warnings(speed, betafrac):
+def test__check_relativistic_warnings(speed, betafrac) -> None:
     with pytest.warns(RelativityWarning):
         _check_relativistic(speed, "f", betafrac=betafrac)
 
 
 # Tests for check_relativistic decorator
 @pytest.mark.parametrize(("speed", "betafrac"), non_relativistic_speed_examples)
-def test_check_relativistic_decorator(speed, betafrac):
+def test_check_relativistic_decorator(speed, betafrac) -> None:
     @check_relativistic(betafrac=betafrac)
     def speed_func():
         return speed
@@ -1277,7 +1277,7 @@ def test_check_relativistic_decorator(speed, betafrac):
 
 
 @pytest.mark.parametrize("speed", [item[0] for item in non_relativistic_speed_examples])
-def test_check_relativistic_decorator_no_args(speed):
+def test_check_relativistic_decorator_no_args(speed) -> None:
     @check_relativistic
     def speed_func():
         return speed
@@ -1286,7 +1286,7 @@ def test_check_relativistic_decorator_no_args(speed):
 
 
 @pytest.mark.parametrize("speed", [item[0] for item in non_relativistic_speed_examples])
-def test_check_relativistic_decorator_no_args_parentheses(speed):
+def test_check_relativistic_decorator_no_args_parentheses(speed) -> None:
     @check_relativistic()
     def speed_func():
         return speed
@@ -1295,7 +1295,7 @@ def test_check_relativistic_decorator_no_args_parentheses(speed):
 
 
 @pytest.mark.parametrize(("speed", "betafrac", "error"), relativistic_error_examples)
-def test_check_relativistic_decorator_errors(speed, betafrac, error):
+def test_check_relativistic_decorator_errors(speed, betafrac, error) -> None:
     @check_relativistic(betafrac=betafrac)
     def speed_func():
         return speed

--- a/plasmapy/utils/decorators/tests/test_converters.py
+++ b/plasmapy/utils/decorators/tests/test_converters.py
@@ -9,7 +9,7 @@ from plasmapy.utils.decorators import validate_quantities
 from plasmapy.utils.decorators.converter import angular_freq_to_hz
 
 
-def test_to_hz():
+def test_to_hz() -> None:
     @angular_freq_to_hz
     def func():
         return 2 * np.pi * u.rad / u.s
@@ -28,7 +28,7 @@ def test_to_hz():
     ), f"Value expected is 1 instead of {func(to_hz=True).value}"
 
 
-def test_to_hz_complicated_signature():
+def test_to_hz_complicated_signature() -> None:
     """
     Test that `angular_freq_to_hz` can decorate a function with
     positional-only, positional, var-positional, keyword, keyword-only,
@@ -55,7 +55,7 @@ def test_to_hz_complicated_signature():
     assert result_hz.value == 1, f"Value expected is 1 instead of {result_hz.value}"
 
 
-def test_to_hz_stacked_decorators():
+def test_to_hz_stacked_decorators() -> None:
     """Test that @angular_freq_to_hz can be stacked with multiple decorators."""
 
     @particle_input
@@ -68,7 +68,7 @@ def test_to_hz_stacked_decorators():
     assert u.isclose(func(to_hz=True), 1 * u.Hz)
 
 
-def test_angular_freq_to_hz_preserves_signature():
+def test_angular_freq_to_hz_preserves_signature() -> None:
     """
     Tests if the angular_freq_to_hz decorator preserves the signature of
     the wrapped function.

--- a/plasmapy/utils/decorators/tests/test_deprecation.py
+++ b/plasmapy/utils/decorators/tests/test_deprecation.py
@@ -4,9 +4,9 @@ from plasmapy.utils.decorators.deprecation import deprecated
 from plasmapy.utils.exceptions import PlasmaPyDeprecationWarning
 
 
-def test_deprecated():
+def test_deprecated() -> None:
     @deprecated(since="0.7.0")
-    def deprecated_function():
+    def deprecated_function() -> None:
         pass
 
     with pytest.warns(PlasmaPyDeprecationWarning):

--- a/plasmapy/utils/decorators/tests/test_helpers.py
+++ b/plasmapy/utils/decorators/tests/test_helpers.py
@@ -37,12 +37,12 @@ class TestModifyDocstring:
         """
         return x + y
 
-    def test_no_arg_exception(self):
+    def test_no_arg_exception(self) -> None:
         """Raise exception if decorator is used without modifying docstring."""
         with pytest.raises(TypeError):
             modify_docstring(self.func_simple_docstring)
 
-    def test_save_original_doc(self):
+    def test_save_original_doc(self) -> None:
         original_doc = self.func_simple_docstring.__doc__
         wfoo = modify_docstring(prepend="Hello")(self.func_simple_docstring)
         assert hasattr(wfoo, "__original_doc__")
@@ -52,13 +52,13 @@ class TestModifyDocstring:
         ("prepend", "append", "expected"),
         [(5, None, TypeError), (None, 5, TypeError)],
     )
-    def test_raises(self, prepend, append, expected):
+    def test_raises(self, prepend, append, expected) -> None:
         with pytest.raises(expected):
             modify_docstring(
                 prepend=prepend, append=append, func=self.func_simple_docstring
             )
 
-    def test_preserve_signature(self):
+    def test_preserve_signature(self) -> None:
         wfoo = modify_docstring(prepend="Hello")(self.func_simple_docstring)
         assert hasattr(wfoo, "__signature__")
         assert wfoo.__signature__ == inspect.signature(self.func_simple_docstring)
@@ -94,7 +94,7 @@ class TestModifyDocstring:
             ),
         ],
     )
-    def test_modification(self, prepend, append, func_name, additions):
+    def test_modification(self, prepend, append, func_name, additions) -> None:
         func = getattr(self, func_name)
 
         expected = "\n".join(
@@ -104,7 +104,7 @@ class TestModifyDocstring:
         wfunc = modify_docstring(prepend=prepend, append=append)(func)
         assert wfunc.__doc__ == expected
 
-    def test_arguments_passed(self):
+    def test_arguments_passed(self) -> None:
         wfunc = modify_docstring(prepend="Hello")(self.func_simple_docstring)
         assert wfunc(5, 4) == 9
 
@@ -112,7 +112,7 @@ class TestModifyDocstring:
 # --------------------------------------------------------------------------------------
 # Test Decorator `preserve_signature`
 # --------------------------------------------------------------------------------------
-def test_preserve_signature():
+def test_preserve_signature() -> None:
     # create function to mock
     def foo(x: float, y: float) -> float:
         return x + y

--- a/plasmapy/utils/decorators/tests/test_lite_func.py
+++ b/plasmapy/utils/decorators/tests/test_lite_func.py
@@ -41,7 +41,7 @@ def bar():
         (print, None, ValueError),  # can not be builtin
     ],
 )
-def test_raises(lite_func, attrs, _error):
+def test_raises(lite_func, attrs, _error) -> None:
     """Test scenarios that will raise an Exception."""
     with pytest.raises(_error):
         bind_lite_func(lite_func, attrs=attrs)(foo)
@@ -56,7 +56,7 @@ def test_raises(lite_func, attrs, _error):
         (foo_lite, {"bar": bar}),
     ],
 )
-def test_binding(lite_func, attrs):
+def test_binding(lite_func, attrs) -> None:
     """Test that the expected members are bound to the decorated function."""
     dfoo = bind_lite_func(lite_func, attrs=attrs)(foo)
 
@@ -85,7 +85,7 @@ def test_binding(lite_func, attrs):
         (foo_lite, {"bar": bar}),
     ],
 )
-def test_lite_func_dunder(lite_func, attrs):
+def test_lite_func_dunder(lite_func, attrs) -> None:
     """Test that the ``__bound_lite_func__`` dunder is properly defined."""
     dfoo = bind_lite_func(lite_func, attrs=attrs)(foo)
 

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -36,11 +36,11 @@ class TestValidateQuantities:
     def foo_anno(x: u.cm):  # noqa: ANN205
         return x
 
-    def test_inheritance(self):
+    def test_inheritance(self) -> None:
         assert issubclass(ValidateQuantities, CheckUnits)
         assert issubclass(ValidateQuantities, CheckValues)
 
-    def test_vq_method__get_validations(self):
+    def test_vq_method__get_validations(self) -> None:
         # method must exist
         assert hasattr(ValidateQuantities, "validations")
         assert hasattr(ValidateQuantities, "_get_validations")
@@ -208,7 +208,7 @@ class TestValidateQuantities:
             assert mock_cu_get.called
             assert mock_cv_get.called
 
-    def test_vq_method__validate_quantity(self):
+    def test_vq_method__validate_quantity(self) -> None:
         # method must exist
         assert hasattr(ValidateQuantities, "_validate_quantity")
 
@@ -338,13 +338,13 @@ class TestValidateQuantities:
             assert mock_cu_checks.called
             assert mock_cv_checks.called
 
-    def test_vq_preserves_signature(self):
+    def test_vq_preserves_signature(self) -> None:
         """Test `ValidateQuantities` preserves signature of wrapped function."""
         wfoo = ValidateQuantities()(self.foo_anno)
         assert hasattr(wfoo, "__signature__")
         assert wfoo.__signature__ == inspect.signature(self.foo_anno)
 
-    def test_vq_called_as_decorator(self):
+    def test_vq_called_as_decorator(self) -> None:
         """
         Test behavior of `ValidateQuantities.__call__` (i.e. used as a decorator).
         """
@@ -456,7 +456,7 @@ class TestValidateQuantities:
         # test on class method
         class Foo:
             @ValidateQuantities()
-            def __init__(self, y: u.cm):
+            def __init__(self, y: u.cm) -> None:
                 self.y = y
 
             @ValidateQuantities(validations_on_return={"can_be_negative": False})
@@ -473,7 +473,7 @@ class TestValidateQuantities:
         side_effect=ValidateQuantities,
         autospec=True,
     )
-    def test_decorator_func_def(self, mock_vq_class):
+    def test_decorator_func_def(self, mock_vq_class) -> None:
         """
         Test that :func:`~plasmapy.utils.decorators.validators.validate_quantities` is
         properly defined.
@@ -557,7 +557,7 @@ class TestValidateClassAttributes:
             x: Optional[int] = None,
             y: Optional[int] = None,
             z: Optional[int] = None,
-        ):
+        ) -> None:
             self.x = x
             self.y = y
             self.z = z
@@ -600,7 +600,7 @@ class TestValidateClassAttributes:
             {"y": 0, "z": 0},
         ],
     )
-    def test_method_errors(self, test_case_constructor_keyword_arguments):
+    def test_method_errors(self, test_case_constructor_keyword_arguments) -> None:
         """
         Test errors raised by the validate_class_attributes decorator.
         """
@@ -628,7 +628,7 @@ class TestValidateClassAttributes:
                     getattr(test_case, method)
 
 
-def test_validate_quantities_argument_type_annotation():
+def test_validate_quantities_argument_type_annotation() -> None:
     """
     Test that |validate_quantities| works with type hint annotations of
     the form ``u.Quantity[u.m]`` on a function argument.
@@ -646,7 +646,7 @@ def test_validate_quantities_argument_type_annotation():
     assert actual.unit == expected.unit
 
 
-def test_validate_quantities_return_type_annotation():
+def test_validate_quantities_return_type_annotation() -> None:
     """
     Test that |validate_quantities| works with type hint annotations of
     the form ``u.Quantity[u.m]`` as a return argument.

--- a/plasmapy/utils/tests/test_code_repr.py
+++ b/plasmapy/utils/tests/test_code_repr.py
@@ -120,7 +120,7 @@ function_case = namedtuple("function_case", ("func", "args", "kwargs", "expected
         ),
     ],
 )
-def test_call_string(func, args, kwargs, expected):
+def test_call_string(func, args, kwargs, expected) -> None:
     """
     Tests that call_string returns a string that is equivalent to the
     function call.
@@ -138,11 +138,11 @@ def test_call_string(func, args, kwargs, expected):
 
 
 class SampleClass:
-    def method(self, *args, **kwargs):
+    def method(self, *args, **kwargs) -> None:
         pass
 
     @property
-    def attr(self):
+    def attr(self) -> None:
         pass
 
 
@@ -193,7 +193,7 @@ method_case = namedtuple(
 )
 def test_method_call_string(
     args_to_cls, kwargs_to_cls, args_to_method, kwargs_to_method, expected
-):
+) -> None:
     """Test that `method_call_string` returns the expected results."""
     actual = method_call_string(
         cls=SampleClass,
@@ -244,7 +244,7 @@ attribute_case = namedtuple(
         ),
     ],
 )
-def test_attribute_call_string(args_to_cls, kwargs_to_cls, expected):
+def test_attribute_call_string(args_to_cls, kwargs_to_cls, expected) -> None:
     """Test that `attribute_call_string` returns the expected results."""
     actual = attribute_call_string(SampleClass, "attr", args_to_cls, kwargs_to_cls)
     assert actual == expected, (
@@ -307,7 +307,7 @@ ndarray_case = namedtuple("ndarray_case", ("array_inputs", "max_items", "expecte
         ),
     ],
 )
-def test__code_repr_of_ndarray(array_inputs, max_items, expected):
+def test__code_repr_of_ndarray(array_inputs, max_items, expected) -> None:
     """
     Test that `numpy.ndarray` objects get converted into a string as
     expected.  Subsequently, test that evaluating the code representation
@@ -352,7 +352,7 @@ quantity_case = namedtuple("QuantityTestCases", ("quantity", "expected"))
         ),
     ],
 )
-def test__code_repr_of_quantity(quantity, expected):
+def test__code_repr_of_quantity(quantity, expected) -> None:
     """
     Test that `astropy.units.Quantity` objects get converted into a
     string as expected.
@@ -366,7 +366,7 @@ def test__code_repr_of_quantity(quantity, expected):
     )
 
 
-def test__string_together_warnings_for_printing():
+def test__string_together_warnings_for_printing() -> None:
     """Test that warning names and messages get strung together correctly."""
     warnings = [UserWarning, DeprecationWarning]
     warning_messages = ["msg1", "msg2"]
@@ -393,7 +393,7 @@ def test__string_together_warnings_for_printing():
         (np.array([1.0, 2.0, 3.0]) * u.m / u.s, "np.array([1., 2., 3.])*u.m/u.s"),
     ],
 )
-def test__code_repr_of_arg(arg, expected):
+def test__code_repr_of_arg(arg, expected) -> None:
     """
     Test that _code_repr_of_arg correctly transforms arguments into a
     `str` the represents how the arg would appear in code.
@@ -417,7 +417,7 @@ def test__code_repr_of_arg(arg, expected):
         (np.array([1.0, 2.0]) * u.m / u.s, {}, "np.array([1., 2.])*u.m/u.s"),
     ],
 )
-def test__code_repr_of_args_and_kwargs(args, kwargs, expected):
+def test__code_repr_of_args_and_kwargs(args, kwargs, expected) -> None:
     """
     Test that `_code_repr_of_args_and_kwargs` returns a string containing
     the positional and keyword arguments, as they would appear in a
@@ -446,7 +446,7 @@ def test__code_repr_of_args_and_kwargs(args, kwargs, expected):
         (ValueError, "a ValueError"),
     ],
 )
-def test__name_with_article(obj, expected):
+def test__name_with_article(obj, expected) -> None:
     """
     Test that `_name_with_article` returns the expected string, which
     contains ``"a "`` or ``"an "`` followed by the name of ``obj``.
@@ -471,7 +471,7 @@ def test__name_with_article(obj, expected):
         (u.Unit, True, "u.Unit"),
     ],
 )
-def test__object_name(obj, showmodule, expected_name):
+def test__object_name(obj, showmodule, expected_name) -> None:
     """Test that `_object_name` produces the expected output."""
     actual_name = _object_name(obj, showmodule=showmodule)
     assert actual_name == expected_name, (

--- a/plasmapy/utils/tests/test_datatype_factory_base.py
+++ b/plasmapy/utils/tests/test_datatype_factory_base.py
@@ -96,7 +96,7 @@ class MissingClassMethodDifferentValidationWidget(BaseWidget):
 
 
 class TestBasicRegistrationFactory:
-    def test_default_factory(self):
+    def test_default_factory(self) -> None:
         DefaultFactory = BasicRegistrationFactory()
 
         DefaultFactory.register(DefaultWidget, is_default=True)
@@ -123,13 +123,13 @@ class TestBasicRegistrationFactory:
         DefaultFactory.unregister(StandardWidget)
         assert type(DefaultFactory(style="standard")) is not StandardWidget
 
-    def test_validation_fun_not_callable(self):
+    def test_validation_fun_not_callable(self) -> None:
         TestFactory = BasicRegistrationFactory()
 
         with pytest.raises(AttributeError):
             TestFactory.register(StandardWidget, validation_function="not_callable")
 
-    def test_no_default_factory(self):
+    def test_no_default_factory(self) -> None:
         NoDefaultFactory = BasicRegistrationFactory()
 
         NoDefaultFactory.register(StandardWidget)
@@ -146,7 +146,7 @@ class TestBasicRegistrationFactory:
         assert type(NoDefaultFactory(style="standard")) is StandardWidget
         assert type(NoDefaultFactory(style="fancy", feature="present")) is FancyWidget
 
-    def test_with_external_registry(self):
+    def test_with_external_registry(self) -> None:
         external_registry = {}
 
         FactoryWithExternalRegistry = BasicRegistrationFactory(
@@ -161,7 +161,7 @@ class TestBasicRegistrationFactory:
         # Ensure the 'external_registry' is being populated see #1988
         assert len(external_registry) == 1
 
-    def test_multiple_match_factory(self):
+    def test_multiple_match_factory(self) -> None:
         MultipleMatchFactory = BasicRegistrationFactory()
 
         MultipleMatchFactory.register(StandardWidget)
@@ -170,7 +170,7 @@ class TestBasicRegistrationFactory:
         with pytest.raises(MultipleMatchError):
             MultipleMatchFactory(style="standard")
 
-    def test_extra_validation_factory(self):
+    def test_extra_validation_factory(self) -> None:
         ExtraValidationFactory = BasicRegistrationFactory(
             additional_validation_functions=["different_validation_function"]
         )

--- a/plasmapy/utils/tests/test_roman.py
+++ b/plasmapy/utils/tests/test_roman.py
@@ -152,7 +152,7 @@ exceptions_table = [
 
 
 @pytest.mark.parametrize(("integer", "roman_numeral"), ints_and_roman_numerals)
-def test_to_roman(integer, roman_numeral):
+def test_to_roman(integer, roman_numeral) -> None:
     """
     Test that `~plasmapy.utils.roman.to_roman` correctly converts
     integers to Roman numerals, and that the inverse is true as well.
@@ -164,7 +164,7 @@ def test_to_roman(integer, roman_numeral):
 @pytest.mark.parametrize(
     ("function", "argument", "expected_exception"), exceptions_table
 )
-def test_to_roman_exceptions(function, argument, expected_exception):
+def test_to_roman_exceptions(function, argument, expected_exception) -> None:
     """
     Test that `~plasmapy.utils.roman` functions raise the correct
     exceptions when necessary.
@@ -183,5 +183,5 @@ test_is_roman_numeral_table = [
 
 
 @pytest.mark.parametrize(("argument", "expected"), test_is_roman_numeral_table)
-def test_is_roman_numeral(argument, expected):
+def test_is_roman_numeral(argument, expected) -> None:
     run_test(func=roman.is_roman_numeral, args=argument, expected_outcome=expected)

--- a/plasmapy/utils/tests/test_units_helpers.py
+++ b/plasmapy/utils/tests/test_units_helpers.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from plasmapy.utils._units_helpers import _get_physical_type_dict
 
 
-def test_get_physical_type_dict_specific_example():
+def test_get_physical_type_dict_specific_example() -> None:
     units = [u.m, u.m**-3, u.m * u.s]
     quantities = [5 * unit for unit in units]
     expected = {quantity.unit.physical_type: quantity for quantity in quantities}
@@ -59,7 +59,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(("collection", "kwargs", "expected"), test_cases)
-def test_get_physical_type_dict(collection, kwargs, expected):
+def test_get_physical_type_dict(collection, kwargs, expected) -> None:
     physical_type_dict = _get_physical_type_dict(collection, **kwargs)
     assert physical_type_dict == expected
 
@@ -89,6 +89,6 @@ test_cases_exceptions = [
 
 
 @pytest.mark.parametrize(("collection", "kwargs", "expected"), test_cases_exceptions)
-def test_get_physical_type_dict_exceptions(collection, kwargs, expected):
+def test_get_physical_type_dict_exceptions(collection, kwargs, expected) -> None:
     with pytest.raises(expected):
         _get_physical_type_dict(collection, **kwargs)


### PR DESCRIPTION
## Description

I used `autotyping` to add `-> None` annotations to functions and methods with no `return` statement. I'm excluding special methods, which were covered in #2437.

## Context

One thing to note is that this adds a lot of `-> None` annotations to test functions and methods.  The main advantage of having the `-> None` annotations in tests is that it enforces that tests are type checked with mypy, since functions and methods without any annotations are seemingly not type checked.  The `-> None` annotation will also let type checkers verify that tests do not have any `return` statements in them.   

## Related issues

This is similar to #2437, only I used the ``--none-return`` flag instead. 