### PR TITLE
Add attribute to provide a LaTeX representation of a `Particle`

### DIFF
--- a/src/plasmapy/particles/_special_particles.py
+++ b/src/plasmapy/particles/_special_particles.py
@@ -7,6 +7,7 @@ __all__ = [
     "antiparticles",
     "create_particles_dict",
     "data_about_special_particles",
+    "latex_str_dict",
     "particle_zoo",
     "ParticleZoo",
     "special_ion_masses",
@@ -298,4 +299,23 @@ antiparticles = {
     "anti_nu_e": "nu_e",
     "anti_nu_mu": "nu_mu",
     "anti_nu_tau": "nu_tau",
+}
+
+latex_str_dict: dict[str, str] = {
+    "p+": "p$^+$",
+    "p-": "p$^-$",
+    "n": "n",
+    "e-": "e$^-$",
+    "e+": "e$^+$",
+    "mu+": "μ$^+$",
+    "mu-": "μ$^-$",
+    "tau+": r"\tau$^+$",
+    "tau-": r"\tau$^-$",
+    "nu_e": r"ν$_e$",
+    "nu_mu": r"ν$_μ$",
+    "nu_tau": r"ν$_τ$",
+    "antineutron": r"\bar{n}",
+    "anti_nu_e": r"\bar{ν}$_e$",
+    "anti_nu_mu": r"\bar{ν}$_μ$",
+    "anti_nu_tau": r"\bar{ν}$_τ$",
 }

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -821,6 +821,19 @@ class Particle(AbstractPhysicalParticle):
         """Return the particle's symbol."""
         return self.symbol
 
+    def latex_str(self) -> str:
+        """LaTeX friendly representation of the particle."""
+        if latex_str_ := _special_particles.get(self.symbol, None):
+            return latex_str_
+
+        isotope_info = f"$^{self.mass_number}$" if self.isotope else ""
+        charge_info = ""
+        if self.is_category(any_of={"charged", "uncharged"}):
+            Z = self.charge_number
+            charge_info = f"{np.abs(Z)}{np.sign(Z)}$" if Z != 0 else "0+"
+            charge_info = "$^{" + charge_info + "}$"
+        return f"{isotope_info}{self.element}{charge_info}"
+
     def __eq__(self, other: object) -> bool:
         """
         Determine if two objects correspond to the same particle.


### PR DESCRIPTION
This PR adds the `Particle.latex_str` attribute, which I expect will be used primarily in plotting. 

Closes #2640. Would be helpful to include for #2639.

I still have to add tests. I started this PR on an airplane, but hopefully I'll get back to it soon!