### PR TITLE
Allow `ionic_levels` to create a `ParticleList` with a supplied list of charge numbers

### DIFF
--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -1065,6 +1065,8 @@ def ionic_levels(
     particle: ParticleLike,
     min_charge: int = 0,
     max_charge: int | None = None,
+    *,
+    Z=None,
 ) -> ParticleList:
     """
     Return a |ParticleList| that includes different ionic levels of a

--- a/plasmapy/particles/tests/test_atomic.py
+++ b/plasmapy/particles/tests/test_atomic.py
@@ -579,18 +579,21 @@ def test_ionic_levels_example() -> None:
 
 
 @pytest.mark.parametrize(
-    ("particle", "min_charge", "max_charge", "expected_charge_numbers"),
+    ("particle", "min_charge", "max_charge", "Z", "expected_charge_numbers"),
     [
-        ("H-1", 0, 1, [0, 1]),
-        ("p+", 1, 1, [1]),
-        (Particle("p+"), 0, 0, [0]),
-        ("C", 3, 5, [3, 4, 5]),
+        ("H-1", 0, 1, None, [0, 1]),
+        ("p+", 1, 1, None, [1]),
+        (Particle("p+"), 0, 0, None, [0]),
+        ("C", 3, 5, None, [3, 4, 5]),
+        ("Fe", None, None, [1, 2, 3.3], [1, 2, 3.3]),
     ],
 )
-def test_ion_list2(particle, min_charge, max_charge, expected_charge_numbers) -> None:
+def test_ion_list2(
+    particle, min_charge, max_charge, Z, expected_charge_numbers
+) -> None:
     """Test that inputs to ionic_levels are interpreted correctly."""
     particle = Particle(particle)
-    ions = ionic_levels(particle, min_charge, max_charge)
+    ions = ionic_levels(particle, min_charge, max_charge, Z=Z)
     np.testing.assert_equal(ions.charge_number, expected_charge_numbers)
     assert ions[0].element == particle.element
     if particle.is_category("isotope"):


### PR DESCRIPTION
The purpose of this PR is to allow calls like:

```python
from plasmapy.particles import ionic_levels

ions = ionic_levels("Fe", Z=[8.6, 6.4, 7.7, 7.8, 8.3, 8.1])
```

The charge numbers can be floats, which would correspond to a `CustomParticle` rather than a `Particle`.