### PR TITLE
Moved charge/mass number to Other Parameters

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -614,3 +614,8 @@ authors:
   alias: carolyz
 
 - alias: Bzero
+
+- given-names: Matteo
+  family-names: Spedicato
+  alias: Spedi
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -618,4 +618,3 @@ authors:
 - given-names: Matteo
   family-names: Spedicato
   alias: Spedi
-

--- a/plasmapy/particles/atomic.py
+++ b/plasmapy/particles/atomic.py
@@ -200,16 +200,18 @@ def particle_mass(
         particle; an integer representing an atomic number; or a
         |Particle|.
 
+    Returns
+    -------
+    `~astropy.units.Quantity`
+        The mass of the particle.
+
+    Other Parameters
+    ----------------
     mass_numb : integer, |keyword-only|, optional
         The mass number of an isotope.
 
     Z : integer, |keyword-only|, optional
         The |charge number| of an ion or neutral atom.
-
-    Returns
-    -------
-    `~astropy.units.Quantity`
-        The mass of the particle.
 
     Raises
     ------
@@ -248,13 +250,15 @@ def isotopic_abundance(isotope: ParticleLike, mass_numb: int | None = None) -> f
         A string representing an element or isotope, or an integer
         representing the atomic number of an element.
 
-    mass_numb : integer, optional
-        The mass number of an isotope.
-
     Returns
     -------
     `float`
         The relative isotopic abundance in the terrestrial environment.
+
+    Other Parameters
+    ----------------
+    mass_numb : integer, |keyword-only|, optional
+        The mass number of an isotope.
 
     Raises
     ------
@@ -404,13 +408,15 @@ def is_stable(particle: ParticleLike, mass_numb: int | None = None) -> bool:
         A string representing an isotope or particle, or an integer
         representing an atomic number.
 
-    mass_numb : integer, optional
-        The mass number of the isotope.
-
     Returns
     -------
     `bool`
         `True` if the isotope is stable, `False` if it is unstable.
+
+    Other Parameters
+    ----------------
+    mass_numb : integer, |keyword-only|, optional
+        The mass number of an isotope.
 
     Raises
     ------
@@ -455,13 +461,15 @@ def half_life(particle: ParticleLike, mass_numb: int | None = None) -> u.Quantit
         representing an atomic number, or an instance of the |Particle|
         class.
 
-    mass_numb : integer, optional
-        The mass number of an isotope.
-
     Returns
     -------
     `~astropy.units.Quantity`
         The half-life of the isotope or particle in units of seconds.
+
+    Other Parameters
+    ----------------
+    mass_numb : integer, |keyword-only|, optional
+        The mass number of an isotope.
 
     Raises
     ------

--- a/plasmapy/particles/symbols.py
+++ b/plasmapy/particles/symbols.py
@@ -103,15 +103,17 @@ def isotope_symbol(isotope: Particle, mass_numb: int | None = None) -> str:
         A `str` representing an element, isotope, or ion or an
         `int` representing an atomic number
 
-    mass_numb : `int` or `str`, optional
-        The mass number of the isotope.
-
     Returns
     -------
     `str`
         The isotopic symbol. The result will generally be returned as
         something like ``'He-4'`` or ``'Au-197'``.  This function will
         return ``'D'`` for deuterium and ``'T'`` for tritium.
+
+    Other Parameters
+    ----------------
+    mass_numb : integer, |keyword-only|, optional
+        The mass number of an isotope.
 
     Raises
     ------
@@ -165,17 +167,19 @@ def ionic_symbol(
         A `str` representing an element, isotope, or ion; or an
         `int` representing an atomic number.
 
-    mass_numb : integer, |keyword-only|, optional
-        The mass number of an isotope.
-
-    Z : integer, |keyword-only|, optional
-        The |charge number| of an ion or neutral atom.
-
     Returns
     -------
     `str`
         The ionic symbol. The result will generally be returned as
         something like ``'He-4 2+'``, ``'D 1+'``, or ``'p+'``.
+
+    Other Parameters
+    ----------------
+    mass_numb : integer, |keyword-only|, optional
+        The mass number of an isotope.
+
+    Z : integer, |keyword-only|, optional
+        The |charge number| of an ion or neutral atom.
 
     Raises
     ------
@@ -231,12 +235,6 @@ def particle_symbol(
         A `str` representing a particle, element, isotope, or ion or an
         `int` representing an atomic number
 
-    mass_numb : integer, |keyword-only|, optional
-        The mass number of an isotope.
-
-    Z : integer, |keyword-only|, optional
-        The |charge number| of an ion or neutral atom.
-
     Returns
     -------
     `str`
@@ -244,6 +242,14 @@ def particle_symbol(
         information when available. The result will generally be
         returned as something like ``'e-'``, ``'Fe'``, ``'He-4 2+'``,
         ``'D'``, ``'n'``, ``'mu-'``, or ``'p+'``.
+
+    Other Parameters
+    ----------------
+    mass_numb : integer, |keyword-only|, optional
+        The mass number of an isotope.
+
+    Z : integer, |keyword-only|, optional
+        The |charge number| of an ion or neutral atom.
 
     Raises
     ------


### PR DESCRIPTION
## Description
Moved the `mass_numb` and `Z` to the Other Parameters section in `plasmapy.particles.atomic` and `plasmapy.particles.symbols`.
