### PR TITLE
Make `common_isotopes`, `known_isotopes`, and `stable_isotopes` each return a `ParticleList`

### DIFF
--- a/changelog/2559.breaking.rst
+++ b/changelog/2559.breaking.rst
@@ -1,0 +1,2 @@
+Modified `~plasmapy.particles.atomic.common_isotopes`, `~plasmapy.particles.atomic.known_isotopes`,
+and `~plasmapy.particles.atomic.known_isotopes` to each return a |ParticleList|.

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -783,7 +783,7 @@ def stable_isotopes(
         return [
             isotope
             for isotope in KnownIsotopes
-            if _isotopes.data_about_isotopes[isotope.symbol]["stable"] == stable_only
+            if _isotopes.data_about_isotopes[isotope.isotope]["stable"] == stable_only
         ]
 
     if argument is not None:

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -493,7 +493,7 @@ def half_life(particle: Particle, mass_numb: int | None = None) -> u.Quantity[u.
     return particle.half_life
 
 
-def known_isotopes(argument: str | int | None = None) -> list[str]:
+def known_isotopes(argument: str | int | None = None) -> ParticleList:
     """
     Return a list of all known isotopes of an element, or a list of all
     known isotopes of every element if no input is provided.
@@ -506,7 +506,7 @@ def known_isotopes(argument: str | int | None = None) -> list[str]:
 
     Returns
     -------
-    `list` of `str`
+    |ParticleList|
         List of all the isotopes of an element that have been
         discovered, sorted from low to high mass number. If no argument
         is provided, then a list of all known isotopes of every element
@@ -536,11 +536,11 @@ def known_isotopes(argument: str | int | None = None) -> list[str]:
     Examples
     --------
     >>> known_isotopes("H")
-    ['H-1', 'D', 'T', 'H-4', 'H-5', 'H-6', 'H-7']
+    ParticleList(['H-1', 'D', 'T', 'H-4', 'H-5', 'H-6', 'H-7'])
     >>> known_isotopes("helium 1+")
-    ['He-3', 'He-4', 'He-5', 'He-6', 'He-7', 'He-8', 'He-9', 'He-10']
+    ParticleList(['He-3', 'He-4', 'He-5', 'He-6', 'He-7', 'He-8', 'He-9', 'He-10'])
     >>> known_isotopes()[0:10]
-    ['H-1', 'D', 'T', 'H-4', 'H-5', 'H-6', 'H-7', 'He-3', 'He-4', 'He-5']
+    ParticleList(['H-1', 'D', 'T', 'H-4', 'H-5', 'H-6', 'H-7', 'He-3', 'He-4', 'He-5'])
     >>> len(known_isotopes())  # the number of known isotopes
     3352
     """
@@ -582,7 +582,7 @@ def known_isotopes(argument: str | int | None = None) -> list[str]:
         for atomic_numb in range(1, len(_elements.data_about_elements) + 1):
             isotopes_list += known_isotopes_for_element(atomic_numb)
 
-    return isotopes_list
+    return ParticleList(isotopes_list)
 
 
 def common_isotopes(
@@ -664,11 +664,11 @@ def common_isotopes(
         CommonIsotopes = [
             isotope
             for isotope in isotopes
-            if "abundance" in _isotopes.data_about_isotopes[isotope]
+            if "abundance" in _isotopes.data_about_isotopes[isotope.isotope]
         ]
 
         isotopic_abundances = [
-            _isotopes.data_about_isotopes[isotope]["abundance"]
+            _isotopes.data_about_isotopes[isotope.isotope]["abundance"]
             for isotope in CommonIsotopes
         ]
 
@@ -783,7 +783,7 @@ def stable_isotopes(
         return [
             isotope
             for isotope in KnownIsotopes
-            if _isotopes.data_about_isotopes[isotope]["stable"] == stable_only
+            if _isotopes.data_about_isotopes[isotope.symbol]["stable"] == stable_only
         ]
 
     if argument is not None:

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -770,8 +770,8 @@ def stable_isotopes(
 
     Find unstable isotopes using the ``unstable`` keyword.
 
-    >>> stable_isotopes("U", unstable=True)[:5]  # only first five
-    ParticleList(['U-217', 'U-218', 'U-219', 'U-220', 'U-221'])
+    >>> stable_isotopes("He", unstable=True)
+    ParticleList(['He-5', 'He-6', 'He-7', 'He-8', 'He-9', 'He-10'])
     """
 
     # TODO: Allow Particle objects representing elements to be inputs

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -604,7 +604,7 @@ def common_isotopes(
 
     Returns
     -------
-    `list` of `str`
+    |ParticleList|
         List of all isotopes of an element with isotopic abundances
         greater than zero, sorted from most abundant to least
         abundant.  If no isotopes have isotopic abundances greater

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -587,7 +587,7 @@ def known_isotopes(argument: str | int | None = None) -> list[str]:
 
 def common_isotopes(
     argument: str | int | None = None, most_common_only: bool = False
-) -> list[str]:
+) -> ParticleList:
     """
     Return a list of isotopes of an element with an isotopic abundances
     greater than zero, or if no input is provided, a list of all such
@@ -641,17 +641,17 @@ def common_isotopes(
     Examples
     --------
     >>> common_isotopes("H")
-    ['H-1', 'D']
+    ParticleList(['H-1', 'D'])
     >>> common_isotopes(44)
-    ['Ru-102', 'Ru-104', 'Ru-101', 'Ru-99', 'Ru-100', 'Ru-96', 'Ru-98']
+    ParticleList(['Ru-102', 'Ru-104', 'Ru-101', 'Ru-99', 'Ru-100', 'Ru-96', 'Ru-98'])
     >>> common_isotopes("beryllium 2+")
-    ['Be-9']
+    ParticleList(['Be-9'])
     >>> common_isotopes("Fe")
-    ['Fe-56', 'Fe-54', 'Fe-57', 'Fe-58']
+    ParticleList(['Fe-56', 'Fe-54', 'Fe-57', 'Fe-58'])
     >>> common_isotopes("Fe", most_common_only=True)
-    ['Fe-56']
+    ParticleList(['Fe-56'])
     >>> common_isotopes()[0:7]
-    ['H-1', 'D', 'He-4', 'He-3', 'Li-7', 'Li-6', 'Be-9']
+    ParticleList(['H-1', 'D', 'He-4', 'He-3', 'Li-7', 'Li-6', 'Be-9'])
     """
 
     # TODO: Allow Particle objects representing elements to be inputs
@@ -703,7 +703,7 @@ def common_isotopes(
         for atomic_numb in range(1, 119):
             isotopes_list += common_isotopes_for_element(atomic_numb, most_common_only)
 
-    return isotopes_list
+    return ParticleList(isotopes_list)
 
 
 def stable_isotopes(

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -493,7 +493,6 @@ def half_life(particle: ParticleLike, mass_numb: int | None = None) -> u.Quantit
     return particle.half_life  # type: ignore[union-attr]
 
 
-
 def known_isotopes(argument: ParticleLike | None = None) -> ParticleList:
     """
     Return a list of all known isotopes of an element, or a list of all

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -708,7 +708,7 @@ def common_isotopes(
 
 def stable_isotopes(
     argument: ParticleLike | None = None, unstable: bool = False
-) -> list[str]:
+) -> ParticleList:
     """
     Return a list of all stable isotopes of an element, or if no input is
     provided, a list of all such isotopes for every element.
@@ -725,7 +725,7 @@ def stable_isotopes(
 
     Returns
     -------
-    `list` of `str`
+    |ParticleList|
         List of all stable isotopes of an element, sorted from low to
         high mass number.  If an element has no stable isotopes, this
         function returns an empty list.
@@ -758,20 +758,20 @@ def stable_isotopes(
     Examples
     --------
     >>> stable_isotopes("H")
-    ['H-1', 'D']
+    ParticleList(['H-1', 'D'])
     >>> stable_isotopes(44)
-    ['Ru-96', 'Ru-98', 'Ru-99', 'Ru-100', 'Ru-101', 'Ru-102', 'Ru-104']
+    ParticleList(['Ru-96', 'Ru-98', 'Ru-99', 'Ru-100', 'Ru-101', 'Ru-102', 'Ru-104'])
     >>> stable_isotopes("beryllium")
-    ['Be-9']
+    ParticleList(['Be-9'])
     >>> stable_isotopes("Pb-209")
-    ['Pb-204', 'Pb-206', 'Pb-207', 'Pb-208']
+    ParticleList(['Pb-204', 'Pb-206', 'Pb-207', 'Pb-208'])
     >>> stable_isotopes(118)
-    []
+    ParticleList([])
 
     Find unstable isotopes using the ``unstable`` keyword.
 
     >>> stable_isotopes("U", unstable=True)[:5]  # only first five
-    ['U-217', 'U-218', 'U-219', 'U-220', 'U-221']
+    ParticleList(['U-217', 'U-218', 'U-219', 'U-220', 'U-221'])
     """
 
     # TODO: Allow Particle objects representing elements to be inputs
@@ -802,7 +802,7 @@ def stable_isotopes(
         for atomic_numb in range(1, 119):
             isotopes_list += stable_isotopes_for_element(atomic_numb, not unstable)
 
-    return isotopes_list
+    return ParticleList(isotopes_list)
 
 
 @particle_input

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -483,18 +483,14 @@ def test_isotopic_abundance() -> None:
         isotopic_abundance("Og-2")
 
 
-isotopic_abundance_elements = (
-    atomic_number(atomic_numb) for atomic_numb in range(1, 119)
-)
+atomic_numbers = range(1, 119)
 
-isotopic_abundance_isotopes = (
-    common_isotopes(element) for element in isotopic_abundance_elements
-)
+isotopic_abundance_isotopes = (common_isotopes(element) for element in atomic_numbers)
 
 isotopic_abundance_sum_table = (
     (element, isotopes)
     for element, isotopes in zip(
-        isotopic_abundance_elements, isotopic_abundance_isotopes, strict=False
+        atomic_numbers, isotopic_abundance_isotopes, strict=False
     )
     if isotopes
 )

--- a/plasmapy/particles/tests/test_particle_class.py
+++ b/plasmapy/particles/tests/test_particle_class.py
@@ -770,7 +770,7 @@ def test_particle_half_life_string() -> None:
     """
 
     for isotope in known_isotopes():
-        half_life = data_about_isotopes[isotope].get("half-life", None)
+        half_life = data_about_isotopes[isotope.isotope].get("half-life", None)
         if isinstance(half_life, str):
             break
 


### PR DESCRIPTION
Whilst working on #2458, I noticed that a few of the functions in `plasmapy.particles.atomic` each returned a `list` containing `Particle` objects.  This PR changes it so that they return a `ParticleList`.