### PR TITLE
Put token for Codecov back in configuration file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
-# CODECOV_TOKEN is set in the repository's secrets.
 codecov:
+  token: 85c13d8a-e9e1-49fd-97d4-7ba103f3e830
   notify:
     wait_for_ci: false
   require_ci_to_pass: false


### PR DESCRIPTION
This PR is an attempt to fix our Codecov configuration which I fixed after it broke, and then broke after I had fixed it.  I suspect taking the token out of the configuration file is what broke it.  

This PR is also an attempt to see if I can include emojis in branch names.  Apparently, yes! Unicode FTW!

## Related issues

This follows up on #2612, #2613, #2615, #2616, and #2617.  