### PR TITLE
Discuss type hint annotations in testing guide

### DIFF
--- a/changelog/2440.doc.rst
+++ b/changelog/2440.doc.rst
@@ -1,0 +1,2 @@
+Added a discussion of |type hint annotations| in the |testing guide|
+within the |contributor guide|.

--- a/docs/_global_substitutions.py
+++ b/docs/_global_substitutions.py
@@ -12,7 +12,7 @@ if the key is ``"particle-like"``, then it can be used as
 ``|particle-like|`` throughout the documentation.
 """
 
-plasmapy_subs = {
+plasmapy_subs: dict[str, str] = {
     "atomic_number": ":func:`~plasmapy.particles.atomic.atomic_number`",
     "atomic_symbol": ":func:`~plasmapy.particles.symbols.atomic_symbol`",
     "charge_number": ":func:`~plasmapy.particles.atomic.charge_number`",
@@ -62,7 +62,7 @@ plasmapy_subs = {
 # The backslash is needed for the substitution to work correctly when
 # used just before a period.
 
-doc_subs = {
+doc_subs: dict[str, str] = {
     "annotated": r":term:`annotated <annotation>`\ ",
     "annotation": r":term:`annotation`\ ",
     "argument": r":term:`argument`\ ",
@@ -95,7 +95,7 @@ doc_subs = {
     "testing guide": r":ref:`testing guide`\ ",
 }
 
-numpy_subs = {
+numpy_subs: dict[str, str] = {
     "array_like": ":term:`numpy:array_like`",
     "DTypeLike": "`~numpy.typing.DTypeLike`",
     "inf": "`~numpy.inf`",
@@ -103,7 +103,7 @@ numpy_subs = {
     "ndarray": ":class:`~numpy.ndarray`",
 }
 
-astropy_subs = {
+astropy_subs: dict[str, str] = {
     "Quantity": ":class:`~astropy.units.Quantity`",
 }
 
@@ -111,7 +111,7 @@ astropy_subs = {
 # links, we first define the links and then process them afterwards into
 # the form of a reStructuredText external link.
 
-links = {
+links: dict[str, str] = {
     "Astropy": "https://docs.astropy.org",
     "black": "https://black.readthedocs.io",
     "Citation File Format": "https://citation-file-format.github.io/",
@@ -128,6 +128,7 @@ links = {
     "matplotlib": "https://matplotlib.org",
     "Matrix chat room": "https://app.element.io/#/room/#plasmapy:openastronomy.org",
     "mpmath": "https://mpmath.org/doc/current",
+    "mypy": "https://mypy.readthedocs.io",
     "nbsphinx": "https://nbsphinx.readthedocs.io",
     "Numba": "https://numba.readthedocs.io",
     "NumPy": "https://numpy.org",
@@ -152,8 +153,10 @@ links = {
     "ruff": "https://docs.astral.sh/ruff",
     "SciPy": "https://scipy.org",
     "Sphinx": "https://www.sphinx-doc.org",
+    "static type checking": "https://realpython.com/lessons/python-type-checking-overview",
     "towncrier": "https://github.com/twisted/towncrier",
     "tox": "https://tox.wiki/en/latest",
+    "type hint annotations": "https://peps.python.org/pep-0484",
     "xarray": "https://docs.xarray.dev",
     "Zenodo": "https://zenodo.org",
 }

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -714,9 +714,14 @@ environments are available, run:
 
    tox -a
 
-These commands can be run in any directory within PlasmaPy's repository
-with the same effect.
+For example, static type checking with |mypy| can be run locally with
 
+.. code-block:: shell
+
+   tox -e mypy
+
+Commands using |tox| can be run in any directory within PlasmaPy's
+repository with the same effect.
 
 .. _code-coverage:
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -287,7 +287,7 @@ tests for the same function, the preferred method is to decorate it with
 .. code-block:: python
 
    @pytest.mark.parametrize("truth_value", [True, False])
-   def test_proof_if_riemann(truth_value):
+   def test_proof_if_riemann(truth_value: bool) -> None:
        assert proof_by_riemann(truth_value)
 
 This code snippet will run :py:`proof_by_riemann(truth_value)` for each
@@ -302,7 +302,7 @@ functions or pass in tuples containing inputs and expected values.
 .. code-block:: python
 
    @pytest.mark.parametrize("truth_value, expected", [(True, True), (False, True)])
-   def test_proof_if_riemann(truth_value, expected):
+   def test_proof_if_riemann(truth_value: bool, expected: bool) -> None:
        assert proof_by_riemann(truth_value) == expected
 
 Test parametrization with argument unpacking
@@ -317,7 +317,7 @@ positional arguments (``a`` and ``b``) and one optional keyword argument
 
 .. code-block:: python
 
-   def add(a, b, reverse_order=False):
+   def add(a: float | str, b: float | str, reverse_order: bool = False) -> float | str:
        if reverse_order:
            return b + a
        return a + b
@@ -356,7 +356,7 @@ and unpacking_ them inside of the test function.
            (["1", "2"], {}, "12"),  # if no keyword arguments, use an empty dict
        ],
    )
-   def test_add(args, kwargs, expected):
+   def test_add(args: list[str], kwargs: dict[str, bool], expected: str) -> None:
        assert add(*args, **kwargs) == expected
 
 Fixtures

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -168,7 +168,7 @@ message to help us find the cause of a particular test failure.
 Type hint annotations
 ---------------------
 
-PlasmaPy has begun using |mypy| to perform |static type checking| on 
+PlasmaPy has begun using |mypy| to perform |static type checking| on
 |type hint annotations|. Adding a :py:`-> None` return annotation lets
 |mypy| verify that tests do not have :py:`return` statements.
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -157,9 +157,9 @@ message to help us find the cause of a particular test failure.
 .. code-block:: python
 
    def test_addition():
-       result = 2 + 2
+       actual = 2 + 2
        expected = 4
-       assert result == expected, f"2 + 2 returns {result} instead of {expected}."
+       assert actual == expected, f"2 + 2 returns {actual} instead of {expected}."
 
 .. tip::
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -165,6 +165,18 @@ message to help us find the cause of a particular test failure.
 
    Use `f-strings`_ to improve error message readability.
 
+Type hint annotations
+---------------------
+
+PlasmaPy has begun using |type hint annotations| and |mypy| to perform
+|static type checking|. Adding a :py:`-> None` return annotation lets
+|mypy| verify that tests do not have :py:`return` statements.
+
+.. code-block:: python
+
+   def test_addition() -> None:
+       assert 2 * 2 == 4
+
 Floating point comparisons
 --------------------------
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -322,6 +322,13 @@ positional arguments (``a`` and ``b``) and one optional keyword argument
            return b + a
        return a + b
 
+.. hint::
+
+   This function uses |type hint annotations| to indicate that ``a`` and
+   ``b`` can be either a :py:`float` or :py:`str`, :py:`reverse_order`
+   should be a :py:`bool`, and :py:`add` should return a :py:`float` or
+   :py:`str`.
+
 Argument unpacking_ lets us provide positional arguments in a `tuple` or
 `list` (commonly referred to as :term:`args`) and keyword arguments in a
 `dict` (commonly referred to as :term:`kwargs`). Unpacking_ occurs when
@@ -358,6 +365,14 @@ and unpacking_ them inside of the test function.
    )
    def test_add(args: list[str], kwargs: dict[str, bool], expected: str) -> None:
        assert add(*args, **kwargs) == expected
+
+.. hint::
+
+   This function uses |type hint annotations| to indicate that ``args``
+   should be a `list` containing `str` objects, ``kwargs`` should be a
+   `dict` containing `str` objects that map to `bool` objects,
+   ``expected`` should be a `str`, and that there should be no
+   :py:`return` statement.
 
 Fixtures
 --------

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -216,11 +216,11 @@ To test that a function issues an appropriate warning, use
    import pytest
 
 
-   def issue_warning():
+   def issue_warning() -> None:
        warnings.warn("warning message", UserWarning)
 
 
-   def test_that_a_warning_is_issued():
+   def test_that_a_warning_is_issued() -> None:
        with pytest.warns(UserWarning):
            issue_warning()
 
@@ -232,11 +232,11 @@ To test that a function raises an appropriate exception, use
    import pytest
 
 
-   def raise_exception():
+   def raise_exception() -> None:
        raise Exception
 
 
-   def test_that_an_exception_is_raised():
+   def test_that_an_exception_is_raised() -> None:
        with pytest.raises(Exception):
            raise_exception()
 
@@ -261,7 +261,7 @@ function.
 
 .. code-block:: python
 
-   def test_proof_by_riemann_hypothesis():
+   def test_proof_by_riemann_hypothesis() -> None:
        assert proof_by_riemann(False)
        assert proof_by_riemann(True)  # will only be run if the previous test passes
 
@@ -272,11 +272,11 @@ both will be run.
 
 .. code-block:: python
 
-   def test_proof_if_riemann_false():
+   def test_proof_if_riemann_false() -> None:
        assert proof_by_riemann(False)
 
 
-   def test_proof_if_riemann_true():
+   def test_proof_if_riemann_true() -> None:
        assert proof_by_riemann(True)
 
 However, this approach can lead to cumbersome, repeated code if you are
@@ -411,7 +411,7 @@ balanced with each other rather than absolute principles.
   .. code-block:: python
 
      @pytest.mark.slow
-     def test_calculating_primes():
+     def test_calculating_primes() -> None:
          calculate_all_primes()
 
 * **Write tests that are easy to understand and change.** To fully

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -168,8 +168,8 @@ message to help us find the cause of a particular test failure.
 Type hint annotations
 ---------------------
 
-PlasmaPy has begun using |type hint annotations| and |mypy| to perform
-|static type checking|. Adding a :py:`-> None` return annotation lets
+PlasmaPy has begun using |mypy| to perform |static type checking| on 
+|type hint annotations|. Adding a :py:`-> None` return annotation lets
 |mypy| verify that tests do not have :py:`return` statements.
 
 .. code-block:: python


### PR DESCRIPTION
## Description

This PR adds some discussion of type hint annotations used in tests, including the `-> None` return annotation that is used by mypy to verify that there are no return statements.  

I'm using Python 3.10+ style annotations since we'll be dropping Python 3.9 support as per NEP soon after our next release.

## Motivation and context

One of the things we'll need to do if we implement mypy in our CI (#2432) is discuss it in the contributor guide.  I'm starting with the testing guide.  I expect that type hint annotations will make our tests a lot more maintainable, especially in cases where we use `@pytest.mark.parametrize` with `args` and `kwargs`.

## Related issues

This PR came about because #2439 is adding a lot of `-> None` return annotations to tests.