### PR TITLE
Apply ruff rules `UP006` and `UP007`

### DIFF
--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -3,7 +3,6 @@
 import os
 import pathlib
 import sys
-from typing import Optional
 
 import requests
 
@@ -27,7 +26,7 @@ def get_pr_authors() -> set[str]:
     return authors - set(EXCLUDED_USERS)
 
 
-def check_citation_file(authors: set[str]) -> tuple[bool, Optional[str]]:
+def check_citation_file(authors: set[str]) -> tuple[bool, str | None]:
     """Verify that all authors of a PR are included in :file:`CITATION.cff`."""
     with pathlib.Path("CITATION.cff").open() as file:
         contents = file.read()

--- a/changelog/2504.trivial.rst
+++ b/changelog/2504.trivial.rst
@@ -1,0 +1,3 @@
+Changed type hint annotations to be consistent with :pep:`604`. Type
+unions are now made using the ``|`` operator rather than with
+`typing.Union`.

--- a/docs/_cff_to_rst.py
+++ b/docs/_cff_to_rst.py
@@ -3,7 +3,6 @@ Convert author information from :file:`CITATION.cff` into a
 reStructuredText-formatted list.
 """
 import pathlib
-from typing import Union
 
 import yaml
 from unidecode import unidecode
@@ -16,7 +15,7 @@ from unidecode import unidecode
 obsolete_github_usernames = {}
 
 
-def parse_cff(filename: str) -> dict[str, Union[str, list[dict[str, str]]]]:
+def parse_cff(filename: str) -> dict[str, str | list[dict[str, str]]]:
     """
     Parse a :file:`CITATION.cff` file into a dictionary.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = '3.10'
+python_version = 3.10
 mypy_path = ./type_stubs
 exclude = (?x)(
           docs|

--- a/plasmapy/analysis/fit_functions.py
+++ b/plasmapy/analysis/fit_functions.py
@@ -14,7 +14,6 @@ import numbers
 import warnings
 from abc import ABC, abstractmethod
 from collections import namedtuple
-from typing import Optional
 
 import numpy as np
 from scipy.optimize import curve_fit, fsolve
@@ -36,8 +35,8 @@ class AbstractFitFunction(ABC):
 
     def __init__(
         self,
-        params: Optional[tuple[float, ...]] = None,
-        param_errors: Optional[tuple[float, ...]] = None,
+        params: tuple[float, ...] | None = None,
+        param_errors: tuple[float, ...] | None = None,
     ) -> None:
         """
         Parameters
@@ -225,7 +224,7 @@ class AbstractFitFunction(ABC):
         return self._FitParamTuple
 
     @property
-    def params(self) -> Optional[tuple]:
+    def params(self) -> tuple | None:
         """The fitted parameters for the fit function."""
         if self._params is None:
             return self._params
@@ -247,7 +246,7 @@ class AbstractFitFunction(ABC):
             )
 
     @property
-    def param_errors(self) -> Optional[tuple]:
+    def param_errors(self) -> tuple | None:
         """The associated errors of the fitted :attr:`params`."""
         if self._param_errors is None:
             return self._param_errors
@@ -801,8 +800,8 @@ class ExponentialPlusLinear(AbstractFitFunction):
 
     def __init__(
         self,
-        params: Optional[tuple[float, ...]] = None,
-        param_errors: Optional[tuple[float, ...]] = None,
+        params: tuple[float, ...] | None = None,
+        param_errors: tuple[float, ...] | None = None,
     ) -> None:
         self._exponential = Exponential()
         self._linear = Linear()
@@ -939,8 +938,8 @@ class ExponentialPlusOffset(AbstractFitFunction):
 
     def __init__(
         self,
-        params: Optional[tuple[float, ...]] = None,
-        param_errors: Optional[tuple[float, ...]] = None,
+        params: tuple[float, ...] | None = None,
+        param_errors: tuple[float, ...] | None = None,
     ) -> None:
         self._explin = ExponentialPlusLinear()
         super().__init__(params=params, param_errors=param_errors)

--- a/plasmapy/analysis/swept_langmuir/floating_potential.py
+++ b/plasmapy/analysis/swept_langmuir/floating_potential.py
@@ -4,7 +4,7 @@ __aliases__ = ["find_vf_"]
 
 import numbers
 import warnings
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple
 
 import numpy as np
 
@@ -21,32 +21,32 @@ class VFExtras(NamedTuple):
     `~plasmapy.analysis.swept_langmuir.floating_potential.find_floating_potential`.
     """
 
-    vf_err: Optional[float]
+    vf_err: float | None
     """
     Alias for field number 0, the error in the calculated floating
     potential from the floating potential curve fit.
     """
 
-    rsq: Optional[float]
+    rsq: float | None
     """
     Alias for field number 1, the r-squared value of the ion-saturation
     curve fit.
     """
 
-    fitted_func: Optional[float]
+    fitted_func: float | None
     """
     Alias for field number 2, the :term:`fit-function` fitted during
     the floating potential curve fit.
     """
 
-    islands: Optional[list[slice]]
+    islands: list[slice] | None
     """
     Alias for field number 3, a list of `slice` objects representing
     the indices of the identified crossing-islands discovered during
     the floating potential curve fit.
     """
 
-    fitted_indices: Optional[slice]
+    fitted_indices: slice | None
     """
     Alias for field number 4, the indices used in the floating potential
     curve fit.
@@ -57,7 +57,7 @@ def find_floating_potential(  # noqa: C901, PLR0912, PLR0915
     voltage: np.ndarray,
     current: np.ndarray,
     threshold: int = 1,
-    min_points: Optional[Union[int, float]] = None,
+    min_points: float | None = None,
     fit_type: str = "exponential",
 ) -> tuple[np.floating, VFExtras]:
     """

--- a/plasmapy/analysis/swept_langmuir/ion_saturation_current.py
+++ b/plasmapy/analysis/swept_langmuir/ion_saturation_current.py
@@ -5,7 +5,7 @@ __all__ = ["find_ion_saturation_current", "ISatExtras"]
 __aliases__ = ["find_isat_"]
 
 import numbers
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 
 import numpy as np
 
@@ -21,19 +21,19 @@ class ISatExtras(NamedTuple):
     `~plasmapy.analysis.swept_langmuir.ion_saturation_current.find_ion_saturation_current`.
     """
 
-    rsq: Optional[float]
+    rsq: float | None
     """
     Alias for field number 0, the r-squared value of the ion-saturation
     curve fit.
     """
 
-    fitted_func: Optional[ffuncs.AbstractFitFunction]
+    fitted_func: ffuncs.AbstractFitFunction | None
     """
     Alias for field number 1, the :term:`fit-function` fitted during
     the ion-saturation curve fit.
     """
 
-    fitted_indices: Optional[slice]
+    fitted_indices: slice | None
     """
     Alias for field number 2, the indices used in the ion-saturation
     curve fit.
@@ -45,8 +45,8 @@ def find_ion_saturation_current(
     current: np.ndarray,
     *,
     fit_type: str = "exp_plus_linear",
-    current_bound: Optional[numbers.Real] = None,
-    voltage_bound: Optional[numbers.Real] = None,
+    current_bound: numbers.Real | None = None,
+    voltage_bound: numbers.Real | None = None,
 ) -> tuple[ffuncs.Linear, ISatExtras]:
     """
     Determines the ion-saturation current (:math:`I_{sat}`) for a given

--- a/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
@@ -8,7 +8,6 @@ __all__ = [
     "Layer",
 ]
 
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -62,7 +61,7 @@ class Layer:
         thickness: u.Quantity[u.m],
         energy_axis: u.Quantity[u.J],
         stopping_power: u.Quantity[u.J / u.m, u.J * u.m**2 / u.kg],
-        mass_density: Optional[u.Quantity[u.kg / u.m**3]] = None,
+        mass_density: u.Quantity[u.kg / u.m**3] | None = None,
         active: bool = True,
         name: str = "",
     ) -> None:

--- a/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -11,7 +11,6 @@ import collections
 import sys
 import warnings
 from collections.abc import Iterable
-from typing import Union
 
 import astropy.constants as const
 import astropy.units as u
@@ -125,7 +124,7 @@ class Tracker:
 
     def __init__(
         self,
-        grids: Union[AbstractGrid, Iterable[AbstractGrid]],
+        grids: AbstractGrid | Iterable[AbstractGrid],
         source: u.Quantity[u.m],
         detector: u.Quantity[u.m],
         detector_hdir=None,

--- a/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
+++ b/plasmapy/diagnostics/charged_particle_radiography/tests/test_synthetic_radiography.py
@@ -2,7 +2,6 @@
 Tests for proton radiography functions
 """
 
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -22,8 +21,8 @@ def _test_grid(  # noqa: C901, PLR0912
     B0: u.Quantity[u.T] = 10 * u.T,
     E0: u.Quantity[u.V / u.m] = 5e8 * u.V / u.m,
     phi0: u.Quantity[u.V] = 1.4e5 * u.V,
-    a: Optional[u.Quantity[u.m]] = None,
-    b: Optional[u.Quantity[u.m]] = None,
+    a: u.Quantity[u.m] | None = None,
+    b: u.Quantity[u.m] | None = None,
 ):
     r"""
     Generates grids representing some common physical scenarios for testing

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -12,7 +12,7 @@ __lite_funcs__ = ["spectral_density_lite"]
 import numbers
 import warnings
 from collections.abc import Callable
-from typing import Any, Optional, Union
+from typing import Any
 
 import astropy.constants as const
 import astropy.units as u
@@ -63,9 +63,9 @@ def spectral_density_lite(
     ion_vel: np.ndarray,
     probe_vec: np.ndarray,
     scatter_vec: np.ndarray,
-    instr_func_arr: Optional[np.ndarray] = None,
-    notch: Optional[np.ndarray] = None,
-) -> tuple[Union[np.floating, np.ndarray], np.ndarray]:
+    instr_func_arr: np.ndarray | None = None,
+    notch: np.ndarray | None = None,
+) -> tuple[np.floating | np.ndarray, np.ndarray]:
     r"""
     The :term:`lite-function` version of
     `~plasmapy.diagnostics.thomson.spectral_density`.  Performs the same
@@ -297,9 +297,9 @@ def spectral_density(  # noqa: C901, PLR0912, PLR0915
     ion_vel: u.Quantity[u.m / u.s] = None,
     probe_vec=None,
     scatter_vec=None,
-    instr_func: Optional[Callable] = None,
+    instr_func: Callable | None = None,
     notch: u.m = None,
-) -> tuple[Union[np.floating, np.ndarray], np.ndarray]:
+) -> tuple[np.floating | np.ndarray, np.ndarray]:
     r"""Calculate the spectral density function for Thomson scattering of
     a probe laser beam by a multi-species Maxwellian plasma.
 

--- a/plasmapy/dispersion/analytical/mhd_waves_.py
+++ b/plasmapy/dispersion/analytical/mhd_waves_.py
@@ -13,7 +13,6 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from numbers import Integral, Real
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -44,8 +43,8 @@ class AbstractMHDWave(ABC):
         *,
         T: u.Quantity[u.K] = 0 * u.K,
         gamma: float = 5 / 3,
-        mass_numb: Optional[Integral] = None,
-        Z: Optional[Real] = None,
+        mass_numb: Integral | None = None,
+        Z: Real | None = None,
     ) -> None:
         # validate arguments
         for arg_name in ("B", "density", "T"):

--- a/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/plasmapy/dispersion/analytical/two_fluid_.py
@@ -6,7 +6,6 @@ __all__ = ["two_fluid"]
 
 import warnings
 from numbers import Integral, Real
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -37,8 +36,8 @@ def two_fluid(
     T_i: u.Quantity[u.K],
     gamma_e: Real = 1,
     gamma_i: Real = 3,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Real] = None,
+    mass_numb: Integral | None = None,
+    Z: Real | None = None,
 ):
     r"""
     Using the solution provided by :cite:t:`bellan:2012`, calculate the

--- a/plasmapy/dispersion/dispersion_functions.py
+++ b/plasmapy/dispersion/dispersion_functions.py
@@ -6,7 +6,6 @@ __all__ = ["plasma_dispersion_func", "plasma_dispersion_func_deriv"]
 
 
 from numbers import Complex
-from typing import Union
 
 import astropy.units as u
 import numpy as np
@@ -14,8 +13,8 @@ from scipy.special import wofz as faddeeva_function
 
 
 def plasma_dispersion_func(
-    zeta: Union[Complex, np.ndarray, u.Quantity[u.dimensionless_unscaled]],
-) -> Union[Complex, np.ndarray, u.Quantity[u.dimensionless_unscaled]]:
+    zeta: Complex | np.ndarray | u.Quantity[u.dimensionless_unscaled],
+) -> Complex | np.ndarray | u.Quantity[u.dimensionless_unscaled]:
     r"""
     Calculate the plasma dispersion function.
 
@@ -80,8 +79,8 @@ def plasma_dispersion_func(
 
 
 def plasma_dispersion_func_deriv(
-    zeta: Union[Complex, np.ndarray, u.Quantity[u.dimensionless_unscaled]],
-) -> Union[Complex, np.ndarray, u.Quantity[u.dimensionless_unscaled]]:
+    zeta: Complex | np.ndarray | u.Quantity[u.dimensionless_unscaled],
+) -> Complex | np.ndarray | u.Quantity[u.dimensionless_unscaled]:
     r"""
     Calculate the derivative of the plasma dispersion function.
 

--- a/plasmapy/dispersion/dispersionfunction.py
+++ b/plasmapy/dispersion/dispersionfunction.py
@@ -11,7 +11,6 @@ Module containing functionality focused on the plasma dispersion function
 __all__ = ["plasma_dispersion_func", "plasma_dispersion_func_deriv"]
 
 import warnings
-from typing import Union
 
 import astropy.units as u
 import numpy as np
@@ -49,8 +48,8 @@ def plasma_dispersion_func_lite(zeta):
 
 @bind_lite_func(plasma_dispersion_func_lite)
 def plasma_dispersion_func(
-    zeta: Union[complex, np.ndarray, u.Quantity],
-) -> Union[complex, np.ndarray, u.Quantity]:
+    zeta: complex | np.ndarray | u.Quantity,
+) -> complex | np.ndarray | u.Quantity:
     r"""
     Calculate the plasma dispersion function.
 
@@ -100,8 +99,8 @@ def plasma_dispersion_func_deriv_lite(zeta):
 
 @bind_lite_func(plasma_dispersion_func_deriv_lite)
 def plasma_dispersion_func_deriv(
-    zeta: Union[complex, np.ndarray, u.Quantity],
-) -> Union[complex, np.ndarray, u.Quantity]:
+    zeta: complex | np.ndarray | u.Quantity,
+) -> complex | np.ndarray | u.Quantity:
     r"""
     Calculate the derivative of the plasma dispersion function.
 

--- a/plasmapy/dispersion/numerical/hollweg_.py
+++ b/plasmapy/dispersion/numerical/hollweg_.py
@@ -6,7 +6,6 @@ __all__ = ["hollweg"]
 
 import warnings
 from numbers import Integral, Real
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -39,8 +38,8 @@ def hollweg(  # noqa: C901, PLR0912, PLR0915
     T_i: u.Quantity[u.K],
     gamma_e: Real = 1,
     gamma_i: Real = 3,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Real] = None,
+    mass_numb: Integral | None = None,
+    Z: Real | None = None,
 ):
     r"""
     Calculate the two-fluid dispersion relation presented by

--- a/plasmapy/dispersion/numerical/kinetic_alfven_.py
+++ b/plasmapy/dispersion/numerical/kinetic_alfven_.py
@@ -6,7 +6,6 @@ __all__ = ["kinetic_alfven"]
 
 import warnings
 from numbers import Integral, Real
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -39,8 +38,8 @@ def kinetic_alfven(  # noqa: C901, PLR0912
     T_i: u.Quantity[u.K],
     gamma_e: Real = 1,
     gamma_i: Real = 3,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Real] = None,
+    mass_numb: Integral | None = None,
+    Z: Real | None = None,
 ):
     r"""Using the equation provided in :cite:t:`bellan:2012`, this function
     calculates the numerical solution to the kinetic Alfvén dispersion

--- a/plasmapy/formulary/braginskii.py
+++ b/plasmapy/formulary/braginskii.py
@@ -116,7 +116,6 @@ notably the asymptotic behavior of alpha-cross and beta_perp as Hall →
 terms, which all other treatments have not. To neglect electron-electron
 collisions, leave :math:`μ = 0`\ . To consider them, specify mu and theta.
 """
-from typing import Optional
 
 __all__ = [
     "ClassicalTransport",
@@ -331,7 +330,7 @@ class ClassicalTransport:
         hall_e=None,
         hall_i=None,
         mu=None,
-        theta: Optional[float] = None,
+        theta: float | None = None,
         coulomb_log_method="classical",
     ) -> None:
         # check the model
@@ -797,7 +796,7 @@ def resistivity(
     model="Braginskii",
     field_orientation="parallel",
     mu=None,
-    theta: Optional[float] = None,
+    theta: float | None = None,
     coulomb_log_method="classical",
 ) -> u.Quantity[u.Ohm * u.m]:
     r"""
@@ -866,7 +865,7 @@ def thermoelectric_conductivity(
     model="Braginskii",
     field_orientation="parallel",
     mu=None,
-    theta: Optional[float] = None,
+    theta: float | None = None,
     coulomb_log_method="classical",
 ):
     r"""
@@ -908,7 +907,7 @@ def ion_thermal_conductivity(
     model="Braginskii",
     field_orientation="parallel",
     mu=None,
-    theta: Optional[float] = None,
+    theta: float | None = None,
     coulomb_log_method="classical",
 ) -> u.Quantity[u.W / u.m / u.K]:
     r"""
@@ -979,7 +978,7 @@ def electron_thermal_conductivity(
     model="Braginskii",
     field_orientation="parallel",
     mu=None,
-    theta: Optional[float] = None,
+    theta: float | None = None,
     coulomb_log_method="classical",
 ) -> u.Quantity[u.W / u.m / u.K]:
     r"""
@@ -1061,7 +1060,7 @@ def ion_viscosity(
     model="Braginskii",
     field_orientation="parallel",
     mu=None,
-    theta: Optional[float] = None,
+    theta: float | None = None,
     coulomb_log_method="classical",
 ) -> u.Quantity[u.Pa * u.s]:
     r"""
@@ -1118,7 +1117,7 @@ def electron_viscosity(
     model="Braginskii",
     field_orientation="parallel",
     mu=None,
-    theta: Optional[float] = None,
+    theta: float | None = None,
     coulomb_log_method="classical",
 ) -> u.Quantity[u.Pa * u.s]:
     r"""
@@ -1163,7 +1162,7 @@ def electron_viscosity(
 
 
 def _nondim_thermal_conductivity(
-    hall, Z, particle, model, field_orientation, mu=None, theta: Optional[float] = None
+    hall, Z, particle, model, field_orientation, mu=None, theta: float | None = None
 ):
     """
     Calculate dimensionless classical thermal conductivity coefficients.
@@ -1206,7 +1205,7 @@ def _nondim_viscosity(
     model,
     field_orientation,  # noqa: ARG001
     mu=None,
-    theta: Optional[float] = None,
+    theta: float | None = None,
 ):
     """
     Calculate dimensionless classical viscosity coefficients.

--- a/plasmapy/formulary/collisions/tests/test_frequencies.py
+++ b/plasmapy/formulary/collisions/tests/test_frequencies.py
@@ -399,11 +399,11 @@ class TestSingleParticleCollisionFrequencies:
         if interaction_type == "e|e":
             charge_constant = 1
         elif interaction_type == "e|i":
-            charge_constant = value_test_case.field_particle.charge_number**2
+            charge_constant = value_test_case.field_particle.charge_number**2  # type: ignore[assignment]
         elif interaction_type == "i|e":
-            charge_constant = value_test_case.test_particle.charge_number**2
+            charge_constant = value_test_case.test_particle.charge_number**2  # type: ignore[assignment]
         elif interaction_type == "i|i":
-            charge_constant = (
+            charge_constant = (  # type: ignore[assignment]
                 value_test_case.test_particle.charge_number
                 * value_test_case.field_particle.charge_number
             ) ** 2

--- a/plasmapy/formulary/densities.py
+++ b/plasmapy/formulary/densities.py
@@ -5,7 +5,6 @@ __all__ = [
 ]
 __aliases__ = ["rho_"]
 import numbers
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -70,7 +69,7 @@ def critical_density(omega: u.Quantity[u.rad / u.s]) -> u.Quantity[u.m**-3]:
 def mass_density(
     density: (u.m**-3, u.kg / (u.m**3)),
     particle: ParticleLike,
-    z_ratio: Optional[numbers.Real] = 1,
+    z_ratio: numbers.Real | None = 1,
 ) -> u.Quantity[u.kg / u.m**3]:
     r"""
     Calculate the mass density from a number density.

--- a/plasmapy/formulary/dimensionless.py
+++ b/plasmapy/formulary/dimensionless.py
@@ -20,7 +20,6 @@ __all__ = [
 __aliases__ = ["betaH_", "nD_", "Re_", "Rm_"]
 
 import numbers
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -448,8 +447,8 @@ def Lundquist_number(
     B: u.Quantity[u.T],
     density: u.Quantity[u.m**-3, u.kg / u.m**3],
     sigma: u.Quantity[u.S / u.m],
-    ion: Optional[ParticleLike] = None,
-    z_mean: Optional[numbers.Real] = None,
+    ion: ParticleLike | None = None,
+    z_mean: numbers.Real | None = None,
 ) -> u.Quantity[u.dimensionless_unscaled]:
     r"""
     Compute the Lundquist number.

--- a/plasmapy/formulary/frequencies.py
+++ b/plasmapy/formulary/frequencies.py
@@ -10,7 +10,6 @@ __aliases__ = ["oc_", "wc_", "wlh_", "wp_", "wuh_"]
 __lite_funcs__ = ["plasma_frequency_lite"]
 
 import numbers
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -45,8 +44,8 @@ def gyrofrequency(
     B: u.Quantity[u.T],
     particle: ParticleLike,
     signed: bool = False,
-    Z: Optional[numbers.Real] = None,
-    mass_numb: Optional[numbers.Integral] = None,
+    Z: numbers.Real | None = None,
+    mass_numb: numbers.Integral | None = None,
 ) -> u.Quantity[u.rad / u.s]:
     r"""
     Calculate the particle gyrofrequency in units of radians per second.
@@ -237,8 +236,8 @@ def plasma_frequency(
     n: u.Quantity[u.m**-3],
     particle: ParticleLike,
     *,
-    mass_numb: Optional[numbers.Integral] = None,
-    Z: Optional[numbers.Real] = None,
+    mass_numb: numbers.Integral | None = None,
+    Z: numbers.Real | None = None,
 ) -> u.Quantity[u.rad / u.s]:
     r"""Calculate the particle plasma frequency.
 
@@ -540,8 +539,8 @@ def Buchsbaum_frequency(
     n2: u.Quantity[u.m**-3],
     ion1: ParticleLike,
     ion2: ParticleLike,
-    Z1: Optional[float] = None,
-    Z2: Optional[float] = None,
+    Z1: float | None = None,
+    Z2: float | None = None,
 ) -> u.Quantity[u.rad / u.s]:
     r"""
     Return the Buchsbaum frequency for a two-ion-species plasma.

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -5,7 +5,6 @@ __aliases__ = ["cwp_", "lambdaD_", "rc_", "rhoc_"]
 
 import warnings
 from numbers import Integral, Real
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -113,8 +112,8 @@ def gyroradius(  # noqa: C901
     T: u.Quantity[u.K] = None,
     lorentzfactor=np.nan,
     relativistic: bool = True,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Real] = None,
+    mass_numb: Integral | None = None,
+    Z: Real | None = None,
 ) -> u.Quantity[u.m]:
     r"""
     Calculate the radius of circular motion for a charged particle in a
@@ -397,8 +396,8 @@ def inertial_length(
     n: u.Quantity[u.m**-3],
     particle: ParticleLike,
     *,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Real] = None,
+    mass_numb: Integral | None = None,
+    Z: Real | None = None,
 ) -> u.Quantity[u.m]:
     r"""
     Calculate a charged particle's inertial length.

--- a/plasmapy/formulary/mathematics.py
+++ b/plasmapy/formulary/mathematics.py
@@ -3,15 +3,14 @@
 __all__ = ["Fermi_integral", "rot_a_to_b"]
 
 import numbers
-from typing import Union
 
 import numpy as np
 from mpmath import polylog
 
 
 def Fermi_integral(
-    x: Union[complex, np.ndarray], j: Union[complex, np.ndarray]
-) -> Union[complex, np.ndarray]:
+    x: complex | np.ndarray, j: complex | np.ndarray
+) -> complex | np.ndarray:
     r"""
     Calculate the complete Fermi-Dirac integral.
 

--- a/plasmapy/formulary/relativity.py
+++ b/plasmapy/formulary/relativity.py
@@ -3,7 +3,6 @@
 __all__ = ["Lorentz_factor", "relativistic_energy", "RelativisticBody"]
 
 from numbers import Integral, Real
-from typing import Optional, Union
 
 import astropy.units as u
 import numpy as np
@@ -96,8 +95,8 @@ def relativistic_energy(
     particle: ParticleLike,
     V: u.Quantity[u.m / u.s],
     *,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Integral] = None,
+    mass_numb: Integral | None = None,
+    Z: Integral | None = None,
     m=None,
     v=None,
 ) -> u.Quantity[u.J]:
@@ -278,8 +277,8 @@ class RelativisticBody:
 
     @staticmethod
     def _get_speed_like_input(
-        velocity_like_arguments: dict[str, Union[u.Quantity, Real]],
-    ) -> dict[str, Union[u.Quantity, Real]]:
+        velocity_like_arguments: dict[str, u.Quantity | Real],
+    ) -> dict[str, u.Quantity | Real]:
         not_none_arguments = {
             key: value
             for key, value in velocity_like_arguments.items()
@@ -296,7 +295,7 @@ class RelativisticBody:
         return not_none_arguments or {"velocity": np.nan * u.m / u.s}
 
     def _store_velocity_like_argument(
-        self, speed_like_input: dict[str, Union[u.Quantity, Real]]
+        self, speed_like_input: dict[str, u.Quantity | Real]
     ) -> None:
         """
         Take the velocity-like argument and store it via the setter for
@@ -323,11 +322,11 @@ class RelativisticBody:
         *,
         total_energy: u.Quantity[u.J] = None,
         kinetic_energy: u.Quantity[u.J] = None,
-        v_over_c: Optional[Real] = None,
-        lorentz_factor: Optional[Real] = None,
-        Z: Optional[Integral] = None,
-        mass_numb: Optional[Integral] = None,
-        dtype: Optional[DTypeLike] = np.longdouble,
+        v_over_c: Real | None = None,
+        lorentz_factor: Real | None = None,
+        Z: Integral | None = None,
+        mass_numb: Integral | None = None,
+        dtype: DTypeLike | None = np.longdouble,
     ) -> None:
         self._particle = particle
 
@@ -349,7 +348,7 @@ class RelativisticBody:
         return f"RelativisticBody({self.particle}, {self.velocity})"
 
     @property
-    def particle(self) -> Union[CustomParticle, Particle, ParticleList]:
+    def particle(self) -> CustomParticle | Particle | ParticleList:
         """
         Representation of the particle(s).
 
@@ -494,7 +493,7 @@ class RelativisticBody:
         self._momentum = (Lorentz_factor(V) * self.mass * V).to(u.kg * u.m / u.s)
 
     @lorentz_factor.setter
-    def lorentz_factor(self, γ: Union[Real, u.Quantity]):
+    def lorentz_factor(self, γ: Real | u.Quantity):
         if not isinstance(γ, Real | u.Quantity):
             raise TypeError("Invalid type for Lorentz factor")
 

--- a/plasmapy/formulary/speeds.py
+++ b/plasmapy/formulary/speeds.py
@@ -12,7 +12,6 @@ __lite_funcs__ = ["thermal_speed_lite"]
 
 import warnings
 from numbers import Integral, Real
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -40,10 +39,10 @@ k_B_si_unitless = k_B.value
 def Alfven_speed(
     B: u.Quantity[u.T],
     density: (u.m**-3, u.kg / u.m**3),
-    ion: Optional[ParticleLike] = None,
+    ion: ParticleLike | None = None,
     *,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Real] = None,
+    mass_numb: Integral | None = None,
+    Z: Real | None = None,
 ) -> u.Quantity[u.m / u.s]:
     r"""Calculate the Alfvén speed.
 
@@ -742,8 +741,8 @@ def kappa_thermal_speed(
     particle: ParticleLike,
     method="most_probable",
     *,
-    mass_numb: Optional[Real] = None,
-    Z: Optional[Real] = None,
+    mass_numb: Real | None = None,
+    Z: Real | None = None,
 ) -> u.Quantity[u.m / u.s]:
     r"""
     Return the most probable speed for a particle within a kappa

--- a/plasmapy/formulary/tests/test_plasma_frequency.py
+++ b/plasmapy/formulary/tests/test_plasma_frequency.py
@@ -171,7 +171,7 @@ class TestPlasmaFrequencyLite:
         inputs_unitless = {
             "n": inputs["n"].to(u.m**-3).value,
             "mass": particle.mass.value,
-            "Z": np.abs(particle.charge_number),
+            "Z": np.abs(particle.charge_number),  # type: ignore[arg-type]
         }
 
         if "to_hz" in inputs:

--- a/plasmapy/particles/_factory.py
+++ b/plasmapy/particles/_factory.py
@@ -8,7 +8,7 @@ __all__: list[str] = []
 
 import contextlib
 from numbers import Integral, Real
-from typing import Any, Optional, Union
+from typing import Any
 
 import astropy.units as u
 from astropy.constants import m_e
@@ -44,9 +44,9 @@ def _generate_particle_factory_error_message(
 def _make_custom_particle_with_real_charge_number(
     arg: ParticleLike,
     *,
-    mass_numb: Optional[Integral] = None,
-    symbol: Optional[str] = None,
-    Z: Optional[Real] = None,
+    mass_numb: Integral | None = None,
+    symbol: str | None = None,
+    Z: Real | None = None,
 ):
     """
     Create a |CustomParticle| for mean or composite ions.
@@ -112,7 +112,7 @@ _particle_types = (Particle, CustomParticle, ParticleList)
 
 def _physical_particle_factory(
     *args, **kwargs
-) -> Union[Particle, CustomParticle, ParticleList]:
+) -> Particle | CustomParticle | ParticleList:
     """
     Return a representation of one or more physical particles.
 

--- a/plasmapy/particles/_parsing.py
+++ b/plasmapy/particles/_parsing.py
@@ -11,7 +11,6 @@ __all__ = [
 import re
 import warnings
 from numbers import Integral
-from typing import Optional, Union
 
 import numpy as np
 
@@ -111,7 +110,7 @@ case_sensitive_aliases, case_insensitive_aliases = create_alias_dicts(
 )
 
 
-def dealias_particle_aliases(alias: Union[str, Integral]) -> str:
+def dealias_particle_aliases(alias: str | Integral) -> str:
     """
     Return the standard symbol for a particle or antiparticle
     when the argument is a valid alias.  If the argument is not a
@@ -129,8 +128,8 @@ def dealias_particle_aliases(alias: Union[str, Integral]) -> str:
 
 def invalid_particle_errmsg(
     argument,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Integral] = None,
+    mass_numb: Integral | None = None,
+    Z: Integral | None = None,
 ):
     """
     Return an appropriate error message for an
@@ -224,9 +223,9 @@ def extract_charge(arg: str):  # noqa: C901, PLR0912
 
 
 def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
-    argument: Union[str, Integral],
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Integral] = None,
+    argument: str | Integral,
+    mass_numb: Integral | None = None,
+    Z: Integral | None = None,
 ):
     """
     Parse information about a particle into a dictionary of standard
@@ -361,7 +360,7 @@ def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
         return isotope
 
     def reconstruct_ion_symbol(
-        element: str, isotope: Optional[Integral] = None, Z: Optional[Integral] = None
+        element: str, isotope: Integral | None = None, Z: Integral | None = None
     ):
         """
         Receive a `str` representing an atomic symbol and/or a
@@ -476,7 +475,7 @@ def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
     }
 
 
-def parse_and_check_molecule_input(argument: str, Z: Optional[Integral] = None):
+def parse_and_check_molecule_input(argument: str, Z: Integral | None = None):
     """
     Separate the constitutive elements and charge of a molecule symbol.
 

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -21,7 +21,7 @@ __all__ = [
     "standard_atomic_weight",
 ]
 
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any
 
 import astropy.units as u
@@ -238,7 +238,7 @@ def particle_mass(
 
 
 @particle_input
-def isotopic_abundance(isotope: Particle, mass_numb: Integral | None = None) -> Real:
+def isotopic_abundance(isotope: Particle, mass_numb: Integral | None = None) -> float:
     """
     Return the isotopic abundances if known, and otherwise zero.
 

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 from numbers import Integral, Real
-from typing import Any, Optional, Union
+from typing import Any
 
 import astropy.units as u
 
@@ -187,8 +187,8 @@ def standard_atomic_weight(element: Particle) -> u.Quantity[u.kg]:
 def particle_mass(
     particle: Particle,
     *,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Integral] = None,
+    mass_numb: Integral | None = None,
+    Z: Integral | None = None,
 ) -> u.Quantity[u.kg]:
     """
     Return the mass of a particle.
@@ -238,7 +238,7 @@ def particle_mass(
 
 
 @particle_input
-def isotopic_abundance(isotope: Particle, mass_numb: Optional[Integral] = None) -> Real:
+def isotopic_abundance(isotope: Particle, mass_numb: Integral | None = None) -> Real:
     """
     Return the isotopic abundances if known, and otherwise zero.
 
@@ -393,7 +393,7 @@ def electric_charge(particle: Particle) -> u.Quantity[u.C]:
 
 
 @particle_input
-def is_stable(particle: Particle, mass_numb: Optional[Integral] = None) -> bool:
+def is_stable(particle: Particle, mass_numb: Integral | None = None) -> bool:
     """
     Return `True` for stable isotopes and particles and `False` for
     unstable isotopes.
@@ -443,9 +443,7 @@ def is_stable(particle: Particle, mass_numb: Optional[Integral] = None) -> bool:
 
 
 @particle_input(any_of={"stable", "unstable", "isotope"})
-def half_life(
-    particle: Particle, mass_numb: Optional[Integral] = None
-) -> u.Quantity[u.s]:
+def half_life(particle: Particle, mass_numb: Integral | None = None) -> u.Quantity[u.s]:
     """
     Return the half-life in seconds for unstable isotopes and particles,
     and |inf| seconds for stable isotopes and particles.
@@ -495,7 +493,7 @@ def half_life(
     return particle.half_life
 
 
-def known_isotopes(argument: Optional[Union[str, Integral]] = None) -> list[str]:
+def known_isotopes(argument: str | Integral | None = None) -> list[str]:
     """
     Return a list of all known isotopes of an element, or a list of all
     known isotopes of every element if no input is provided.
@@ -588,7 +586,7 @@ def known_isotopes(argument: Optional[Union[str, Integral]] = None) -> list[str]
 
 
 def common_isotopes(
-    argument: Optional[Union[str, Integral]] = None, most_common_only: bool = False
+    argument: str | Integral | None = None, most_common_only: bool = False
 ) -> list[str]:
     """
     Return a list of isotopes of an element with an isotopic abundances
@@ -659,7 +657,7 @@ def common_isotopes(
     # TODO: Allow Particle objects representing elements to be inputs
 
     def common_isotopes_for_element(
-        argument: Union[str, int], most_common_only: Optional[bool]
+        argument: str | int, most_common_only: bool | None
     ) -> list[str]:
         isotopes = known_isotopes(argument)
 
@@ -709,7 +707,7 @@ def common_isotopes(
 
 
 def stable_isotopes(
-    argument: Optional[ParticleLike] = None, unstable: bool = False
+    argument: ParticleLike | None = None, unstable: bool = False
 ) -> list[str]:
     """
     Return a list of all stable isotopes of an element, or if no input is
@@ -779,7 +777,7 @@ def stable_isotopes(
     # TODO: Allow Particle objects representing elements to be inputs
 
     def stable_isotopes_for_element(
-        argument: Union[str, int], stable_only: Optional[bool]
+        argument: str | int, stable_only: bool | None
     ) -> list[str]:
         KnownIsotopes = known_isotopes(argument)
         return [
@@ -873,7 +871,7 @@ def reduced_mass(
     )
 
 
-def periodic_table_period(argument: Union[str, Integral]) -> Integral:
+def periodic_table_period(argument: str | Integral) -> Integral:
     """
     Return the periodic table period.
 
@@ -916,7 +914,7 @@ def periodic_table_period(argument: Union[str, Integral]) -> Integral:
     return _elements.data_about_elements[symbol]["period"]
 
 
-def periodic_table_group(argument: Union[str, Integral]) -> Integral:
+def periodic_table_group(argument: str | Integral) -> Integral:
     """
     Return the periodic table group.
 
@@ -964,7 +962,7 @@ def periodic_table_group(argument: Union[str, Integral]) -> Integral:
     return _elements.data_about_elements[symbol]["group"]
 
 
-def periodic_table_block(argument: Union[str, Integral]) -> str:
+def periodic_table_block(argument: str | Integral) -> str:
     """
     Return the periodic table block.
 
@@ -1015,7 +1013,7 @@ def periodic_table_block(argument: Union[str, Integral]) -> str:
     return _elements.data_about_elements[symbol]["block"]
 
 
-def periodic_table_category(argument: Union[str, Integral]) -> str:
+def periodic_table_category(argument: str | Integral) -> str:
     """
     Return the periodic table category.
 
@@ -1065,7 +1063,7 @@ def periodic_table_category(argument: Union[str, Integral]) -> str:
 def ionic_levels(
     particle: Particle,
     min_charge: Integral = 0,
-    max_charge: Optional[Integral] = None,
+    max_charge: Integral | None = None,
 ) -> ParticleList:
     """
     Return a |ParticleList| that includes different ionic levels of a

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -9,7 +9,7 @@ import warnings
 from collections.abc import Callable, Iterable, MutableMapping
 from inspect import BoundArguments
 from numbers import Integral, Real
-from typing import Any, TypedDict, get_type_hints
+from typing import Any, TypeAlias, TypedDict, get_type_hints
 
 import numpy as np
 import wrapt
@@ -40,7 +40,7 @@ class _CallableDataDict(TypedDict, total=False):
     signature: inspect.Signature
 
 
-_basic_particle_input_annotations = (
+_basic_particle_input_annotations: tuple[type | TypeAlias, ...] = (
     Particle,  # deprecated
     ParticleLike,
     ParticleListLike,
@@ -49,7 +49,9 @@ _basic_particle_input_annotations = (
 )
 _optional_particle_input_annotations = tuple(
     annotation | None
-    for annotation in _basic_particle_input_annotations
+    # remove [:-1] index in following line when dropping (Particle, Particle)
+    # as a valid annotation
+    for annotation in _basic_particle_input_annotations[:-1]
     if annotation != (Particle, Particle)  # temporary hack
 )
 _particle_input_annotations = (

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -32,11 +32,11 @@ class _CallableDataDict(TypedDict, total=False):
     allow_custom_particles: bool
     allow_particle_lists: bool
     annotations: dict[str, Any]
-    any_of: Optional[Union[str, Iterable[str]]]
+    any_of: str | Iterable[str] | None
     callable_: Callable[..., Any]
-    exclude: Optional[Union[str, Iterable[str]]]
+    exclude: str | Iterable[str] | None
     parameters_to_process: list[str]
-    require: Optional[Union[str, Iterable[str]]]
+    require: str | Iterable[str] | None
     signature: inspect.Signature
 
 
@@ -57,7 +57,7 @@ _particle_input_annotations = (
 )
 
 
-def _make_into_set_or_none(obj: Any) -> Optional[Iterable[str]]:
+def _make_into_set_or_none(obj: Any) -> Iterable[str] | None:
     """
     Return `None` if ``obj`` is `None`, and otherwise convert ``obj``
     into a `set`.
@@ -180,9 +180,9 @@ class _ParticleInput:
         self,
         callable_: Callable[..., Any],
         *,
-        require: Optional[Union[str, Iterable[str]]] = None,
-        any_of: Optional[Union[str, Iterable[str]]] = None,
-        exclude: Optional[Union[str, Iterable[str]]] = None,
+        require: str | Iterable[str] | None = None,
+        any_of: str | Iterable[str] | None = None,
+        exclude: str | Iterable[str] | None = None,
         allow_custom_particles: bool = True,
         allow_particle_lists: bool = True,
     ) -> None:
@@ -244,7 +244,7 @@ class _ParticleInput:
         return self._data.get("annotations")  # type: ignore[return-value]
 
     @property
-    def require(self) -> Optional[Iterable[str]]:
+    def require(self) -> Iterable[str] | None:
         """
         Categories that the particle must belong to.
 
@@ -255,11 +255,11 @@ class _ParticleInput:
         return self._data["require"]
 
     @require.setter
-    def require(self, require_: Optional[Union[str, Iterable[str]]]) -> None:
+    def require(self, require_: str | Iterable[str] | None) -> None:
         self._data["require"] = _make_into_set_or_none(require_)
 
     @property
-    def any_of(self) -> Optional[Iterable[str]]:
+    def any_of(self) -> Iterable[str] | None:
         """
         Categories of which the particle must belong to at least one.
 
@@ -270,11 +270,11 @@ class _ParticleInput:
         return self._data["any_of"]
 
     @any_of.setter
-    def any_of(self, any_of_: Optional[Union[str, Iterable[str]]]) -> None:
+    def any_of(self, any_of_: str | Iterable[str] | None) -> None:
         self._data["any_of"] = _make_into_set_or_none(any_of_)
 
     @property
-    def exclude(self) -> Optional[Iterable[str]]:
+    def exclude(self) -> Iterable[str] | None:
         """
         Categories that the particle cannot belong to.
 
@@ -285,7 +285,7 @@ class _ParticleInput:
         return self._data["exclude"]
 
     @exclude.setter
-    def exclude(self, exclude_: Optional[Union[str, Iterable[str]]]) -> None:
+    def exclude(self, exclude_: str | Iterable[str] | None) -> None:
         self._data["exclude"] = _make_into_set_or_none(exclude_)
 
     @property
@@ -333,7 +333,7 @@ class _ParticleInput:
         return self._data["parameters_to_process"]
 
     def verify_charge_categorization(
-        self, particle: Union[Particle, CustomParticle, ParticleList]
+        self, particle: Particle | CustomParticle | ParticleList
     ) -> None:
         """
         Raise an exception if the particle does not meet charge
@@ -367,10 +367,10 @@ class _ParticleInput:
 
     @staticmethod
     def category_errmsg(
-        particle: Union[Particle, CustomParticle, ParticleList],
-        require: Optional[Union[str, Iterable[str]]],
-        exclude: Optional[Union[str, Iterable[str]]],
-        any_of: Optional[Union[str, Iterable[str]]],
+        particle: Particle | CustomParticle | ParticleList,
+        require: str | Iterable[str] | None,
+        exclude: str | Iterable[str] | None,
+        any_of: str | Iterable[str] | None,
         callable_name: str,
     ) -> str:
         """
@@ -401,7 +401,7 @@ class _ParticleInput:
         return category_errmsg
 
     def verify_particle_categorization(
-        self, particle: Union[Particle, CustomParticle, ParticleList]
+        self, particle: Particle | CustomParticle | ParticleList
     ) -> None:
         """
         Verify that the particle meets the categorization criteria.
@@ -438,7 +438,7 @@ class _ParticleInput:
             raise ParticleError(errmsg)
 
     def verify_particle_name_criteria(
-        self, parameter: str, particle: Union[Particle, CustomParticle, ParticleList]
+        self, parameter: str, particle: Particle | CustomParticle | ParticleList
     ) -> None:
         """
         Check that parameters with special names meet the expected
@@ -454,7 +454,7 @@ class _ParticleInput:
             return
 
         name_categorization_exception: list[
-            tuple[str, dict[str, Optional[Union[str, Iterable[str]]]], type]
+            tuple[str, dict[str, str | Iterable[str] | None], type]
         ] = [
             ("element", {"require": "element"}, InvalidElementError),
             ("isotope", {"require": "isotope"}, InvalidIsotopeError),
@@ -482,7 +482,7 @@ class _ParticleInput:
                 )
 
     def verify_allowed_types(
-        self, particle: Union[Particle, CustomParticle, ParticleList]
+        self, particle: Particle | CustomParticle | ParticleList
     ) -> None:
         """
         Verify that the particle object contains only the allowed types
@@ -514,8 +514,8 @@ class _ParticleInput:
         self,
         parameter: str,
         argument: Any,
-        Z: Optional[float],
-        mass_numb: Optional[int],
+        Z: float | None,
+        mass_numb: int | None,
     ) -> Any:
         """
         Process an argument that has an appropriate annotation.
@@ -587,9 +587,7 @@ class _ParticleInput:
 
     parameters_to_skip = ("Z", "mass_numb")
 
-    def perform_pre_validations(
-        self, Z: Optional[float], mass_numb: Optional[int]
-    ) -> None:
+    def perform_pre_validations(self, Z: float | None, mass_numb: int | None) -> None:
         """
         Perform a variety of pre-checks on the arguments.
 
@@ -669,11 +667,11 @@ class _ParticleInput:
 
 
 def particle_input(
-    callable_: Optional[Callable[..., Any]] = None,
+    callable_: Callable[..., Any] | None = None,
     *,
-    require: Optional[Union[str, Iterable[str]]] = None,
-    any_of: Optional[Union[str, Iterable[str]]] = None,
-    exclude: Optional[Union[str, Iterable[str]]] = None,
+    require: str | Iterable[str] | None = None,
+    any_of: str | Iterable[str] | None = None,
+    exclude: str | Iterable[str] | None = None,
     allow_custom_particles: bool = True,
     allow_particle_lists: bool = True,
 ) -> Callable[..., Any]:

--- a/plasmapy/particles/decorators.py
+++ b/plasmapy/particles/decorators.py
@@ -9,7 +9,7 @@ import warnings
 from collections.abc import Callable, Iterable, MutableMapping
 from inspect import BoundArguments
 from numbers import Integral, Real
-from typing import Any, Optional, TypedDict, Union, get_type_hints
+from typing import Any, TypedDict, get_type_hints
 
 import numpy as np
 import wrapt
@@ -44,11 +44,11 @@ _basic_particle_input_annotations = (
     Particle,  # deprecated
     ParticleLike,
     ParticleListLike,
-    Union[ParticleLike, ParticleListLike],
+    ParticleLike | ParticleListLike,
     (Particle, Particle),  # deprecated
 )
 _optional_particle_input_annotations = tuple(
-    Optional[annotation]
+    annotation | None
     for annotation in _basic_particle_input_annotations
     if annotation != (Particle, Particle)  # temporary hack
 )

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -7,7 +7,6 @@ __all__ = ["IonicLevel", "IonizationState"]
 
 import warnings
 from numbers import Integral, Real
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -127,7 +126,7 @@ class IonicLevel:
         return self._ionic_fraction
 
     @ionic_fraction.setter
-    def ionic_fraction(self, ionfrac: Optional[Real]):
+    def ionic_fraction(self, ionfrac: Real | None):
         if ionfrac is None or np.isnan(ionfrac):
             self._ionic_fraction = np.nan
         else:
@@ -501,7 +500,7 @@ class IonizationState:
                 f"Unable to set ionic fractions of {self.element} to {fractions}."
             ) from exc
 
-    def _is_normalized(self, tol: Optional[Real] = None) -> bool:
+    def _is_normalized(self, tol: Real | None = None) -> bool:
         """
         `True` if the sum of the ionization fractions is equal to
         ``1`` within the allowed tolerance, and `False` otherwise.
@@ -664,7 +663,7 @@ class IonizationState:
         return self._particle.element
 
     @property
-    def isotope(self) -> Optional[str]:
+    def isotope(self) -> str | None:
         """
         The isotope symbol for an isotope, or `None` if the particle is
         not an isotope.

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -5,7 +5,6 @@ isotopes.
 __all__ = ["IonizationStateCollection"]
 
 from numbers import Integral, Real
-from typing import Optional, Union
 
 import astropy.units as u
 import numpy as np
@@ -135,11 +134,11 @@ class IonizationStateCollection:
     @validate_quantities(T_e={"equivalencies": u.temperature_energy()})
     def __init__(
         self,
-        inputs: Union[dict[str, np.ndarray], list, tuple],
+        inputs: dict[str, np.ndarray] | list | tuple,
         *,
         T_e: u.Quantity[u.K] = np.nan * u.K,
-        abundances: Optional[dict[str, Real]] = None,
-        log_abundances: Optional[dict[str, Real]] = None,
+        abundances: dict[str, Real] | None = None,
+        log_abundances: dict[str, Real] | None = None,
         n0: u.Quantity[u.m**-3] = np.nan * u.m**-3,
         tol: Real = 1e-15,
         kappa: Real = np.inf,
@@ -188,7 +187,7 @@ class IonizationStateCollection:
     def __repr__(self) -> str:
         return self.__str__()
 
-    def __getitem__(self, *values) -> Union[IonizationState, IonicLevel]:
+    def __getitem__(self, *values) -> IonizationState | IonicLevel:
         errmsg = f"Invalid indexing for IonizationStateCollection instance: {values[0]}"
 
         one_input = not isinstance(values[0], tuple)
@@ -400,7 +399,7 @@ class IonizationStateCollection:
     @ionic_fractions.setter
     def ionic_fractions(  # noqa: C901, PLR0912, PLR0915
         self,
-        inputs: Union[dict, list, tuple],
+        inputs: dict | list | tuple,
     ):
         """
         Set the ionic fractions.
@@ -676,12 +675,12 @@ class IonizationStateCollection:
         }
 
     @property
-    def abundances(self) -> Optional[dict[ParticleLike, Real]]:
+    def abundances(self) -> dict[ParticleLike, Real] | None:
         """The elemental abundances."""
         return self._pars["abundances"]
 
     @abundances.setter
-    def abundances(self, abundances_dict: Optional[dict[ParticleLike, Real]]):
+    def abundances(self, abundances_dict: dict[ParticleLike, Real] | None):
         """
         Set the elemental (or isotopic) abundances.  The elements and
         isotopes must be the same as or a superset of the elements whose
@@ -748,7 +747,7 @@ class IonizationStateCollection:
         }
 
     @log_abundances.setter
-    def log_abundances(self, value: Optional[dict[str, Real]]):
+    def log_abundances(self, value: dict[str, Real] | None):
         """Set the base 10 logarithm of the relative abundances."""
         if value is not None:
             try:

--- a/plasmapy/particles/nuclear.py
+++ b/plasmapy/particles/nuclear.py
@@ -3,7 +3,6 @@ __all__ = ["nuclear_binding_energy", "nuclear_reaction_energy", "mass_energy"]
 
 import re
 from numbers import Integral
-from typing import Optional, Union
 
 import astropy.units as u
 
@@ -14,7 +13,7 @@ from plasmapy.particles.particle_class import Particle
 
 @particle_input(any_of={"isotope", "baryon"})
 def nuclear_binding_energy(
-    particle: Particle, mass_numb: Optional[Integral] = None
+    particle: Particle, mass_numb: Integral | None = None
 ) -> u.Quantity[u.J]:
     """
     Return the nuclear binding energy associated with an isotope.
@@ -71,7 +70,7 @@ def nuclear_binding_energy(
 
 @particle_input
 def mass_energy(
-    particle: Particle, mass_numb: Optional[Integral] = None
+    particle: Particle, mass_numb: Integral | None = None
 ) -> u.Quantity[u.J]:
     """
     Return a particle's mass energy.  If the particle is an isotope or
@@ -184,7 +183,7 @@ def nuclear_reaction_energy(*args, **kwargs) -> u.Quantity[u.J]:  # noqa: C901, 
     errmsg = "Invalid nuclear reaction."
 
     def process_particles_list(
-        unformatted_particles_list: list[Union[str, Particle]],
+        unformatted_particles_list: list[str | Particle],
     ) -> list[Particle]:
         """
         Take an unformatted list of particles and puts each

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from numbers import Integral, Real
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import astropy.constants as const
 import astropy.units as u
@@ -113,13 +113,13 @@ class AbstractParticle(ABC):
 
     @property
     @abstractmethod
-    def mass(self) -> Union[u.Quantity, Real]:
+    def mass(self) -> u.Quantity | Real:
         """Provide the particle's mass."""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def charge(self) -> Union[u.Quantity, Real]:
+    def charge(self) -> u.Quantity | Real:
         """Provide the particle's electric charge."""
         raise NotImplementedError
 
@@ -225,9 +225,9 @@ class AbstractPhysicalParticle(AbstractParticle):
     def is_category(
         self,
         *category_tuple,
-        require: Optional[Union[str, Iterable[str]]] = None,
-        any_of: Optional[Union[str, Iterable[str]]] = None,
-        exclude: Optional[Union[str, Iterable[str]]] = None,
+        require: str | Iterable[str] | None = None,
+        any_of: str | Iterable[str] | None = None,
+        exclude: str | Iterable[str] | None = None,
     ) -> bool:
         """Determine if the particle meets categorization criteria.
 
@@ -324,7 +324,7 @@ class AbstractPhysicalParticle(AbstractParticle):
         False
         """
 
-        def become_set(arg: Union[str, set, Sequence]) -> set[str]:
+        def become_set(arg: str | set | Sequence) -> set[str]:
             """Change the argument into a `set`."""
             if arg is None:
                 return set()
@@ -581,8 +581,8 @@ class Particle(AbstractPhysicalParticle):
         self,
         argument: ParticleLike,
         *_,
-        mass_numb: Optional[Integral] = None,
-        Z: Optional[Integral] = None,
+        mass_numb: Integral | None = None,
+        Z: Integral | None = None,
     ) -> None:
         # TODO: Remove the following block during or after the 0.9.0 release
 
@@ -977,7 +977,7 @@ class Particle(AbstractPhysicalParticle):
             )
 
     @property
-    def element(self) -> Optional[str]:
+    def element(self) -> str | None:
         """
         The atomic symbol if the particle corresponds to an element, and
         `None` otherwise.
@@ -991,7 +991,7 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["element"]
 
     @property
-    def isotope(self) -> Optional[str]:
+    def isotope(self) -> str | None:
         """
         The isotope symbol if the particle corresponds to an isotope,
         and `None` otherwise.
@@ -1005,7 +1005,7 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["isotope"]
 
     @property
-    def ionic_symbol(self) -> Optional[str]:
+    def ionic_symbol(self) -> str | None:
         """
         The ionic symbol if the particle corresponds to an ion or
         neutral atom, and `None` otherwise.
@@ -1022,7 +1022,7 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["ion"]
 
     @property
-    def roman_symbol(self) -> Optional[str]:
+    def roman_symbol(self) -> str | None:
         """
         The spectral name of the particle (i.e. the ionic symbol in
         Roman numeral notation).
@@ -1076,7 +1076,7 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["element name"]
 
     @property
-    def isotope_name(self) -> Optional[str]:
+    def isotope_name(self) -> str | None:
         """
         The name of the element along with the isotope symbol if the
         particle corresponds to an isotope, or `None` if it does not.
@@ -1554,7 +1554,7 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["lepton number"]
 
     @property
-    def half_life(self) -> Union[u.Quantity, str]:
+    def half_life(self) -> u.Quantity | str:
         """
         The particle's half-life in seconds, or a `str` with half-life
         information.
@@ -1885,9 +1885,9 @@ class DimensionlessParticle(AbstractParticle):
     def __init__(
         self,
         *,
-        mass: Optional[Real] = None,
-        charge: Optional[Real] = None,
-        symbol: Optional[str] = None,
+        mass: Real | None = None,
+        charge: Real | None = None,
+        symbol: str | None = None,
     ) -> None:
         try:
             self.mass = mass
@@ -1987,7 +1987,7 @@ class DimensionlessParticle(AbstractParticle):
         return self._charge
 
     @mass.setter
-    def mass(self, m: Optional[Union[Real, u.Quantity]]):
+    def mass(self, m: Real | u.Quantity | None):
         try:
             self._mass = self._validate_parameter(m, can_be_negative=False)
         except (TypeError, ValueError):
@@ -1997,7 +1997,7 @@ class DimensionlessParticle(AbstractParticle):
             ) from None
 
     @charge.setter
-    def charge(self, q: Optional[Union[Real, u.Quantity]]):
+    def charge(self, q: Real | u.Quantity | None):
         try:
             self._charge = self._validate_parameter(q, can_be_negative=True)
         except (TypeError, ValueError):
@@ -2095,9 +2095,9 @@ class CustomParticle(AbstractPhysicalParticle):
         self,
         mass: u.Quantity[u.kg] = None,
         charge: u.Quantity[u.C] = None,
-        symbol: Optional[str] = None,
+        symbol: str | None = None,
         *,
-        Z: Optional[Real] = None,
+        Z: Real | None = None,
     ) -> None:
         # TODO: py3.10 replace ifology with structural pattern matching
 
@@ -2124,8 +2124,8 @@ class CustomParticle(AbstractPhysicalParticle):
     def _from_quantities(
         cls,
         *quantities,
-        symbol: Optional[str] = None,
-        Z: Optional[Real] = None,
+        symbol: str | None = None,
+        Z: Real | None = None,
     ) -> CustomParticle:
         """
         An alternate constructor for |CustomParticle| objects where the
@@ -2248,7 +2248,7 @@ class CustomParticle(AbstractPhysicalParticle):
         return self._charge
 
     @charge.setter
-    def charge(self, q: Optional[Union[u.Quantity, Real]]):
+    def charge(self, q: u.Quantity | Real | None):
         if q is None:
             q = np.nan * u.C
         elif isinstance(q, str):
@@ -2398,9 +2398,7 @@ class CustomParticle(AbstractPhysicalParticle):
         return hash(self.__repr__())
 
 
-def molecule(
-    symbol: str, Z: Optional[Integral] = None
-) -> Union[Particle, CustomParticle]:
+def molecule(symbol: str, Z: Integral | None = None) -> Particle | CustomParticle:
     r"""
     Parse a molecule symbol into a |CustomParticle| or |Particle|.
 
@@ -2494,7 +2492,7 @@ def molecule(
 # If ParticleLike is renamed or moves out of particle_class.py, check
 # for a link to its doc page in error messages in _factory.py.
 
-ParticleLike = Union[str, Integral, Particle, CustomParticle, u.Quantity]
+ParticleLike = str | Integral | Particle | CustomParticle | u.Quantity
 
 ParticleLike.__doc__ = r"""
 An `object` is particle-like if it can be identified as an instance of

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from numbers import Integral, Real
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, TypeAlias, Union
 
 import astropy.constants as const
 import astropy.units as u
@@ -2492,7 +2492,7 @@ def molecule(symbol: str, Z: Integral | None = None) -> Particle | CustomParticl
 # If ParticleLike is renamed or moves out of particle_class.py, check
 # for a link to its doc page in error messages in _factory.py.
 
-ParticleLike = Union[str, Integral, Particle, CustomParticle, u.Quantity]  # noqa: UP007
+ParticleLike: TypeAlias = Union[str, Integral, Particle, CustomParticle, u.Quantity]  # noqa: UP007
 
 ParticleLike.__doc__ = r"""
 An `object` is particle-like if it can be identified as an instance of

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from numbers import Integral, Real
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import astropy.constants as const
 import astropy.units as u
@@ -2492,7 +2492,7 @@ def molecule(symbol: str, Z: Integral | None = None) -> Particle | CustomParticl
 # If ParticleLike is renamed or moves out of particle_class.py, check
 # for a link to its doc page in error messages in _factory.py.
 
-ParticleLike = str | Integral | Particle | CustomParticle | u.Quantity
+ParticleLike = Union[str, Integral, Particle, CustomParticle, u.Quantity]  # noqa: UP007
 
 ParticleLike.__doc__ = r"""
 An `object` is particle-like if it can be identified as an instance of

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -113,13 +113,13 @@ class AbstractParticle(ABC):
 
     @property
     @abstractmethod
-    def mass(self) -> u.Quantity | Real:
+    def mass(self) -> u.Quantity | float:
         """Provide the particle's mass."""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def charge(self) -> u.Quantity | Real:
+    def charge(self) -> u.Quantity | float:
         """Provide the particle's electric charge."""
         raise NotImplementedError
 
@@ -395,10 +395,10 @@ class Particle(AbstractPhysicalParticle):
         integer representing the atomic number of an element; or a
         |Particle|.
 
-    mass_numb : integer, |keyword-only|, optional
+    mass_numb : int, |keyword-only|, optional
         The mass number of an isotope.
 
-    Z : integer, |keyword-only|, optional
+    Z : int, |keyword-only|, optional
         The |charge number| of an ion or neutral atom.
 
     Raises
@@ -581,8 +581,8 @@ class Particle(AbstractPhysicalParticle):
         self,
         argument: ParticleLike,
         *_,
-        mass_numb: Integral | None = None,
-        Z: Integral | None = None,
+        mass_numb: int | None = None,
+        Z: int | None = None,
     ) -> None:
         # TODO: Remove the following block during or after the 0.9.0 release
 
@@ -1465,7 +1465,7 @@ class Particle(AbstractPhysicalParticle):
             raise InvalidIonError(_category_errmsg(self, "ion"))
 
     @property
-    def isotopic_abundance(self) -> Real:
+    def isotopic_abundance(self) -> float:
         """
         The isotopic abundance of an isotope.
 
@@ -1587,7 +1587,7 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["half-life"]
 
     @property
-    def spin(self) -> Real:
+    def spin(self) -> float:
         """
         The intrinsic spin of the particle.
 
@@ -1684,7 +1684,7 @@ class Particle(AbstractPhysicalParticle):
         """
         return self.is_category("ion")
 
-    def ionize(self, n: Integral = 1, inplace: bool = False):
+    def ionize(self, n: int = 1, inplace: bool = False):
         """
         Create a new |Particle| instance corresponding to the current
         |Particle| after being ionized ``n`` times.
@@ -1766,7 +1766,7 @@ class Particle(AbstractPhysicalParticle):
         else:
             return Particle(base_particle, Z=new_charge_number)
 
-    def recombine(self, n: Integral = 1, inplace: bool = False):
+    def recombine(self, n: int = 1, inplace: bool = False):
         """
         Create a new |Particle| instance corresponding to the current
         |Particle| after undergoing recombination ``n`` times.
@@ -1885,8 +1885,8 @@ class DimensionlessParticle(AbstractParticle):
     def __init__(
         self,
         *,
-        mass: Real | None = None,
-        charge: Real | None = None,
+        mass: float | None = None,
+        charge: float | None = None,
         symbol: str | None = None,
     ) -> None:
         try:
@@ -1987,7 +1987,7 @@ class DimensionlessParticle(AbstractParticle):
         return self._charge
 
     @mass.setter
-    def mass(self, m: Real | u.Quantity | None):
+    def mass(self, m: float | u.Quantity | None):
         try:
             self._mass = self._validate_parameter(m, can_be_negative=False)
         except (TypeError, ValueError):
@@ -1997,7 +1997,7 @@ class DimensionlessParticle(AbstractParticle):
             ) from None
 
     @charge.setter
-    def charge(self, q: Real | u.Quantity | None):
+    def charge(self, q: float | u.Quantity | None):
         try:
             self._charge = self._validate_parameter(q, can_be_negative=True)
         except (TypeError, ValueError):
@@ -2034,20 +2034,20 @@ class CustomParticle(AbstractPhysicalParticle):
 
     Parameters
     ----------
-    mass : ~astropy.units.Quantity, optional
+    mass : `~astropy.units.Quantity`, optional
         The mass of the custom particle in units of mass.  Defaults to
         |nan| kg.
 
-    charge : ~astropy.units.Quantity or ~numbers.Real, optional
+    charge : `~astropy.units.Quantity` | `float`, optional
         The electric charge of the custom particle.  If provided as a
         `~astropy.units.Quantity`, then it must be in units of electric
         charge. Defaults to |nan| C.
 
-    Z : ~numbers.Real, |keyword-only|, optional
+    Z : `float`, |keyword-only|, optional
         The :term:`charge number`, which is equal to the ratio of the
         charge to the elementary charge.
 
-    symbol : str, optional
+    symbol : `str`, optional
         The symbol to be assigned to the custom particle.
 
     Raises
@@ -2097,7 +2097,7 @@ class CustomParticle(AbstractPhysicalParticle):
         charge: u.Quantity[u.C] = None,
         symbol: str | None = None,
         *,
-        Z: Real | None = None,
+        Z: float | None = None,
     ) -> None:
         # TODO: py3.10 replace ifology with structural pattern matching
 
@@ -2125,7 +2125,7 @@ class CustomParticle(AbstractPhysicalParticle):
         cls,
         *quantities,
         symbol: str | None = None,
-        Z: Real | None = None,
+        Z: float | None = None,
     ) -> CustomParticle:
         """
         An alternate constructor for |CustomParticle| objects where the
@@ -2248,7 +2248,7 @@ class CustomParticle(AbstractPhysicalParticle):
         return self._charge
 
     @charge.setter
-    def charge(self, q: u.Quantity | Real | None):
+    def charge(self, q: u.Quantity | float | None):
         if q is None:
             q = np.nan * u.C
         elif isinstance(q, str):
@@ -2285,7 +2285,7 @@ class CustomParticle(AbstractPhysicalParticle):
             )
 
     @property
-    def charge_number(self) -> Real:
+    def charge_number(self) -> float:
         """The ratio of the charge to the elementary charge."""
         return (self.charge / const.e.si).value
 
@@ -2398,7 +2398,7 @@ class CustomParticle(AbstractPhysicalParticle):
         return hash(self.__repr__())
 
 
-def molecule(symbol: str, Z: Integral | None = None) -> Particle | CustomParticle:
+def molecule(symbol: str, Z: int | None = None) -> Particle | CustomParticle:
     r"""
     Parse a molecule symbol into a |CustomParticle| or |Particle|.
 

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -5,7 +5,6 @@ __all__ = ["ParticleList", "ParticleListLike"]
 import collections
 import contextlib
 from collections.abc import Callable, Iterable, Sequence
-from typing import Optional, Union
 
 import astropy.units as u
 import numpy as np
@@ -151,8 +150,8 @@ class ParticleList(collections.UserList):
 
     @staticmethod
     def _list_of_particles_and_custom_particles(
-        particles: Optional[Iterable[ParticleLike]],
-    ) -> list[Union[Particle, CustomParticle]]:
+        particles: Iterable[ParticleLike] | None,
+    ) -> list[Particle | CustomParticle]:
         """
         Convert an iterable that provides |particle-like| objects into a
         `list` containing |Particle| and |CustomParticle| instances.
@@ -188,7 +187,7 @@ class ParticleList(collections.UserList):
 
         return new_particles
 
-    def __init__(self, particles: Optional[Iterable] = None) -> None:
+    def __init__(self, particles: Iterable | None = None) -> None:
         self._data = self._list_of_particles_and_custom_particles(particles)
 
     @staticmethod
@@ -265,7 +264,7 @@ class ParticleList(collections.UserList):
         return self._get_particle_attribute("charge", unit=u.C, default=np.nan * u.C)
 
     @property
-    def data(self) -> list[Union[Particle, CustomParticle]]:
+    def data(self) -> list[Particle | CustomParticle]:
         """
         A `list` containing the particles contained in the
         |ParticleList| instance.
@@ -317,9 +316,9 @@ class ParticleList(collections.UserList):
     def is_category(
         self,
         *category_tuple,
-        require: Optional[Union[str, Iterable[str]]] = None,
-        any_of: Optional[Union[str, Iterable[str]]] = None,
-        exclude: Optional[Union[str, Iterable[str]]] = None,
+        require: str | Iterable[str] | None = None,
+        any_of: str | Iterable[str] | None = None,
+        exclude: str | Iterable[str] | None = None,
     ) -> list[bool]:
         """
         Determine element-wise if the particles in the |ParticleList|
@@ -399,7 +398,7 @@ class ParticleList(collections.UserList):
             default=np.nan * u.J,
         )
 
-    def sort(self, key: Optional[Callable] = None, reverse: bool = False):
+    def sort(self, key: Callable | None = None, reverse: bool = False):
         """
         Sort the |ParticleList| in-place.
 
@@ -466,7 +465,7 @@ class ParticleList(collections.UserList):
         *,
         use_rms_charge: bool = False,
         use_rms_mass: bool = False,
-    ) -> Union[CustomParticle, Particle]:
+    ) -> CustomParticle | Particle:
         """
         Return a particle with the average mass and charge.
 
@@ -574,7 +573,7 @@ Raises
 
 ParticleList.reverse.__doc__ = """Reverse the |ParticleList| in place."""
 
-ParticleListLike = Union[ParticleList, Sequence[ParticleLike]]
+ParticleListLike = ParticleList | Sequence[ParticleLike]
 
 ParticleListLike.__doc__ = r"""
 An `object` is |particle-list-like| if it can be identified as a

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -5,6 +5,7 @@ __all__ = ["ParticleList", "ParticleListLike"]
 import collections
 import contextlib
 from collections.abc import Callable, Iterable, Sequence
+from typing import Union
 
 import astropy.units as u
 import numpy as np
@@ -573,7 +574,7 @@ Raises
 
 ParticleList.reverse.__doc__ = """Reverse the |ParticleList| in place."""
 
-ParticleListLike = ParticleList | Sequence[ParticleLike]
+ParticleListLike = Union[ParticleList, Sequence[ParticleLike]]  # noqa: UP007
 
 ParticleListLike.__doc__ = r"""
 An `object` is |particle-list-like| if it can be identified as a

--- a/plasmapy/particles/particle_collections.py
+++ b/plasmapy/particles/particle_collections.py
@@ -5,7 +5,7 @@ __all__ = ["ParticleList", "ParticleListLike"]
 import collections
 import contextlib
 from collections.abc import Callable, Iterable, Sequence
-from typing import Union
+from typing import TypeAlias, Union
 
 import astropy.units as u
 import numpy as np
@@ -574,7 +574,7 @@ Raises
 
 ParticleList.reverse.__doc__ = """Reverse the |ParticleList| in place."""
 
-ParticleListLike = Union[ParticleList, Sequence[ParticleLike]]  # noqa: UP007
+ParticleListLike: TypeAlias = Union[ParticleList, Sequence[ParticleLike]]  # noqa: UP007
 
 ParticleListLike.__doc__ = r"""
 An `object` is |particle-list-like| if it can be identified as a

--- a/plasmapy/particles/symbols.py
+++ b/plasmapy/particles/symbols.py
@@ -11,7 +11,6 @@ __all__ = [
 ]
 
 from numbers import Integral
-from typing import Optional
 
 from plasmapy.particles.decorators import particle_input
 from plasmapy.particles.particle_class import Particle
@@ -94,7 +93,7 @@ def atomic_symbol(element: Particle) -> str:
 
 
 @particle_input
-def isotope_symbol(isotope: Particle, mass_numb: Optional[Integral] = None) -> str:
+def isotope_symbol(isotope: Particle, mass_numb: Integral | None = None) -> str:
     """
     Return the symbol representing an isotope.
 
@@ -154,8 +153,8 @@ def isotope_symbol(isotope: Particle, mass_numb: Optional[Integral] = None) -> s
 def ionic_symbol(
     particle: Particle,
     *,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Integral] = None,
+    mass_numb: Integral | None = None,
+    Z: Integral | None = None,
 ) -> str:
     """
     Return the ionic symbol of an ion or neutral atom.
@@ -220,8 +219,8 @@ def ionic_symbol(
 def particle_symbol(
     particle: Particle,
     *,
-    mass_numb: Optional[Integral] = None,
-    Z: Optional[Integral] = None,
+    mass_numb: Integral | None = None,
+    Z: Integral | None = None,
 ) -> str:
     """
     Return the symbol of a particle.

--- a/plasmapy/particles/tests/test_decorators.py
+++ b/plasmapy/particles/tests/test_decorators.py
@@ -2,7 +2,7 @@
 
 import inspect
 from collections.abc import Callable, Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 import astropy.constants as const
 import astropy.units as u
@@ -29,9 +29,9 @@ def function_decorated_with_particle_input(
     a: Any,
     particle: ParticleLike,
     b: Any = None,
-    Z: Optional[float] = None,
-    mass_numb: Optional[int] = None,
-) -> Union[Particle, CustomParticle, ParticleList]:
+    Z: float | None = None,
+    mass_numb: int | None = None,
+) -> Particle | CustomParticle | ParticleList:
     """
     A simple function that is decorated with `particle_input` and
     returns the particle instance corresponding to the inputs.
@@ -53,9 +53,9 @@ def function_decorated_with_call_of_particle_input(
     a: Any,
     particle: ParticleLike,
     b: Any = None,
-    Z: Optional[float] = None,
-    mass_numb: Optional[int] = None,
-) -> Union[Particle, CustomParticle, ParticleList]:
+    Z: float | None = None,
+    mass_numb: int | None = None,
+) -> Particle | CustomParticle | ParticleList:
     """
     A simple function that is decorated with `@particle_input()` and
     returns the Particle instance corresponding to the inputs.
@@ -72,9 +72,7 @@ def function_decorated_with_call_of_particle_input(
     return particle
 
 
-particle_input_simple_table: list[
-    tuple[tuple[Union[int, str], ...], dict[str, Any], str]
-] = [
+particle_input_simple_table: list[tuple[tuple[int | str, ...], dict[str, Any], str]] = [
     ((1, "p+"), {"b": 2}, "p+"),
     ((1, "Fe"), {"mass_numb": 56, "Z": 3}, "Fe-56 3+"),
     ((1,), {"particle": "e-"}, "e-"),
@@ -92,7 +90,7 @@ particle_input_simple_table: list[
 @pytest.mark.parametrize(("args", "kwargs", "symbol"), particle_input_simple_table)
 def test_particle_input_simple(
     func: Callable[..., Any],
-    args: tuple[Union[int, str], ...],
+    args: tuple[int | str, ...],
     kwargs: dict[str, Any],
     symbol: str,
 ) -> None:
@@ -157,7 +155,7 @@ class ClassWithDecoratedMethods:
     @particle_input
     def method_decorated_with_no_parentheses(
         self, particle: ParticleLike
-    ) -> Union[Particle, CustomParticle, ParticleList]:
+    ) -> Particle | CustomParticle | ParticleList:
         # Because run-time logic is needed, mypy is unable to infer
         # that @particle_input is doing a type conversion here. We
         # would need a dynamic type checker to address this case.
@@ -166,7 +164,7 @@ class ClassWithDecoratedMethods:
     @particle_input()
     def method_decorated_with_parentheses(
         self, particle: ParticleLike
-    ) -> Union[Particle, CustomParticle, ParticleList]:
+    ) -> Particle | CustomParticle | ParticleList:
         return particle  # type: ignore[return-value]
 
 
@@ -203,8 +201,8 @@ def test_no_annotations_exception() -> None:
 def ambiguous_keywords(
     p1: ParticleLike,
     p2: ParticleLike,
-    Z: Optional[float] = None,
-    mass_numb: Optional[int] = None,
+    Z: float | None = None,
+    mass_numb: int | None = None,
 ) -> None:
     """
     A trivial function with two annotated arguments plus the keyword
@@ -237,7 +235,7 @@ def test_optional_particle() -> None:
     @particle_input
     def has_default_particle(
         particle: ParticleLike = particle,
-    ) -> Union[Particle, CustomParticle, ParticleList]:
+    ) -> Particle | CustomParticle | ParticleList:
         return particle  # type: ignore[return-value]
 
     assert has_default_particle() == Particle(particle)
@@ -288,7 +286,7 @@ categorization_particle_exception = [
     ("categorization", "particle", "exception"), categorization_particle_exception
 )
 def test_decorator_categories(
-    categorization: dict[str, Union[str, Iterable[str]]],
+    categorization: dict[str, str | Iterable[str]],
     particle: ParticleLike,
     exception: type,
 ) -> None:
@@ -302,7 +300,7 @@ def test_decorator_categories(
     @particle_input(**categorization)  # type: ignore[arg-type]
     def decorated_function(
         argument: ParticleLike,
-    ) -> Union[Particle, CustomParticle, ParticleList]:
+    ) -> Particle | CustomParticle | ParticleList:
         return argument  # type: ignore[return-value]
 
     if exception:
@@ -324,7 +322,7 @@ def test_optional_particle_annotation_parameter() -> None:
     """
 
     @particle_input
-    def func_optional_particle(particle: Optional[ParticleLike]) -> Optional[Particle]:
+    def func_optional_particle(particle: ParticleLike | None) -> Particle | None:
         return particle  # type: ignore[return-value]
 
     assert func_optional_particle(None) is None, (
@@ -397,9 +395,7 @@ def test_annotated_classmethod() -> None:
     class HasAnnotatedClassMethod:
         @classmethod
         @particle_input
-        def f(
-            cls, particle: ParticleLike
-        ) -> Union[Particle, CustomParticle, ParticleList]:
+        def f(cls, particle: ParticleLike) -> Particle | CustomParticle | ParticleList:
             return particle  # type: ignore[return-value]
 
     has_annotated_classmethod = HasAnnotatedClassMethod()
@@ -415,9 +411,7 @@ def test_self_stacked_decorator(
 
     @outer_decorator
     @inner_decorator
-    def f(
-        x: Any, particle: ParticleLike
-    ) -> Union[Particle, CustomParticle, ParticleList]:
+    def f(x: Any, particle: ParticleLike) -> Particle | CustomParticle | ParticleList:
         return particle  # type: ignore[return-value]
 
     result = f(1, "p+")
@@ -530,7 +524,7 @@ def test_particle_input_verification(
     """Test the allow_custom_particles keyword argument to particle_input."""
 
     @particle_input(**kwargs_to_particle_input)
-    def f(particle: ParticleLike) -> Union[Particle, CustomParticle, ParticleList]:
+    def f(particle: ParticleLike) -> Particle | CustomParticle | ParticleList:
         return particle  # type: ignore[return-value]
 
     with pytest.raises(ParticleError):
@@ -562,19 +556,19 @@ class ParameterNamesCase:
 
 
 @particle_input
-def get_element(element: ParticleLike) -> Union[Particle, CustomParticle, ParticleList]:
+def get_element(element: ParticleLike) -> Particle | CustomParticle | ParticleList:
     return element  # type: ignore[return-value]
 
 
 @particle_input
-def get_isotope(isotope: ParticleLike) -> Union[Particle, CustomParticle, ParticleList]:
+def get_isotope(isotope: ParticleLike) -> Particle | CustomParticle | ParticleList:
     return isotope  # type: ignore[return-value]
 
 
 @particle_input
 def get_ion(
-    ion: ParticleLike, Z: Optional[float] = None
-) -> Union[Particle, CustomParticle, ParticleList]:
+    ion: ParticleLike, Z: float | None = None
+) -> Particle | CustomParticle | ParticleList:
     return ion  # type: ignore[return-value]
 
 
@@ -681,8 +675,8 @@ def test_creating_mean_particle_for_parameter_named_ion() -> None:
 
 @particle_input
 def return_particle(
-    particle: ParticleLike, Z: Optional[float] = None, mass_numb: Optional[int] = None
-) -> Union[Particle, CustomParticle, ParticleList]:
+    particle: ParticleLike, Z: float | None = None, mass_numb: int | None = None
+) -> Particle | CustomParticle | ParticleList:
     """A simple function that is decorated by particle_input."""
     return particle  # type: ignore[return-value]
 

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -14,7 +14,6 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from functools import cached_property
-from typing import Union
 
 import astropy.units as u
 import numpy as np
@@ -669,8 +668,8 @@ class AbstractGrid(ABC):
 
     def _make_grid(  # noqa: C901, PLR0912
         self,
-        start: Union[float, u.Quantity],
-        stop: Union[float, u.Quantity],
+        start: float | u.Quantity,
+        stop: float | u.Quantity,
         num: int = 100,
         units=None,
         **kwargs,
@@ -904,7 +903,7 @@ class AbstractGrid(ABC):
 
     @abstractmethod
     def nearest_neighbor_interpolator(
-        self, pos: Union[np.ndarray, u.Quantity], *args, persistent: bool = False
+        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
     ):
         r"""
         Interpolate values on the grid using a nearest-neighbor scheme with
@@ -1095,7 +1094,7 @@ class CartesianGrid(AbstractGrid):
 
     @modify_docstring(prepend=AbstractGrid.nearest_neighbor_interpolator.__doc__)
     def nearest_neighbor_interpolator(
-        self, pos: Union[np.ndarray, u.Quantity], *args, persistent: bool = False
+        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
     ):
         r""" """  # noqa: D419
 
@@ -1134,7 +1133,7 @@ class CartesianGrid(AbstractGrid):
         return output[0] if len(output) == 1 else tuple(output)
 
     def volume_averaged_interpolator(
-        self, pos: Union[np.ndarray, u.Quantity], *args, persistent: bool = False
+        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
     ):
         r"""
         Interpolate values on the grid using a volume-averaged scheme with
@@ -1399,7 +1398,7 @@ class NonUniformCartesianGrid(AbstractGrid):
 
     @modify_docstring(prepend=AbstractGrid.nearest_neighbor_interpolator.__doc__)
     def nearest_neighbor_interpolator(
-        self, pos: Union[np.ndarray, u.Quantity], *args, persistent: bool = False
+        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
     ):
         r""" """  # noqa: D419
         # Shared setup

--- a/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -1,6 +1,5 @@
 """Functionality for reading in HDF5 files following the OpenPMD standard."""
 from types import TracebackType
-from typing import Optional
 
 __all__ = ["HDF5Reader"]
 
@@ -76,9 +75,9 @@ class HDF5Reader(GenericPlasma):
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
     ):
         self.h5.close()
 

--- a/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
+++ b/plasmapy/plasma/sources/tests/test_openpmd_hdf5.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import astropy.units as u
 import pytest
 
@@ -131,7 +129,7 @@ units_test_table = [
 
 @pytest.mark.parametrize(("openPMD_dims", "expected"), units_test_table)
 @pytest.mark.slow()
-def test_fetch_units(openPMD_dims, expected: Union[tuple, list]) -> None:
+def test_fetch_units(openPMD_dims, expected: tuple | list) -> None:
     units = openpmd_hdf5._fetch_units(openPMD_dims)
     assert units == expected
 

--- a/plasmapy/simulation/particle_tracker.py
+++ b/plasmapy/simulation/particle_tracker.py
@@ -18,7 +18,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import astropy.units as u
 import h5py
@@ -190,13 +190,13 @@ class AbstractSaveRoutine(ABC):
     Then, the hook calls `save_now` to determine whether or not the simulation state should be saved.
     """
 
-    def __init__(self, output_directory: Optional[Path] = None) -> None:
+    def __init__(self, output_directory: Path | None = None) -> None:
         self.output_directory = output_directory
 
         self.x_all = []
         self.v_all = []
 
-        self._particle_tracker: Optional[ParticleTracker] = None
+        self._particle_tracker: ParticleTracker | None = None
 
     @property
     def tracker(self) -> Optional["ParticleTracker"]:
@@ -397,9 +397,9 @@ class ParticleTracker:
 
     def __init__(
         self,
-        grids: Union[AbstractGrid, Iterable[AbstractGrid]],
-        termination_condition: Union[AbstractTerminationCondition, None] = None,
-        save_routine: Union[AbstractSaveRoutine, None] = None,
+        grids: AbstractGrid | Iterable[AbstractGrid],
+        termination_condition: AbstractTerminationCondition | None = None,
+        save_routine: AbstractSaveRoutine | None = None,
         dt=None,
         dt_range=None,
         field_weighting="volume averaged",
@@ -496,8 +496,8 @@ class ParticleTracker:
 
     def setup_adaptive_time_step(
         self,
-        time_steps_per_gyroperiod: Optional[int] = 12,
-        Courant_parameter: Optional[float] = 0.5,
+        time_steps_per_gyroperiod: int | None = 12,
+        Courant_parameter: float | None = 0.5,
     ) -> None:
         """Set parameters for the adaptive time step candidates.
 
@@ -690,7 +690,7 @@ class ParticleTracker:
         # Keep track of how many push steps have occurred for trajectory tracing
         self.iteration_number = 0
 
-        self.time: Union[NDArray[np.float64], float] = (
+        self.time: NDArray[np.float64] | float = (
             np.zeros((self.nparticles, 1)) if not self.is_synchronized_time_step else 0
         )
         # Create flags for tracking when particles during the simulation
@@ -778,7 +778,7 @@ class ParticleTracker:
     # Run/push loop methods
     # *************************************************************************
 
-    def _adaptive_dt(self, Ex, Ey, Ez, Bx, By, Bz) -> Union[NDArray[np.float64], float]:  # noqa: ARG002
+    def _adaptive_dt(self, Ex, Ey, Ez, Bx, By, Bz) -> NDArray[np.float64] | float:  # noqa: ARG002
         r"""
         Calculate the appropriate dt for each grid based on a number of
         considerations

--- a/plasmapy/utils/_pytest_helpers/pytest_helpers.py
+++ b/plasmapy/utils/_pytest_helpers/pytest_helpers.py
@@ -12,7 +12,7 @@ import functools
 import inspect
 import warnings
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any
 
 import astropy.constants as const
 import astropy.tests.helper as astrohelper
@@ -69,7 +69,7 @@ def _process_input(wrapped_function: Callable):
 def run_test(  # noqa: C901
     func,
     args: Any = (),
-    kwargs: Optional[dict] = None,
+    kwargs: dict | None = None,
     expected_outcome: Any = None,
     rtol: float = 0.0,
     atol: float = 0.0,

--- a/plasmapy/utils/_units_helpers.py
+++ b/plasmapy/utils/_units_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 __all__: list[str] = []
 
 from numbers import Number
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import astropy.units as u
 
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 def _get_physical_type_dict(
     iterable: Iterable,
     *,
-    only_quantities: Optional[bool] = False,
-    numbers_become_quantities: Optional[bool] = False,
-    strict: Optional[bool] = False,
-    allowed_physical_types: Optional[set[Union[str, u.PhysicalType]]] = None,
+    only_quantities: bool | None = False,
+    numbers_become_quantities: bool | None = False,
+    strict: bool | None = False,
+    allowed_physical_types: set[str | u.PhysicalType] | None = None,
 ) -> dict[u.PhysicalType, u.Quantity]:
     """
     Return a `dict` that contains `~astropy.units.PhysicalType` objects

--- a/plasmapy/utils/code_repr.py
+++ b/plasmapy/utils/code_repr.py
@@ -5,7 +5,7 @@ __all__ = ["call_string", "attribute_call_string", "method_call_string"]
 import inspect
 from collections.abc import Callable
 from numbers import Integral
-from typing import Any, Optional, Union
+from typing import Any
 
 import astropy.units as u
 import numpy as np
@@ -90,7 +90,7 @@ def _code_repr_of_arg(arg, max_items=np.inf) -> str:
 
 
 def _code_repr_of_args_and_kwargs(
-    args: Any = None, kwargs: Optional[dict] = None, max_items=np.inf
+    args: Any = None, kwargs: dict | None = None, max_items=np.inf
 ) -> str:
     """
     Take positional and keyword arguments, and format them into a
@@ -190,7 +190,7 @@ def _string_together_warnings_for_printing(
 def call_string(
     f: Callable,
     args: Any = None,
-    kwargs: Optional[dict[str, Any]] = None,
+    kwargs: dict[str, Any] | None = None,
     max_items: Integral = 12,
 ) -> str:
     """
@@ -251,8 +251,8 @@ def call_string(
 def attribute_call_string(
     cls,
     attr: str,
-    args_to_cls: Optional[Union[tuple, Any]] = None,
-    kwargs_to_cls: Optional[dict[str, Any]] = None,
+    args_to_cls: tuple | Any | None = None,
+    kwargs_to_cls: dict[str, Any] | None = None,
     max_items: Integral = 12,
 ) -> str:
     """
@@ -326,10 +326,10 @@ def method_call_string(
     cls,
     method: str,
     *,
-    args_to_cls: Optional[Any] = None,
-    kwargs_to_cls: Optional[dict[str, Any]] = None,
-    args_to_method: Optional[Any] = None,
-    kwargs_to_method: Optional[dict[str, Any]] = None,
+    args_to_cls: Any | None = None,
+    kwargs_to_cls: dict[str, Any] | None = None,
+    args_to_method: Any | None = None,
+    kwargs_to_method: dict[str, Any] | None = None,
     max_items: Integral = 12,
 ) -> str:
     """

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -16,7 +16,7 @@ import inspect
 import warnings
 from functools import reduce
 from operator import add
-from typing import Any, Optional, Union
+from typing import Any
 
 import astropy.units as u
 import numpy as np
@@ -139,7 +139,7 @@ class CheckValues(CheckBase):
 
     def __init__(
         self,
-        checks_on_return: Optional[dict[str, bool]] = None,
+        checks_on_return: dict[str, bool] | None = None,
         **checks: dict[str, bool],
     ) -> None:
         super().__init__(checks_on_return=checks_on_return, **checks)
@@ -468,8 +468,8 @@ class CheckUnits(CheckBase):
 
     def __init__(
         self,
-        checks_on_return: Union[u.Unit, list[u.Unit], dict[str, Any]] = None,
-        **checks: Union[u.Unit, list[u.Unit], dict[str, Any]],
+        checks_on_return: u.Unit | list[u.Unit] | dict[str, Any] = None,
+        **checks: u.Unit | list[u.Unit] | dict[str, Any],
     ) -> None:
         super().__init__(checks_on_return=checks_on_return, **checks)
 
@@ -785,10 +785,10 @@ class CheckUnits(CheckBase):
     def _check_unit_core(  # noqa: C901, PLR0912, PLR0915
         self, arg, arg_name: str, arg_checks: dict[str, Any]
     ) -> tuple[
-        Optional[u.Quantity],
-        Optional[u.Unit],
-        Optional[list[Any]],
-        Optional[Exception],
+        u.Quantity | None,
+        u.Unit | None,
+        list[Any] | None,
+        Exception | None,
     ]:
         """
         Determines if `arg` passes unit checks `arg_checks` and if the units of
@@ -901,7 +901,7 @@ class CheckUnits(CheckBase):
 
     @staticmethod
     def _condition_target_units(
-        targets: list[Union[str, u.Unit, u.Quantity]],
+        targets: list[str | u.Unit | u.Quantity],
         from_annotations: bool = False,
     ) -> list:
         """
@@ -1056,7 +1056,7 @@ class CheckUnits(CheckBase):
 
 def check_units(
     func=None,
-    checks_on_return: Optional[dict[str, Any]] = None,
+    checks_on_return: dict[str, Any] | None = None,
     **checks: dict[str, Any],
 ):
     """
@@ -1185,7 +1185,7 @@ def check_units(
 
 def check_values(
     func=None,
-    checks_on_return: Optional[dict[str, bool]] = None,
+    checks_on_return: dict[str, bool] | None = None,
     **checks: dict[str, bool],
 ):
     """

--- a/plasmapy/utils/decorators/helpers.py
+++ b/plasmapy/utils/decorators/helpers.py
@@ -5,12 +5,9 @@ __all__ = ["modify_docstring", "preserve_signature"]
 
 import functools
 import inspect
-from typing import Optional
 
 
-def modify_docstring(
-    func=None, prepend: Optional[str] = None, append: Optional[str] = None
-):
+def modify_docstring(func=None, prepend: str | None = None, append: str | None = None):
     r"""
     A decorator which programmatically prepends and/or appends the docstring
     of the decorated method/function.  The unmodified/original docstring is

--- a/plasmapy/utils/decorators/lite_func.py
+++ b/plasmapy/utils/decorators/lite_func.py
@@ -7,7 +7,6 @@ __all__ = ["bind_lite_func"]
 import functools
 import inspect
 from collections.abc import Callable
-from typing import Optional
 
 from numba.extending import is_jitted
 
@@ -24,7 +23,7 @@ class _LiteFuncDict(dict):
     # This is only to give __bound_lite_func__ a docstring.
 
 
-def bind_lite_func(lite_func, attrs: Optional[dict[str, Callable]] = None):
+def bind_lite_func(lite_func, attrs: dict[str, Callable] | None = None):
     """
     Decorator to bind a lightweight "lite" version of a formulary
     function to the full formulary function, as well as any supporting

--- a/plasmapy/utils/decorators/tests/test_converters.py
+++ b/plasmapy/utils/decorators/tests/test_converters.py
@@ -1,5 +1,4 @@
 import inspect
-from typing import Optional
 
 import astropy.units as u
 import numpy as np
@@ -61,7 +60,7 @@ def test_to_hz_stacked_decorators() -> None:
     @particle_input
     @validate_quantities
     @angular_freq_to_hz
-    def func(particle: Optional[ParticleLike] = None):
+    def func(particle: ParticleLike | None = None):
         return 2 * np.pi * u.rad / u.s
 
     assert u.isclose(func(), 2 * np.pi * u.rad / u.s)

--- a/plasmapy/utils/decorators/tests/test_validators.py
+++ b/plasmapy/utils/decorators/tests/test_validators.py
@@ -3,7 +3,6 @@ Tests for 'validate` decorators (i.e. decorators that check objects and change t
 when possible).
 """
 import inspect
-from typing import Optional
 from unittest import mock
 
 import astropy.units as u
@@ -554,9 +553,9 @@ class TestValidateClassAttributes:
     class SampleCase:  # noqa: D106
         def __init__(
             self,
-            x: Optional[int] = None,
-            y: Optional[int] = None,
-            z: Optional[int] = None,
+            x: int | None = None,
+            y: int | None = None,
+            z: int | None = None,
         ) -> None:
             self.x = x
             self.y = y

--- a/plasmapy/utils/decorators/validators.py
+++ b/plasmapy/utils/decorators/validators.py
@@ -7,7 +7,7 @@ import functools
 import inspect
 import warnings
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 import astropy.units as u
 
@@ -543,9 +543,9 @@ def validate_quantities(func=None, validations_on_return=None, **validations):
 
 def get_attributes_not_provided(
     self,
-    expected_attributes: Optional[list[str]] = None,
-    both_or_either_attributes: Optional[list[Iterable[str]]] = None,
-    mutually_exclusive_attributes: Optional[list[Iterable[str]]] = None,
+    expected_attributes: list[str] | None = None,
+    both_or_either_attributes: list[Iterable[str]] | None = None,
+    mutually_exclusive_attributes: list[Iterable[str]] | None = None,
 ):
     """
     Collect attributes that weren't provided during instantiation needed
@@ -584,9 +584,9 @@ def get_attributes_not_provided(
 
 
 def validate_class_attributes(
-    expected_attributes: Optional[list[str]] = None,
-    both_or_either_attributes: Optional[list[Iterable[str]]] = None,
-    mutually_exclusive_attributes: Optional[list[Iterable[str]]] = None,
+    expected_attributes: list[str] | None = None,
+    both_or_either_attributes: list[Iterable[str]] | None = None,
+    mutually_exclusive_attributes: list[Iterable[str]] | None = None,
 ):
     """
     A decorator responsible for raising errors if the expected arguments weren't

--- a/plasmapy/utils/roman.py
+++ b/plasmapy/utils/roman.py
@@ -19,7 +19,6 @@ __all__ = [
 
 import re
 from numbers import Integral
-from typing import Union
 
 import numpy as np
 
@@ -59,7 +58,7 @@ _romanNumeralPattern = re.compile(
 )
 
 
-def to_roman(n: Union[Integral, np.integer]) -> str:
+def to_roman(n: Integral | np.integer) -> str:
     """
     Convert an integer to a Roman numeral.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,8 +335,6 @@ ignore = [
   "TD003", # missing-todo-link
   "TRY003", # raise-vanilla-args
   "TRY301", # raise-within-try
-  "UP006", # non-pep585-annotation
-  "UP007", # non-pep604-annotation
   "UP025", # unicode-kind-prefix
   "W191", # tab-indentation (formatter conflict)
 ]


### PR DESCRIPTION
I updated the `ruff` configuration to enable rules [`UP006`](https://docs.astral.sh/ruff/rules/non-pep585-annotation/) and [`UP007`](https://docs.astral.sh/ruff/rules/non-pep604-annotation/).  

All of the changes were associated with `UP007`, which changed the `typing.Union[X, Y]` syntax to `X | Y`. This PR is a follow-up to #2501 which dropped Python 3.9 support. This syntax was introduced in Python 3.10.

In the definition of `ParticleLike` and `ParticleListLike`, I kept the `typing.Union` syntax in the definition, since we weren't able to redefine `ParticleLike.__doc__` when using the `X | Y` syntax.

I had been worried that `@particle_input` would handle annotations like `Optional[ParticleLike]` and `ParticleLike | None` differently, but it worked out okay.

Closes #2502.