### PR TITLE
Benchmark between different documentation build options

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,21 @@ jobs:
     name: Documentation, pinned dependencies
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+
+        - name: Full build
+          toxenv: py312-build_docs
+
+        - name: Parallel build
+          toxenv: py312-build_docs_parallel
+
+        - name: Lite build
+          toxenv: py312-build_docs_no_examples
+
     steps:
 
     - name: Checkout code
@@ -112,7 +127,7 @@ jobs:
         key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
 
     - name: Build docs
-      run: tox -e build_docs_pins -- -q
+      run: tox -e ${{ matrix.toxenv }}
 
     - name: Print troubleshooting information on failure
       if: ${{ failure() }}

--- a/tox.ini
+++ b/tox.ini
@@ -85,19 +85,30 @@ commands =
 
 [testenv:build_docs]
 changedir = {toxinidir}
-extras = docs
 setenv =
     HOME = {envtmpdir}
+    PYDEVD_DISABLE_FILE_VALIDATION=1
 commands =
-    sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
+    sphinx-build docs docs{/}_build{/}html -W -n --keep-going -q -b html {posargs}
+deps = -r{toxinidir}/requirements/requirements_docs_py312.txt
 
-[testenv:build_docs_pins]
+[testenv:build_docs_parallel]
 changedir = {toxinidir}
 setenv =
     HOME = {envtmpdir}
     PYDEVD_DISABLE_FILE_VALIDATION=1
 commands =
-    sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
+    sphinx-build docs docs{/}_build{/}html -W -n --keep-going -q -j auto -b html {posargs}
+deps = -r{toxinidir}/requirements/requirements_docs_py312.txt
+
+[testenv:build_docs_no_examples]
+changedir = {toxinidir}
+extras = docs
+setenv =
+    HOME = {envtmpdir}
+    PYDEVD_DISABLE_FILE_VALIDATION=1
+commands =
+    sphinx-build -D nbsphinx_execute='never' docs docs{/}_build{/}html -W -n -q --keep-going -b html {posargs}
 deps = -r{toxinidir}/requirements/requirements_docs_py312.txt
 
 [testenv:linkcheck]
@@ -119,14 +130,6 @@ deps =
     git+https://github.com/sphinx-doc/sphinx
 description =
     sphinxdev: with the development version of sphinx
-
-[testenv:build_docs_no_examples]
-changedir = {toxinidir}
-extras = docs
-setenv =
-    HOME = {envtmpdir}
-commands =
-    sphinx-build -D nbsphinx_execute='never' docs docs{/}_build{/}html -b html {posargs}
 
 [testenv:linters]
 deps =


### PR DESCRIPTION
This PR is a benchmark for three different setups for fresh documentation builds for PlasmaPy on GitHub Actions with `ubuntu-latest`:

 - Build docs, regular, serial: 172 s (baseline)
 - Build docs, regular, parallel (with `-j auto`): 187 s  (109% of baseline)
 - Build docs, skip notebooks, serial: 143 s (83% of baseline)

Running `sphinx-build` in parallel makes it take 9% longer than running it serially!  

My conclusions are:

 - We shouldn't parallelize PlasmaPy's doc builds — at least for now. 
 - My main hypotheses for the reasons why doc builds are slightly slower in parallel are:
   1. A limitation of `sphinx-build`
   2. A Sphinx extension or something about PlasmaPy's config is blocking possible performance gains from parallel doc builds.
 - Skipping example notebook builds will save ∼30 s.  We should consider if that is worth it, keeping in mind that the notebook builds will still be done by Read the Docs.
 - Astral needs to set up a bat-signal so we can get them to rewrite Sphinx in Rust.
 - Bat signals probably don't work that well on clear nights or during the day or in space and they've probably been obsoleted by cell phones anyway.