### PR TITLE
Create universal wheel in tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist = clean,py312,build_docs
-
 isolated_build = True
 
 [testenv]
+package = wheel
+wheel_build_env = .pkg
 allowlist_externals =
     /bin/bash
     /usr/bin/bash


### PR DESCRIPTION
This PR follows the advice in this blog post on [turbocharging tox](https://hynek.me/articles/turbo-charge-tox/).

> ```toml
> [testenv]
> package = wheel
> wheel_build_env = .pkg
> ```
>
> The first line tells tox to build and install wheels instead of source distributions, and the second line tells it to share the same build environment – and thus wheel – across all tox environments.