### PR TITLE
Several improvements to OTS fitting

### DIFF
--- a/changelog/2636.feature.rst
+++ b/changelog/2636.feature.rst
@@ -1,0 +1,2 @@
+Added support for new ``background``, ``ion_mu`` and ``ion_z`` fitting
+parameters to the `~plasmapy.diagnostics.thomson.spectral_density_model` function.

--- a/src/plasmapy/diagnostics/thomson.py
+++ b/src/plasmapy/diagnostics/thomson.py
@@ -694,6 +694,7 @@ def _spectral_density_model(wavelengths, settings=None, **params):
 
     # LOAD FROM PARAMS
     n = params["n"]
+    background = params["background"]
     T_e = _params_to_array(params, "T_e")
     T_i = _params_to_array(params, "T_i")
     efract = _params_to_array(params, "efract")
@@ -728,6 +729,9 @@ def _spectral_density_model(wavelengths, settings=None, **params):
     )
 
     model_Skw *= 1 / np.max(model_Skw)
+
+    # Add background after normalization
+    model_Skw += background
 
     return model_Skw
 
@@ -791,6 +795,7 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
           sum to 1)
         - :samp:`"electron_speed_{e#}"` : Electron speed in m/s
         - :samp:`"ion_speed_{ei}"` : Ion speed in m/s
+        - :samp:`"background"` : Background level, as fraction of max signal
 
         These quantities can be either fixed or varying.
 
@@ -828,6 +833,10 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
             f"The following required parameters were not provided in the "
             f"'params': {missing_params}"
         )
+
+    # Add background if not provided
+    if "background" not in params:
+        params.add("background", value=0.0, vary=False)
 
     # **********************
     # Count number of populations

--- a/src/plasmapy/diagnostics/thomson.py
+++ b/src/plasmapy/diagnostics/thomson.py
@@ -57,7 +57,7 @@ def spectral_density_lite(
     efract: np.ndarray,
     ifract: np.ndarray,
     ion_z: np.ndarray,
-    ion_mass: np.ndarray,
+    ion_mu: np.ndarray,
     electron_vel: np.ndarray,
     ion_vel: np.ndarray,
     probe_vec: np.ndarray,
@@ -110,8 +110,9 @@ def spectral_density_lite(
         An `~numpy.ndarray` of the charge number :math:`Z` of each ion
         species.
 
-    ion_mass : (Ni,) `~numpy.ndarray`
-        An `~numpy.ndarray` of the mass of each ion species in kg.
+    ion_mu : (Ni,) `~numpy.ndarray`
+        An `~numpy.ndarray` of the mass number of each ion species,
+        :math:`/mu = m_i/m_p`.
 
     electron_vel : (Ne, 3) `~numpy.ndarray`
         Velocity of each electron population in the rest frame (in m/s).
@@ -163,6 +164,8 @@ def spectral_density_lite(
     """
 
     scattering_angle = np.arccos(np.dot(probe_vec, scatter_vec))
+
+    ion_mass = ion_mu * m_p_si_unitless
 
     # Calculate plasma parameters
     # Temperatures here in K!
@@ -262,13 +265,17 @@ def spectral_density_lite(
     if notch is not None:
         # If only one notch is included, create a dummy second dimension
         if np.ndim(notch) == 1:
-            notch = np.array([notch])
+            notch = np.array(
+                [
+                    notch,
+                ]
+            )
 
         for notch_i in notch:
             # For each notch, identify the index for the beginning and end
             # wavelengths and set Skw to zero between those indices
-            x0 = np.argwhere(wavelengths > notch_i[0])[0][0]
-            x1 = np.argwhere(wavelengths > notch_i[1])[0][0]
+            x0 = np.argmin(np.abs(wavelengths - notch_i[0]))
+            x1 = np.argmin(np.abs(wavelengths - notch_i[1]))
             Skw[x0:x1] = 0
 
     return np.mean(alpha), Skw
@@ -542,7 +549,7 @@ def spectral_density(  # noqa: C901, PLR0912, PLR0915
 
     # Create arrays of ion Z and mass from particles given
     ion_z = ions.charge_number
-    ion_mass = ions.mass
+    ion_mu = ions.mass.to(u.kg).value / m_p_si_unitless
 
     probe_vec = probe_vec / np.linalg.norm(probe_vec)
     scatter_vec = scatter_vec / np.linalg.norm(scatter_vec)
@@ -601,7 +608,7 @@ def spectral_density(  # noqa: C901, PLR0912, PLR0915
         efract=efract,
         ifract=ifract,
         ion_z=ion_z,
-        ion_mass=ion_mass.to(u.kg).value,
+        ion_mu=ion_mu,
         ion_vel=ion_vel.to(u.m / u.s).value,
         electron_vel=electron_vel.to(u.m / u.s).value,
         probe_vec=probe_vec,
@@ -682,8 +689,6 @@ def _spectral_density_model(wavelengths, settings=None, **params):
     """
 
     # LOAD FROM SETTINGS
-    ion_z = settings["ion_z"]
-    ion_mass = settings["ion_mass"]
     probe_vec = settings["probe_vec"]
     scatter_vec = settings["scatter_vec"]
     electron_vdir = settings["electron_vdir"]
@@ -697,6 +702,8 @@ def _spectral_density_model(wavelengths, settings=None, **params):
     background = params["background"]
     T_e = _params_to_array(params, "T_e")
     T_i = _params_to_array(params, "T_i")
+    ion_mu = _params_to_array(params, "ion_mu")
+    ion_z = _params_to_array(params, "ion_z")
     efract = _params_to_array(params, "efract")
     ifract = _params_to_array(params, "ifract")
 
@@ -719,7 +726,7 @@ def _spectral_density_model(wavelengths, settings=None, **params):
         efract=efract,
         ifract=ifract,
         ion_z=ion_z,
-        ion_mass=ion_mass,
+        ion_mu=ion_mu,
         electron_vel=electron_vel,
         ion_vel=ion_vel,
         probe_vec=probe_vec,
@@ -759,7 +766,10 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
         - ``"ions"`` : list of particle strings,
           `~plasmapy.particles.particle_class.Particle` objects, or a
           `~plasmapy.particles.particle_collections.ParticleList`
-          describing each ion species. All ions must be positive.
+          describing each ion species. All ions must be positive. Ion mass
+          and charge number from this list will be automatically
+          added as fixed parameters, overridden by any ``ion_mass`` or ``ion_z``
+          parameters explicitly created.
 
         and may contain the following optional variables:
 
@@ -795,6 +805,8 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
           sum to 1)
         - :samp:`"electron_speed_{e#}"` : Electron speed in m/s
         - :samp:`"ion_speed_{ei}"` : Ion speed in m/s
+        - :samp:`"ion_mu_{i#}"` : Ion mass number, :math:`\mu = m_i/m_p`
+        - :samp:`"ion_z_{i#}"` : Ion charge number
         - :samp:`"background"` : Background level, as fraction of max signal
 
         These quantities can be either fixed or varying.
@@ -818,7 +830,6 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
         "probe_wavelength",
         "probe_vec",
         "scatter_vec",
-        "ions",
     }
 
     if missing_settings := required_settings - set(settings):
@@ -838,6 +849,21 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
     if "background" not in params:
         params.add("background", value=0.0, vary=False)
 
+    # Add ion values as fixed parameters if a particle list is provided
+    # in settings
+    # Do not override any existing parameters
+    if "ions" in settings:
+        for i, ion in enumerate(settings["ions"]):
+            _ion = Particle(ion)
+            if f"ion_mu_{i!s}" not in params:
+                params.add(
+                    f"ion_mu_{i!s}",
+                    value=_ion.mass.to(u.kg).value / m_p_si_unitless,
+                    vary=False,
+                )
+            if f"ion_z_{i!s}" not in params:
+                params.add(f"ion_z_{i!s}", value=_ion.charge_number, vary=False)
+
     # **********************
     # Count number of populations
     # **********************
@@ -853,53 +879,15 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
     # **********************
     # Required settings and parameters per population
     # **********************
-    for p, nums in zip(["T_e", "T_i"], [num_e, num_i], strict=False):
+    for p, nums in zip(
+        ["T_e", "T_i", "ion_mu", "ion_z"], [num_e, num_i, num_i, num_i], strict=False
+    ):
         for num in range(nums):
             key = f"{p}_{num!s}"
             if key not in params:
                 raise ValueError(
                     f"{p} was not provided in kwarg 'parameters', but is required."
                 )
-
-    # **************
-    # ions
-    # **************
-
-    ions = settings["ions"]
-    # Condition ions
-    # If a single value is provided, turn into a particle list
-    if isinstance(ions, ParticleList):
-        pass
-    elif isinstance(ions, str):
-        ions = ParticleList([Particle(ions)])
-    # If a list is provided, ensure all values are Particles, then convert
-    # to a ParticleList
-    elif isinstance(ions, list):
-        for ii, ion in enumerate(ions):
-            if isinstance(ion, Particle):
-                continue
-            ions[ii] = Particle(ion)
-        ions = ParticleList(ions)
-    else:
-        raise TypeError(
-            "The type of object provided to the ``ions`` keyword "
-            f"is not supported: {type(ions)}"
-        )
-
-    # Validate ions
-    if len(ions) == 0:
-        raise ValueError("At least one ion species needs to be defined.")
-
-    try:
-        if sum(ion.charge_number <= 0 for ion in ions):
-            raise ValueError("All ions must be positively charged.")
-    # Catch error if charge information is missing
-    except ChargeError as ex:
-        raise ValueError("All ions must be positively charged.") from ex
-
-    # Create arrays of ion Z and mass from particles given
-    settings["ion_z"] = ions.charge_number
-    settings["ion_mass"] = ions.mass
 
     # **************
     # efract and ifract

--- a/src/plasmapy/diagnostics/thomson.py
+++ b/src/plasmapy/diagnostics/thomson.py
@@ -57,7 +57,7 @@ def spectral_density_lite(
     efract: np.ndarray,
     ifract: np.ndarray,
     ion_z: np.ndarray,
-    ion_mu: np.ndarray,
+    ion_mass: np.ndarray,
     electron_vel: np.ndarray,
     ion_vel: np.ndarray,
     probe_vec: np.ndarray,
@@ -110,9 +110,8 @@ def spectral_density_lite(
         An `~numpy.ndarray` of the charge number :math:`Z` of each ion
         species.
 
-    ion_mu : (Ni,) `~numpy.ndarray`
-        An `~numpy.ndarray` of the mass number of each ion species,
-        :math:`/mu = m_i/m_p`.
+    ion_mass : (Ni,) `~numpy.ndarray`
+        An `~numpy.ndarray` of the mass number of each ion species in kg.
 
     electron_vel : (Ne, 3) `~numpy.ndarray`
         Velocity of each electron population in the rest frame (in m/s).
@@ -164,8 +163,6 @@ def spectral_density_lite(
     """
 
     scattering_angle = np.arccos(np.dot(probe_vec, scatter_vec))
-
-    ion_mass = ion_mu * m_p_si_unitless
 
     # Calculate plasma parameters
     # Temperatures here in K!
@@ -547,10 +544,6 @@ def spectral_density(  # noqa: C901, PLR0912, PLR0915
             f"T_e ({T_e.size}), or electron velocity ({electron_vel.shape[0]})."
         )
 
-    # Create arrays of ion Z and mass from particles given
-    ion_z = ions.charge_number
-    ion_mu = ions.mass.to(u.kg).value / m_p_si_unitless
-
     probe_vec = probe_vec / np.linalg.norm(probe_vec)
     scatter_vec = scatter_vec / np.linalg.norm(scatter_vec)
 
@@ -607,8 +600,8 @@ def spectral_density(  # noqa: C901, PLR0912, PLR0915
         T_i.to(u.K).value,
         efract=efract,
         ifract=ifract,
-        ion_z=ion_z,
-        ion_mu=ion_mu,
+        ion_z=ions.charge_number,
+        ion_mass=ions.mass.to(u.kg).value,
         ion_vel=ion_vel.to(u.m / u.s).value,
         electron_vel=electron_vel.to(u.m / u.s).value,
         probe_vec=probe_vec,
@@ -717,6 +710,9 @@ def _spectral_density_model(wavelengths, settings=None, **params):
     T_e *= 11604.51812155
     T_i *= 11604.51812155
 
+    # lite function takes ion mass, not mu=m_i/m_p
+    ion_mass = ion_mu * m_p_si_unitless
+
     alpha, model_Skw = spectral_density_lite(
         wavelengths,
         probe_wavelength,
@@ -726,7 +722,7 @@ def _spectral_density_model(wavelengths, settings=None, **params):
         efract=efract,
         ifract=ifract,
         ion_z=ion_z,
-        ion_mu=ion_mu,
+        ion_mass=ion_mass,
         electron_vel=electron_vel,
         ion_vel=ion_vel,
         probe_vec=probe_vec,

--- a/tests/diagnostics/test_thomson.py
+++ b/tests/diagnostics/test_thomson.py
@@ -133,14 +133,14 @@ def args_to_lite_args(kwargs):  # noqa: C901
         ]
 
     ion_z = np.zeros(len(kwargs["ions"]))
-    ion_mu = np.zeros(len(kwargs["ions"]))
+    ion_mass = np.zeros(len(kwargs["ions"]))
     for i, particle in enumerate(kwargs["ions"]):
         if not isinstance(particle, Particle):
             particle = Particle(particle)  # noqa: PLW2901
         ion_z[i] = particle.charge_number
-        ion_mu[i] = particle_mass(particle).to(u.kg).value / const.m_p.si.value
+        ion_mass[i] = particle_mass(particle).to(u.kg).value
     kwargs["ion_z"] = ion_z
-    kwargs["ion_mu"] = ion_mu
+    kwargs["ion_mass"] = ion_mass
     del kwargs["ions"]
 
     return kwargs


### PR DESCRIPTION
This PR makes updates to the OTS fitting module to address the following changes listed in #2591: 

Requested new features
- Allow ion_z and ion_mass to be parameters that can be fit.
- Add constant background parameter 

Changes made in this PR
- Added a new `background` parameter that is added as a constant offset to the normalized Skw to represent noise floor. 
- Changed the way the notch keyword in the lite function is applied to fix a bug. 
- Changed _model function to look for `ion_mu` and `ion_z` in params instead of settings. 
- Changed Model creation function to create fixed parameters for any `ion_mu` or `ion_z` parameters not set explicitly.  Remove old `ions` validation that doesn't apply anymore. 
- Refactored tests to get rid of support changes, get rid of some warnings. 
- Added a new test for explicitly setting `ion_mu` and `ion_z` as varying parameters.

The changes to the fitting algorithm are non-breaking, since the Model function can still take a list of ions in settings. There should be no breaking changes.