### PR TITLE
Update dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ version: 2
 updates:
 
 - package-ecosystem: github-actions
-  directory: /
+  directory: /.github/workflows
   labels:
   - GitHub Actions
   - no changelog entry needed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
   reviewers:
   - namurphy
   schedule:
-    interval: weekly
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
   reviewers:
   - namurphy
   schedule:
-    interval: daily
+    interval: weekly


### PR DESCRIPTION
An unintended consequence of the creation of a pinned requirements file for minimal dependencies in #2523 is that dependabot has begun creating pull requests to update the outdated versions of dependencies in that file.  

The purpose of this PR is to get dependabot to not do those updates.