### PR TITLE
Add new hyperlink redirects and add links to docstring of documentation configuration file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -416,7 +416,7 @@ authors:
   family-names: Rajashekar
   affiliation: PES University
   orcid: https://orcid.org/0000-0002-4914-6612
-  alias: DarkAEther
+  alias: vrajashkr
 
 - given-names: Afzal
   family-names: Rao

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -443,7 +443,6 @@ linkcheck_ignore = [
     r"https://hdl\.handle\.net/10037/29416",
     r"https://www\.iter\.org/",
     r"https://www\.sciencedirect\.com/book/9780123748775/.*",
-    r"https://github.com/sponsors/DarkAEther",
 ]
 
 # nbsphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,20 @@
-"""The configuration file for building PlasmaPy's documentation."""
+"""
+The configuration file for building PlasmaPy's documentation.
+
+For more information, please see the following links:
+
+PlasmaPy documentation guide:
+    https://docs.plasmapy.org/en/latest/contributing/doc_guide.html
+
+Sphinx documentation:
+    https://www.sphinx-doc.org
+
+Sphinx configuration variables:
+    https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+Sphinx extensions (built-in):
+    https://www.sphinx-doc.org/en/master/usage/extensions/index.html
+"""
 
 #!/usr/bin/env python3
 
@@ -328,6 +344,7 @@ linkcheck_allowed_redirects = {
     r"https://docs.+\.io": r"https://docs.+\.io/en/.+",
     r"https://docs.+\.com": r"https://docs.+\.com/en/.+",
     r"https://docs.+\.dev": r"https://docs.+\.dev/en/.+",
+    r"https://github\.com/sponsors/.+": r"https://github\.com/.+",
     r"https://en.wikipedia.org/wiki.+": "https://en.wikipedia.org/wiki.+",
     r"https://.+\.readthedocs\.io": r"https://.+\.readthedocs\.io/en/.+",
     r"https://www\.sphinx-doc\.org": r"https://www\.sphinx-doc\.org/en/.+",
@@ -426,7 +443,7 @@ linkcheck_ignore = [
     r"https://hdl\.handle\.net/10037/29416",
     r"https://www\.iter\.org/",
     r"https://www\.sciencedirect\.com/book/9780123748775/.*",
-    r"https://github.com/DarkAEther",  # author profile not found (HTTP 404)
+    r"https://github.com/sponsors/DarkAEther",
 ]
 
 # nbsphinx


### PR DESCRIPTION
There was an update in `sphinx-issues` which set the default for the `:user:` role to point to `github.com/sponsors/username` instead of `github.com/username` (https://github.com/sloria/sphinx-issues/issues/129, https://github.com/sloria/sphinx-issues/pull/131). This led to a number of redirects to show up when we did a linkcheck build, so I added a line to `docs/conf.py` to specify that these redirects should be allowed when doing a linkcheck.  

I added some links to the docstring for `docs/conf.py` that point to helpful locations like our documentation guide and Sphinx's documentation.

I also updated the GitHub username of a past contributor.