### PR TITLE
Apply search-and-replace for `|nox|` to `|Nox|` as a reStructuredText substitution

### DIFF
--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -54,3 +54,7 @@
 - search: 'ion="p"'
   replacement: 'ion="p+"'
   description: Use canonical symbol for proton
+
+- search: '|nox|'
+  replacement: '|Nox|'
+  description: Nox is capitalized except when used as a command

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ Documentation Improvements
   |tox|
   via the ``tox-uv`` extension, and the |documentation guide| to reflect that
   the
-  documentation is now built with |nox| instead of |tox| (:pr:`2590`)
+  documentation is now built with |Nox| instead of |tox| (:pr:`2590`)
 - Add examples to the docstring for
   `~plasmapy.formulary.radiation.thermal_bremsstrahlung`. (:pr:`2618`)
 - Update the dependency version support policy in the |coding guide|.
@@ -135,12 +135,12 @@ Internal Changes and Refactorings
   integration
   and for documentation builds, while adding corresponding documentation.
   (:pr:`2650`)
-- Added :file:`noxfile.py` as a configuration file for |nox|. This file
+- Added :file:`noxfile.py` as a configuration file for |Nox|. This file
   initially contains
   environments for building documentation, checking hyperlinks, and performing
   static
   type checking with |mypy| (:pr:`2654`)
-- Began using |nox| for some testing environments in |GitHub Actions|,
+- Began using |Nox| for some testing environments in |GitHub Actions|,
   including for the
   documentation build and static type checking. (:pr:`2656`)
 

--- a/changelog/2664.internal.rst
+++ b/changelog/2664.internal.rst
@@ -1,2 +1,2 @@
 Converted the |tox| environment for regenerating the requirements files
-used in continuous integration checks to |nox|.
+used in continuous integration checks to |Nox|.

--- a/changelog/2681.internal.rst
+++ b/changelog/2681.internal.rst
@@ -1,1 +1,1 @@
-Created a parametrized |nox| session to run tests.
+Created a parametrized |Nox| session to run tests.

--- a/changelog/2682.internal.rst
+++ b/changelog/2682.internal.rst
@@ -1,2 +1,2 @@
-Added |nox| sessions to test importing PlasmaPy, validating :file:`CITATION.cff`,
+Added |Nox| sessions to test importing PlasmaPy, validating :file:`CITATION.cff`,
 and building a source distribution and wheel.

--- a/docs/_global_substitutions.py
+++ b/docs/_global_substitutions.py
@@ -133,7 +133,7 @@ links_to_become_subs: dict[str, str] = {
     "mpmath": "https://mpmath.org/doc/current",
     "mypy": "https://mypy.readthedocs.io",
     "nbsphinx": "https://nbsphinx.readthedocs.io",
-    "nox": "https://nox.thea.codes",
+    "Nox": "https://nox.thea.codes",
     "Numba": "https://numba.readthedocs.io",
     "NumPy": "https://numpy.org",
     "office hours": "https://www.plasmapy.org/meetings/office_hours/",

--- a/docs/changelog/2024.5.0.rst
+++ b/docs/changelog/2024.5.0.rst
@@ -39,7 +39,7 @@ Documentation Improvements
   |tox|
   via the ``tox-uv`` extension, and the |documentation guide| to reflect that
   the
-  documentation is now built with |nox| instead of |tox| (:pr:`2590`)
+  documentation is now built with |Nox| instead of |tox| (:pr:`2590`)
 - Add examples to the docstring for
   `~plasmapy.formulary.radiation.thermal_bremsstrahlung`. (:pr:`2618`)
 - Update the dependency version support policy in the |coding guide|.
@@ -135,12 +135,12 @@ Internal Changes and Refactorings
   integration
   and for documentation builds, while adding corresponding documentation.
   (:pr:`2650`)
-- Added :file:`noxfile.py` as a configuration file for |nox|. This file
+- Added :file:`noxfile.py` as a configuration file for |Nox|. This file
   initially contains
   environments for building documentation, checking hyperlinks, and performing
   static
   type checking with |mypy| (:pr:`2654`)
-- Began using |nox| for some testing environments in |GitHub Actions|,
+- Began using |Nox| for some testing environments in |GitHub Actions|,
   including for the
   documentation build and static type checking. (:pr:`2656`)
 

--- a/docs/contributing/doc_guide.rst
+++ b/docs/contributing/doc_guide.rst
@@ -1153,16 +1153,16 @@ Building documentation
    documentation locally on your own computer. New contributors can
    safely skip this section.
 
-There are two methods for building the documentation: make_ and |nox|.
+There are two methods for building the documentation: make_ and |Nox|.
 
 * Using make_ will build the documentation based off of what is in the
   current directory structure. make_ is quicker for local builds than
-  |nox| but requires you to install and set up all dependencies.
+  |Nox| but requires you to install and set up all dependencies.
 
-* Using |nox| does not require setting up all dependencies ahead of
+* Using |Nox| does not require setting up all dependencies ahead of
   time, but is more computationally intensive since it creates a virtual
   environment and builds the package before building the documentation.
-  Consequently, PlasmaPy uses |nox| for building the documentation on
+  Consequently, PlasmaPy uses |Nox| for building the documentation on
   continuous integration testing platforms.
 
 .. _doc-build-prereqs:
@@ -1184,20 +1184,20 @@ It may also be necessary to install the following software:
 
 * `graphviz <https://graphviz.org/download>`__
 * `pandoc <https://pandoc.org/installing.html>`__
-* make_ (not necessary for building the documentation with |nox| or
+* make_ (not necessary for building the documentation with |Nox| or
   sphinx_build)
 
 Building documentation
 ----------------------
 
-PlasmaPy's documentation can be built using |nox|, make_, or
-sphinx-build_. We recommend starting with |nox|.
+PlasmaPy's documentation can be built using |Nox|, make_, or
+sphinx-build_. We recommend starting with |Nox|.
 
 .. tabs::
 
    .. group-tab:: nox
 
-      We can use |nox| to build the documentation locally by running:
+      We can use |Nox| to build the documentation locally by running:
 
       .. code-block:: bash
 
@@ -1207,7 +1207,7 @@ sphinx-build_. We recommend starting with |nox|.
       example, use :bash:`nox -s docs -- -v` to increase output
       verbosity.
 
-      Building with |nox| is well-suited for reproducible documentation
+      Building with |Nox| is well-suited for reproducible documentation
       builds in an isolated Python environment, which is why it is used
       in continuous integration tests.
 
@@ -1232,7 +1232,7 @@ sphinx-build_. We recommend starting with |nox|.
    .. group-tab:: sphinx-build
 
       Using sphinx-build_ allows us to choose different `options to
-      sphinx-build`_ than the defaults used by |nox| and make_.
+      sphinx-build`_ than the defaults used by |Nox| and make_.
 
       PlasmaPy's documentation can be build by going to the top-level
       directory of the repository and running:
@@ -1269,7 +1269,7 @@ To check hyperlinks locally, run:
 .. tip::
 
    When writing documentation, please fix any new warnings that arise.
-   To enforce this, the ``docs`` |nox| environment fails if there are
+   To enforce this, the ``docs`` |Nox| environment fails if there are
    any warnings.
 
 Troubleshooting

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -45,7 +45,7 @@ tests marked as slow.
 .. important::
 
    PlasmaPy is in the process of switching its test runner from |tox| to
-   |nox|. In the near future, it will likely be necessary to run ``nox``
+   |Nox|. In the near future, it will likely be necessary to run ``nox``
    instead of ``tox`` to invoke tests.
 
 Writing tests


### PR DESCRIPTION
It turns out that Nox is capitalized except when used as a command.  I started making this change in #2685, but decided to put it in its own PR to isolate it in code review.