### PR TITLE
Add `sphinx-lint` to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,11 @@ repos:
     additional_dependencies:
     - black==24.1.1
 
+- repo: https://github.com/sphinx-contrib/sphinx-lint
+  rev: v0.9.1
+  hooks:
+  - id: sphinx-lint
+
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.7.1
   hooks:

--- a/changelog/2561.internal.rst
+++ b/changelog/2561.internal.rst
@@ -1,0 +1,2 @@
+Added ``sphinx-lint`` as a |pre-commit| hook to find
+reStructuredText errors.

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -102,7 +102,7 @@ Changelog guidelines
 
 * Changelog entries are not required for changes that are sufficiently
   minor, such as typo fixes or fixed hyperlinks. When this is the case,
-  a package maintainer will add the :guilabel`no changelog entry needed`
+  a package maintainer will add the :guilabel:`no changelog entry needed`
   label to the pull request.
 
 * Use the past tense to describe the change, and the present tense to

--- a/docs/plasma/index.rst
+++ b/docs/plasma/index.rst
@@ -88,7 +88,7 @@ a Plasma3D system, first create an instance of the
 the :attr:`~plasmapy.plasma.sources.plasma3d.Plasma3D.density`,
 :attr:`~plasmapy.plasma.sources.plasma3d.Plasma3D.momentum`,
 :attr:`~plasmapy.plasma.sources.plasma3d.Plasma3D.pressure` and
-attr:`~plasmapy.plasma.sources.plasma3d.Plasma3D.magnetic_field`.
+:attr:`~plasmapy.plasma.sources.plasma3d.Plasma3D.magnetic_field`.
 
 .. note::
 

--- a/licenses/sphinx_license.rst
+++ b/licenses/sphinx_license.rst
@@ -1,7 +1,7 @@
 License for Sphinx
 ==================
 
-Copyright (c) 2007-2021 by the Sphinx team (see AUTHORS file).
+Copyright (c) 2007-2024 by the Sphinx team (see AUTHORS file).
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -177,7 +177,7 @@ met:
     the documentation and/or other materials provided with the
     distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR
 IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,


### PR DESCRIPTION
This PR adds [sphinx-lint](https://github.com/sphinx-contrib/sphinx-lint) as a pre-commit hook.