### PR TITLE
Refactor script for checking `CITATION.cff`

### DIFF
--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -82,7 +82,6 @@ persistent identifier used by researchers, authors, and open source
 contributors. Sign up at: https://orcid.org/register
 
 Thank you for contributing!
-
 """
 
     logging.info(instructions_to_add_author)

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -34,7 +34,11 @@ def find_missing_github_usernames(authors: list[str]) -> list[str]:
     """Verify that all authors of a PR are included in :file:`CITATION.cff`."""
     with pathlib.Path("CITATION.cff").open() as file:
         lines = file.read()
-        return [author for author in authors if f"alias: {author}" not in lines]
+        return [
+            author
+            for author in authors
+            if f"alias: {author}" not in lines and f"- alias: {author}" not in lines
+        ]
 
 
 def main():

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -55,10 +55,14 @@ def main():
 
     instructions_to_add_author = f"""
 
-To ensure that you get credit for your contribution to PlasmaPy, please
-add the following authors to CITATION.cff: {missing_github_usernames!r}
+To ensure that you get credit for your contribution, please add the
+following authors to CITATION.cff: {", ".join(sorted(missing_github_usernames))!r}
 
-The entry should be of the form:
+This file can be edited directly on GitHub at:
+
+   https://github.com/{REPO}/edit/{branch_name}/CITATION.cff
+
+Each entry should be of the form:
 
 - given-names: <given names>
   family-names: <family names>
@@ -66,10 +70,6 @@ The entry should be of the form:
   orcid: https://orcid.org/<ORCiD number>
   alias: <GitHub username>
   email: <email address>
-
-This file can be edited directly on GitHub at:
-
-https://github.com/{REPO}/edit/{branch_name}/CITATION.cff
 
 All fields are optional except "alias", which is the GitHub username.
 The "affiliation", "orcid", and/or "email" fields are sometimes needed

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -49,8 +49,8 @@ def main():
     if not missing_github_usernames:
         msg = (
             f"The authors of pull request {PR_NUMBER} for {REPO} are: "
-            f"{', '.join(sorted(authors))}. No authors need to be "
-            "added to CITATION.cff."
+            f"{', '.join(sorted(authors))}. All authors are included "
+            "in CITATION.cff. ✔️"
         )
         logging.info(msg)
         sys.exit(0)

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -30,22 +30,19 @@ def get_pr_authors() -> set[str]:
     return authors - excluded_authors
 
 
-def check_citation_file(authors: set[str]) -> tuple[bool, str | None]:
+def find_missing_github_usernames(authors: set[str]) -> set[str]:
     """Verify that all authors of a PR are included in :file:`CITATION.cff`."""
     with pathlib.Path("CITATION.cff").open() as file:
-        contents = file.read()
-        for author in authors:
-            if f"alias: {author}" not in contents:
-                return False, author
-    return True, None
+        lines = file.read()
+        return {author for author in authors if f"alias: {author}" not in lines}
 
 
 def main():
     """Check that all authors are included in CITATION.cff."""
     authors = get_pr_authors()
-    check_passed, missing_github_username = check_citation_file(authors)
+    missing_github_usernames = find_missing_github_usernames(authors)
 
-    if check_passed:
+    if not missing_github_usernames:
         msg = (
             f"The authors of pull request {PR_NUMBER} for {REPO} are: "
             f"{', '.join(sorted(authors))}. No authors need to be "
@@ -58,7 +55,7 @@ def main():
 
     error_message = f"""
 To ensure that you get credit for your contribution to PlasmaPy, please
-add the following authors to CITATION.cff: {missing_github_username!r}
+add the following authors to CITATION.cff: {missing_github_usernames!r}
 
 The entry should be of the form:
 

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -50,7 +50,7 @@ def main():
         msg = (
             f"The authors of pull request {PR_NUMBER} for {REPO} are: "
             f"{', '.join(sorted(authors))}. All authors are included "
-            "in CITATION.cff. ✔️"
+            "in CITATION.cff. 😸"
         )
         logging.info(msg)
         sys.exit(0)

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -70,11 +70,8 @@ Each entry should be of the form:
   affiliation: <affiliation>
   orcid: https://orcid.org/<ORCiD number>
   alias: {username}
-  email: <email address>
 
 All fields are optional except "alias", which is the GitHub username.
-The "affiliation", "orcid", and/or "email" fields are sometimes needed
-for conference abstract or journal article submissions about PlasmaPy.
 
 We encourage all contributors to sign up for an ORCID iD: a unique,
 persistent identifier used by researchers, authors, and open source

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -16,21 +16,21 @@ REPO = os.getenv("GITHUB_REPOSITORY")
 excluded_authors = {"dependabot[bot]", "pre-commit-ci[bot]", "sourcery-ai"}
 
 
-def get_pr_authors() -> set[str]:
+def get_pr_authors() -> list[str]:
     """Get the GitHub usernames of the pull request."""
     url = f"https://api.github.com/repos/{REPO}/pulls/{PR_NUMBER}/commits"
     headers = {"Authorization": f"Bearer {GITHUB_TOKEN}"}
     response = requests.get(url, headers=headers, timeout=15)
     response.raise_for_status()
 
-    authors = {
+    authors = [
         commit["author"]["login"] for commit in response.json() if commit["author"]
-    }
+    ]
 
     return authors - excluded_authors
 
 
-def find_missing_github_usernames(authors: set[str]) -> list[str]:
+def find_missing_github_usernames(authors: list[str]) -> list[str]:
     """Verify that all authors of a PR are included in :file:`CITATION.cff`."""
     with pathlib.Path("CITATION.cff").open() as file:
         lines = file.read()
@@ -51,21 +51,17 @@ def main():
         logging.info(msg)
         sys.exit(0)
 
-    branch_name = os.getenv("GITHUB_HEAD_REF")
-
-    if len(missing_github_usernames) == 1:
-        alias_field = missing_github_usernames[0]
-    else:
-        alias_field = "<GitHub username>"
+    branch = os.getenv("GITHUB_HEAD_REF")
+    username = missing_github_usernames[0]
 
     instructions_to_add_author = f"""
 
 To ensure that you get credit for your contribution, please add the
 following authors to CITATION.cff: {", ".join(missing_github_usernames)!r}
 
-This file can be edited directly on GitHub at:
+This file can be edited at:
 
-https://github.com/{REPO}/edit/{branch_name}/CITATION.cff
+https://github.com/{username}/PlasmaPy/edit/{branch}/CITATION.cff
 
 Each entry should be of the form:
 
@@ -73,7 +69,7 @@ Each entry should be of the form:
   family-names: <family names>
   affiliation: <affiliation>
   orcid: https://orcid.org/<ORCiD number>
-  alias: {alias_field}
+  alias: {username}
   email: <email address>
 
 All fields are optional except "alias", which is the GitHub username.

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -53,28 +53,37 @@ def main():
 
     branch_name = os.getenv("GITHUB_HEAD_REF")
 
-    error_message = f"""\n
+    instructions_to_add_author = f"""
+
 To ensure that you get credit for your contribution to PlasmaPy, please
-add the following authors to CITATION.cff: {missing_github_usernames!r}\n\n
-The entry should be of the form:\n\n
+add the following authors to CITATION.cff: {missing_github_usernames!r}
+
+The entry should be of the form:
+
 - given-names: <given names>
   family-names: <family names>
   affiliation: <affiliation>
   orcid: https://orcid.org/<ORCiD number>
   alias: <GitHub username>
-  email: <email address>\n\n
-This file can be edited directly on GitHub at:\n\n
-https://github.com/{REPO}/edit/{branch_name}/CITATION.cff\n\n
-We encourage all contributors to sign up for an ORCID iD: a unique,
-persistent identifier used by researchers, authors, and open source
-contributors. Sign up at: https://orcid.org/register\n\n
+  email: <email address>
+
+This file can be edited directly on GitHub at:
+
+https://github.com/{REPO}/edit/{branch_name}/CITATION.cff
+
 All fields are optional except "alias", which is the GitHub username.
 The "affiliation", "orcid", and/or "email" fields are sometimes needed
-for conference abstract or journal article submissions about PlasmaPy.\n\n
+for conference abstract or journal article submissions about PlasmaPy.
+
+We encourage all contributors to sign up for an ORCID iD: a unique,
+persistent identifier used by researchers, authors, and open source
+contributors. Sign up at: https://orcid.org/register
+
 Thank you for contributing!
+
 """
 
-    logging.info(error_message)
+    logging.info(instructions_to_add_author)
     sys.exit(1)
 
 

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -27,12 +27,6 @@ def get_pr_authors() -> set[str]:
         commit["author"]["login"] for commit in response.json() if commit["author"]
     }
 
-    msg = (
-        f"The authors of pull request {PR_NUMBER} for {REPO} are: "
-        f"{', '.join(sorted(authors))}."
-    )
-
-    logging.info(msg)
     return authors - excluded_authors
 
 
@@ -52,7 +46,11 @@ def main():
     check_passed, missing_github_username = check_citation_file(authors)
 
     if check_passed:
-        msg = f"The following authors are present in CITATION.cff: {authors}"
+        msg = (
+            f"The authors of pull request {PR_NUMBER} for {REPO} are: "
+            f"{', '.join(sorted(authors))}. No authors need to be "
+            "added to CITATION.cff."
+        )
         logging.info(msg)
         sys.exit(0)
 
@@ -60,7 +58,7 @@ def main():
 
     error_message = f"""
 To ensure that you get credit for your contribution to PlasmaPy, please
-add {missing_github_username!r} as an author to CITATION.cff.
+add the following authors to CITATION.cff: {missing_github_username!r}
 
 The entry should be of the form:
 
@@ -68,7 +66,7 @@ The entry should be of the form:
   family-names: <family names>
   affiliation: <affiliation>
   orcid: https://orcid.org/<ORCiD number>
-  alias: {missing_github_username}
+  alias: <GitHub username>
   email: <email address>
 
 This file can be edited directly on GitHub at:

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -23,11 +23,11 @@ def get_pr_authors() -> list[str]:
     response = requests.get(url, headers=headers, timeout=15)
     response.raise_for_status()
 
-    authors = [
+    authors = {
         commit["author"]["login"] for commit in response.json() if commit["author"]
-    ]
+    }
 
-    return authors - excluded_authors
+    return sorted(authors - excluded_authors)
 
 
 def find_missing_github_usernames(authors: list[str]) -> list[str]:

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -30,11 +30,11 @@ def get_pr_authors() -> set[str]:
     return authors - excluded_authors
 
 
-def find_missing_github_usernames(authors: set[str]) -> set[str]:
+def find_missing_github_usernames(authors: set[str]) -> list[str]:
     """Verify that all authors of a PR are included in :file:`CITATION.cff`."""
     with pathlib.Path("CITATION.cff").open() as file:
         lines = file.read()
-        return {author for author in authors if f"alias: {author}" not in lines}
+        return [author for author in authors if f"alias: {author}" not in lines]
 
 
 def main():
@@ -53,14 +53,19 @@ def main():
 
     branch_name = os.getenv("GITHUB_HEAD_REF")
 
+    if len(missing_github_usernames) == 1:
+        alias_field = missing_github_usernames[0]
+    else:
+        alias_field = "<GitHub username>"
+
     instructions_to_add_author = f"""
 
 To ensure that you get credit for your contribution, please add the
-following authors to CITATION.cff: {", ".join(sorted(missing_github_usernames))!r}
+following authors to CITATION.cff: {", ".join(missing_github_usernames)!r}
 
 This file can be edited directly on GitHub at:
 
-   https://github.com/{REPO}/edit/{branch_name}/CITATION.cff
+https://github.com/{REPO}/edit/{branch_name}/CITATION.cff
 
 Each entry should be of the form:
 
@@ -68,7 +73,7 @@ Each entry should be of the form:
   family-names: <family names>
   affiliation: <affiliation>
   orcid: https://orcid.org/<ORCiD number>
-  alias: <GitHub username>
+  alias: {alias_field}
   email: <email address>
 
 All fields are optional except "alias", which is the GitHub username.

--- a/.github/scripts/authors_in_cff.py
+++ b/.github/scripts/authors_in_cff.py
@@ -53,31 +53,24 @@ def main():
 
     branch_name = os.getenv("GITHUB_HEAD_REF")
 
-    error_message = f"""
+    error_message = f"""\n
 To ensure that you get credit for your contribution to PlasmaPy, please
-add the following authors to CITATION.cff: {missing_github_usernames!r}
-
-The entry should be of the form:
-
+add the following authors to CITATION.cff: {missing_github_usernames!r}\n\n
+The entry should be of the form:\n\n
 - given-names: <given names>
   family-names: <family names>
   affiliation: <affiliation>
   orcid: https://orcid.org/<ORCiD number>
   alias: <GitHub username>
-  email: <email address>
-
-This file can be edited directly on GitHub at:
-
-https://github.com/{REPO}/edit/{branch_name}/CITATION.cff
-
+  email: <email address>\n\n
+This file can be edited directly on GitHub at:\n\n
+https://github.com/{REPO}/edit/{branch_name}/CITATION.cff\n\n
 We encourage all contributors to sign up for an ORCID iD: a unique,
 persistent identifier used by researchers, authors, and open source
-contributors. Sign up at: https://orcid.org/register
-
+contributors. Sign up at: https://orcid.org/register\n\n
 All fields are optional except "alias", which is the GitHub username.
 The "affiliation", "orcid", and/or "email" fields are sometimes needed
-for conference abstract or journal article submissions about PlasmaPy.
-
+for conference abstract or journal article submissions about PlasmaPy.\n\n
 Thank you for contributing!
 """
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,7 +27,8 @@ cff-version: 1.2.0
 
 authors:
 
-- given-names: Nicholas
+- alias: namurphy
+  given-names: Nicholas
   family-names: Murphy
   email: namurphy@cfa.harvard.edu
   affiliation: Center for Astrophysics | Harvard & Smithsonian

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,7 +32,6 @@ authors:
   email: namurphy@cfa.harvard.edu
   affiliation: Center for Astrophysics | Harvard & Smithsonian
   orcid: https://orcid.org/0000-0001-6628-8033
-  alias: namurphy
 
 - given-names: Erik
   family-names: Everson

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,14 +27,14 @@ cff-version: 1.2.0
 
 authors:
 
-- alias: namurphy
-  given-names: Nicholas
+- given-names: Nicholas
   family-names: Murphy
   email: namurphy@cfa.harvard.edu
   affiliation: Center for Astrophysics | Harvard & Smithsonian
   orcid: https://orcid.org/0000-0001-6628-8033
+  alias: namurphy
 
-- given-names: Erik
+- given-names: Erik T.
   family-names: Everson
   email: eeverson@ucla.edu
   affiliation: UCLA
@@ -47,13 +47,13 @@ authors:
   orcid: https://orcid.org/0000-0001-6291-8843
   alias: StanczakDominik
 
-- given-names: Peter
+- given-names: Peter V.
   family-names: Heuer
   affiliation: University of Rochester
   orcid: https://orcid.org/0000-0001-5050-6606
   alias: pheuer
 
-- given-names: Pawel
+- given-names: Pawel M.
   family-names: Kozlowski
   affiliation: Los Alamos National Laboratory
   orcid: https://orcid.org/0000-0001-6849-3612


### PR DESCRIPTION
This PR does some refactoring of the script that checks whether each author of a pull request is included in `CITATION.cff`.  

This PR also fixes an error in the link to edit `CITATION.cff`.  The link had previously pointed to the `PlasmaPy/PlasmaPy` repo instead of the fork.  It does still assume that the fork is named "PlasmaPy" which will be true most of the time but possibly not all.