### PR TITLE
Update Codecov settings and usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,11 +74,12 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       if: ${{ contains(matrix.toxenv,'_cov') }}
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
+        fail_ci_if_error: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   documentation:
 

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -114,13 +114,14 @@ jobs:
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
 
-    - name: Upload coverage to codecov
+    - name: Upload coverage reports to Codecov
       if: ${{ contains(matrix.toxenv,'_cov') }}
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
+        fail_ci_if_error: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 
   install-plasmapy-via-conda-forge:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,8 @@
+# CODECOV_TOKEN is set in the repository's secrets.
 codecov:
   notify:
-    wait_for_ci: no
-  require_ci_to_pass: no
+    wait_for_ci: false
+  require_ci_to_pass: false
 coverage:
   range: 75..98
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,17 @@
 codecov:
-  token: 85c13d8a-e9e1-49fd-97d4-7ba103f3e830
   notify:
     wait_for_ci: no
   require_ci_to_pass: no
 coverage:
+  range: 75..98
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
+        threshold: 0.2%
         removed_code_behavior: adjust_base
+        if_not_found: failure
+    patch:
+      default:
+        threshold: 0.2%
+        removed_code_behavior: adjust_base
+        if_not_found: failure


### PR DESCRIPTION
## Description

This PR does some clean-up of the Codecov configuration file in `codecov.yml`, as well as how the Codecov action gets used in CI and in weekly tests.

This PR sets `fail_ci_if_error` to `true`, which will help us notice a lot sooner when our Codecov configuration breaks. 

## Motivation and context

I recently noticed that we had not been uploading coverage reports from `main` to Codecov for approximately two months. Coverage reports from forks were still getting uploaded correctly (since they can be done tokenlessly), which meant that we hadn't noticed it for a while.  However, the coverage reports from pull requests were being compared against a commit to `main` from two months ago (around the time of #2478).  I recently fixed this problem by setting `CODECOV_TOKEN` as a GitHub secret, and wanted to follow up with some subsequent clean-up (and a better explanation).  

## Related issues

This is a follow-up to changes begun in: #2612, #2613, #2615, #2616.  I noticed the problem in #2598, with some follow-up in #2601.