### PR TITLE
Temporarily require `sphinx == 7.2.6`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ docs = [
   "pygments >= 2.17.2",
   # install setuptools to get pkg_resources for doc build
   "setuptools; python_version >= '3.12'",
+  # see issue 2497
   "sphinx == 7.2.6",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ docs = [
   "pygments >= 2.17.2",
   # install setuptools to get pkg_resources for doc build
   "setuptools; python_version >= '3.12'",
-  "sphinx >= 7.2.6",
+  "sphinx == 7.2.6",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.0",
   "sphinx-copybutton >= 0.5.2",


### PR DESCRIPTION
Because of the new `ImportError` we're getting associated with `plasmapy_sphinx` for the development version of Sphinx, this PR temporarily hard codes the requirements of `sphinx == 7.2.6`.

For more information, see #2497.