### PR TITLE
Revise testing environment for performing linkchecks of documentation builds

### DIFF
--- a/.github/workflows/check-hyperlinks.yml
+++ b/.github/workflows/check-hyperlinks.yml
@@ -28,4 +28,4 @@ jobs:
       run: sudo apt-get install graphviz pandoc
 
     - name: Check hyperlinks
-      run: tox -e build_docs_linkcheck -- -q
+      run: tox -e linkcheck

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -1251,6 +1251,12 @@ You can alternatively shorten the documentation build by running:
 This command will build the documentation without executing the
 :ref:`example notebooks <example_notebooks>`.
 
+To check hyperlinks, run:
+
+.. code-block:: bash
+
+   tox -e linkcheck
+
 .. tip::
 
    When writing documentation, please make sure to fix any warnings that

--- a/tox.ini
+++ b/tox.ini
@@ -63,14 +63,13 @@ commands =
     echo "Troubleshooting guide: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting"
 deps = -r{toxinidir}/requirements.txt
 
-[testenv:build_docs_linkcheck]
+[testenv:linkcheck]
 changedir = {toxinidir}
 setenv =
     HOME = {envtmpdir}
     PYDEVD_DISABLE_FILE_VALIDATION=1
 commands =
-    sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b linkcheck {posargs}
-    cat docs/_build/html/output.txt
+    sphinx-build docs docs{/}_build{/}html -W -n -q --keep-going -b linkcheck {posargs}
 deps = -r{toxinidir}/requirements.txt
 
 [testenv:build_docs-sphinxdev]


### PR DESCRIPTION
 - I renamed the `tox` environment from `build_docs_linkcheck` to `linkcheck` since that's what I kept trying to use.
 - I moved the (incredibly helpful!) `-q` flag from the GitHub Action to the `tox` environment. This way, it is in place when we run linkcheck through `tox` locally. The new setup makes it so that only errors and warnings show up in the output of doing `tox -e linkcheck`.
 - I updated the documentation guide to mention `tox -e linkcheck`.