### PR TITLE
Add some new ruff rules

### DIFF
--- a/plasmapy/analysis/tests/test_fit_functions.py
+++ b/plasmapy/analysis/tests/test_fit_functions.py
@@ -317,7 +317,7 @@ class BaseFFTests(ABC):
 
         with with_condition:
             results = ff_obj.func_err(x, **kwargs)
-            if "rety" in kwargs and kwargs["rety"]:
+            if kwargs.get("rety"):
                 y_err, y = results
             else:
                 y_err = results

--- a/plasmapy/plasma/grids.py
+++ b/plasmapy/plasma/grids.py
@@ -15,6 +15,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from functools import cached_property
+from typing import ClassVar
 
 import astropy.units as u
 import numpy as np
@@ -113,7 +114,7 @@ class AbstractGrid(ABC):
 
     # These standard keys are used to refer to certain
     # physical quantities. This dictionary also provides the expected unit.
-    _recognized_quantities_list = [
+    _recognized_quantities_list: ClassVar[list[RecognizedQuantity]] = [
         RecognizedQuantity("x", "x spatial position", u.m),
         RecognizedQuantity("y", "y spatial position", u.m),
         RecognizedQuantity("z", "z spatial position", u.m),
@@ -128,7 +129,7 @@ class AbstractGrid(ABC):
     ]
 
     # Create a dict of recognized quantities for fast access by key
-    _recognized_quantities = {}
+    _recognized_quantities: ClassVar[list[RecognizedQuantity]] = {}
     for _rq in _recognized_quantities_list:
         _recognized_quantities[_rq.key] = _rq
 
@@ -885,7 +886,7 @@ class AbstractGrid(ABC):
 
     # This property holds the list of quantity keys currently being interpolated
     # It's used in the following cached properties
-    _interp_args = []
+    _interp_args: ClassVar = []
 
     @cached_property
     def _interp_quantities(self):

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -9,6 +9,8 @@ Module for defining the base framework of the plasma classes.
 __all__ = ["BasePlasma", "GenericPlasma"]
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import ClassVar
 
 
 class BasePlasma(ABC):
@@ -27,7 +29,7 @@ class BasePlasma(ABC):
     """
 
     # GenericPlasma subclass registry
-    _registry = {}
+    _registry: ClassVar[dict[type, Callable]] = {}
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)

--- a/plasmapy/plasma/plasma_base.py
+++ b/plasmapy/plasma/plasma_base.py
@@ -29,7 +29,7 @@ class BasePlasma(ABC):
     """
 
     # GenericPlasma subclass registry
-    _registry: ClassVar[dict[type, Callable]] = {}
+    _registry: ClassVar[dict[type, Callable]] = {}  # type: ignore[type-arg]
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -460,7 +460,7 @@ class CheckUnits(CheckBase):
     #   2. Add a corresponding conditioning statement to `_get_unit_checks`
     #   3. Add a corresponding behavior to `_check_unit`
     #
-    __check_defaults: ClassVar[dict[str, bool]] = {
+    __check_defaults: ClassVar[dict[str, object]] = {
         "units": None,
         "equivalencies": None,
         "pass_equivalent_units": False,

--- a/plasmapy/utils/decorators/checks.py
+++ b/plasmapy/utils/decorators/checks.py
@@ -17,7 +17,7 @@ import inspect
 import warnings
 from functools import reduce
 from operator import add
-from typing import Any
+from typing import Any, ClassVar
 
 import astropy.units as u
 import numpy as np
@@ -129,7 +129,7 @@ class CheckValues(CheckBase):
     #   1. Add a key & default value to the `__check_defaults` dictionary
     #   2. Add a corresponding if-statement to method `_check_value`
     #
-    __check_defaults = {
+    __check_defaults: ClassVar[dict[str, bool]] = {
         "can_be_negative": True,
         "can_be_complex": False,
         "can_be_inf": True,
@@ -460,7 +460,7 @@ class CheckUnits(CheckBase):
     #   2. Add a corresponding conditioning statement to `_get_unit_checks`
     #   3. Add a corresponding behavior to `_check_unit`
     #
-    __check_defaults = {
+    __check_defaults: ClassVar[dict[str, bool]] = {
         "units": None,
         "equivalencies": None,
         "pass_equivalent_units": False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,7 +412,6 @@ max-complexity = 10
 "test_*" = ["D100", "D101", "D102", "D103", "D104", "D209", "D400", "D401", "N801", "RUF012", "SLF001"]
 "*/*/tests/__init__.py" = ["D104"]
 
-
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -399,6 +399,7 @@ max-complexity = 10
 "__init__.py" = ["D104", "E402", "F401", "F402", "F403"] # ignore import errors
 ".github/scripts/*.py" = ["D103", "INP001"]
 "docs/conf.py" = ["D100", "D103", "E402", "EXE001", "EXE005", "F401"]
+"docs/notebooks/formulary/coulomb.ipynb" = ["I001"]
 "plasmapy/analysis/fit_functions.py" = ["D301"]
 "plasmapy/formulary/braginskii.py" = ["C901", "RET503", "RET504"]
 "plasmapy/formulary/tests/test_distribution.py" = ["ARG005"]
@@ -410,6 +411,7 @@ max-complexity = 10
 "setup.py" = ["D100"]
 "test_*" = ["D100", "D101", "D102", "D103", "D104", "D209", "D400", "D401", "N801", "RUF012", "SLF001"]
 "*/*/tests/__init__.py" = ["D104"]
+
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,9 +279,14 @@ extend-select = [
   "RUF008", # mutable-dataclass-default
   "RUF009", # function-call-in-dataclass-default-argument
   "RUF010", # explicit-f-string-type-conversion
+  "RUF012", # mutable-class-default
   "RUF013", # implicit-optional
   "RUF015", # unnecessary-iterable-allocation-for-first-element
   "RUF016", # invalid-index-type
+  "RUF017", # quadratic-list-summation
+  "RUF018", # assignment-in-assert
+  "RUF019", # unnecessary-key-check
+  "RUF020", # never-union
   "RUF100", # unused-noqa
   "RUF200", # invalid-pyproject-toml
   "S", # flake8-bandit
@@ -403,7 +408,7 @@ max-complexity = 10
 "plasmapy/utils/_pytest_helpers/tests/test_pytest_helpers.py" = ["BLE001", "TRY002"]
 "plasmapy/utils/decorators/tests/test_converters.py" = ["ARG001", "ARG005"]
 "setup.py" = ["D100"]
-"test_*" = ["D100", "D101", "D102", "D103", "D104", "D209", "D400", "D401", "N801", "SLF001"]
+"test_*" = ["D100", "D101", "D102", "D103", "D104", "D209", "D400", "D401", "N801", "RUF012", "SLF001"]
 "*/*/tests/__init__.py" = ["D104"]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
This PR adds a few rules in ruff's [`RUF`](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf) rule set that have been taken out of ruff's nursery and thus are ready to be used in production.