### PR TITLE
Include coverage in a weekly test

### DIFF
--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -30,6 +30,11 @@ jobs:
           python: '3.11'
           toxenv: py311-pins-pytest_all
 
+        - name: Python 3.11, all tests, code coverage, macOS
+          os: macos-latest
+          python: '3.11'
+          toxenv: py311-pins-pytest_cov_all
+
         - name: Python 3.10, all tests, Windows
           os: windows-latest
           python: '3.10'


### PR DESCRIPTION
The code coverage reports have been acting a little weird lately.  In #2598, for example, the BASE commit is from two months ago (with the nearest commits being #2477, #2478, & #2481).  This PR is an attempt to get coverage reports uploaded from `main`.  

Even if this PR does work, it's more of a patch 🩹 rather than a complete fix.  It might be helpful to set it up so that the coverage test gets run every time a pull request is merged.

It may also be that we have code coverage set up incorrectly, or that the github token expired or something.  