### PR TITLE
Specify a version for Ruby in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_schedule: monthly
 
 default_language_version:
-  ruby: 3.3.0
+  ruby: 2.7.2
 
 repos:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,9 @@ ci:
   autofix_prs: false
   autoupdate_schedule: monthly
 
+default_language_version:
+  ruby: 3.3.0
+
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ ci:
   autofix_prs: false
   autoupdate_schedule: monthly
 
+# Specify the default version of Ruby in case it is not installed
 default_language_version:
   ruby: 2.7.2
 


### PR DESCRIPTION
@pheuer and @JaydenR2305 recently ran into a problem in #2245 where pre-commit complained that it couldn't find the Ruby executable which was needed by a particular pre-commit hook.  I happened across https://github.com/pre-commit/pre-commit/issues/1930 that says that we can bypass this problem by specifying the version of Ruby that pre-commit should use.  Non-intuitive but helpful to know!