### PR TITLE
Add a function to update downloaded files 

### DIFF
--- a/plasmapy/utils/data/downloader.py
+++ b/plasmapy/utils/data/downloader.py
@@ -6,10 +6,11 @@ downloading files from |PlasmaPy's data repository|.
 
 from pathlib import Path
 from urllib.parse import urljoin
+from shutil import rmtree
 
 import requests
 
-__all__ = ["get_file"]
+__all__ = ["get_file", 'update_downloads']
 
 # Note: GitHub links have a problem where the Content-Encoding is set to
 # 'gzip' but the file is not actually compressed. This header is just ignored
@@ -19,8 +20,50 @@ _BASE_URL = "https://raw.githubusercontent.com/PlasmaPy/PlasmaPy-data/main/"
 # TODO: use a config file variable to allow users to set a location
 # for the data download folder?
 
+# Default location for downloaded data
+_default_downloads_folder = Path(Path.home(), ".plasmapy", "downloads")
 
-def get_file(basename, base_url=_BASE_URL, directory=None):
+
+def update_downloads(directory:str|None=None)->None:
+    """
+    Updates all downloaded resource files in the provided directory. 
+    
+    Parameters
+    ----------
+    directory : str, optional
+        The full path to the desired download location. Defaults to the
+        default PlasmaPy data download directory
+        :file:`plasmapy/utils/data/downloads/`\ .
+        
+        
+    Returns
+    -------
+    files_updated : list(str)
+        A list of paths for files that were re-downloaded
+        
+    """
+    
+    if directory is None:
+        directory = _default_downloads_folder
+        
+    files_updated = []
+    for path in directory.glob('**/*'):
+        if path.is_file():
+            # For each file, try to download again, accepting 404 errors
+            # which will occur if the file doesn't exist on the repository
+            try:
+                path = get_file(path.name, directory=directory, 
+                                force_download=True)
+                files_updated.append(path)
+            except OSError:
+                pass
+            
+    return files_updated
+                
+
+
+def get_file(basename, base_url=_BASE_URL, directory=None, 
+             force_download=False):
     r"""
     Download a file from a URL (if the file does not already exist) and
     return the full local path to the file.
@@ -38,18 +81,30 @@ def get_file(basename, base_url=_BASE_URL, directory=None):
         The full path to the desired download location. Defaults to the
         default PlasmaPy data download directory
         :file:`plasmapy/utils/data/downloads/`\ .
+        
+    force_download : bool, optional
+        If True, re-download the file even if it already exists in the
+        destination file. The default value is `False`.
 
     Returns
     -------
     path : str
         The full local path to the downloaded file.
+        
+        
+    Notes
+    -----
+    Once a file is downloaded, it will not be re-downloaded even if the file
+    changes on the remote repository. To update (re-download) all data files,
+    use the `~plasmapy.util.downloader.update_downloads` function.
+     
     """
 
     if "." not in str(basename):
         raise ValueError(f"'filename' ({basename}) must include an extension.")
 
     if directory is None:
-        directory = Path(Path.home(), ".plasmapy", "downloads")
+        directory = _default_downloads_folder
 
         # Create the .plasmapy/downloads directory if it does not already
         # exist
@@ -57,9 +112,9 @@ def get_file(basename, base_url=_BASE_URL, directory=None):
             directory.mkdir()
 
     path = Path(directory, basename)
-
+    
     # If file doesn't exist locally, download it
-    if not path.is_file():
+    if not path.is_file() or force_download:
         url = urljoin(base_url, basename)
 
         reply = requests.get(url)  # noqa: S113
@@ -70,6 +125,12 @@ def get_file(basename, base_url=_BASE_URL, directory=None):
                 "likely indicates that the file does not exist at the "
                 "URL provided."
             )
+            
+        # If force_download is set, remove any existing copy of the file
+        # Only do this after the request, in case request raises an 
+        # exception 
+        if path.is_file():
+            path.unlink()
 
         with path.open(mode="wb") as f:
             f.write(reply.content)


### PR DESCRIPTION
## Description

This PR adds a function `util.downloader.update_downloads()` that update any downloaded resource files. 



## Motivation and context

The way the `downloader.get_file` function works, once a file exists in the directory with the requested name that file path will always be returned. There is no way of detecting when a file of the same name is updated on the github repository. I could do this using the GitHub file SHA, but that would require a GitHub API token, which I really don't want to involve here. 

My short-term solution is to add a function `update_downloads()` that manually goes through and re-downloads any files the user has already downloaded. The idea is that users could call this function manually if desired. We can add a note to functions that use the `get_file` function about this option. 

The function will only delete files that match a file name on the repository, and will never delete directories. So, I think this is pretty safe (e.g. users cannot accidentally delete their home directory or something). 