### PR TITLE
Fix sentence in gyroradius documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -453,6 +453,12 @@ authors:
   family-names: Rao
   alias: thecasuist
 
+- given-names: Jeffrey
+  family-names: Reep
+  affiliation: University of Hawai'i at Manoa
+  orcid: https://orcid.org/0000-0003-4739-1152
+  alias: jwreep
+
 - alias: seanjunheng2
 
 - given-names: Steve

--- a/changelog/2560.doc.rst
+++ b/changelog/2560.doc.rst
@@ -1,1 +1,1 @@
-Updated the docstring for plasmapy.formulary.lengths.gyroradius to finish an unfinished sentence.
+Updated the docstring for `~plasmapy.formulary.lengths.gyroradius to` finish an unfinished sentence.

--- a/changelog/2560.doc.rst
+++ b/changelog/2560.doc.rst
@@ -1,1 +1,1 @@
-Updated the docstring for `~plasmapy.formulary.lengths.gyroradius to` finish an unfinished sentence.
+Updated the docstring for `~plasmapy.formulary.lengths.gyroradius` to finish an unfinished sentence.

--- a/changelog/2560.doc.rst
+++ b/changelog/2560.doc.rst
@@ -1,0 +1,1 @@
+Updated the docstring for plasmapy.formulary.lengths.gyroradius to finish an unfinished sentence.

--- a/plasmapy/formulary/lengths.py
+++ b/plasmapy/formulary/lengths.py
@@ -187,7 +187,7 @@ def gyroradius(
     --------
     The Lorentz factor can be inferred from ``Vperp`` or ``T`` but near
     the speed of light, this can lead to rounding errors. For very high
-    values of the Lo
+    values of the Lorentz factor, its use should be preferred.
 
     Notes
     -----


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

<!-- Please summarize the changes here. -->

There was an unfinished sentence in the gyroradius description, warning about ``Vperp`` or ``T`` in the relativistic case.  I simply finished the sentence, which presumably was warning users to use the Lorentz factor.  

## Motivation and context

<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->

More complete documentation!

## Related issues

<!-- Please link to any related issues and PRs. If this PR will fully resolve and issue, include text like "Closes #1542" so that the issue will be automatically closed when this PR is merged. -->
