### PR TITLE
Fix typo in gyroradius formula

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -606,3 +606,5 @@ authors:
 - given-names: Carol
   family-names: Zhang
   alias: carolyz
+
+- alias: Bzero

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -207,7 +207,7 @@ def gyroradius(  # noqa: C901
 
     .. math::
 
-        r_{Ls} = \frac{V_{⟂,s}{ω_{c,s}}
+        r_{Ls} = \frac{V_{⟂,s}}{ω_{c,s}}
 
     where :math:`ω_{c,s}` is the particle gyrofrequency. To turn off
     relativistic effects, set the ``relativistic`` keyword to `False`.


### PR DESCRIPTION
## Description

This pull request fixes a small typo in the non-relativistic gyroradius formula.