### PR TITLE
Fix GitHub Action to regenerate requirements

### DIFF
--- a/.github/workflows/update-pinned-reqs.yml
+++ b/.github/workflows/update-pinned-reqs.yml
@@ -23,6 +23,9 @@ jobs:
       with:
         python-version: 3.12
 
+    - name: Install tox
+      run: python -m pip install --upgrade tox
+
     - name: Rebuild requirements
       run: tox -e requirements
 


### PR DESCRIPTION
I recently updated the GitHub Action and tox environment to regenerate requirements files. However, for some reason I dropped the tox installation step, which broke the workflow. This PR adds this step back.