### PR TITLE
Fix bug when giving `thermal_bremsstrahlung multiple` density values

### DIFF
--- a/changelog/2627.bugfix.rst
+++ b/changelog/2627.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug when `~formulary.radiation.thermal_bremsstrahlung` is given multiple input density values.

--- a/changelog/2627.bugfix.rst
+++ b/changelog/2627.bugfix.rst
@@ -1,1 +1,1 @@
-Fix a bug when `~formulary.radiation.thermal_bremsstrahlung` is given multiple input density values.
+Fix a bug when `~plasmapy.formulary.radiation.thermal_bremsstrahlung` is given multiple input density values.

--- a/plasmapy/formulary/radiation.py
+++ b/plasmapy/formulary/radiation.py
@@ -124,7 +124,7 @@ def thermal_bremsstrahlung(
     ω_pe = plasma_frequency(n=n_e, particle="e-")
 
     # Check that all ω < ω_pe (this formula is only valid in this limit)
-    if np.min(ω) < ω_pe:
+    if np.min(ω) < np.max(ω_pe):
         raise PhysicsError(
             "Lowest frequency must be larger than the electron "
             f"plasma frequency {ω_pe:.1e}, but min(ω) = {np.min(ω):.1e}"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

Fixes #2619 



## Motivation and context

<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->
A `ValueError` was raised when supplying `~formulary.radiation.thermal_bremsstrahlung` multiple density values.  

This issue occurred because `if np.min(ω) < ω_pe:` is ambiguous in comparisons if `ω_pe` is an array.  The fix changes this to use the maximum electron plasma frequency, and raises the `PhysicsError` if any input frequencies are less than this.

(As a sidenote, is this the correct intended functionality?  Or would it be better to return the f-f emission for array values where it is valid?)


## Related issues
#2619 
