### PR TITLE
Cache documentation build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,8 @@ jobs:
       with:
         path: |
           .tox
-        key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          docs/_build
+        key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}
 
     - name: Build docs
       run: tox -e build_docs_pins -- -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,6 +110,7 @@ jobs:
         path: |
           .tox
           docs/_build
+          docs/api
         key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt', 'docs/conf.py') }}
 
     - name: Build docs

--- a/changelog/2553.internal.rst
+++ b/changelog/2553.internal.rst
@@ -1,0 +1,2 @@
+Using caching via |GitHub Actions| to speed up the documentation build
+during continuous integration.

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -632,8 +632,7 @@ Docstring guidelines
 
 * All functions, classes, and objects that are part of the public
   :wikipedia:`API` must have a docstring that follows the numpydoc_
-  standard. Refer to the numpydoc_ standard for how to write docstrings
-  for classes, class attributes, and constants.
+  standard.
 
 * The short summary statement at the beginning of a docstring should be
   one line long, but may be longer if necessary.

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ fqdn==1.5.1
 future==1.0.0
     # via uncertainties
 h5py==3.10.0
-hypothesis==6.98.13
+hypothesis==6.98.15
 identify==2.5.35
     # via pre-commit
 idna==3.6
@@ -122,7 +122,7 @@ jinja2==3.1.3
     #   numpydoc
     #   sphinx
     #   towncrier
-json5==0.9.17
+json5==0.9.18
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
@@ -293,7 +293,7 @@ pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
 pytest-xdist==3.5.0
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   jupyter-client

--- a/requirements/requirements_docs_py312.txt
+++ b/requirements/requirements_docs_py312.txt
@@ -42,7 +42,7 @@ ipywidgets==8.1.2
 isoduration==20.11.0
 jedi==0.19.1
 jinja2==3.1.3
-json5==0.9.17
+json5==0.9.18
 jsonpointer==2.4
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
@@ -92,7 +92,7 @@ pyerfa==2.0.1.1
 pygments==2.17.2
 pyparsing==3.1.1
 pyproject-api==1.6.1
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 pytz==2024.1
 pyyaml==6.0.1

--- a/requirements/requirements_tests_minimal_py310.txt
+++ b/requirements/requirements_tests_minimal_py310.txt
@@ -118,7 +118,7 @@ jinja2==3.1.3
     #   jupyterlab
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.17
+json5==0.9.18
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
@@ -289,7 +289,7 @@ pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
 pytest-xdist==3.5.0
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   jupyter-client

--- a/requirements/requirements_tests_py310.txt
+++ b/requirements/requirements_tests_py310.txt
@@ -33,7 +33,7 @@ fonttools==4.49.0
 fqdn==1.5.1
 future==1.0.0
 h5py==3.10.0
-hypothesis==6.98.13
+hypothesis==6.98.15
 identify==2.5.35
 idna==3.6
 iniconfig==2.0.0
@@ -43,7 +43,7 @@ ipywidgets==8.1.2
 isoduration==20.11.0
 jedi==0.19.1
 jinja2==3.1.3
-json5==0.9.17
+json5==0.9.18
 jsonpointer==2.4
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
@@ -94,7 +94,7 @@ pytest==8.0.2
 pytest-datadir==1.5.0
 pytest-regressions==2.5.0
 pytest-xdist==3.5.0
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 pytz==2024.1
 pyyaml==6.0.1

--- a/requirements/requirements_tests_py311.txt
+++ b/requirements/requirements_tests_py311.txt
@@ -32,7 +32,7 @@ fonttools==4.49.0
 fqdn==1.5.1
 future==1.0.0
 h5py==3.10.0
-hypothesis==6.98.13
+hypothesis==6.98.15
 identify==2.5.35
 idna==3.6
 iniconfig==2.0.0
@@ -42,7 +42,7 @@ ipywidgets==8.1.2
 isoduration==20.11.0
 jedi==0.19.1
 jinja2==3.1.3
-json5==0.9.17
+json5==0.9.18
 jsonpointer==2.4
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
@@ -93,7 +93,7 @@ pytest==8.0.2
 pytest-datadir==1.5.0
 pytest-regressions==2.5.0
 pytest-xdist==3.5.0
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 pytz==2024.1
 pyyaml==6.0.1

--- a/requirements/requirements_tests_py312.txt
+++ b/requirements/requirements_tests_py312.txt
@@ -32,7 +32,7 @@ fonttools==4.49.0
 fqdn==1.5.1
 future==1.0.0
 h5py==3.10.0
-hypothesis==6.98.13
+hypothesis==6.98.15
 identify==2.5.35
 idna==3.6
 iniconfig==2.0.0
@@ -42,7 +42,7 @@ ipywidgets==8.1.2
 isoduration==20.11.0
 jedi==0.19.1
 jinja2==3.1.3
-json5==0.9.17
+json5==0.9.18
 jsonpointer==2.4
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
@@ -93,7 +93,7 @@ pytest==8.0.2
 pytest-datadir==1.5.0
 pytest-regressions==2.5.0
 pytest-xdist==3.5.0
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
 pytz==2024.1
 pyyaml==6.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ extras = docs
 setenv =
     HOME = {envtmpdir}
 commands =
-    sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
+    sphinx-build docs docs{/}_build{/}html -W -n -j auto --keep-going -b html {posargs}
 
 [testenv:build_docs_pins]
 changedir = {toxinidir}
@@ -97,7 +97,7 @@ setenv =
     HOME = {envtmpdir}
     PYDEVD_DISABLE_FILE_VALIDATION=1
 commands =
-    sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
+    sphinx-build docs docs{/}_build{/}html -W -n -j auto --keep-going -b html {posargs}
 deps = -r{toxinidir}/requirements/requirements_docs_py312.txt
 
 [testenv:linkcheck]
@@ -114,7 +114,7 @@ changedir = {toxinidir}
 extras = docs
 setenv =
     HOME = {envtmpdir}
-commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
+commands = sphinx-build docs docs{/}_build{/}html -W -n -j auto --keep-going -b html {posargs}
 deps =
     git+https://github.com/sphinx-doc/sphinx
 description =


### PR DESCRIPTION
Closes #2258.  At least, assuming I can get it to work!

The way it is set up now, I don't think the artifacts in `docs/_build` are being used when regenerating the documentation.  I think the speedup is just from caching `.tox`.