### PR TITLE
Add `import`, `cff`, and `build` sessions for nox

### DIFF
--- a/changelog/2682.internal.rst
+++ b/changelog/2682.internal.rst
@@ -1,0 +1,1 @@
+Added |nox| sessions for trying :py:`import plasmapy` and validating :file:`CITATION.cff`.

--- a/changelog/2682.internal.rst
+++ b/changelog/2682.internal.rst
@@ -1,1 +1,2 @@
-Added |nox| sessions for trying :py:`import plasmapy` and validating :file:`CITATION.cff`.
+Added |nox| sessions to test importing PlasmaPy, validating :file:`CITATION.cff`,
+and building a source distribution and wheel.

--- a/noxfile.py
+++ b/noxfile.py
@@ -174,3 +174,15 @@ def cff(session):
     """Validate CITATION.cff."""
     session.install("cffconvert")
     session.run("cffconvert", "--validate")
+
+
+build_command = ("python", "-m", "build")
+
+
+@nox.session
+def build(session):
+    """Build and verify a source distribution and wheel."""
+    session.install("twine", "build")
+    session.run(*build_command, "--sdist")
+    session.run(*build_command, "--wheel")
+    session.run("twine", "check", "dist/*")

--- a/noxfile.py
+++ b/noxfile.py
@@ -160,3 +160,10 @@ def mypy(session):
     session.install("mypy >= 1.10.0", "pip")
     session.install("-r", "requirements.txt")
     session.run(*mypy_command, *mypy_options, *session.posargs)
+
+
+@nox.session
+def try_import(session):
+    """Install PlasmaPy and import it."""
+    session.install(".")
+    session.run("python", "-c", "import plasmapy")

--- a/noxfile.py
+++ b/noxfile.py
@@ -176,13 +176,11 @@ def cff(session):
     session.run("cffconvert", "--validate")
 
 
-build_command = ("python", "-m", "build")
-
-
 @nox.session
 def build(session):
     """Build and verify a source distribution and wheel."""
     session.install("twine", "build")
+    build_command = ("python", "-m", "build")
     session.run(*build_command, "--sdist")
     session.run(*build_command, "--wheel")
     session.run("twine", "check", "dist/*")

--- a/noxfile.py
+++ b/noxfile.py
@@ -167,3 +167,10 @@ def try_import(session):
     """Install PlasmaPy and import it."""
     session.install(".")
     session.run("python", "-c", "import plasmapy")
+
+
+@nox.session
+def cff(session):
+    """Validate CITATION.cff."""
+    session.install("cffconvert")
+    session.run("cffconvert", "--validate")

--- a/noxfile.py
+++ b/noxfile.py
@@ -162,7 +162,7 @@ def mypy(session):
     session.run(*mypy_command, *mypy_options, *session.posargs)
 
 
-@nox.session
+@nox.session(name="import")
 def try_import(session):
     """Install PlasmaPy and import it."""
     session.install(".")


### PR DESCRIPTION
This PR adds three quick nox sessions:
 - `import`, which installs PlasmaPy and then attempts to run `import plasmapy`
 - `cff`, which validates `CITATION.cff`
 - `build`, which builds a source distribution (sdist) and wheel, and then uses twine to validate them.

📝 The `import` session is based off of an existing tox environment, while the `cff` and `build` are coming from commands in GitHub workflows.

✨ Setting these up in `noxfile.py` probably took me perhaps ∼30–50% of the time it would have taken me to set these up in `tox.ini`, largely because I would have had to go back to the tox docs to look up how to do this.  

While tox is an incredible tool, I never want to edit a `tox.ini` file ever again!  😹