### PR TITLE
Switch to a GitHub Action for validating CITATION.cff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,6 @@ jobs:
           python: '3.12'
           toxenv: mypy
 
-        - name: Linters, Python 3.12, Ubuntu
-          os: ubuntu-latest
-          python: '3.12'
-          toxenv: linters
-
     steps:
 
     - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,3 +182,16 @@ jobs:
     - name: Perform editable installation with tests & docs requirements sets
       run: |
         pip install --progress-bar off -e .[tests,docs]
+
+  validate-citation-cff:
+    runs-on: ubuntu-latest
+    name: Validate CITATION.cff
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Validate CITATION.cff
+      uses: dieghernan/cff-validator@v3

--- a/tox.ini
+++ b/tox.ini
@@ -101,14 +101,6 @@ deps =
 commands =
     mypy plasmapy --install-types --non-interactive --show-error-context --show-error-code-links --pretty
 
-[testenv:linters]
-deps =
-    cffconvert
-    pygments
-commands =
-    cffconvert --validate
-    pre-commit run --all-files --show-diff-on-failure
-
 [testenv:py310-lowest_direct-pypi-import]
 basepython = python3.10
 extras =


### PR DESCRIPTION
This PR switches to using `cffconvert --validate` to using the [cff-validator](https://github.com/marketplace/actions/cff-validator) GitHub Action, as brought up in https://github.com/spacepy/spacepy/issues/736.  As a plus, we get to drop the `linters` environment in `tox.ini`!