### PR TITLE
Use autotyping on return values

### DIFF
--- a/plasmapy/analysis/nullpoint.py
+++ b/plasmapy/analysis/nullpoint.py
@@ -687,7 +687,7 @@ def _trilinear_analysis(vspace, cell):  # noqa: C901, PLR0915
     ByBzEndpoints = []
 
     # Check if the null point already exists in root list
-    def is_root_in_list(root, arr):
+    def is_root_in_list(root, arr) -> bool:
         for r in arr:
             x_close = np.isclose(root[0], r[0], atol=_EQUALITY_ATOL)
             y_close = np.isclose(root[1], r[1], atol=_EQUALITY_ATOL)

--- a/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -999,7 +999,7 @@ class Tracker:
         """
         return np.sum(self.on_grid, axis=-1) > 0
 
-    def _stop_condition(self):
+    def _stop_condition(self) -> bool:
         r"""
         The stop condition is that most of the particles have entered the grid
         and almost all have now left it.

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -334,7 +334,7 @@ class IonizationStateCollection:
     def __iter__(self):
         yield from [self[key] for key in self.ionic_fractions]
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, IonizationStateCollection):
             return False
 

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -97,7 +97,7 @@ class AbstractGrid(ABC):
                 f"positional arguments but {len(seeds)} were given"
             )
 
-    def _validate(self):
+    def _validate(self) -> bool:
         r"""
         Checks to make sure that the grid parameters are
         consistent with the coordinate system and units selected.

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -82,7 +82,7 @@ class HDF5Reader(GenericPlasma):
     ):
         self.h5.close()
 
-    def _check_valid_openpmd_version(self):
+    def _check_valid_openpmd_version(self) -> bool:
         try:
             openPMD_version = self.h5.attrs["openPMD"].decode("utf-8")
             if _valid_version(openPMD_version):

--- a/plasmapy/plasma/sources/plasmablob.py
+++ b/plasmapy/plasma/sources/plasmablob.py
@@ -143,5 +143,5 @@ class PlasmaBlob(GenericPlasma):
         return quantum_theta(self.T_e, self.n_e)
 
     @classmethod
-    def is_datasource_for(cls, **kwargs):
+    def is_datasource_for(cls, **kwargs) -> bool:
         return "T_e" in kwargs and "n_e" in kwargs

--- a/plasmapy/plasma/tests/test_plasma_base.py
+++ b/plasmapy/plasma/tests/test_plasma_base.py
@@ -10,13 +10,13 @@ class NoDataSource(BasePlasma):
 
 class IsDataSource(BasePlasma):
     @classmethod
-    def is_datasource_for(cls, **kwargs):
+    def is_datasource_for(cls, **kwargs) -> bool:
         return True
 
 
 class IsNotDataSource(BasePlasma):
     @classmethod
-    def is_datasource_for(cls, **kwargs):
+    def is_datasource_for(cls, **kwargs) -> bool:
         return False
 
 

--- a/plasmapy/utils/_pytest_helpers/tests/test_pytest_helpers.py
+++ b/plasmapy/utils/_pytest_helpers/tests/test_pytest_helpers.py
@@ -35,7 +35,7 @@ def issue_warning(*args, **kwargs) -> int:
     return 42
 
 
-def adams_number(*args, **kwargs):
+def adams_number(*args, **kwargs) -> int:
     return 42
 
 

--- a/plasmapy/utils/calculator/widget_helpers.py
+++ b/plasmapy/utils/calculator/widget_helpers.py
@@ -137,7 +137,7 @@ class _GenericWidget(abc.ABC):
             Value of the widget
         """
 
-    def edge_case_condition(self, value):  # noqa: ARG002
+    def edge_case_condition(self, value) -> bool:  # noqa: ARG002
         """
         Edge case condition for the widget.
 
@@ -604,7 +604,7 @@ def _handle_clear_click(event) -> None:
         fn.output_widget.clear_output()
 
 
-def _colored_text(color, text):
+def _colored_text(color, text) -> str:
     """
     Prepares an inline string with the given color.
 

--- a/plasmapy/utils/decorators/tests/test_lite_func.py
+++ b/plasmapy/utils/decorators/tests/test_lite_func.py
@@ -20,7 +20,7 @@ def foo_lite(x):
     return x
 
 
-def bar():
+def bar() -> str:
     """
     Test support function for the Lite-Function framework.  To be bound
     to foo.

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -564,29 +564,29 @@ class TestValidateClassAttributes:
 
         @property
         @validate_class_attributes(expected_attributes=["x"])
-        def require_x(self):
+        def require_x(self) -> int:
             return 0
 
         @property
         @validate_class_attributes(expected_attributes=["x", "y"])
-        def require_x_and_y(self):
+        def require_x_and_y(self) -> int:
             return 0
 
         @property
         @validate_class_attributes(both_or_either_attributes=[("x", "y")])
-        def require_x_or_y(self):
+        def require_x_or_y(self) -> int:
             return 0
 
         @property
         @validate_class_attributes(
             expected_attributes=["x"], both_or_either_attributes=[("y", "z")]
         )
-        def require_x_and_either_y_or_z(self):
+        def require_x_and_either_y_or_z(self) -> int:
             return 0
 
         @property
         @validate_class_attributes(mutually_exclusive_attributes=[("x", "y")])
-        def require_only_either_x_or_y(self):
+        def require_only_either_x_or_y(self) -> int:
             return 0
 
     @pytest.mark.parametrize(

--- a/plasmapy/utils/tests/test_code_repr.py
+++ b/plasmapy/utils/tests/test_code_repr.py
@@ -24,7 +24,7 @@ def generic_function(*args, **kwargs):
     return None
 
 
-def adams_number():
+def adams_number() -> int:
     return 42
 
 


### PR DESCRIPTION
This is another in a series of PRs that use autotyping to automatically add type hints. This one is using the `--scalar-return` flag.
