### PR TITLE
Improve type hint annotations for `@particle_input`

### DIFF
--- a/changelog/2443.trivial.rst
+++ b/changelog/2443.trivial.rst
@@ -1,2 +1,2 @@
 Improved type hint annotations for `plasmapy.particles.decorators`,
-which includes |particle_input|.
+which includes |particle_input|, and the corresponding tests.

--- a/changelog/2443.trivial.rst
+++ b/changelog/2443.trivial.rst
@@ -1,0 +1,2 @@
+Improved type hint annotations for `plasmapy.particles.decorators`,
+which includes |particle_input|.

--- a/mypy.ini
+++ b/mypy.ini
@@ -118,34 +118,34 @@ disable_error_code = no-untyped-call,no-untyped-def
 disable_error_code = no-untyped-def
 
 [mypy-plasmapy.diagnostics.charged_particle_radiography.detector_stacks]
-disable_error_code = call-overload,no-untyped-def
+disable_error_code = call-overload,misc,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography]
-disable_error_code = assignment,attr-defined,has-type,misc,no-untyped-call,no-untyped-def,type-var,var-annotated
+disable_error_code = assignment,attr-defined,has-type,misc,no-untyped-call,no-untyped-def,type-arg,type-var,var-annotated
 
 [mypy-plasmapy.diagnostics.charged_particle_radiography.tests.test_detector_stacks]
 disable_error_code = no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.diagnostics.charged_particle_radiography.tests.test_synthetic_radiography]
-disable_error_code = no-untyped-call,no-untyped-def
+disable_error_code = arg-type,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.diagnostics.langmuir]
-disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,operator,var-annotated
+disable_error_code = assignment,attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,operator,type-arg,valid-type,var-annotated
 
 [mypy-plasmapy.diagnostics.tests.test_langmuir]
-disable_error_code = no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.diagnostics.tests.test_thomson]
 disable_error_code = attr-defined,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.diagnostics.thomson]
-disable_error_code = arg-type,assignment,attr-defined,misc,no-untyped-call,no-untyped-def,type-arg
+disable_error_code = arg-type,assignment,attr-defined,misc,no-untyped-call,no-untyped-def,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.dispersion.analytical.mhd_waves_]
-disable_error_code = attr-defined,has-type,misc,no-untyped-call,no-untyped-def,syntax
+disable_error_code = assignment,attr-defined,has-type,misc,no-any-return,no-untyped-call,no-untyped-def,return-value,syntax,type-arg,valid-type
 
 [mypy-plasmapy.dispersion.analytical.stix_]
-disable_error_code = arg-type,assignment,attr-defined,call-overload,misc,no-untyped-call,no-untyped-def
+disable_error_code = arg-type,assignment,attr-defined,call-overload,misc,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.dispersion.analytical.tests.test_mhd_wave_class]
 disable_error_code = no-untyped-call,no-untyped-def
@@ -157,19 +157,19 @@ disable_error_code = attr-defined,no-untyped-call,no-untyped-def
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.dispersion.analytical.two_fluid_]
-disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,union-attr
+disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.dispersion.dispersion_functions]
-disable_error_code = type-arg
+disable_error_code = no-any-return,type-arg
 
 [mypy-plasmapy.dispersion.dispersionfunction]
-disable_error_code = misc,no-untyped-def,type-arg
+disable_error_code = arg-type,misc,no-untyped-def,return-value,type-arg
 
 [mypy-plasmapy.dispersion.numerical.hollweg_]
-disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,union-attr
+disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.dispersion.numerical.kinetic_alfven_]
-disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,union-attr
+disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.dispersion.numerical.tests.test_hollweg_]
 disable_error_code = attr-defined,no-untyped-def
@@ -181,31 +181,31 @@ disable_error_code = attr-defined,no-untyped-def
 disable_error_code = arg-type,no-untyped-def
 
 [mypy-plasmapy.formulary.braginskii]
-disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def,type-arg
+disable_error_code = assignment,attr-defined,has-type,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.formulary.collisions.coulomb]
-disable_error_code = assignment,attr-defined,misc,name-defined,no-untyped-call,no-untyped-def,syntax
+disable_error_code = assignment,attr-defined,misc,name-defined,no-any-return,no-untyped-call,no-untyped-def,syntax,type-arg,valid-type
 
 [mypy-plasmapy.formulary.collisions.dimensionless]
-disable_error_code = assignment,attr-defined,call-overload,misc,no-untyped-call,no-untyped-def
+disable_error_code = assignment,attr-defined,call-overload,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.formulary.collisions.frequencies]
-disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,union-attr
+disable_error_code = assignment,attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.formulary.collisions.helio.collisional_analysis]
-disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def
+disable_error_code = arg-type,assignment,attr-defined,misc,no-untyped-call,no-untyped-def,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.formulary.collisions.helio.tests.test_collisional_analysis]
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.collisions.lengths]
-disable_error_code = assignment,attr-defined,call-overload,misc,name-defined,no-untyped-call,no-untyped-def,syntax
+disable_error_code = assignment,attr-defined,call-overload,misc,name-defined,no-any-return,no-untyped-call,no-untyped-def,syntax,type-arg,valid-type
 
 [mypy-plasmapy.formulary.collisions.misc]
-disable_error_code = assignment,attr-defined,call-overload,misc,name-defined,no-untyped-call,no-untyped-def,syntax
+disable_error_code = assignment,attr-defined,call-overload,misc,name-defined,no-any-return,no-untyped-call,no-untyped-def,syntax,type-arg,valid-type
 
 [mypy-plasmapy.formulary.collisions.tests.test_coulomb]
-disable_error_code = attr-defined,no-untyped-def
+disable_error_code = attr-defined,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.formulary.collisions.tests.test_dimensionless]
 disable_error_code = attr-defined,no-untyped-def
@@ -220,49 +220,49 @@ disable_error_code = attr-defined,no-untyped-def
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.densities]
-disable_error_code = assignment,attr-defined,misc,no-untyped-call,syntax
+disable_error_code = assignment,attr-defined,misc,no-any-return,no-untyped-call,syntax,type-arg,valid-type
 
 [mypy-plasmapy.formulary.dielectric]
-disable_error_code = misc,no-untyped-call,no-untyped-def
+disable_error_code = misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.formulary.dimensionless]
-disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.formulary.distribution]
 disable_error_code = attr-defined,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.formulary.drifts]
-disable_error_code = misc
+disable_error_code = misc,no-any-return,type-arg,valid-type
 
 [mypy-plasmapy.formulary.frequencies]
-disable_error_code = arg-type,attr-defined,misc,no-any-return,no-untyped-call,union-attr
+disable_error_code = arg-type,attr-defined,misc,no-any-return,no-untyped-call,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.formulary.ionization]
-disable_error_code = misc,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.formulary.lengths]
-disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def
+disable_error_code = assignment,attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.formulary.magnetostatics]
-disable_error_code = assignment,misc,no-untyped-call,no-untyped-def
+disable_error_code = assignment,attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.formulary.mathematics]
 disable_error_code = no-any-return,type-arg
 
 [mypy-plasmapy.formulary.misc]
-disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.formulary.quantum]
-disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def,union-attr
+disable_error_code = assignment,attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.formulary.radiation]
-disable_error_code = attr-defined,misc,no-any-return,no-untyped-call,type-arg,union-attr
+disable_error_code = assignment,attr-defined,misc,no-any-return,no-untyped-call,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.formulary.relativity]
-disable_error_code = attr-defined,misc,no-any-return,no-redef,no-untyped-call,no-untyped-def,return-value,union-attr
+disable_error_code = arg-type,assignment,attr-defined,misc,no-any-return,no-redef,no-untyped-call,no-untyped-def,return-value,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.formulary.speeds]
-disable_error_code = attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,syntax,union-attr
+disable_error_code = assignment,attr-defined,misc,no-any-return,no-untyped-call,no-untyped-def,syntax,type-arg,union-attr,valid-type
 
 [mypy-plasmapy.formulary.tests.test_densities]
 disable_error_code = attr-defined,no-untyped-def
@@ -271,10 +271,10 @@ disable_error_code = attr-defined,no-untyped-def
 disable_error_code = no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_dimensionless]
-disable_error_code = attr-defined,no-untyped-def
+disable_error_code = arg-type,attr-defined,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_distribution]
-disable_error_code = attr-defined
+disable_error_code = attr-defined,no-untyped-call
 
 [mypy-plasmapy.formulary.tests.test_fermi_integral]
 disable_error_code = arg-type,attr-defined
@@ -283,7 +283,10 @@ disable_error_code = arg-type,attr-defined
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_lengths]
-disable_error_code = attr-defined,no-untyped-def
+disable_error_code = attr-defined,no-untyped-call,no-untyped-def
+
+[mypy-plasmapy.formulary.tests.test_magnetostatics]
+disable_error_code = attr-defined
 
 [mypy-plasmapy.formulary.tests.test_mathematics]
 disable_error_code = no-untyped-def
@@ -304,7 +307,7 @@ disable_error_code = attr-defined,no-untyped-def
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_thermal_speed]
-disable_error_code = attr-defined,no-untyped-def
+disable_error_code = attr-defined,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.formulary.tests.test_transport]
 disable_error_code = attr-defined,no-untyped-call,no-untyped-def
@@ -313,7 +316,7 @@ disable_error_code = attr-defined,no-untyped-call,no-untyped-def
 disable_error_code = arg-type,no-untyped-def
 
 [mypy-plasmapy.particles._factory]
-disable_error_code = arg-type,no-any-return,no-untyped-def,operator,type-arg
+disable_error_code = arg-type,attr-defined,no-any-return,no-untyped-def,operator,type-arg
 
 [mypy-plasmapy.particles._isotopes]
 disable_error_code = arg-type,no-untyped-def
@@ -322,28 +325,28 @@ disable_error_code = arg-type,no-untyped-def
 disable_error_code = arg-type,assignment,call-overload,no-any-return,no-untyped-def,return-value,syntax,type-arg,union-attr,var-annotated
 
 [mypy-plasmapy.particles._special_particles]
-disable_error_code = type-arg,var-annotated
+disable_error_code = attr-defined,type-arg,var-annotated
 
 [mypy-plasmapy.particles.atomic]
-disable_error_code = arg-type,assignment,misc,no-any-return,no-untyped-call,no-untyped-def,union-attr
+disable_error_code = arg-type,assignment,misc,no-any-return,no-untyped-call,no-untyped-def,return-value,type-arg,union-attr
 
 [mypy-plasmapy.particles.decorators]
-disable_error_code = arg-type,assignment,call-arg,index,misc,no-any-return,no-untyped-call,no-untyped-def,operator,return-value,type-arg,union-attr,var-annotated
+disable_error_code = arg-type,call-arg,no-any-return,return-value,typeddict-item
 
 [mypy-plasmapy.particles.ionization_state]
-disable_error_code = arg-type,assignment,call-overload,misc,no-any-return,no-untyped-call,no-untyped-def,operator,return-value,type-arg
+disable_error_code = arg-type,assignment,call-overload,has-type,misc,no-any-return,no-untyped-call,no-untyped-def,operator,return-value,type-arg,valid-type
 
 [mypy-plasmapy.particles.ionization_state_collection]
 disable_error_code = arg-type,assignment,has-type,index,misc,no-any-return,no-untyped-call,no-untyped-def,operator,return-value,type-arg,union-attr,valid-type,var-annotated
 
 [mypy-plasmapy.particles.nuclear]
-disable_error_code = misc,no-untyped-def,union-attr
+disable_error_code = misc,no-any-return,no-untyped-def,return-value,type-arg,union-attr
 
 [mypy-plasmapy.particles.particle_class]
-disable_error_code = arg-type,assignment,attr-defined,has-type,index,misc,no-any-return,no-redef,no-untyped-def,return-value,type-arg,valid-type,var-annotated
+disable_error_code = arg-type,assignment,attr-defined,has-type,index,misc,no-any-return,no-redef,no-untyped-def,override,return-value,type-arg,valid-type,var-annotated
 
 [mypy-plasmapy.particles.particle_collections]
-disable_error_code = no-any-return,no-untyped-call,no-untyped-def,override,type-arg,valid-type,var-annotated
+disable_error_code = assignment,attr-defined,name-defined,no-any-return,no-untyped-call,no-untyped-def,override,type-arg,valid-type,var-annotated
 
 [mypy-plasmapy.particles.serialization]
 disable_error_code = no-untyped-def
@@ -358,7 +361,7 @@ disable_error_code = attr-defined,no-untyped-def
 disable_error_code = arg-type,attr-defined,no-untyped-def
 
 [mypy-plasmapy.particles.tests.test_decorators]
-disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def,return-value
+disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,return-value,type-arg
 
 [mypy-plasmapy.particles.tests.test_exceptions]
 disable_error_code = attr-defined,no-untyped-def,operator,var-annotated
@@ -394,10 +397,10 @@ disable_error_code = no-untyped-def
 disable_error_code = no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.plasma.equilibria1d]
-disable_error_code = misc,no-untyped-def
+disable_error_code = attr-defined,misc,no-any-return,no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.plasma.grids]
-disable_error_code = misc,name-match,no-any-return,no-untyped-call,no-untyped-def,type-arg,var-annotated
+disable_error_code = index,misc,name-match,no-any-return,no-untyped-call,no-untyped-def,type-arg,var-annotated
 
 [mypy-plasmapy.plasma.plasma_base]
 disable_error_code = no-untyped-def,var-annotated
@@ -406,7 +409,7 @@ disable_error_code = no-untyped-def,var-annotated
 disable_error_code = arg-type,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.plasma.sources.plasma3d]
-disable_error_code = misc,no-untyped-call,no-untyped-def,type-arg
+disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def,type-arg
 
 [mypy-plasmapy.plasma.sources.plasmablob]
 disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def
@@ -433,7 +436,7 @@ disable_error_code = attr-defined,no-untyped-def
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.simulation.abstractions]
-disable_error_code = no-untyped-def
+disable_error_code = no-untyped-def,type-arg,valid-type
 
 [mypy-plasmapy.simulation.particle_integrators]
 disable_error_code = no-untyped-def
@@ -445,7 +448,7 @@ disable_error_code = attr-defined,misc,no-untyped-call,no-untyped-def,var-annota
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.tests._helpers.tests.sample_functions]
-disable_error_code = no-untyped-def,valid-type
+disable_error_code = no-any-return,no-untyped-def,valid-type
 
 [mypy-plasmapy.utils._pytest_helpers.pytest_helpers]
 disable_error_code = arg-type,assignment,attr-defined,no-untyped-call,no-untyped-def,type-arg,var-annotated
@@ -454,7 +457,7 @@ disable_error_code = arg-type,assignment,attr-defined,no-untyped-call,no-untyped
 disable_error_code = attr-defined,call-arg,no-untyped-def
 
 [mypy-plasmapy.utils._units_helpers]
-disable_error_code = type-arg
+disable_error_code = no-untyped-call,type-arg
 
 [mypy-plasmapy.utils.calculator]
 disable_error_code = arg-type
@@ -478,13 +481,13 @@ disable_error_code = no-untyped-call,no-untyped-def
 disable_error_code = no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.utils.decorators.checks]
-disable_error_code = arg-type,assignment,no-untyped-call,no-untyped-def,type-arg,var-annotated
+disable_error_code = arg-type,assignment,attr-defined,no-untyped-call,no-untyped-def,type-arg,var-annotated
 
 [mypy-plasmapy.utils.decorators.converter]
 disable_error_code = call-arg,no-untyped-call,no-untyped-def
 
 [mypy-plasmapy.utils.decorators.deprecation]
-disable_error_code = assignment,attr-defined,no-untyped-def
+disable_error_code = assignment,attr-defined,misc,no-untyped-def
 
 [mypy-plasmapy.utils.decorators.helpers]
 disable_error_code = no-untyped-call,no-untyped-def
@@ -493,7 +496,7 @@ disable_error_code = no-untyped-call,no-untyped-def
 disable_error_code = attr-defined,no-untyped-def,type-arg
 
 [mypy-plasmapy.utils.decorators.tests.test_checks]
-disable_error_code = attr-defined,call-overload,index,misc,name-defined,no-untyped-call,no-untyped-def,operator
+disable_error_code = attr-defined,call-overload,index,misc,name-defined,no-any-return,no-untyped-call,no-untyped-def,operator
 
 [mypy-plasmapy.utils.decorators.tests.test_converters]
 disable_error_code = attr-defined,misc,no-untyped-def
@@ -508,7 +511,7 @@ disable_error_code = no-untyped-call,no-untyped-def
 disable_error_code = no-untyped-def
 
 [mypy-plasmapy.utils.decorators.tests.test_validators]
-disable_error_code = attr-defined,call-arg,misc,name-defined,no-untyped-call,no-untyped-def
+disable_error_code = attr-defined,call-arg,misc,name-defined,no-any-return,no-untyped-call,no-untyped-def,type-arg
 
 [mypy-plasmapy.utils.decorators.validators]
 disable_error_code = attr-defined,no-untyped-def,var-annotated
@@ -526,4 +529,4 @@ disable_error_code = no-untyped-call,no-untyped-def,var-annotated
 disable_error_code = attr-defined,no-untyped-def
 
 [mypy-plasmapy.utils.tests.test_units_helpers]
-disable_error_code = name-match,no-untyped-def
+disable_error_code = attr-defined,name-match,no-untyped-call,no-untyped-def

--- a/mypy.ini
+++ b/mypy.ini
@@ -357,9 +357,6 @@ disable_error_code = attr-defined,no-untyped-def
 [mypy-plasmapy.particles.tests.test_atomic]
 disable_error_code = arg-type,attr-defined,no-untyped-def
 
-[mypy-plasmapy.particles.tests.test_decorators]
-disable_error_code = assignment,attr-defined,misc,no-untyped-call,no-untyped-def,return-value,type-arg
-
 [mypy-plasmapy.particles.tests.test_exceptions]
 disable_error_code = attr-defined,no-untyped-def,operator,var-annotated
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -330,9 +330,6 @@ disable_error_code = attr-defined,type-arg,var-annotated
 [mypy-plasmapy.particles.atomic]
 disable_error_code = arg-type,assignment,misc,no-any-return,no-untyped-call,no-untyped-def,return-value,type-arg,union-attr
 
-[mypy-plasmapy.particles.decorators]
-disable_error_code = arg-type,call-arg,no-any-return,return-value,typeddict-item
-
 [mypy-plasmapy.particles.ionization_state]
 disable_error_code = arg-type,assignment,call-overload,has-type,misc,no-any-return,no-untyped-call,no-untyped-def,operator,return-value,type-arg,valid-type
 

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -603,7 +603,6 @@ class _ParticleInput:
     def perform_pre_validations(
         self, Z: Optional[float], mass_numb: Optional[int]
     ) -> None:
-        # TODO: too specific?
         """
         Perform a variety of pre-checks on the arguments.
 
@@ -680,10 +679,6 @@ class _ParticleInput:
             bound_arguments.arguments[parameter] = processed_kwargs[parameter]
 
         return bound_arguments
-
-
-# TODO: callable_: Callable[[...], ...]
-# TODO: -> Callable[[...], ...]
 
 
 def particle_input(

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -970,9 +970,9 @@ def particle_input(
         instance: Any,
         args: Iterable[Any],
         kwargs: MutableMapping[str, Any],
-    ) -> Callable[..., Any]:  # type: ignore[no-any-return]
+    ) -> Callable[..., Any]:
         bound_arguments = particle_validator.process_arguments(args, kwargs, instance)
-        return callable__(
+        return callable__(  # type: ignore[no-any-return]
             *bound_arguments.args,
             **bound_arguments.kwargs,
         )

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -9,7 +9,7 @@ import numpy as np
 import warnings
 import wrapt
 
-from collections.abc import Callable, Iterable, MutableMapping, Sequence
+from collections.abc import Callable, Iterable, MutableMapping
 from inspect import BoundArguments
 from numbers import Integral, Real
 from typing import Any, Optional, TypedDict, Union
@@ -86,7 +86,7 @@ def _make_into_set_or_none(obj: Any) -> Optional[Iterable[str]]:
 def _bind_arguments(
     wrapped_signature: inspect.Signature,
     callable_: Callable[..., Any],
-    args: Sequence[Any],
+    args: Iterable[Any],
     kwargs: MutableMapping[str, Any],
     instance: Any = None,
 ) -> inspect.BoundArguments:
@@ -635,7 +635,10 @@ class _ParticleInput:
             )
 
     def process_arguments(
-        self, args: Sequence[Any], kwargs: dict[str, Any], instance: Any = None
+        self,
+        args: Iterable[Any],
+        kwargs: MutableMapping[str, Any],
+        instance: Any = None,
     ) -> BoundArguments:
         """
         Process the arguments passed to the callable_ callable.
@@ -965,10 +968,13 @@ def particle_input(
     def wrapper(
         callable__: Callable[..., Any],
         instance: Any,
-        args: Sequence[Any],
-        kwargs: dict[str, Any],
-    ) -> Callable[..., Any]:
+        args: Iterable[Any],
+        kwargs: MutableMapping[str, Any],
+    ) -> Callable[..., Any]:  # type: ignore[no-any-return]
         bound_arguments = particle_validator.process_arguments(args, kwargs, instance)
-        return callable__(*bound_arguments.args, **bound_arguments.kwargs)  # type: ignore[no-any-return]
+        return callable__(
+            *bound_arguments.args,
+            **bound_arguments.kwargs,
+        )
 
     return wrapper(callable_, instance=None, args=(), kwargs={})

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -8,10 +8,10 @@ import numpy as np
 import warnings
 import wrapt
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from inspect import BoundArguments
 from numbers import Integral, Real
-from typing import Any, Optional, Union
+from typing import Any, Optional, TypedDict, Union
 
 from plasmapy.particles._factory import _physical_particle_factory
 from plasmapy.particles.exceptions import (
@@ -25,6 +25,19 @@ from plasmapy.particles.exceptions import (
 from plasmapy.particles.particle_class import CustomParticle, Particle, ParticleLike
 from plasmapy.particles.particle_collections import ParticleList, ParticleListLike
 from plasmapy.utils.exceptions import PlasmaPyDeprecationWarning
+
+
+class _CallableDataDict(TypedDict, total=False):
+    allow_custom_particles: bool
+    allow_particle_lists: bool
+    annotations: dict[str, Any]
+    any_of: Optional[Union[str, Iterable[str]]]
+    callable_: Callable[..., Any]
+    exclude: Optional[Union[str, Iterable[str]]]
+    parameters_to_process: list[str]
+    require: Optional[Union[str, Iterable[str]]]
+    signature: inspect.Signature
+
 
 _basic_particle_input_annotations = (
     Particle,  # deprecated
@@ -43,7 +56,7 @@ _particle_input_annotations = (
 )
 
 
-def _get_annotations(callable_: Callable):
+def _get_annotations(callable_: Callable[..., Any]) -> Optional[Any]:
     """
     Access the annotations of a callable.
 
@@ -56,7 +69,7 @@ def _get_annotations(callable_: Callable):
     return getattr(callable_, "__annotations__", None)
 
 
-def _make_into_set_or_none(obj) -> Optional[set]:
+def _make_into_set_or_none(obj: Any) -> Optional[Iterable[str]]:
     """
     Return `None` if ``obj`` is `None`, and otherwise convert ``obj``
     into a `set`.
@@ -71,10 +84,10 @@ def _make_into_set_or_none(obj) -> Optional[set]:
 
 def _bind_arguments(
     wrapped_signature: inspect.Signature,
-    callable_: Callable,
-    args: Optional[tuple] = None,
+    callable_: Callable[..., Any],
+    args: Optional[Sequence[Any]] = None,
     kwargs: Optional[dict[str, Any]] = None,
-    instance=None,
+    instance: Any = None,
 ) -> inspect.BoundArguments:
     """
     Bind the arguments provided by ``args`` and ``kwargs`` to
@@ -114,6 +127,12 @@ def _bind_arguments(
     # parameter from a callable decorated with @particle_input. After
     # that, we should change this warning to an exception for ∼2 more
     # releases before deleting it.
+
+    if args is None:
+        args = ()
+
+    if kwargs is None:
+        kwargs = {}
 
     if "z_mean" in kwargs and "Z" not in kwargs and "Z" in wrapped_signature.parameters:
         function_name = getattr(callable_, "__name__", None)
@@ -177,16 +196,16 @@ class _ParticleInput:
 
     def __init__(
         self,
-        callable_: Callable,
+        callable_: Callable[..., Any],
         *,
-        require: Optional[Union[str, set, list, tuple]] = None,
-        any_of: Optional[Union[str, set, list, tuple]] = None,
-        exclude: Optional[Union[str, set, list, tuple]] = None,
+        require: Optional[Union[str, Iterable[str]]] = None,
+        any_of: Optional[Union[str, Iterable[str]]] = None,
+        exclude: Optional[Union[str, Iterable[str]]] = None,
         allow_custom_particles: bool = True,
         allow_particle_lists: bool = True,
     ) -> None:
-        self._data = {}
-        self.callable_ = callable_
+        self._data: _CallableDataDict = {}
+        self.callable_: Callable[..., Any] = callable_
         self.require = require
         self.any_of = any_of
         self.exclude = exclude
@@ -194,7 +213,7 @@ class _ParticleInput:
         self.allow_particle_lists = allow_particle_lists
 
     @property
-    def callable_(self) -> Callable:
+    def callable_(self) -> Callable[..., Any]:
         """
         The callable that is being decorated.
 
@@ -202,11 +221,11 @@ class _ParticleInput:
         -------
         callable
         """
-        return self._data["callable"]
+        return self._data["callable_"]
 
     @callable_.setter
-    def callable_(self, callable_: Callable) -> None:
-        self._data["callable"] = callable_
+    def callable_(self, callable_: Callable[..., Any]) -> None:
+        self._data["callable_"] = callable_
         self._data["annotations"] = _get_annotations(callable_)
         self._data["parameters_to_process"] = self.find_parameters_to_process()
         self._data["signature"] = inspect.signature(callable_)
@@ -243,7 +262,7 @@ class _ParticleInput:
         return self._data.get("annotations")
 
     @property
-    def require(self) -> Optional[set]:
+    def require(self) -> Optional[Iterable[str]]:
         """
         Categories that the particle must belong to.
 
@@ -254,11 +273,11 @@ class _ParticleInput:
         return self._data["require"]
 
     @require.setter
-    def require(self, require_: Optional[Union[str, set, list, tuple]]) -> None:
+    def require(self, require_: Optional[Union[str, Iterable[str]]]) -> None:
         self._data["require"] = _make_into_set_or_none(require_)
 
     @property
-    def any_of(self) -> Optional[set]:
+    def any_of(self) -> Optional[Iterable[str]]:
         """
         Categories of which the particle must belong to at least one.
 
@@ -269,11 +288,11 @@ class _ParticleInput:
         return self._data["any_of"]
 
     @any_of.setter
-    def any_of(self, any_of_: Optional[Union[str, set, list, tuple]]) -> None:
+    def any_of(self, any_of_: Optional[Union[str, Iterable[str]]]) -> None:
         self._data["any_of"] = _make_into_set_or_none(any_of_)
 
     @property
-    def exclude(self) -> Optional[set]:
+    def exclude(self) -> Optional[Iterable[str]]:
         """
         Categories that the particle cannot belong to.
 
@@ -284,7 +303,7 @@ class _ParticleInput:
         return self._data["exclude"]
 
     @exclude.setter
-    def exclude(self, exclude_) -> None:
+    def exclude(self, exclude_: Optional[Union[str, Iterable[str]]]) -> None:
         self._data["exclude"] = _make_into_set_or_none(exclude_)
 
     @property
@@ -331,7 +350,9 @@ class _ParticleInput:
         """
         return self._data["parameters_to_process"]
 
-    def verify_charge_categorization(self, particle) -> None:
+    def verify_charge_categorization(
+        self, particle: Union[Particle, CustomParticle, ParticleList]
+    ) -> None:
         """
         Raise an exception if the particle does not meet charge
         categorization criteria.
@@ -351,7 +372,7 @@ class _ParticleInput:
 
         if isinstance(uncharged, Iterable):
             uncharged = any(uncharged)
-            lacks_charge_info = any(lacks_charge_info)
+            lacks_charge_info = any(lacks_charge_info)  # type: ignore[arg-type]
 
         if must_be_charged and (uncharged or must_have_charge_info):
             raise ChargeError(f"{self.callable_} can only accept charged particles.")
@@ -363,7 +384,13 @@ class _ParticleInput:
             )
 
     @staticmethod
-    def category_errmsg(particle, require, exclude, any_of, callable_name) -> str:
+    def category_errmsg(
+        particle: Union[Particle, CustomParticle, ParticleList],
+        require: Optional[Union[str, Iterable[str]]],
+        exclude: Optional[Union[str, Iterable[str]]],
+        any_of: Optional[Union[str, Iterable[str]]],
+        callable_name: str,
+    ) -> str:
         """
         Return an error message for when a particle does not meet
         categorization criteria.
@@ -391,14 +418,24 @@ class _ParticleInput:
 
         return category_errmsg
 
-    def verify_particle_categorization(self, particle) -> None:
+    def verify_particle_categorization(
+        self, particle: Union[Particle, CustomParticle, ParticleList]
+    ) -> None:
         """
         Verify that the particle meets the categorization criteria.
+
+        Parameters
+        ----------
+        particle : Particle | CustomParticle
 
         Raises
         ------
         |ParticleError|
             If the particle does not meet the categorization criteria.
+
+        Notes
+        -----
+        This method does not yet work with |ParticleList| objects.
 
         See Also
         --------
@@ -418,7 +455,9 @@ class _ParticleInput:
             )
             raise ParticleError(errmsg)
 
-    def verify_particle_name_criteria(self, parameter, particle):
+    def verify_particle_name_criteria(
+        self, parameter: str, particle: Union[Particle, CustomParticle, ParticleList]
+    ) -> None:
         """
         Check that parameters with special names meet the expected
         categorization criteria.
@@ -449,7 +488,7 @@ class _ParticleInput:
             meets_name_criteria = particle.is_category(**categorization)
 
             if isinstance(particle, Iterable) and not isinstance(particle, str):
-                meets_name_criteria = all(meets_name_criteria)
+                meets_name_criteria = all(meets_name_criteria)  # type: ignore[arg-type]
 
             if not meets_name_criteria:
                 raise exception(
@@ -458,7 +497,9 @@ class _ParticleInput:
                     f"valid {parameter}."
                 )
 
-    def verify_allowed_types(self, particle):
+    def verify_allowed_types(
+        self, particle: Union[Particle, CustomParticle, ParticleList]
+    ) -> None:
         """
         Verify that the particle object contains only the allowed types
         of particles.
@@ -489,8 +530,8 @@ class _ParticleInput:
         self,
         parameter: str,
         argument: Any,
-        Z: Optional[Integral],
-        mass_numb: Optional[Integral],
+        Z: Optional[float],
+        mass_numb: Optional[int],
     ) -> Any:
         """
         Process an argument that has an appropriate annotation.
@@ -562,7 +603,10 @@ class _ParticleInput:
 
     parameters_to_skip = ("Z", "mass_numb")
 
-    def perform_pre_validations(self, Z, mass_numb):
+    def perform_pre_validations(
+        self, Z: Optional[float], mass_numb: Optional[int]
+    ) -> None:
+        # TODO: too specific?
         """
         Perform a variety of pre-checks on the arguments.
 
@@ -594,7 +638,7 @@ class _ParticleInput:
             )
 
     def process_arguments(
-        self, args: tuple, kwargs: dict[str, Any], instance=None
+        self, args: Sequence[Any], kwargs: dict[str, Any], instance: Any = None
     ) -> BoundArguments:
         """
         Process the arguments passed to the callable_ callable.
@@ -638,15 +682,19 @@ class _ParticleInput:
         return bound_arguments
 
 
+# TODO: callable_: Callable[[...], ...]
+# TODO: -> Callable[[...], ...]
+
+
 def particle_input(
-    callable_: Optional[Callable] = None,
+    callable_: Optional[Callable[..., Any]] = None,
     *,
-    require: Optional[Union[str, set, list, tuple]] = None,
-    any_of: Optional[Union[str, set, list, tuple]] = None,
-    exclude: Optional[Union[str, set, list, tuple]] = None,
+    require: Optional[Union[str, Iterable[str]]] = None,
+    any_of: Optional[Union[str, Iterable[str]]] = None,
+    exclude: Optional[Union[str, Iterable[str]]] = None,
     allow_custom_particles: bool = True,
     allow_particle_lists: bool = True,
-) -> Callable:
+) -> Callable[..., Any]:
     r"""
     Convert |particle-like| |arguments| into particle objects.
 
@@ -918,8 +966,14 @@ def particle_input(
 
     @wrapt.decorator
     def wrapper(
-        callable__: Callable, instance: Any, args: tuple, kwargs: dict[str, Any]
-    ):
+        callable__: Callable[..., Any],
+        instance: Any,
+        args: Sequence[Any],
+        kwargs: dict[str, Any],
+    ) -> Callable[..., Any]:
+        # TODO: Callable[[...], ...]
+        # TODO: for instance, could we be more specific than Any?
+
         bound_arguments = particle_validator.process_arguments(args, kwargs, instance)
         return callable__(*bound_arguments.args, **bound_arguments.kwargs)
 

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -156,7 +156,9 @@ class ClassWithDecoratedMethods:
 
     @particle_input
     def method_decorated_with_no_parentheses(self, particle: ParticleLike) -> Particle:
-        # Because run-time logic is needed, mypy will assume that
+        # Because run-time logic is needed, mypy is unable to infer
+        # that @particle_input is doing a type conversion here. We 
+        # would need a dynamic type checker to address this case.
         return particle  # type: ignore[return-value]
 
     @particle_input()

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -31,7 +31,7 @@ def function_decorated_with_particle_input(
     b: Any = None,
     Z: Optional[float] = None,
     mass_numb: Optional[int] = None,
-) -> Particle:
+) -> Union[Particle, CustomParticle, ParticleList]:
     """
     A simple function that is decorated with `particle_input` and
     returns the particle instance corresponding to the inputs.
@@ -55,7 +55,7 @@ def function_decorated_with_call_of_particle_input(
     b: Any = None,
     Z: Optional[float] = None,
     mass_numb: Optional[int] = None,
-) -> Particle:
+) -> Union[Particle, CustomParticle, ParticleList]:
     """
     A simple function that is decorated with `@particle_input()` and
     returns the Particle instance corresponding to the inputs.
@@ -155,14 +155,18 @@ class ClassWithDecoratedMethods:
     """
 
     @particle_input
-    def method_decorated_with_no_parentheses(self, particle: ParticleLike) -> Particle:
+    def method_decorated_with_no_parentheses(
+        self, particle: ParticleLike
+    ) -> Union[Particle, CustomParticle, ParticleList]:
         # Because run-time logic is needed, mypy is unable to infer
-        # that @particle_input is doing a type conversion here. We 
+        # that @particle_input is doing a type conversion here. We
         # would need a dynamic type checker to address this case.
         return particle  # type: ignore[return-value]
 
     @particle_input()
-    def method_decorated_with_parentheses(self, particle: ParticleLike) -> Particle:
+    def method_decorated_with_parentheses(
+        self, particle: ParticleLike
+    ) -> Union[Particle, CustomParticle, ParticleList]:
         return particle  # type: ignore[return-value]
 
 
@@ -231,7 +235,9 @@ def test_optional_particle() -> None:
     particle = "He"
 
     @particle_input
-    def has_default_particle(particle: ParticleLike = particle) -> Particle:
+    def has_default_particle(
+        particle: ParticleLike = particle,
+    ) -> Union[Particle, CustomParticle, ParticleList]:
         return particle  # type: ignore[return-value]
 
     assert has_default_particle() == Particle(particle)
@@ -294,7 +300,9 @@ def test_decorator_categories(
     """
 
     @particle_input(**categorization)  # type: ignore[arg-type]
-    def decorated_function(argument: ParticleLike) -> Particle:
+    def decorated_function(
+        argument: ParticleLike,
+    ) -> Union[Particle, CustomParticle, ParticleList]:
         return argument  # type: ignore[return-value]
 
     if exception:
@@ -389,7 +397,9 @@ def test_annotated_classmethod() -> None:
     class HasAnnotatedClassMethod:
         @classmethod
         @particle_input
-        def f(cls, particle: ParticleLike) -> Particle:
+        def f(
+            cls, particle: ParticleLike
+        ) -> Union[Particle, CustomParticle, ParticleList]:
             return particle  # type: ignore[return-value]
 
     has_annotated_classmethod = HasAnnotatedClassMethod()
@@ -405,7 +415,9 @@ def test_self_stacked_decorator(
 
     @outer_decorator
     @inner_decorator
-    def f(x: Any, particle: ParticleLike) -> Particle:
+    def f(
+        x: Any, particle: ParticleLike
+    ) -> Union[Particle, CustomParticle, ParticleList]:
         return particle  # type: ignore[return-value]
 
     result = f(1, "p+")
@@ -518,7 +530,7 @@ def test_particle_input_verification(
     """Test the allow_custom_particles keyword argument to particle_input."""
 
     @particle_input(**kwargs_to_particle_input)
-    def f(particle: ParticleLike) -> Particle:
+    def f(particle: ParticleLike) -> Union[Particle, CustomParticle, ParticleList]:
         return particle  # type: ignore[return-value]
 
     with pytest.raises(ParticleError):
@@ -550,17 +562,19 @@ class ParameterNamesCase:
 
 
 @particle_input
-def get_element(element: ParticleLike) -> Particle:
+def get_element(element: ParticleLike) -> Union[Particle, CustomParticle, ParticleList]:
     return element  # type: ignore[return-value]
 
 
 @particle_input
-def get_isotope(isotope: ParticleLike) -> Particle:
+def get_isotope(isotope: ParticleLike) -> Union[Particle, CustomParticle, ParticleList]:
     return isotope  # type: ignore[return-value]
 
 
 @particle_input
-def get_ion(ion: ParticleLike, Z: Optional[float] = None) -> Particle:
+def get_ion(
+    ion: ParticleLike, Z: Optional[float] = None
+) -> Union[Particle, CustomParticle, ParticleList]:
     return ion  # type: ignore[return-value]
 
 
@@ -668,7 +682,7 @@ def test_creating_mean_particle_for_parameter_named_ion() -> None:
 @particle_input
 def return_particle(
     particle: ParticleLike, Z: Optional[float] = None, mass_numb: Optional[int] = None
-) -> Particle:
+) -> Union[Particle, CustomParticle, ParticleList]:
     """A simple function that is decorated by particle_input."""
     return particle  # type: ignore[return-value]
 

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -5,8 +5,8 @@ import astropy.units as u
 import inspect
 import pytest
 
-from collections.abc import Iterable
-from typing import Any, Callable, Optional, Union
+from collections.abc import Callable, Iterable
+from typing import Any, Optional, Union
 
 from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.exceptions import (

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -1,12 +1,13 @@
+"""Tests for `plasmapy.particles.decorators`."""
+
 import astropy.constants as const
 import astropy.units as u
 import inspect
 import pytest
 
-from numbers import Real
-from typing import Optional
+from collections.abc import Iterable
+from typing import Any, Callable, Optional, Union
 
-from plasmapy.particles import ParticleList
 from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.exceptions import (
     ChargeError,
@@ -17,6 +18,7 @@ from plasmapy.particles.exceptions import (
     ParticleError,
 )
 from plasmapy.particles.particle_class import CustomParticle, Particle, ParticleLike
+from plasmapy.particles.particle_collections import ParticleList
 from plasmapy.utils.code_repr import call_string
 from plasmapy.utils.decorators.validators import validate_quantities
 from plasmapy.utils.exceptions import PlasmaPyDeprecationWarning
@@ -24,10 +26,10 @@ from plasmapy.utils.exceptions import PlasmaPyDeprecationWarning
 
 @particle_input
 def function_decorated_with_particle_input(
-    a,
+    a: Any,
     particle: ParticleLike,
-    b=None,
-    Z: Optional[int] = None,
+    b: Any = None,
+    Z: Optional[float] = None,
     mass_numb: Optional[int] = None,
 ) -> Particle:
     """
@@ -48,10 +50,10 @@ def function_decorated_with_particle_input(
 
 @particle_input()
 def function_decorated_with_call_of_particle_input(
-    a,
+    a: Any,
     particle: ParticleLike,
-    b=None,
-    Z: Optional[int] = None,
+    b: Any = None,
+    Z: Optional[float] = None,
     mass_numb: Optional[int] = None,
 ) -> Particle:
     """
@@ -70,7 +72,9 @@ def function_decorated_with_call_of_particle_input(
     return particle
 
 
-particle_input_simple_table = [
+particle_input_simple_table: list[
+    tuple[tuple[Union[int, str], ...], dict[str, Any], str]
+] = [
     ((1, "p+"), {"b": 2}, "p+"),
     ((1, "Fe"), {"mass_numb": 56, "Z": 3}, "Fe-56 3+"),
     ((1,), {"particle": "e-"}, "e-"),
@@ -86,7 +90,12 @@ particle_input_simple_table = [
     ],
 )
 @pytest.mark.parametrize(("args", "kwargs", "symbol"), particle_input_simple_table)
-def test_particle_input_simple(func, args, kwargs, symbol) -> None:
+def test_particle_input_simple(
+    func: Callable[..., Any],
+    args: tuple[Union[int, str], ...],
+    kwargs: dict[str, Any],
+    symbol: str,
+) -> None:
     """
     Test that simple functions decorated by particle_input correctly
     return the correct Particle object.
@@ -127,7 +136,9 @@ particle_input_error_table = [
 @pytest.mark.parametrize(
     ("func", "kwargs", "expected_error"), particle_input_error_table
 )
-def test_particle_input_errors(func, kwargs, expected_error) -> None:
+def test_particle_input_errors(
+    func: Callable[..., Any], kwargs: dict[str, Any], expected_error: type
+) -> None:
     """
     Test that functions decorated with `@particle_input` raise the
     expected errors.
@@ -145,15 +156,16 @@ class ClassWithDecoratedMethods:
 
     @particle_input
     def method_decorated_with_no_parentheses(self, particle: ParticleLike) -> Particle:
-        return particle
+        # Because run-time logic is needed, mypy will assume that
+        return particle  # type: ignore[return-value]
 
     @particle_input()
     def method_decorated_with_parentheses(self, particle: ParticleLike) -> Particle:
-        return particle
+        return particle  # type: ignore[return-value]
 
 
 @pytest.mark.parametrize("symbol", ["muon", "He 2+"])
-def test_particle_input_classes(symbol) -> None:
+def test_particle_input_classes(symbol: str) -> None:
     """Test that @particle_input works for instance methods."""
     expected = Particle(symbol)
     instance = ClassWithDecoratedMethods()
@@ -183,7 +195,10 @@ def test_no_annotations_exception() -> None:
 
 @particle_input
 def ambiguous_keywords(
-    p1: ParticleLike, p2: ParticleLike, Z=None, mass_numb=None
+    p1: ParticleLike,
+    p2: ParticleLike,
+    Z: Optional[float] = None,
+    mass_numb: Optional[int] = None,
 ) -> None:
     """
     A trivial function with two annotated arguments plus the keyword
@@ -199,7 +214,7 @@ ambiguous_arguments = [
 
 
 @pytest.mark.parametrize(("args", "kwargs"), ambiguous_arguments)
-def test_function_with_ambiguity(args, kwargs) -> None:
+def test_function_with_ambiguity(args: tuple[str, ...], kwargs: dict[str, int]) -> None:
     """
     Test that a function decorated with particle_input that has two
     annotated arguments along with `Z` and `mass_numb` raises an
@@ -214,8 +229,8 @@ def test_optional_particle() -> None:
     particle = "He"
 
     @particle_input
-    def has_default_particle(particle: ParticleLike = particle):
-        return particle
+    def has_default_particle(particle: ParticleLike = particle) -> Particle:
+        return particle  # type: ignore[return-value]
 
     assert has_default_particle() == Particle(particle)
     assert has_default_particle("Ne") == Particle("Ne")
@@ -264,7 +279,11 @@ categorization_particle_exception = [
 @pytest.mark.parametrize(
     ("categorization", "particle", "exception"), categorization_particle_exception
 )
-def test_decorator_categories(categorization, particle, exception) -> None:
+def test_decorator_categories(
+    categorization: dict[str, Union[str, Iterable[str]]],
+    particle: ParticleLike,
+    exception: type,
+) -> None:
     """
     Test that the ``require``, ``any_of``, and ``exclude`` categories
     lead to a |ParticleError| being raised when an inputted particle
@@ -272,9 +291,9 @@ def test_decorator_categories(categorization, particle, exception) -> None:
     to a |ParticleError| when the inputted particle matches the criteria.
     """
 
-    @particle_input(**categorization)
+    @particle_input(**categorization)  # type: ignore[arg-type]
     def decorated_function(argument: ParticleLike) -> Particle:
-        return argument
+        return argument  # type: ignore[return-value]
 
     if exception:
         with pytest.raises(exception):
@@ -296,7 +315,7 @@ def test_optional_particle_annotation_parameter() -> None:
 
     @particle_input
     def func_optional_particle(particle: Optional[ParticleLike]) -> Optional[Particle]:
-        return particle
+        return particle  # type: ignore[return-value]
 
     assert func_optional_particle(None) is None, (
         "The particle keyword in the particle_input decorator is set "
@@ -305,20 +324,24 @@ def test_optional_particle_annotation_parameter() -> None:
     )
 
 
-def undecorated_function(particle: ParticleLike, distance: u.Quantity[u.m]):
+def undecorated_function(
+    particle: ParticleLike, distance: u.Quantity[u.m]
+) -> tuple[ParticleLike, u.Quantity[u.m]]:
     return particle, distance
 
 
 decorator_pairs = [
     (particle_input, validate_quantities),
     (particle_input(), validate_quantities),
-    (particle_input, validate_quantities()),
-    (particle_input(), validate_quantities()),
+    (particle_input, validate_quantities()),  # type: ignore[no-untyped-call]
+    (particle_input(), validate_quantities()),  # type: ignore[no-untyped-call]
 ]
 
 
 @pytest.mark.parametrize(("decorator1", "decorator2"), decorator_pairs)
-def test_stacking_decorators(decorator1, decorator2) -> None:
+def test_stacking_decorators(
+    decorator1: Callable[..., Any], decorator2: Callable[..., Any]
+) -> None:
     """
     Test that particle_input and validate_quantities can be stacked in
     either order with or without parentheses.
@@ -338,7 +361,9 @@ def test_stacking_decorators(decorator1, decorator2) -> None:
 
 
 @pytest.mark.parametrize(("decorator1", "decorator2"), decorator_pairs)
-def test_preserving_signature_with_stacked_decorators(decorator1, decorator2) -> None:
+def test_preserving_signature_with_stacked_decorators(
+    decorator1: Callable[..., Any], decorator2: Callable[..., Any]
+) -> None:
     """
     Test that |particle_input| & |validate_quantities| preserve the
     function signature after being stacked.
@@ -363,7 +388,7 @@ def test_annotated_classmethod() -> None:
         @classmethod
         @particle_input
         def f(cls, particle: ParticleLike) -> Particle:
-            return particle
+            return particle  # type: ignore[return-value]
 
     has_annotated_classmethod = HasAnnotatedClassMethod()
     assert has_annotated_classmethod.f("p+") == Particle("p+")
@@ -371,13 +396,15 @@ def test_annotated_classmethod() -> None:
 
 @pytest.mark.parametrize("outer_decorator", [particle_input, particle_input()])
 @pytest.mark.parametrize("inner_decorator", [particle_input, particle_input()])
-def test_self_stacked_decorator(outer_decorator, inner_decorator) -> None:
+def test_self_stacked_decorator(
+    outer_decorator: Callable[..., Any], inner_decorator: Callable[..., Any]
+) -> None:
     """Test that particle_input can be stacked with itself."""
 
     @outer_decorator
     @inner_decorator
-    def f(x, particle: ParticleLike):
-        return particle
+    def f(x: Any, particle: ParticleLike) -> Particle:
+        return particle  # type: ignore[return-value]
 
     result = f(1, "p+")
     assert result == "p+"
@@ -386,7 +413,9 @@ def test_self_stacked_decorator(outer_decorator, inner_decorator) -> None:
 
 @pytest.mark.parametrize("outer_decorator", [particle_input, particle_input()])
 @pytest.mark.parametrize("inner_decorator", [particle_input, particle_input()])
-def test_class_stacked_decorator(outer_decorator, inner_decorator) -> None:
+def test_class_stacked_decorator(
+    outer_decorator: Callable[..., Any], inner_decorator: Callable[..., Any]
+) -> None:
     """
     Test that particle_input can be stacked with itself for an
     instance method.
@@ -403,7 +432,7 @@ def test_class_stacked_decorator(outer_decorator, inner_decorator) -> None:
     assert isinstance(result.particle, Particle)
 
 
-validate_quantities_ = validate_quantities(
+validate_quantities_ = validate_quantities(  # type: ignore[no-untyped-call]
     T_e={"equivalencies": u.temperature_energy()}
 )
 
@@ -413,7 +442,7 @@ def test_annotated_init() -> None:
 
     class HasAnnotatedInit:
         @particle_input(require="element")
-        def __init__(self, particle: ParticleLike, ionic_fractions=None) -> None:
+        def __init__(self, particle: ParticleLike, ionic_fractions: Any = None) -> None:
             self.particle = particle
 
     x = HasAnnotatedInit("H-1", ionic_fractions=32)
@@ -444,7 +473,8 @@ def test_annotated_init() -> None:
     ],
 )
 def test_particle_input_with_validate_quantities(
-    outer_decorator, inner_decorator
+    outer_decorator: Callable[..., Any],
+    inner_decorator: Callable[..., Any],
 ) -> None:
     """Test that particle_input can be stacked with validate_quantities."""
 
@@ -480,12 +510,14 @@ kwargs_to_decorator_and_args = [
 @pytest.mark.parametrize(
     ("kwargs_to_particle_input", "arg"), kwargs_to_decorator_and_args
 )
-def test_particle_input_verification(kwargs_to_particle_input, arg) -> None:
+def test_particle_input_verification(
+    kwargs_to_particle_input: dict[str, Any], arg: Any
+) -> None:
     """Test the allow_custom_particles keyword argument to particle_input."""
 
     @particle_input(**kwargs_to_particle_input)
-    def f(particle: ParticleLike):
-        return particle
+    def f(particle: ParticleLike) -> Particle:
+        return particle  # type: ignore[return-value]
 
     with pytest.raises(ParticleError):
         f(arg)
@@ -499,11 +531,11 @@ class ParameterNamesCase:
 
     def __init__(
         self,
-        category,
-        function,
-        particles_in_category,
-        particles_not_in_category,
-        exception,
+        category: str,
+        function: Callable[..., Any],
+        particles_in_category: list[ParticleLike],
+        particles_not_in_category: list[ParticleLike],
+        exception: type,
     ) -> None:
         self.category = category
         self.function = function
@@ -516,18 +548,18 @@ class ParameterNamesCase:
 
 
 @particle_input
-def get_element(element: ParticleLike):
-    return element
+def get_element(element: ParticleLike) -> Particle:
+    return element  # type: ignore[return-value]
 
 
 @particle_input
-def get_isotope(isotope: ParticleLike):
-    return isotope
+def get_isotope(isotope: ParticleLike) -> Particle:
+    return isotope  # type: ignore[return-value]
 
 
 @particle_input
-def get_ion(ion: ParticleLike, Z: Optional[Real] = None):
-    return ion
+def get_ion(ion: ParticleLike, Z: Optional[float] = None) -> Particle:
+    return ion  # type: ignore[return-value]
 
 
 cases = [
@@ -564,7 +596,9 @@ class TestParticleInputParameterNames:
     categories.
     """
 
-    def test_individual_particles_not_in_category(self, case) -> None:
+    def test_individual_particles_not_in_category(
+        self, case: ParameterNamesCase
+    ) -> None:
         """
         Test that the appropriate exception is raised when the function
         is provided with individual particles that are not in the
@@ -574,7 +608,7 @@ class TestParticleInputParameterNames:
             with pytest.raises(case.exception):
                 case.function(particle)
 
-    def test_particle_list_not_in_category(self, case) -> None:
+    def test_particle_list_not_in_category(self, case: ParameterNamesCase) -> None:
         """
         Test that the appropriate exception is raised when the function
         is provided with multiple particles at once that are all not in
@@ -583,7 +617,7 @@ class TestParticleInputParameterNames:
         with pytest.raises(case.exception):
             case.function(case.particles_not_in_category)
 
-    def test_particle_list_some_in_category(self, case) -> None:
+    def test_particle_list_some_in_category(self, case: ParameterNamesCase) -> None:
         """
         Test that the appropriate exception is raised when the function
         is provided with multiple particles at once, of which some are
@@ -595,7 +629,9 @@ class TestParticleInputParameterNames:
     # If "ionic_level" gets added as a particle category, then add
     # assertions to the following test using is_category.
 
-    def test_individual_particles_all_in_category(self, case) -> None:
+    def test_individual_particles_all_in_category(
+        self, case: ParameterNamesCase
+    ) -> None:
         """
         Test that no exception is raised when the function is provided
         with individual particles that are all in the category.
@@ -603,7 +639,7 @@ class TestParticleInputParameterNames:
         for particle in case.particles_in_category:
             case.function(particle)
 
-    def test_particle_list_all_in_category(self, case) -> None:
+    def test_particle_list_all_in_category(self, case: ParameterNamesCase) -> None:
         """
         Test that no exception is raised when the function is provided
         with multiple particles at once which are all in the category.
@@ -628,9 +664,11 @@ def test_creating_mean_particle_for_parameter_named_ion() -> None:
 
 
 @particle_input
-def return_particle(particle: ParticleLike, Z=None, mass_numb=None):
+def return_particle(
+    particle: ParticleLike, Z: Optional[float] = None, mass_numb: Optional[int] = None
+) -> Particle:
     """A simple function that is decorated by particle_input."""
-    return particle
+    return particle  # type: ignore[return-value]
 
 
 def test_particle_input_warning_for_integer_z_mean() -> None:
@@ -667,8 +705,10 @@ def test_particle_input_with_var_positional_arguments() -> None:
     """
 
     @particle_input
-    def function_with_var_positional_arguments(*args, particle: ParticleLike = None):
-        return args, particle
+    def function_with_var_positional_arguments(
+        *args: Any, particle: ParticleLike = None
+    ) -> tuple[tuple[Any], Particle]:
+        return args, particle  # type: ignore[return-value]
 
     args = (5, 6, 7)
     particle = "p+"
@@ -688,9 +728,9 @@ def test_particle_input_with_pos_and_var_positional_arguments() -> None:
 
     @particle_input
     def function_with_pos_and_var_positional_arguments(
-        a, *args, particle: ParticleLike = None
-    ):
-        return args, particle
+        a: Any, *args: Any, particle: ParticleLike = None
+    ) -> tuple[tuple[Any, ...], Particle]:
+        return args, particle  # type: ignore[return-value]
 
     a = 1
     args = (5, 6, 7)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

This PR adds & improves type hint annotations in `plasmapy.particles.decorators` which is where `@particle_input` is defined, along with the tests.

There are some `# type: ignore[...]` statements for errors due to mypy's limitation as a static (rather than dynamic) type checker. We'll probably need to add that to the contributor guide.  

## Motivation and context

See #2434.  



## Related issues

This PR is a spinoff of #2429, and the motivation for #2442.  Closes #2434.