### PR TITLE
Specify version of `black` in `pre-commit` hook for `blacken-docs` 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,8 @@ repos:
   - id: blacken-docs
     name: autoformat code blocks in docs
     exclude: docs/contributing/coding_guide.rst
+    additional_dependencies:
+    - black==24.1.0
 
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.7.1

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -744,8 +744,7 @@ def particle_input(
           class SomeClass:
               @particle_input
               @validate_quantities
-              def instance_method(self, particle: ParticleLike, B: u.Quantity[u.T]):
-                  ...
+              def instance_method(self, particle: ParticleLike, B: u.Quantity[u.T]): ...
 
     .. note::
 


### PR DESCRIPTION
While we mostly switched over to the `ruff` formatter, we still use `black` via `blacken-docs` to autoformat code in documentation.  There was a breaking change in the most recent release, so this PR specifies the version of `black` used by `blacken-docs`.