### PR TITLE
Add setuptools as documentation build dependency for Python 3.12+

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.abspath("."))  # noqa: PTH100
 from datetime import datetime
 
 import _cff_to_rst
-import pkg_resources  # deprecated
+import pkg_resources  # deprecated; after removal, drop setuptools dependency for docs
 from _global_substitutions import global_substitutions
 from sphinx.application import Sphinx
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "pytest == 7.4.4",
   "requests >= 2.28.0",
   "scipy >= 1.8.0",
+  "setuptools >= 61.2.0",
   "tqdm >= 4.60.0",
   "voila >= 0.5.0",
   "wrapt >= 1.14.0",
@@ -64,6 +65,8 @@ docs = [
   "numpydoc >= 1.6.0",
   "pillow >= 10.2.0",
   "pygments >= 2.17.2",
+  # install setuptools to get pkg_resources for doc build
+  "setuptools; python_version >= '3.12'",
   "sphinx >= 7.2.6",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.0",


### PR DESCRIPTION
After switching our documentation build over to Python 3.12 in #2368, I found in the weekly tests that we need to declare `setuptools` as a dependency for Python 3.12+ so that we can use `pkg_resources` in `docs/conf.py`.  I'm adding this dependency for the time being, though later on we want to stop using `pkg_resources` (#1620).