### PR TITLE
Drop the `py310-conda` tox environment

### DIFF
--- a/changelog/2526.trivial.rst
+++ b/changelog/2526.trivial.rst
@@ -1,0 +1,1 @@
+Removed the unused `py310-conda` |tox| environment.

--- a/changelog/2526.trivial.rst
+++ b/changelog/2526.trivial.rst
@@ -1,1 +1,1 @@
-Removed the unused `py310-conda` |tox| environment.
+Removed the unused ``py310-conda`` |tox| environment.

--- a/tox.ini
+++ b/tox.ini
@@ -93,25 +93,6 @@ commands =
 basepython = python3.12
 deps = -r{toxinidir}/requirements.txt
 
-# This env requires tox-conda.
-[testenv:py310-conda]
-basepython = python3.10
-extras =
-deps =
-    lmfit
-    pytest-cov
-    pytest-xdist
-conda_deps =
-    astropy >= 5.0.2
-    h5py >= 3.3.0
-    matplotlib >= 3.5.1
-    mpmath >= 1.2.1
-    numpy >= 1.23.0
-    pytest == 7.4.4
-    scipy >= 1.5.0
-    sphinx
-    sphinx_rtd_theme
-
 # This env tests minimal versions of each dependency.
 [testenv:py310-all-minimal]
 basepython = python3.10


### PR DESCRIPTION
For a while we've had a test environment for conda with Python 3.10.  However, we haven't used it in CI for quite a while.  It's also one more place where we have to specify requirements.  Since we're not using it, it also has the potential to become outdated.  This PR removes this unused environment.  