### PR TITLE
Perform linkchecks when pull requests are accordingly labeled

### DIFF
--- a/.github/workflows/check-hyperlinks.yml
+++ b/.github/workflows/check-hyperlinks.yml
@@ -4,13 +4,16 @@ on:
   schedule:
   - cron: 37 7 * * 2
   workflow_dispatch:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+    branches:
+    - main
 
 jobs:
-
   linkcheck:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'perform linkchecks in CI')
     steps:
-
     - name: Checkout code
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/check-hyperlinks.yml
+++ b/.github/workflows/check-hyperlinks.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   linkcheck:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'perform linkchecks in CI')
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'perform linkcheck in CI')
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
This PR, brought to you partially by ChatGPT, makes it so that the workflow that checks hyperlinks will be performed on pull requests when they are provided with an appropriate label.