### PR TITLE
Include `CODECOV_TOKEN` in the GitHub workflows that it is used in

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,8 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       if: ${{ contains(matrix.toxenv,'_cov') }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -116,9 +116,12 @@ jobs:
 
     - name: Upload coverage to codecov
       if: ${{ contains(matrix.toxenv,'_cov') }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
+
 
   install-plasmapy-via-conda-forge:
     name: Install PlasmaPy from conda-forge


### PR DESCRIPTION
I forgot this step in #2615.  Following [these instructions](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions).  

Again, I need to merge it to see if it works (sigh).