### PR TITLE
Update usage of datetime

### DIFF
--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -159,7 +159,7 @@ class AbstractParticle(ABC):
             "plasmapy_particle": {
                 "type": type(self).__name__,
                 "module": self.__module__,
-                "date_created": datetime.datetime.now(datetime.UTC).strftime(
+                "date_created": datetime.datetime.now(datetime.timezone.UTC).strftime(
                     "%Y-%m-%d %H:%M:%S UTC"
                 ),
                 "__init__": {"args": (), "kwargs": {}},

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -13,11 +13,11 @@ __all__ = [
     "valid_categories",
 ]
 
+import datetime
 import json
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
-from datetime import datetime
 from numbers import Integral, Real
 from typing import TYPE_CHECKING, TypeAlias, Union
 
@@ -159,7 +159,7 @@ class AbstractParticle(ABC):
             "plasmapy_particle": {
                 "type": type(self).__name__,
                 "module": self.__module__,
-                "date_created": datetime.utcnow().strftime(  # noqa: DTZ003
+                "date_created": datetime.datetime.now(datetime.UTC).strftime(
                     "%Y-%m-%d %H:%M:%S UTC"
                 ),
                 "__init__": {"args": (), "kwargs": {}},

--- a/plasmapy/particles/particle_class.py
+++ b/plasmapy/particles/particle_class.py
@@ -159,7 +159,7 @@ class AbstractParticle(ABC):
             "plasmapy_particle": {
                 "type": type(self).__name__,
                 "module": self.__module__,
-                "date_created": datetime.datetime.now(datetime.timezone.UTC).strftime(
+                "date_created": datetime.datetime.now(datetime.UTC).strftime(
                     "%Y-%m-%d %H:%M:%S UTC"
                 ),
                 "__init__": {"args": (), "kwargs": {}},


### PR DESCRIPTION
This PR fixes a `DeprecationWarning` about the usage of `datetime.datetime.utcnow` in `particle_class.py`.