### PR TITLE
Update Codecov settings

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,7 +17,7 @@ bug:
 'CI':
   - changed-files:
     - any-glob-to-any-file: [
-      '.codecov.yaml',
+      'codecov.yaml',
       '.github/workflows/*test*.yml',
       '.pre-commit-config.yaml',
       '.readthedocs.yml',

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,15 +4,13 @@ codecov:
     wait_for_ci: false
   require_ci_to_pass: false
 coverage:
-  range: 75..98
+  range: 80..98
   status:
     project:
       default:
-        threshold: 0.2%
+        threshold: 0.1%
         removed_code_behavior: adjust_base
-        if_not_found: failure
     patch:
       default:
-        threshold: 0.2%
+        threshold: 0.5%
         removed_code_behavior: adjust_base
-        if_not_found: failure

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 0.1%
+        threshold: 0.2%
         removed_code_behavior: adjust_base
     patch:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
     wait_for_ci: false
   require_ci_to_pass: false
 coverage:
-  range: 80..98
+  range: 90..98
   status:
     project:
       default:

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -828,7 +828,7 @@ Coverage configurations
 
 Configurations for coverage tests are given in the ``[coverage:run]``
 and ``[coverage:report]`` sections of :file:`setup.cfg`. Codecov_
-configurations are given in :file:`.codecov.yaml`.
+configurations are given in :file:`codecov.yaml`.
 
 Using an integrated development environment
 -------------------------------------------


### PR DESCRIPTION
We've been having some problems with our Codecov configuration the last few months.  This PR makes it so that CI can pass if the Codecov report doesn't upload correctly.  I've correspondingly set it so that the codecov/patch check is now required, so it's more apparent if it is missing.  This is a bandaid 🩹 which we'll have to look into further. 