### PR TITLE
Modify the way settings are passed to the _spectral_density_model function 

### DIFF
--- a/changelog/2623.bugfix.rst
+++ b/changelog/2623.bugfix.rst
@@ -1,0 +1,2 @@
+Made `~plasmapy.diagnostics.thomson.spectral_density_model` compatible with the
+new version of ``lmfit==1.3.0``.

--- a/plasmapy/diagnostics/thomson.py
+++ b/plasmapy/diagnostics/thomson.py
@@ -1000,10 +1000,12 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
     #       quantities isn't consistent with the number of that species defined
     #       by ifract or efract.
 
+    def _spectral_density_model_lambda(wavelengths, **params):
+        return _spectral_density_model(wavelengths, settings=settings, **params)
+
     # Create and return the lmfit.Model
     return Model(
-        _spectral_density_model,
+        _spectral_density_model_lambda,
         independent_vars=["wavelengths"],
         nan_policy="omit",
-        settings=settings,
     )


### PR DESCRIPTION
Addresses #2620 without capping the version of `lmfit`

Supercedes #2621 

Instead of passing `settings` to `Model` and relying on `lmfit` to pass that to `_spectral_density_model`, this PR uses a lambda function to freeze in the settings (which are constant) prior to giving the function to `lmfit`.


```python
def _spectral_density_model_lambda(wavelengths, **params):
        return _spectral_density_model(wavelengths, settings=settings, **params)

    # Create and return the lmfit.Model
    return Model(
        _spectral_density_model_lambda,
        independent_vars=["wavelengths"],
        nan_policy="omit",
    )
```
