### PR TITLE
Use nox for some testing environments in GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,48 @@ env:
 
 jobs:
 
+
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+
+        - name: Static type checking with mypy, Python 3.12, Ubuntu
+          os: ubuntu-latest
+          python: '3.12'
+          noxenv: mypy
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        cache: pip
+
+    - name: Install nox and uv
+      run: python -m pip install --progress-bar off --upgrade nox uv
+
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          .nox
+        key: ${{ matrix.noxenv }}-${{ runner.os }}-${{ hashFiles('requirements.txt', 'pyproject.toml') }}
+
+    - name: Run tests
+      run: nox -e ${{ matrix.noxenv }}
+
   documentation:
 
     name: Documentation, Python 3.12, Ubuntu, nox
@@ -53,6 +95,3 @@ jobs:
     - name: Print troubleshooting information on failure
       if: ${{ failure() }}
       run: echo -e $DOC_TROUBLESHOOTING
-
-    - name: man echo
-      run: man echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
           .nox
         key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
 
-    - name: Build documentation with Sphinx
-      run: nox -e docs -- -q
+#    - name: Build documentation with Sphinx
+#      run: nox -e docs -- -q
 
     - name: Print troubleshooting information on failure
-      if: ${{ failure() }}
-      run: echo $DOC_TROUBLESHOOTING
+#      if: ${{ failure() }}
+      run: echo -e $DOC_TROUBLESHOOTING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOC_TROUBLESHOOTING: "For help with fixing failures, please check out the documentation troubleshooting guide at:\n\n  https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting\n\nWarnings like 'reference target not found' occur when Sphinx tries to interpret text as a Python object, but is unable to do so. This warning can often be fixed by surrounding text in double back ticks instead of single back ticks (e.g., by changing `y` to ``y``) so that it gets formatted as an in-line literal."
+  DOC_TROUBLESHOOTING: "For help with fixing failures, please check out the documentation troubleshooting guide at: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting\n\nWarnings like 'reference target not found' occur when Sphinx tries to interpret text as a Python object, but is unable to do so. This warning can often be fixed by surrounding text in double back ticks instead of single back ticks (e.g., by changing `y` to ``y``) so that it gets formatted as an in-line literal."
 
 jobs:
 
@@ -53,3 +53,6 @@ jobs:
     - name: Print troubleshooting information on failure
 #      if: ${{ failure() }}
       run: echo -e $DOC_TROUBLESHOOTING
+
+    - name: man echo
+      run: man echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOC_TROUBLESHOOTING: "\nDocumentation troubleshooting guide:\n\nhttps://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting\n\n"
+  DOC_TROUBLESHOOTING: "For help with fixing failures, please check out the documentation troubleshooting guide at:\n\n  https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting\n\nWarnings like 'reference target not found' occur when Sphinx tries to interpret text as a Python object, but is unable to do so. This warning can often be fixed by surrounding text in double back ticks instead of single back ticks (e.g., by changing `y` to ``y``) so that it gets formatted as an in-line literal."
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
     - name: Build documentation with Sphinx
       run: nox -e docs -- -q
 
-    - name: Intentional failure to test printing of doc troubleshooting
-      run: nox -e docs -- -q
-
     - name: Print troubleshooting information on failure
       if: ${{ failure() }}
       run: echo $DOC_TROUBLESHOOTING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
   documentation:
 
-    name: Documentation, Python 3.12, Ubuntu, nox
+    name: Documentation, Python 3.12, Ubuntu
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOC_TROUBLESHOOTING: "For help with fixing failures, please check out the documentation troubleshooting guide at: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting\n\nWarnings like 'reference target not found' occur when Sphinx tries to interpret text as a Python object, but is unable to do so. This warning can often be fixed by surrounding text in double back ticks instead of single back ticks (e.g., by changing `y` to ``y``) so that it gets formatted as an in-line literal."
+  DOC_TROUBLESHOOTING: "Warnings like 'reference target not found' occur when Sphinx tries to interpret text as a Python object, but is unable to do so. This warning can often be fixed by surrounding text in double back ticks instead of single back ticks (e.g., by changing `y` to ``y``) so that it gets formatted as an in-line literal. For more information about addressing documentation build failures, please check out the documentation troubleshooting guide at: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting"
 
 jobs:
 
@@ -47,11 +47,11 @@ jobs:
           .nox
         key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
 
-#    - name: Build documentation with Sphinx
-#      run: nox -e docs -- -q
+    - name: Build documentation with Sphinx
+      run: nox -e docs -- -q
 
     - name: Print troubleshooting information on failure
-#      if: ${{ failure() }}
+      if: ${{ failure() }}
       run: echo -e $DOC_TROUBLESHOOTING
 
     - name: man echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,9 @@ jobs:
           .nox
         key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
 
+    - name: Build documentation with Sphinx
+      run: nox -e docs -- -q
+
     - name: Print troubleshooting information on failure
+      if: ${{ failure() }}
       run: echo $DOC_TROUBLESHOOTING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+    - stable
+    - v*.*.*
+    tags:
+    - v*
+  pull_request:
+  workflow_dispatch:
+
+env:
+  DOC_TROUBLESHOOTING: "\nDocumentation troubleshooting guide:\n\nhttps://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting\n\n"
+
+jobs:
+
+  documentation:
+
+    name: Documentation, Python 3.12, Ubuntu, nox
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install graphviz and pandoc
+      run: sudo apt-get install graphviz pandoc
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: pip
+
+    - name: Install nox uv
+      run: python -m pip install --progress-bar off --upgrade nox uv
+
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          .nox
+        key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+
+    - name: Build documentation with Sphinx
+      run: nox -e docs -- -q
+
+    - name: Print troubleshooting information on failure
+      if: ${{ failure() }}
+      run: echo $DOC_TROUBLESHOOTING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
     - name: Build documentation with Sphinx
       run: nox -e docs -- -q
 
+    - name: Intentional failure to test printing of doc troubleshooting
+      run: nox -e docs -- -q
+
     - name: Print troubleshooting information on failure
       if: ${{ failure() }}
       run: echo $DOC_TROUBLESHOOTING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,5 @@ jobs:
           .nox
         key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
 
-    - name: Build documentation with Sphinx
-      run: nox -e docs -- -q
-
     - name: Print troubleshooting information on failure
-      if: ${{ failure() }}
       run: echo $DOC_TROUBLESHOOTING

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -29,10 +29,10 @@ jobs:
         python-version: 3.12
 
     - name: Install Python dependencies
-      run: python -m pip install --upgrade tox tox-uv
+      run: python -m pip install --upgrade nox uv
 
     - name: Install graphviz & pandoc
       run: sudo apt-get install graphviz pandoc
 
     - name: Check hyperlinks
-      run: tox -e linkcheck
+      run: nox -e linkcheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,6 @@ jobs:
           python: '3.10'
           toxenv: py310-lowest_direct-pytest_skipslow
 
-        - name: Static type checking with mypy, Python 3.12, Ubuntu
-          os: ubuntu-latest
-          python: '3.12'
-          toxenv: mypy
-
     steps:
 
     - name: Checkout code
@@ -80,45 +75,6 @@ jobs:
         fail_ci_if_error: false
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  documentation:
-
-    name: Documentation, Python 3.12, Ubuntu
-    runs-on: ubuntu-latest
-
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Install graphviz and pandoc
-      run: sudo apt-get install graphviz pandoc
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-        cache: pip
-
-    - name: Install tox and its extensions
-      run: python -m pip install --progress-bar off --upgrade tox tox-uv
-
-    - name: Cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          .tox
-        key: docs-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
-
-    - name: Build docs
-      run: tox -e build_docs -- -q
-
-    - name: Print troubleshooting information on failure
-      if: ${{ failure() }}
-      run: |
-        echo "\nDocumentation troubleshooting guide:\n\nhttps://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting\n\n"
 
   import-plasmapy:
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include *.yaml
 include *.yml
 include changelog/README.rst
 include CITATION.cff
+include noxfile.py
 include pyproject.toml
 include tox.ini
 

--- a/changelog/2656.internal.rst
+++ b/changelog/2656.internal.rst
@@ -1,0 +1,2 @@
+Began using |nox| for some testing environments in |GitHub Actions|, including for the
+documentation build and static type checking.

--- a/docs/_global_substitutions.py
+++ b/docs/_global_substitutions.py
@@ -132,6 +132,7 @@ links_to_become_subs: dict[str, str] = {
     "mpmath": "https://mpmath.org/doc/current",
     "mypy": "https://mypy.readthedocs.io",
     "nbsphinx": "https://nbsphinx.readthedocs.io",
+    "nox": "https://nox.thea.codes",
     "Numba": "https://numba.readthedocs.io",
     "NumPy": "https://numpy.org",
     "office hours": "https://www.plasmapy.org/meetings/office_hours/",

--- a/docs/about/citation.rst
+++ b/docs/about/citation.rst
@@ -56,4 +56,4 @@ on, such as `Astropy <https://www.astropy.org/acknowledging.html>`__,
 .. note::
 
    All public releases of PlasmaPy are openly archived in the `PlasmaPy
-   Community <https://zenodo.org/communities/plasmapy>`__ on |Zenodo|.
+   Community <https://zenodo.org/communities/plasmapy/records>`__ on |Zenodo|.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -338,11 +338,17 @@ linkcheck_anchors_ignore = [
     "L[0-9].+",
     "!forum/plasmapy",
 ]
+
+# The default value of linkcheck_report_timeouts_as_broken will default
+# to False for Sphinx 8.0, so the following line can be removed.
+linkcheck_report_timeouts_as_broken = False
+
 linkcheck_allowed_redirects = {
     r"https://doi\.org/.+": r"https://.+",  # DOI links are persistent
-    r"https://docs.+\.org": r"https://docs.+\.org/en/.+",
+    r"https://.+\.org": r"https://.+\.org/en/.+",
     r"https://docs.+\.io": r"https://docs.+\.io/en/.+",
     r"https://docs.+\.com": r"https://docs.+\.com/en/.+",
+    r"https://docs.+\.codes": r"https://docs.+\.codes/en/.+",
     r"https://docs.+\.dev": r"https://docs.+\.dev/en/.+",
     r"https://github\.com/sponsors/.+": r"https://github\.com/.+",
     r"https://en.wikipedia.org/wiki.+": "https://en.wikipedia.org/wiki.+",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -348,7 +348,7 @@ linkcheck_allowed_redirects = {
     r"https://.+\.org": r"https://.+\.org/en/.+",
     r"https://docs.+\.io": r"https://docs.+\.io/en/.+",
     r"https://docs.+\.com": r"https://docs.+\.com/en/.+",
-    r"https://docs.+\.codes": r"https://docs.+\.codes/en/.+",
+    r"https://.+\.codes": r"https://.+\.codes/en/.+",
     r"https://docs.+\.dev": r"https://docs.+\.dev/en/.+",
     r"https://github\.com/sponsors/.+": r"https://github\.com/.+",
     r"https://en.wikipedia.org/wiki.+": "https://en.wikipedia.org/wiki.+",

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -1391,7 +1391,7 @@ invisible imports with ``.. autolink-preface::``.
 
 If this warning occurs in the "Examples" section of a docstring, put
 ``.. autolink-skip: section`` at the beginning of that section (see
-:issue:`2554`). These warnings sometimes only show up when rebuilding
+:pr:`2554`). These warnings sometimes only show up when rebuilding
 the documentation.
 
 A related warning is "Could not match transformation of _ on source

--- a/docs/contributing/getting_ready.rst
+++ b/docs/contributing/getting_ready.rst
@@ -333,7 +333,7 @@ when you :py:`import plasmapy`.
 .. _powershell: https://learn.microsoft.com/en-us/powershell
 .. _Real Python: https://realpython.com
 .. _remote: https://github.com/git-guides/git-remote
-.. _sign up on GitHub: https://github.com/join
+.. _sign up on GitHub: https://github.com/signup
 .. _terminal user guide: https://support.apple.com/guide/terminal/welcome/mac
 .. _this xkcd comic: https://xkcd.com/1987
 .. _unix tutorial: https://www.hpc.iastate.edu/guides/unix-introduction/unix-tutorial-1

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,5 +53,7 @@ def mypy(session):
         "--pretty",
         "--exclude",
         "build",
+        "--exclude",
+        "_version.py",
         *session.posargs,
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def docs(session):
     """Build documentation with Sphinx."""
     session.install(*doc_requirements)
     session.install(".")
-    session.run(*sphinx_commands, *html)
+    session.run(*sphinx_commands, *html, *session.posargs)
 
 
 @nox.session(python=maxpython)
@@ -35,7 +35,7 @@ def linkcheck(session):
     """Check hyperlinks in documentation."""
     session.install(*doc_requirements)
     session.install(".")
-    session.run(*sphinx_commands, *check_hyperlinks)
+    session.run(*sphinx_commands, *check_hyperlinks, *session.posargs)
 
 
 @nox.session(python=maxpython)
@@ -53,4 +53,5 @@ def mypy(session):
         "--pretty",
         "--exclude",
         "build",
+        *session.posargs,
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ sphinx_commands = (
 )
 
 html = ("-b", "html")
-check_hyperlinks = ("-b", "linkcheck")
+check_hyperlinks = ("-b", "linkcheck", "-q")
 
 
 @nox.session(python=maxpython)

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,20 +40,15 @@ def linkcheck(session):
 
 @nox.session(python=maxpython)
 def mypy(session):
-    """Perform static type checking."""
-    session.install("mypy >= 1.9.0", "pip")
-    session.install("-r", "requirements.txt")
-    session.run(
-        "mypy",
-        ".",
+    """Perform static type checking with mypy."""
+    mypy_command = ("mypy", ".")
+    mypy_options = (
         "--install-types",
         "--non-interactive",
         "--show-error-context",
         "--show-error-code-links",
         "--pretty",
-        "--exclude",
-        "build",
-        "--exclude",
-        "_version.py",
-        *session.posargs,
     )
+    session.install("mypy >= 1.9.0", "pip")
+    session.install("-r", "requirements.txt")
+    session.run(*mypy_command, *mypy_options, *session.posargs)

--- a/src/plasmapy/__init__.py
+++ b/src/plasmapy/__init__.py
@@ -48,7 +48,9 @@ try:
     try:
         from plasmapy._dev.scm_version import version as __version__
     except ImportError:
-        from plasmapy._version import version as __version__
+        from plasmapy._version import (
+            version as __version__,  # type: ignore[import-not-found,no-redef,unused-ignore]
+        )
 except Exception:  # coverage: ignore  # noqa: BLE001
     __version__ = "0.0.0"  # package is not installed
 

--- a/src/plasmapy/__init__.py
+++ b/src/plasmapy/__init__.py
@@ -48,8 +48,8 @@ try:
     try:
         from plasmapy._dev.scm_version import version as __version__
     except ImportError:
-        from plasmapy._version import (
-            version as __version__,  # type: ignore[import-not-found,no-redef,unused-ignore]
+        from plasmapy._version import (  # type: ignore[import-not-found,no-redef,unused-ignore]
+            version as __version__,
         )
 except Exception:  # coverage: ignore  # noqa: BLE001
     __version__ = "0.0.0"  # package is not installed


### PR DESCRIPTION
This PR switches some GitHub workflows from being run with tox to being run with nox, including:

 - Documentation
 - mypy
 - linkcheck

## Motivation

Presently, our tox configuration file is difficult to understand and maintain. Using nox lets us have a configuration file that is written in Python.

## Related issues

This PR is a follow-up on #2654. See also #1734 & #1735.