### PR TITLE
Fix path in GitHub Action for creating issue with release checklist

### DIFF
--- a/.github/workflows/create-release-issue.yml
+++ b/.github/workflows/create-release-issue.yml
@@ -19,5 +19,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        checklist=$(sed "s/%VERSION%/${{ github.event.inputs.version }}/g" .github/markdown/release-checklist.md)
+        checklist=$(sed "s/%VERSION%/${{ github.event.inputs.version }}/g" .github/content/release-checklist.md)
         gh issue create --title "Release ${{ github.event.inputs.version }}" --body "$checklist" --label "release"


### PR DESCRIPTION
The GitHub Action to create an issue with a release checklist failed when I ran it because I had forgotten to update the file path.  This PR makes that correction.