### PR TITLE
Enables tests for `plamapy.<subpackage>` to be run with `pytest -P <subpackage>`

### DIFF
--- a/ci_requirements/tests-3.10-lowest-direct.txt
+++ b/ci_requirements/tests-3.10-lowest-direct.txt
@@ -221,6 +221,7 @@ packaging==23.2
     #   nox
     #   pyproject-api
     #   pytest
+    #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   tox
     #   tox-uv
@@ -274,12 +275,14 @@ pytest==8.0.2
     # via
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-filter-subpackage==0.2.0
 pytest-regressions==2.5.0
 pytest-rerunfailures==13.0
 pytest-xdist==3.5.0
@@ -382,7 +385,7 @@ urllib3==1.26.18
     # via requests
 uv==0.1.42
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit

--- a/ci_requirements/tests-3.10.txt
+++ b/ci_requirements/tests-3.10.txt
@@ -213,6 +213,7 @@ packaging==24.0
     #   nox
     #   pyproject-api
     #   pytest
+    #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   tox
     #   tox-uv
@@ -265,12 +266,14 @@ pytest==8.2.0
     # via
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-filter-subpackage==0.2.0
 pytest-regressions==2.5.0
 pytest-rerunfailures==14.0
 pytest-xdist==3.6.1
@@ -388,7 +391,7 @@ urllib3==2.2.1
     # via requests
 uv==0.1.42
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit

--- a/ci_requirements/tests-3.11-lowest-direct.txt
+++ b/ci_requirements/tests-3.11-lowest-direct.txt
@@ -215,6 +215,7 @@ packaging==23.2
     #   nox
     #   pyproject-api
     #   pytest
+    #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   tox
     #   tox-uv
@@ -268,12 +269,14 @@ pytest==8.0.2
     # via
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-filter-subpackage==0.2.0
 pytest-regressions==2.5.0
 pytest-rerunfailures==13.0
 pytest-xdist==3.5.0
@@ -370,7 +373,7 @@ urllib3==1.26.18
     # via requests
 uv==0.1.42
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit

--- a/ci_requirements/tests-3.11.txt
+++ b/ci_requirements/tests-3.11.txt
@@ -207,6 +207,7 @@ packaging==24.0
     #   nox
     #   pyproject-api
     #   pytest
+    #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   tox
     #   tox-uv
@@ -259,12 +260,14 @@ pytest==8.2.0
     # via
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-filter-subpackage==0.2.0
 pytest-regressions==2.5.0
 pytest-rerunfailures==14.0
 pytest-xdist==3.6.1
@@ -374,7 +377,7 @@ urllib3==2.2.1
     # via requests
 uv==0.1.42
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit

--- a/ci_requirements/tests-3.12-lowest-direct.txt
+++ b/ci_requirements/tests-3.12-lowest-direct.txt
@@ -215,6 +215,7 @@ packaging==23.2
     #   nox
     #   pyproject-api
     #   pytest
+    #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   tox
     #   tox-uv
@@ -268,12 +269,14 @@ pytest==8.0.2
     # via
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-filter-subpackage==0.2.0
 pytest-regressions==2.5.0
 pytest-rerunfailures==13.0
 pytest-xdist==3.5.0
@@ -368,7 +371,7 @@ urllib3==1.26.18
     # via requests
 uv==0.1.42
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit

--- a/ci_requirements/tests-3.12.txt
+++ b/ci_requirements/tests-3.12.txt
@@ -207,6 +207,7 @@ packaging==24.0
     #   nox
     #   pyproject-api
     #   pytest
+    #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   tox
     #   tox-uv
@@ -259,12 +260,14 @@ pytest==8.2.0
     # via
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-filter-subpackage==0.2.0
 pytest-regressions==2.5.0
 pytest-rerunfailures==14.0
 pytest-xdist==3.6.1
@@ -372,7 +375,7 @@ urllib3==2.2.1
     # via requests
 uv==0.1.42
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -685,13 +685,19 @@ This command will run all of the tests found within your current
 directory and all of its subdirectories. Because it takes time to run
 PlasmaPy's tests, it is usually most convenient to specify that only a
 subset of the tests be run. To run the tests contained within a
-particular file or directory, include its name after `pytest`. If you
-are in the directory :file:`plasmapy/particles/tests/`, then the tests
-in in :file:`test_atomic.py` can be run with:
+particular file or directory, include its name after `pytest`.
 
 .. code-block:: console
 
-   pytest test_atomic.py
+   pytest tests/particles/test_atomic.py
+
+The ``pytest-filter-subpackage`` extension lets us use the ``-P`` flag
+to specify a subpackage that tests should be run for. To perform tests
+for `plasmapy.particles`, run:
+
+.. code-block:: console
+
+   pytest -P particles
 
 The documentation for `pytest` describes `how to invoke pytest`_ and
 specify which tests will or will not be run. A few useful examples of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ tests = [
   "pre-commit >= 3.6.0",
   "pytest >= 8.0.2",
   "pytest-cov >= 5.0.0",
+  "pytest-filter-subpackage >= 0.2.0",
   "pytest-regressions >= 2.5.0",
   "pytest-rerunfailures >= 13.0",
   "pytest-xdist >= 3.5.0",


### PR DESCRIPTION
I recently learned that it is possible in Astropy to run tests for subpackages using the ``-P`` flag.  After digging a little bit, I found that this capability comes from the [`pytest-filter-subpackage`](https://github.com/astropy/pytest-filter-subpackage) extension to pytest.  This PR adds `pytest-filter-subpackage` to the `tests` dependency set, and adds a short discussion in the testing guide.

After this PR is merged, we will be able to run tests for subpackages with:

```console
pytest -P particles
```

We will also be able to do this from nox (#2685):

```console
nox -- -P particles
```

This only works for subpackages (i.e., directories) and not files.  