### PR TITLE
Add type stub file for `@wrapt.decorator`

### DIFF
--- a/changelog/2442.trivial.rst
+++ b/changelog/2442.trivial.rst
@@ -1,0 +1,1 @@
+Added a stub file containing type hint annotations for ``@wrapt.decorator``.

--- a/mypy.ini
+++ b/mypy.ini
@@ -54,9 +54,6 @@ ignore_missing_imports = true
 [mypy-setuptools.*]
 ignore_missing_imports = true
 
-[mypy-wrapt.*]
-ignore_missing_imports = true
-
 [mypy-plasmapy._dev.scm_version]
 ignore_errors = true
 
@@ -67,9 +64,6 @@ ignore_errors = true
 # typing errors should not be reported for specific modules. As we
 # gradually make PlasmaPy consistent with mypy's strict mode, we can
 # remove the disabled error codes file-by-file.
-
-[mypy-plasmapy]
-disable_error_code = no-untyped-def
 
 [mypy-plasmapy.analysis.fit_functions]
 disable_error_code = assignment,attr-defined,misc,name-match,no-any-return,no-untyped-call,no-untyped-def,type-arg
@@ -105,7 +99,7 @@ disable_error_code = arg-type,no-untyped-call,no-untyped-def
 disable_error_code = no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.analysis.time_series.excess_statistics]
-disable_error_code = no-untyped-call,no-untyped-def,var-annotated
+disable_error_code = no-untyped-def,var-annotated
 
 [mypy-plasmapy.analysis.time_series.running_moments]
 disable_error_code = name-match,no-untyped-call,no-untyped-def
@@ -210,19 +204,19 @@ disable_error_code = assignment,attr-defined,call-overload,misc,name-defined,no-
 disable_error_code = assignment,attr-defined,call-overload,misc,name-defined,no-untyped-call,no-untyped-def,syntax
 
 [mypy-plasmapy.formulary.collisions.tests.test_coulomb]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.collisions.tests.test_dimensionless]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.collisions.tests.test_frequencies]
 disable_error_code = attr-defined,no-untyped-call,no-untyped-def,union-attr
 
 [mypy-plasmapy.formulary.collisions.tests.test_lengths]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.collisions.tests.test_misc]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.densities]
 disable_error_code = assignment,attr-defined,misc,no-untyped-call,syntax
@@ -270,58 +264,46 @@ disable_error_code = attr-defined,misc,no-any-return,no-redef,no-untyped-call,no
 disable_error_code = attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,syntax,union-attr
 
 [mypy-plasmapy.formulary.tests.test_densities]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_dielectric]
 disable_error_code = no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_dimensionless]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
-
-[mypy-plasmapy.formulary.tests.test_distribution]
 disable_error_code = attr-defined,no-untyped-def
 
-[mypy-plasmapy.formulary.tests.test_drifts]
-disable_error_code = no-untyped-def
+[mypy-plasmapy.formulary.tests.test_distribution]
+disable_error_code = attr-defined
 
 [mypy-plasmapy.formulary.tests.test_fermi_integral]
-disable_error_code = arg-type,attr-defined,no-untyped-def
+disable_error_code = arg-type,attr-defined
 
 [mypy-plasmapy.formulary.tests.test_frequencies]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
-
-[mypy-plasmapy.formulary.tests.test_ionization]
-disable_error_code = no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_lengths]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
-
-[mypy-plasmapy.formulary.tests.test_magnetostatics]
-disable_error_code = no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_mathematics]
 disable_error_code = no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_misc]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_plasma_frequency]
-disable_error_code = attr-defined,call-overload,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,call-overload,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_quantum]
 disable_error_code = attr-defined,no-untyped-call,no-untyped-def
-
-[mypy-plasmapy.formulary.tests.test_radiation]
-disable_error_code = no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_relativity]
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_speeds]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_thermal_speed]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_transport]
 disable_error_code = attr-defined,no-untyped-call,no-untyped-def
@@ -345,7 +327,7 @@ disable_error_code = type-arg,var-annotated
 disable_error_code = arg-type,assignment,misc,no-any-return,no-untyped-call,no-untyped-def,union-attr
 
 [mypy-plasmapy.particles.decorators]
-disable_error_code = arg-type,assignment,index,misc,no-any-return,no-untyped-call,no-untyped-def,operator,return-value,type-arg,union-attr,var-annotated
+disable_error_code = arg-type,assignment,call-arg,index,misc,no-any-return,no-untyped-call,no-untyped-def,operator,return-value,type-arg,union-attr,var-annotated
 
 [mypy-plasmapy.particles.ionization_state]
 disable_error_code = arg-type,assignment,call-overload,misc,no-any-return,no-untyped-call,no-untyped-def,operator,return-value,type-arg
@@ -417,7 +399,7 @@ disable_error_code = misc,no-untyped-def
 disable_error_code = misc,name-match,no-any-return,no-untyped-call,no-untyped-def,type-arg,var-annotated
 
 [mypy-plasmapy.plasma.plasma_base]
-disable_error_code = no-untyped-call,no-untyped-def,var-annotated
+disable_error_code = no-untyped-def,var-annotated
 
 [mypy-plasmapy.plasma.sources.openpmd_hdf5]
 disable_error_code = arg-type,no-untyped-call,no-untyped-def
@@ -437,17 +419,14 @@ disable_error_code = no-untyped-def
 [mypy-plasmapy.plasma.sources.tests.test_plasmablob]
 disable_error_code = attr-defined,no-untyped-def
 
-[mypy-plasmapy.plasma.tests.test_equilibria1d]
-disable_error_code = no-untyped-def
-
 [mypy-plasmapy.plasma.tests.test_grids]
 disable_error_code = abstract,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.plasma.tests.test_lundquist]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-call
 
 [mypy-plasmapy.plasma.tests.test_plasma_base]
-disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.plasma.tests.test_plasma_factory]
 disable_error_code = attr-defined,no-untyped-def
@@ -465,7 +444,7 @@ disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def,var-annota
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.tests._helpers.tests.sample_functions]
-disable_error_code = misc,no-untyped-def,valid-type
+disable_error_code = no-untyped-def,valid-type
 
 [mypy-plasmapy.utils._pytest_helpers.pytest_helpers]
 disable_error_code = arg-type,assignment,attr-defined,no-untyped-call,no-untyped-def,type-arg,var-annotated
@@ -477,7 +456,7 @@ disable_error_code = attr-defined,call-arg,no-untyped-def
 disable_error_code = type-arg
 
 [mypy-plasmapy.utils.calculator]
-disable_error_code = arg-type,no-untyped-def
+disable_error_code = arg-type
 
 [mypy-plasmapy.utils.calculator.main_interface]
 disable_error_code = no-untyped-call,no-untyped-def
@@ -501,7 +480,7 @@ disable_error_code = no-untyped-call,no-untyped-def
 disable_error_code = arg-type,assignment,no-untyped-call,no-untyped-def,type-arg,var-annotated
 
 [mypy-plasmapy.utils.decorators.converter]
-disable_error_code = no-untyped-def
+disable_error_code = call-arg,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.utils.decorators.deprecation]
 disable_error_code = assignment,attr-defined,no-untyped-def
@@ -519,7 +498,7 @@ disable_error_code = attr-defined,call-overload,index,misc,name-defined,no-untyp
 disable_error_code = attr-defined,misc,no-untyped-def
 
 [mypy-plasmapy.utils.decorators.tests.test_deprecation]
-disable_error_code = no-untyped-call,no-untyped-def
+disable_error_code = misc,no-untyped-call
 
 [mypy-plasmapy.utils.decorators.tests.test_helpers]
 disable_error_code = no-untyped-call,no-untyped-def

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,11 @@
 [mypy]
 python_version = 3.9
 pretty = true
+mypy_path = ./type_stubs
 exclude = (?x)(
-          docs|
-          \.run|
-          \.tox
+          /docs/
+          | /\.run/
+          | /\.tox/
           )
 
 enable_error_code = ignore-without-code

--- a/type_stubs/wrapt.pyi
+++ b/type_stubs/wrapt.pyi
@@ -1,0 +1,12 @@
+__all__ = ["decorator"]
+
+from typing import Any, Callable, TypeVar
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+def decorator(
+    wrapper: _F,
+    enabled: Any = None,
+    adapter: Any = None,
+    proxy: Any = None,
+) -> _F: ...


### PR DESCRIPTION
## Description

This PR adds a [type stub file](https://mypy.readthedocs.io/en/stable/stubs.html) for [`wrapt`](https://wrapt.readthedocs.io/).

## Motivation and context

A few of our widely used decorators like `@particle_input` make use of `@wrapt.decorator`. Because `wrapt` is untyped, we were running into issues with mypy not type checking some of our code because `@wrapt.decorator` is untyped. Adding a type stub file lets us get past that.  This also serves as a prototype type stub file.

## Related issues

This came up in #2429.