### PR TITLE
Minor updates of docstrings

### DIFF
--- a/plasmapy/analysis/time_series/excess_statistics.py
+++ b/plasmapy/analysis/time_series/excess_statistics.py
@@ -37,8 +37,8 @@ class ExcessStatistics:
     `ValueError`
         If ``time_step`` ≤ 0.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from plasmapy.analysis.time_series.excess_statistics import ExcessStatistics
     >>> signal = [0, 0, 2, 2, 0, 4]
     >>> thresholds = [1, 3, 5]

--- a/plasmapy/analysis/time_series/running_moments.py
+++ b/plasmapy/analysis/time_series/running_moments.py
@@ -44,8 +44,8 @@ def running_mean(signal, radius: int):
     `TypeError`
         If ``radius`` is not of type `int`.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from plasmapy.analysis.time_series.running_moments import running_mean
     >>> running_mean([1, 2, 3, 4], 1)
     array([2., 3.])
@@ -118,8 +118,8 @@ def running_moment(signal, radius: int, moment=1, time=None):
     -----
     The running rms divides by ``window``, not ``(window - 1)``.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from plasmapy.analysis.time_series.running_moments import running_moment
     >>> running_moment([1, 2, 3, 2, 1], 1, 4, [1, 2, 3, 4, 5])
     Running_Moment(run_moment=array([3.]), time=[3])

--- a/plasmapy/dispersion/analytical/stix_.py
+++ b/plasmapy/dispersion/analytical/stix_.py
@@ -158,8 +158,8 @@ def stix(  # noqa: C901, PLR0912, PLR0915
     vanish (cutoffs) and :math:`k \to \infty` for perpendicular
     propagation during wave resonance :math:`S \to 0`.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import astropy.units as u
     >>> from plasmapy.particles import Particle
     >>> from plasmapy.dispersion.analytical.stix_ import stix

--- a/plasmapy/formulary/radiation.py
+++ b/plasmapy/formulary/radiation.py
@@ -34,8 +34,8 @@ def thermal_bremsstrahlung(
     kmax: u.Quantity[u.m] = None,
 ) -> u.Quantity[u.kg * u.m**-1 * u.s**-2]:
     r"""
-    Calculate the bremsstrahlung emission spectrum for a Maxwellian plasma
-    in the Rayleigh-Jeans limit :math:`ℏ ω ≪ k_B T_e`.
+    Calculate the bremsstrahlung emission spectrum for a Maxwellian
+    plasma in the Rayleigh-Jeans limit :math:`ℏ ω ≪ k_B T_e`.
 
     .. math::
        \frac{dP}{dω} = \frac{8 \sqrt{2}}{3\sqrt{π}}
@@ -56,8 +56,8 @@ def thermal_bremsstrahlung(
         y = \frac{1}{2} \frac{ω^2 m_e}{k_{max}^2 k_B T_e}
 
     where :math:`k_{max}` is a maximum wavenumber approximated here as
-    :math:`k_{max} = 1/λ_B` where  :math:`λ_B` is the electron
-    de Broglie wavelength.
+    :math:`k_{max} = 1/λ_B` where  :math:`λ_B` is the electron de
+    Broglie wavelength.
 
     Parameters
     ----------
@@ -66,14 +66,16 @@ def thermal_bremsstrahlung(
         calculated (convertible to Hz).
 
     n_e : `~astropy.units.Quantity`
-        Electron number density in the plasma (convertible to m\ :sup:`-3`\ ).
+        Electron number density in the plasma (convertible to
+        m\ :sup:`-3`\ ).
 
     T_e : `~astropy.units.Quantity`
         Temperature of the electrons (in K or convertible to eV).
 
     n_i : `~astropy.units.Quantity`, optional
-        Ion number density in the plasma (convertible to m\ :sup:`-3`\ ). Defaults
-        to the quasi-neutral condition :math:`n_i = n_e / Z`\ .
+        Ion number density in the plasma (convertible to
+        m\ :sup:`-3`\ ). Defaults to the quasineutral condition
+        :math:`n_i = n_e / Z`\ .
 
     ion : |particle-like|, default: ``"p+"``
         An instance of `~plasmapy.particles.particle_class.Particle`, or
@@ -93,21 +95,17 @@ def thermal_bremsstrahlung(
     For details, see :cite:t:`bekefi:1966`\ .
     """
 
-    # Default n_i is n_e/Z:
-    if n_i is None:
+    if n_i is None:  # assume quasineutrality
         n_i = n_e / ion.charge_number
 
-    # Default value of kmax is the electrom thermal de Broglie wavelength
+    # Default value of kmax is the electron thermal de Broglie wavelength
     if kmax is None:
         kmax = (np.sqrt(const.m_e.si * const.k_B.si * T_e) / const.hbar.si).to(1 / u.m)
 
-    # Convert frequencies to angular frequencies
     ω = (frequencies * 2 * np.pi * u.rad).to(u.rad / u.s)
-
-    # Calculate the electron plasma frequency
     ω_pe = plasma_frequency(n=n_e, particle="e-")
 
-    # Check that all ω < wpe (this formula is only valid in this limit)
+    # Check that all ω < ω_pe (this formula is only valid in this limit)
     if np.min(ω) < ω_pe:
         raise PhysicsError(
             "Lowest frequency must be larger than the electron "

--- a/plasmapy/formulary/radiation.py
+++ b/plasmapy/formulary/radiation.py
@@ -32,7 +32,7 @@ def thermal_bremsstrahlung(
     n_i: u.Quantity[u.m**-3] = None,
     ion: ParticleLike = "p+",
     kmax: u.Quantity[u.m] = None,
-) -> np.ndarray:
+) -> u.Quantity[u.kg * u.m**-1 * u.s**-2]:
     r"""
     Calculate the bremsstrahlung emission spectrum for a Maxwellian plasma
     in the Rayleigh-Jeans limit :math:`ℏ ω ≪ k_B T_e`.

--- a/plasmapy/formulary/radiation.py
+++ b/plasmapy/formulary/radiation.py
@@ -95,7 +95,7 @@ def thermal_bremsstrahlung(
     For details, see :cite:t:`bekefi:1966`\ .
     """
 
-    if n_i is None:  # assume quasineutrality
+    if n_i is None:  # default is quasineutrality
         n_i = n_e / ion.charge_number
 
     # Default value of kmax is the electron thermal de Broglie wavelength

--- a/plasmapy/particles/ionization_state.py
+++ b/plasmapy/particles/ionization_state.py
@@ -214,6 +214,7 @@ class IonizationState:
 
     Examples
     --------
+    >>> import astropy.units as u
     >>> states = IonizationState("H", [0.6, 0.4], n_elem=1 * u.cm**-3, T_e=11000 * u.K)
     >>> states.ionic_fractions[0]  # fraction of hydrogen that is neutral
     0.6
@@ -862,6 +863,7 @@ class IonizationState:
 
         Examples
         --------
+        >>> import astropy.units as u
         >>> He_states = IonizationState(
         ...     "He",
         ...     [0.941, 0.058, 0.001],

--- a/plasmapy/particles/ionization_state_collection.py
+++ b/plasmapy/particles/ionization_state_collection.py
@@ -929,6 +929,7 @@ class IonizationStateCollection:
 
         Examples
         --------
+        >>> import astropy.units as u
         >>> states = IonizationStateCollection(
         ...     {"H": [0.1, 0.9], "He": [0.95, 0.05, 0.0]},
         ...     T_e=12000 * u.K,

--- a/plasmapy/utils/calculator/widget_helpers.py
+++ b/plasmapy/utils/calculator/widget_helpers.py
@@ -471,10 +471,10 @@ class _FunctionInfo:
         spec_combo: `list`
             List of parameters to be used in the function
 
-        Example
-        -------
-        For plasmapy.formulary.gyroradius the specific combo's are as follows:
-        ["B","particle","Vperp"] and ["B","particle","T"]
+        Examples
+        --------
+        For `plasmapy.formulary.gyroradius` the specific combos are as follows:
+        :py:`["B","particle","Vperp"]` and :py:`["B","particle","T"]`
         """
         if not self.spec_combo:
             self.spec_combo = []


### PR DESCRIPTION
 - I added `>>> import astropy.units as u` to the Examples sections of several docstrings
 - I changed some docstring section titles from `Example` to `Examples` to be consistent with the numpydoc docstring standard.