### PR TITLE
ci: run hyperlink checking with quiet mode flag enabled

### DIFF
--- a/.github/workflows/check-hyperlinks.yml
+++ b/.github/workflows/check-hyperlinks.yml
@@ -28,4 +28,4 @@ jobs:
       run: sudo apt-get install graphviz pandoc
 
     - name: Check hyperlinks
-      run: tox -e build_docs_linkcheck
+      run: tox -e build_docs_linkcheck -- -q

--- a/changelog/2476.trivial.rst
+++ b/changelog/2476.trivial.rst
@@ -1,0 +1,1 @@
+Check hyperlinks: run the ``sphinx`` linkchecker in quiet mode to make it easier to find problem links from the console output.

--- a/changelog/2476.trivial.rst
+++ b/changelog/2476.trivial.rst
@@ -1,1 +1,1 @@
-Check hyperlinks: run the ``sphinx`` linkchecker in quiet mode to make it easier to find problem links from the console output.
+Enabled the ``sphinx`` linkchecker in quiet mode to make it easier to find problem links from the console output.


### PR DESCRIPTION
## Description
The [Sphinx linkcheck builder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder) supports a [`-q / --quiet` flag](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-q) that reduces output verbosity while continuing to output warnings and errors.

This change enables the flag for the scheduled [`Check hyperlinks` GitHub Actions worklow](https://github.com/PlasmaPy/PlasmaPy/blob/46f59fc2d2d4d14cf3c6367adbe1d903472fd3f0/.github/workflows/check-hyperlinks.yml).

## Motivation and context
For projects like this one that feature large numbers of healthy hyperlinks, the default linkchecker output to stdout can be overly verbose, with broken/problem hyperlink reports interspersed among many reports of healthy links, making it hard to collect and find the set of problems to fix.

> [!NOTE]
> The `linkcheck` builder emits a warning when it encounters an HTTP redirect that doesn't match an entry within the [`linkcheck_allowed_redirects` patterns](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_allowed_redirects) - `PlasmaPy` has a few of these at the moment - mostly related to GitHub users.  Although allowing valid redirects is generally good practice, it is possible to ignore (skip) checking for link patterns by using [`linkcheck_ignore`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_ignore) if necessary.

## Related issues
N/A