### PR TITLE
Remove `setup.py`

### DIFF
--- a/changelog/2558.internal.rst
+++ b/changelog/2558.internal.rst
@@ -1,0 +1,1 @@
+Removed :file:`setup.py`.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
Since PlasmaPy has `pyproject.toml`, our `setup.py` file is no longer necessary. In particular, the `setup.py` configuration [is now considered legacy](https://pip.pypa.io/en/stable/reference/build-system/setup-py/). This PR removes `setup.py`.

We had previously kept a simple `setup.py` around because `pip install -e` had only recently been implemented for projects without `setup.py`.

Cross-references: #1680, #1758 

