### PR TITLE
Remove upper limit on Sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ docs = [
   # install setuptools to get pkg_resources for doc build
   "setuptools; python_version >= '3.12'",
   # see issue 2497
-  "sphinx == 7.2.6",
+  "sphinx >= 7.3.7",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.0",
   "sphinx-copybutton >= 0.5.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -362,7 +362,7 @@ sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   nbsphinx
     #   numpydoc

--- a/requirements/requirements_docs_py312.txt
+++ b/requirements/requirements_docs_py312.txt
@@ -110,7 +110,7 @@ six==1.16.0
 sniffio==1.3.1
 snowballstemmer==2.2.0
 soupsieve==2.5
-sphinx==7.2.6
+sphinx==7.3.7
 sphinx-changelog==1.5.0
 sphinx-codeautolink==0.15.1
 sphinx-collapse==0.1.3


### PR DESCRIPTION
In #2497, we described an error that was occurring in the dev version of Sphinx, so we preemptively pinned `sphinx == 7.2.6`.  There were a few Sphinx 7.3.* releases in the last week or two, so this PR removes the strict requirement.  And the documentation build is passing, so yay! 🎆 