### PR TITLE
Speed up tests by caching `.tox` in GitHub Actions and update tox environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade tox
 
     - name: Run tests
-      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+      run: tox -e ${{ matrix.toxenv }}
 
     - name: Upload coverage to codecov if requested
       if: ${{ contains(matrix.toxenv,'-cov') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,7 @@ jobs:
 
     - name: Save cache
       uses: actions/cache/save@v3
+      if: steps.restore-cache.outputs.cache-hit != 'true'
       with:
         path: |
           .tox
@@ -115,26 +116,19 @@ jobs:
     - name: Restore cache
       uses: actions/cache/restore@v3
       id: restore-doc-cache
-      if: ${{ github.event_name == 'pull_request' }}
       with:
         path: |
-          docs/api
-          docs/_build
-          docs/about/_authors.rst
           .tox
-        key: ${{ runner.os }}-${{ matrix.toxenv }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}-${{ github.event.number }}
+        key: ${{ runner.os }}-build_docs_pins-${{ hashFiles('requirements.txt') }}
 
     - name: Build docs
       run: tox -e build_docs_pins -- -q
 
-    - name: Save cache for pull requests
+    - name: Save cache
       uses: actions/cache/save@v3
-      if: ${{ github.event_name == 'pull_request' }}
+      if: steps.restore-doc-cache.outputs.cache-hit != 'true'
       with:
         path: |
-          docs/api
-          docs/_build
-          docs/about/_authors.rst
           .tox
         key: ${{ steps.restore-doc-cache.outputs.cache-primary-key }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,10 +110,7 @@ jobs:
       with:
         path: |
           .tox
-          docs/_build
-          docs/api
-          docs
-        key: build_docs-${{ runner.os }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}-${{ github.event.number }}"
+        key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}-${{ github.event.number }}"
 
     - name: Build docs
       run: tox -e build_docs_pins -- -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,13 +64,12 @@ jobs:
     - name: Install and upgrade tox
       run: python -m pip install --progress-bar off --upgrade tox
 
-    - name: Restore cache
-      uses: actions/cache/restore@v3
-      id: restore-cache
+    - name: Cache
+      uses: actions/cache@v4
       with:
         path: |
           .tox
-        key: ${{ runner.os }}-${{ matrix.toxenv }}-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-${{ matrix.toxenv }}-${{ hashFiles('requirements.txt', 'pyproject.toml') }}
 
     - name: Run tests
       run: tox -e ${{ matrix.toxenv }}
@@ -80,14 +79,6 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
-
-    - name: Save cache
-      uses: actions/cache/save@v3
-      if: steps.restore-cache.outputs.cache-hit != 'true'
-      with:
-        path: |
-          .tox
-        key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
   documentation:
 
@@ -113,24 +104,19 @@ jobs:
     - name: Install tox
       run: python -m pip install --progress-bar off --upgrade tox
 
-    - name: Restore cache
-      uses: actions/cache/restore@v3
-      id: restore-doc-cache
+    - name: Cache
+      uses: actions/cache@v4
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         path: |
           .tox
-        key: ${{ runner.os }}-build_docs_pins-${{ hashFiles('requirements.txt') }}
+          docs/_build
+          docs/api
+          docs
+        key: build_docs-${{ runner.os }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}
 
     - name: Build docs
       run: tox -e build_docs_pins -- -q
-
-    - name: Save cache
-      uses: actions/cache/save@v3
-      if: steps.restore-doc-cache.outputs.cache-hit != 'true'
-      with:
-        path: |
-          .tox
-        key: ${{ steps.restore-doc-cache.outputs.cache-primary-key }}
 
     - name: Print troubleshooting information on failure
       if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,17 +26,17 @@ jobs:
         - name: Python 3.12 (Ubuntu), with doctests, skip slow
           os: ubuntu-latest
           python: '3.12'
-          toxenv: py312-pins-doctest
+          toxenv: py312-pins-pytest_doctests_skipslow
 
         - name: Python 3.11 (macOS), code coverage
           os: macos-latest
           python: '3.11'
-          toxenv: py311-pins-cov-all
+          toxenv: py311-pins-pytest_cov_all
 
         - name: Python 3.10 (Ubuntu), minimal dependencies, skip slow
           os: ubuntu-latest
           python: '3.10'
-          toxenv: py310-pins-minimal
+          toxenv: py310-minimal-pytest_skipslow
 
         - name: mypy
           os: ubuntu-latest
@@ -61,8 +61,8 @@ jobs:
         python-version: ${{ matrix.python }}
         cache: pip
 
-    - name: Install and upgrade tox
-      run: python -m pip install --progress-bar off --upgrade tox
+    - name: Install and upgrade test tools
+      run: python -m pip install --progress-bar off --upgrade tox pytest-github-actions-annotate-failures
 
     - name: Cache
       uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,8 +112,29 @@ jobs:
     - name: Install tox
       run: python -m pip install --progress-bar off --upgrade tox
 
+    - name: Restore cache
+      uses: actions/cache/restore@v3
+      id: restore-doc-cache
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        path: |
+          docs/api
+          docs/_build
+          .tox
+        key: ${{ runner.os }}-${{ matrix.toxenv }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}-${{ github.event.number }}
+
     - name: Build docs
       run: tox -e build_docs_pins -- -q
+
+    - name: Save cache for pull requests
+      uses: actions/cache/save@v3
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        path: |
+          docs/api
+          docs/_build
+          .tox
+        key: ${{ steps.restore-doc-cache.outputs.cache-primary-key }}
 
     - name: Print troubleshooting information on failure
       if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,19 +62,19 @@ jobs:
         cache: pip
 
     - name: Install and upgrade test tools
-      run: python -m pip install --progress-bar off --upgrade tox pytest-github-actions-annotate-failures
+      run: python -m pip install --progress-bar off --upgrade tox
 
     - name: Cache
       uses: actions/cache@v4
       with:
         path: |
           .tox
-        key: ${{ runner.os }}-${{ matrix.toxenv }}-${{ hashFiles('requirements.txt', 'pyproject.toml') }}
+        key: ${{ matrix.toxenv }}-${{ runner.os }}-${{ hashFiles('requirements.txt', 'pyproject.toml') }}
 
     - name: Run tests
       run: tox -e ${{ matrix.toxenv }}
 
-    - name: Upload coverage to codecov if requested
+    - name: Upload coverage reports to Codecov
       if: ${{ contains(matrix.toxenv,'-cov') }}
       uses: codecov/codecov-action@v4
       with:
@@ -106,11 +106,10 @@ jobs:
 
     - name: Cache
       uses: actions/cache@v4
-      if: ${{ github.event_name == 'pull_request' }}
       with:
         path: |
           .tox
-        key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}-${{ github.event.number }}"
+        key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
 
     - name: Build docs
       run: tox -e build_docs_pins -- -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,7 @@ jobs:
         path: |
           docs/api
           docs/_build
+          docs/about/_authors.rst
           .tox
         key: ${{ runner.os }}-${{ matrix.toxenv }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}-${{ github.event.number }}
 
@@ -133,6 +134,7 @@ jobs:
         path: |
           docs/api
           docs/_build
+          docs/about/_authors.rst
           .tox
         key: ${{ steps.restore-doc-cache.outputs.cache-primary-key }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           os: ubuntu-latest
           python: '3.12'
           toxenv: py312-pins-doctest
-          toxargs: --develop
 
         - name: Python 3.11 (macOS), code coverage
           os: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,14 @@ jobs:
     - name: Install and upgrade tox
       run: python -m pip install --progress-bar off --upgrade tox
 
+    - name: Restore cache
+      uses: actions/cache/restore@v3
+      id: restore-cache
+      with:
+        path: |
+          .tox
+        key: ${{ runner.os }}-${{ matrix.toxenv }}-${{ hashFiles('requirements.txt') }}
+
     - name: Run tests
       run: tox -e ${{ matrix.toxenv }}
 
@@ -72,6 +80,13 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
+
+    - name: Save cache
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          .tox
+        key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
   documentation:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
           docs/_build
           docs/api
           docs
-        key: build_docs-${{ runner.os }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}
+        key: build_docs-${{ runner.os }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}-${{ github.event.number }}"
 
     - name: Build docs
       run: tox -e build_docs_pins -- -q

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -20,42 +20,42 @@ jobs:
         - name: Python 3.12 (macOS)
           os: macos-latest
           python: '3.12'
-          toxenv: py312-pins-all-doctest
+          toxenv: py312-pins-pytest_doctests_all
 
         - name: Python 3.11 (Ubuntu)
           os: ubuntu-latest
           python: '3.11'
-          toxenv: py311-pins-all
+          toxenv: py311-pins-pytest_all
 
         - name: Python 3.10 (Windows)
           os: windows-latest
           python: '3.10'
-          toxenv: py310-pins-all
+          toxenv: py310-pins-pytest_all
 
         - name: Python 3.10 (Windows), minimal dependencies
           os: windows-latest
           python: '3.10'
-          toxenv: py310-pins-minimal-all
+          toxenv: py310-minimal-pytest_all
 
         - name: Python 3.10 with Astropy dev (Ubuntu)
           os: ubuntu-latest
           python: '3.10'
-          toxenv: py310-astropydev-all
+          toxenv: py310-pytest_all-astropydev
 
         - name: Python 3.10 with matplotlib dev (Ubuntu)
           os: ubuntu-latest
           python: '3.10'
-          toxenv: py310-matplotlibdev-all
+          toxenv: py310-pytest_all-matplotlibdev
 
         - name: Python 3.10 with NumPy dev (Ubuntu)
           os: ubuntu-latest
           python: '3.10'
-          toxenv: py310-numpydev-all
+          toxenv: py310-pytest_all-numpydev
 
         - name: Python '3.10' with xarray dev (Ubuntu)
           os: ubuntu-latest
           python: '3.10'
-          toxenv: py310-xarraydev-all
+          toxenv: py310-pytest_all-xarraydev
 
         - name: Documentation with Sphinx dev (Ubuntu)
           os: ubuntu-latest
@@ -70,13 +70,13 @@ jobs:
 
         - name: Import PlasmaPy (macOS)
           os: macos-latest
-          python: '3.11'
-          toxenv: py311-minimal-pypi-import
+          python: '3.10'
+          toxenv: py310-minimal-pypi-import
 
         - name: Import PlasmaPy (Ubuntu)
           os: ubuntu-latest
-          python: '3.12'
-          toxenv: py312-minimal-pypi-import
+          python: '3.10'
+          toxenv: py310-minimal-pypi-import
 
     steps:
 

--- a/changelog/2552.internal.rst
+++ b/changelog/2552.internal.rst
@@ -1,4 +1,4 @@
-Applied caching through |GitHub Actions| to speed up continuous 
+Applied caching through |GitHub Actions| to speed up continuous
 integration tests and documentation builds. Because the Python environments used
 by |tox| to run tests no longer need to be recreated every time tests are run,
 caching speeds up several continuous integration tests by ∼2–3 minutes.

--- a/changelog/2552.internal.rst
+++ b/changelog/2552.internal.rst
@@ -1,0 +1,2 @@
+Applied caching in |GitHub Actions| to speed up continuous integration tests
+and documentation builds in pull requests.

--- a/changelog/2552.internal.rst
+++ b/changelog/2552.internal.rst
@@ -1,2 +1,4 @@
-Applied caching in |GitHub Actions| to speed up continuous integration tests
-and documentation builds in pull requests.
+Applied caching through |GitHub Actions| to speed up continuous 
+integration tests and documentation builds. Because the Python environments used
+by |tox| to run tests no longer need to be recreated every time tests are run,
+caching speeds up several continuous integration tests by ∼2–3 minutes.

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,8 @@ commands = coverage erase
 deps =
     uv
 changedir = {toxinidir}
-            BUILD_REQS = python -m uv pip compile pyproject.toml --upgrade
+setenv =
+    BUILD_REQS = python -m uv pip compile pyproject.toml --upgrade
 commands =
     # Build the main requirements file to contain a full dev environment,
     # and include annotations.

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ setenv =
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
     PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 --tb=short
-    BUILD_REQS = python -m uv pip compile pyproject.toml --upgrade
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
@@ -48,10 +47,10 @@ skip_install = true
 commands = coverage erase
 
 [testenv:requirements]
-basepython = python3.12
-changedir = {toxinidir}
 deps =
     uv
+changedir = {toxinidir}
+    BUILD_REQS = python -m uv pip compile pyproject.toml --upgrade
 commands =
     # Build the main requirements file to contain a full dev environment,
     # and include annotations.

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     COLUMNS = 80
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 --tb=short
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 --tb=short -n=auto --dist=loadfile
 
 extras = tests
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv =
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
     PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 --tb=short
+
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
@@ -23,14 +24,15 @@ deps =
     numpydev: numpy
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
-    cov: pytest-cov
-    !minimal: pytest-xdist
-    pytest-github-actions-annotate-failures
+    pytest_cov_all: pytest-cov
+    # pytest-github-actions-annotate-failures
 commands =
-    !all: {env:PYTEST_COMMAND} {posargs} -m 'not slow'
-    all: {env:PYTEST_COMMAND} {posargs}
-    cov-all: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}pyproject.toml --cov-append --cov-report xml:coverage.xml
-    doctest: {env:PYTEST_COMMAND} {posargs} --doctest-modules --doctest-continue-on-failure
+    pytest_all: {env:PYTEST_COMMAND} {posargs}
+    pytest_skipslow: {env:PYTEST_COMMAND} {posargs} -m "not slow"
+    pytest_doctests_all: {env:PYTEST_COMMAND} {posargs} --doctest-modules --doctest-continue-on-failure
+    pytest_doctests_skipslow: {env:PYTEST_COMMAND} {posargs} --doctest-modules --doctest-continue-on-failure -m "not slow"
+    pytest_cov_all: {env:PYTEST_COMMAND} {posargs} --cov=plasmapy --cov-report=xml --cov-config={toxinidir}{/}pyproject.toml --cov-append --cov-report xml:coverage.xml
+
 description =
     run tests
     astropydev: with the development version of astropy
@@ -39,7 +41,22 @@ description =
     sphinxdev: with the development version of sphinx
     xarraydev: with the development version of xarray
     minimal: with minimal versions of dependencies
-    cov: with code coverage
+
+[testenv:py312-pins]
+basepython = python3.12
+deps = -r{toxinidir}/requirements/requirements_tests_py312.txt
+
+[testenv:py311-pins]
+basepython = python3.11
+deps = -r{toxinidir}/requirements/requirements_tests_py311.txt
+
+[testenv:py310-pins]
+basepython = python3.10
+deps = -r{toxinidir}/requirements/requirements_tests_py310.txt
+
+[testenv:py310-minimal]
+basepython = python3.10
+deps = -r{toxinidir}/requirements/requirements_tests_minimal_py310.txt
 
 [testenv:clean]
 deps = coverage
@@ -109,27 +126,6 @@ setenv =
     HOME = {envtmpdir}
 commands =
     sphinx-build -D nbsphinx_execute='never' docs docs{/}_build{/}html -b html {posargs}
-
-[testenv:py312-pins]
-basepython = python3.12
-deps = -r{toxinidir}/requirements/requirements_tests_py312.txt
-
-[testenv:py311-pins]
-basepython = python3.11
-deps = -r{toxinidir}/requirements/requirements_tests_py311.txt
-
-[testenv:py310-pins]
-basepython = python3.10
-deps = -r{toxinidir}/requirements/requirements_tests_py310.txt
-
-# This env tests minimal versions of each dependency.
-[testenv:py310-pins-minimal]
-basepython = python3.10
-extras = tests
-deps = -r{toxinidir}/requirements/requirements_tests_minimal_py310.txt
-
-setenv =
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5
 
 [testenv:linters]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
     matplotlibdev: git+https://github.com/matplotlib/matplotlib
-    numpydev: numpy
+    numpydev: git+https://github.com/numpy/numpy
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
     xarraydev: git+https://github.com/pydata/xarray
     pytest_cov_all: pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands = coverage erase
 deps =
     uv
 changedir = {toxinidir}
-    BUILD_REQS = python -m uv pip compile pyproject.toml --upgrade
+            BUILD_REQS = python -m uv pip compile pyproject.toml --upgrade
 commands =
     # Build the main requirements file to contain a full dev environment,
     # and include annotations.

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ allowlist_externals =
     echo
 setenv =
     MPLBACKEND = agg
-    COLUMNS = 180
+    COLUMNS = 80
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
     PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 --tb=short

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     COLUMNS = 180
     PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.anaconda.org/scipy-wheels-nightly/simple}
     PIP_EXTRA_INDEX_URL = {env:PIP_EXTRA_INDEX_URL:https://pypi.org/simple}
-    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 -n=auto --dist=loadfile --tb=short
+    PYTEST_COMMAND = pytest --pyargs plasmapy --durations=5 --tb=short
     BUILD_REQS = python -m uv pip compile pyproject.toml --upgrade
 extras = tests
 deps =


### PR DESCRIPTION
Continuous integration tests are most beneficial when they provide rapid 🚀 feedback. One of the time sinks in tests has been that `tox` has had to recreate Python environments every time tests are run.  

This PR enables caching for our test suite and documentation build via GitHub Actions. **Caching speeds up our Python 3.12 tests in CI (which skip slow tests but include doctests) from ∼3.5 min to ≲ 1 min!** We save the ∼2.5 minutes by not having to always recreate Python environments.

I renamed tox environments to make them easier to keep track of (at least for me). In particular, I reduced the extent to which `tox.ini` makes use of [generative environments](https://tox.wiki/en/4.13.0/user_guide.html#generative-environments) when specifying the commands for pytest to run. This is less clever, but probably a bit more maintainable.

I also did a bit of cleanup of `tox.ini` and GitHub Actions.

## Related issues

I attemped to take care of #2258 here by caching `docs/_build`, `docs/api`, and `docs/about/_authors.rst`, but I got a weird doc build error that I didn't attempt to figure out.