### PR TITLE
Alphabetize authors in `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -59,10 +59,25 @@ authors:
   orcid: https://orcid.org/0000-0001-6849-3612
   alias: lemmatum
 
+- given-names: Elliot
+  family-names: Johnson
+  affiliation: University of Delaware
+  orcid: https://orcid.org/0000-0003-2892-6924
+  alias: ejohnson-96
+
 - given-names: Ritiek
   family-names: Malhotra
   affiliation: Chandigarh University
   alias: ritiek
+
+- given-names: James
+  family-names: Addison
+  alias: jayaddison
+
+- given-names: Ataf Fazledin
+  family-names: Ahamed
+  affiliation: OpenRefactory Inc.
+  alias: fazledyn-or
 
 - given-names: Christoper
   family-names: Arran
@@ -194,6 +209,11 @@ authors:
   orcid: https://orcid.org/0000-0001-5308-6870
   alias: bryancfoo
 
+- given-names: Heinz-Alexander
+  family-names: Fütterer
+  orcid: https://orcid.org/0000-0003-4397-027X
+  alias: afuetterer
+
 - given-names: Rajagopalan
   family-names: Gangadharan
   alias: RAJAGOPALAN-GANGADHARAN
@@ -214,6 +234,10 @@ authors:
   family-names: Guidoni
   orcid: https://orcid.org/0000-0003-1439-4218
   affiliation: American University
+
+- given-names: Julia
+  family-names: Guimiot
+  alias: JuliaGuimiot
 
 - given-names: Colby
   family-names: Haggerty
@@ -267,11 +291,10 @@ authors:
   orcid: https://orcid.org/0000-0003-2892-6924
   alias: jeandet
 
-- given-names: Elliot
-  family-names: Johnson
-  affiliation: University of Delaware
-  orcid: https://orcid.org/0000-0003-2892-6924
-  alias: ejohnson-96
+- given-names: Evan
+  family-names: Jones
+  orcid: https://orcid.org/0009-0004-6699-4869
+  alias: E-W-Jones
 
 - given-names: Marcin
   family-names: Kastek
@@ -280,6 +303,11 @@ authors:
 - given-names: James
   family-names: Kent
   alias: jdkent
+
+- given-names: Dusan
+  family-names: Klima
+  orcid: https://orcid.org/0009-0008-5134-6171
+  alias: ironwod
 
 - given-names: Siddharth
   family-names: Kulshrestha
@@ -377,6 +405,9 @@ authors:
 
 - alias: nrb1234
 
+- given-names: Oscar
+  alias: 0scvr
+
 - given-names: Mahima
   family-names: Pannala
   alias: mahimapannala
@@ -451,6 +482,10 @@ authors:
   orcid: https://orcid.org/0000-0002-5598-046X
   alias: savcheva
 
+- given-names: Cora
+  family-names: Schneck
+  alias: cyschneck
+
 - given-names: Chengcai
   family-names: Shen
   affiliation: Center for Astrophysics | Harvard & Smithsonian
@@ -493,6 +528,10 @@ authors:
   family-names: Skinner
   affiliation: Phoenix Security Labs
   alias: cskinner74
+
+- given-names: Tomasz Adam
+  family-names: Skrzypczak
+  alias: tomasz-adam-skrzypczak
 
 - given-names: Nikita
   family-names: Smirnov
@@ -567,42 +606,3 @@ authors:
 - given-names: Carol
   family-names: Zhang
   alias: carolyz
-
-- given-names: Cora
-  family-names: Schneck
-  alias: cyschneck
-
-- given-names: Julia
-  family-names: Guimiot
-  alias: JuliaGuimiot
-
-- given-names: Evan
-  family-names: Jones
-  orcid: https://orcid.org/0009-0004-6699-4869
-  alias: E-W-Jones
-
-- given-names: Oscar
-  alias: 0scvr
-
-- given-names: Ataf Fazledin
-  family-names: Ahamed
-  affiliation: OpenRefactory Inc.
-  alias: fazledyn-or
-
-- given-names: Tomasz Adam
-  family-names: Skrzypczak
-  alias: tomasz-adam-skrzypczak
-
-- given-names: Dusan
-  family-names: Klima
-  orcid: https://orcid.org/0009-0008-5134-6171
-  alias: ironwod
-
-- given-names: Heinz-Alexander
-  family-names: Fütterer
-  orcid: https://orcid.org/0000-0003-4397-027X
-  alias: afuetterer
-
-- given-names: James
-  family-names: Addison
-  alias: jayaddison


### PR DESCRIPTION
A quick PR to alphabetize the author list in `CITATION.cff` following the `v2024.2.0` release. This'll make it easier in the next release when adding new contributors to the author list on the Zenodo record.