### PR TITLE
Silence some require_quantities warnings in particle_tracker

### DIFF
--- a/changelog/2519.trivial.rst
+++ b/changelog/2519.trivial.rst
@@ -1,0 +1,5 @@
+Added a flag to `~plasmapy.plasma.grids.AbstractGrid.require_quantities`
+to silence warnings when a quantity is not provided and is assumed to be
+zero everywhere. Modified `~plasmapy.simulation.particle_tracker.ParticleTracker` to
+not display this warning for the E and B field components, since one of these is often
+not explicitly provided.

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -163,10 +163,9 @@ class AbstractGrid(ABC):
             of zeros. If false, an exception will be raised instead.
             The default is False.
 
-        warn_on_replace_with_zeros : `bool`, optional
-            If true, warn if a required quantity is replaced with an
-            array of zeros. If false, no warning is shown. The default
-            is true.
+        warn_on_replace_with_zeros : `bool`, default: `True`
+            If `True`, warn if a required quantity is replaced with an
+            array of zeros. If `False`, no warning is shown.
 
         Raises
         ------

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -142,7 +142,12 @@ class AbstractGrid(ABC):
         """
         return self._recognized_quantities
 
-    def require_quantities(self, req_quantities, replace_with_zeros: bool = False):
+    def require_quantities(
+        self,
+        req_quantities,
+        replace_with_zeros: bool = False,
+        warn_on_replace_with_zeros: bool = True,
+    ):
         r"""
         Check to make sure that a list of required quantities are present.
         Optionally, can create missing quantities and fill them with
@@ -157,6 +162,11 @@ class AbstractGrid(ABC):
             If true, missing quantities will be replaced with an array
             of zeros. If false, an exception will be raised instead.
             The default is False.
+
+        warn_on_replace_with_zeros : `bool`, optional
+            If true, warn if a required quantity is replaced with an
+            array of zeros. If false, no warning is shown. The default
+            is true.
 
         Raises
         ------
@@ -186,11 +196,12 @@ class AbstractGrid(ABC):
                         "to be zero."
                     )
 
-                warnings.warn(
-                    f"{rq} is not specified for the provided grid."
-                    "This quantity will be assumed to be zero.",
-                    RuntimeWarning,
-                )
+                if warn_on_replace_with_zeros:
+                    warnings.warn(
+                        f"{rq} is not specified for the provided grid."
+                        "This quantity will be assumed to be zero.",
+                        RuntimeWarning,
+                    )
 
                 unit = self.recognized_quantities[rq].unit
                 arg = {rq: np.zeros(self.shape) * unit}

--- a/plasmapy/simulation/particle_tracker.py
+++ b/plasmapy/simulation/particle_tracker.py
@@ -374,15 +374,14 @@ class ParticleTracker:
 
         The default is 'volume averaged'.
 
-    req_quantities : `list` of str, optional
+    req_quantities : `list` of `str`, default : `None`
         A list of quantity keys required to be specified on the Grid object.
         The base particle pushing simulation requires the quantities
         [E_x, E_y, E_z, B_x, B_y, B_z]. This keyword is for specifying
-        quantities in addition to these six. If any additional required
-        quantities are missing, that quantity will be assumed to be zero
+        quantities in addition to these six. If any required
+        quantities are missing, those quantities will be assumed to be zero
         everywhere. A warning will be raised if any of the additional
-        required quantities are missing and are set to zero. The default is
-        None.
+        required quantities are missing and are set to zero.
 
     verbose : bool, optional
         If true, updates on the status of the program will be printed

--- a/plasmapy/simulation/particle_tracker.py
+++ b/plasmapy/simulation/particle_tracker.py
@@ -377,11 +377,12 @@ class ParticleTracker:
     req_quantities : `list` of str, optional
         A list of quantity keys required to be specified on the Grid object.
         The base particle pushing simulation requires the quantities
-        [E_x, E_y, E_z, B_x, B_y, B_z].
-        If any additional required quantities are missing, a warning will be
-        given and that quantity will be assumed to be zero everywhere.
-        This keyword is for specifying quantities in addition to these six.
-        The default is None.
+        [E_x, E_y, E_z, B_x, B_y, B_z]. This keyword is for specifying
+        quantities in addition to these six. If any additional required
+        quantities are missing, that quantity will be assumed to be zero
+        everywhere. A warning will be raised if any of the additional
+        required quantities are missing and are set to zero. The default is
+        None.
 
     verbose : bool, optional
         If true, updates on the status of the program will be printed


### PR DESCRIPTION
Addresses issue #2514 by adding a keyword `warn_on_replace_with_zeros` to `AbstractGrid.require_quantites`, then calling `require_quantities` twice in particle_tracker. The first time, for the E&B fields, the warnings are silenced, while the second time, for any other required quantities, they are not. 