### PR TITLE
Fix error in nox session for regenerating requirements files and update requirements file used by Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,4 +20,4 @@ python:
   install:
   - method: pip
     path: .
-  - requirements: ci_requirements/requirements_docs_py312.txt
+  - requirements: ci_requirements/docs-3.12.txt

--- a/ci_requirements/all-3.12.txt
+++ b/ci_requirements/all-3.12.txt
@@ -15,6 +15,7 @@ arrow==1.3.0
 asteval==0.9.32
     # via lmfit
 astropy==6.1.0
+    # via plasmapy (pyproject.toml)
 astropy-iers-data==0.2024.5.13.0.30.12
     # via astropy
 asttokens==2.4.1
@@ -58,6 +59,8 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
+coverage==7.5.1
+    # via pytest-cov
 cycler==0.12.1
     # via matplotlib
 debugpy==1.8.1
@@ -72,6 +75,7 @@ distlib==0.3.8
     # via virtualenv
 docutils==0.20.1
     # via
+    #   plasmapy (pyproject.toml)
     #   nbsphinx
     #   pybtex-docutils
     #   sphinx
@@ -95,7 +99,9 @@ fqdn==1.5.1
 future==1.0.0
     # via uncertainties
 h5py==3.11.0
-hypothesis==6.101.0
+    # via plasmapy (pyproject.toml)
+hypothesis==6.102.1
+    # via plasmapy (pyproject.toml)
 identify==2.5.36
     # via pre-commit
 idna==3.7
@@ -110,17 +116,20 @@ incremental==22.10.0
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.4
+    # via plasmapy (pyproject.toml)
 ipython==8.24.0
     # via
     #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.2
+    # via plasmapy (pyproject.toml)
 isoduration==20.11.0
     # via jsonschema
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
+    #   plasmapy (pyproject.toml)
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
@@ -174,11 +183,13 @@ latexcodec==3.0.0
 llvmlite==0.42.0
     # via numba
 lmfit==1.3.1
+    # via plasmapy (pyproject.toml)
 markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
 matplotlib==3.8.4
+    # via plasmapy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -186,6 +197,7 @@ matplotlib-inline==0.1.7
 mistune==3.0.2
     # via nbconvert
 mpmath==1.3.0
+    # via plasmapy (pyproject.toml)
 nbclient==0.7.4
     # via
     #   nbconvert
@@ -202,14 +214,18 @@ nbformat==5.10.4
     #   nbconvert
     #   nbsphinx
 nbsphinx==0.9.4
+    # via plasmapy (pyproject.toml)
 nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.8.0
     # via pre-commit
 nox==2024.4.15
+    # via plasmapy (pyproject.toml)
 numba==0.59.1
+    # via plasmapy (pyproject.toml)
 numpy==1.26.4
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   contourpy
     #   h5py
@@ -221,10 +237,12 @@ numpy==1.26.4
     #   scipy
     #   xarray
 numpydoc==1.7.0
+    # via plasmapy (pyproject.toml)
 overrides==7.7.0
     # via jupyter-server
 packaging==24.0
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   ipykernel
     #   jupyter-server
@@ -240,7 +258,9 @@ packaging==24.0
     #   tox-uv
     #   xarray
 pandas==2.2.2
-    # via xarray
+    # via
+    #   plasmapy (pyproject.toml)
+    #   xarray
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -249,6 +269,7 @@ pexpect==4.9.0
     # via ipython
 pillow==10.3.0
     # via
+    #   plasmapy (pyproject.toml)
     #   matplotlib
     #   sphinx-gallery
 platformdirs==4.2.1
@@ -261,6 +282,7 @@ pluggy==1.5.0
     #   pytest
     #   tox
 pre-commit==3.7.1
+    # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.43
@@ -285,6 +307,7 @@ pyerfa==2.0.1.4
     # via astropy
 pygments==2.18.0
     # via
+    #   plasmapy (pyproject.toml)
     #   ipython
     #   nbconvert
     #   sphinx
@@ -295,15 +318,22 @@ pyproject-api==1.6.1
     # via tox
 pytest==8.2.0
     # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-cov
     #   pytest-datadir
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
+pytest-cov==5.0.0
+    # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
+    # via plasmapy (pyproject.toml)
 pytest-rerunfailures==14.0
+    # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
+    # via plasmapy (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   arrow
@@ -333,6 +363,7 @@ referencing==0.35.1
     #   jupyter-events
 requests==2.31.0
     # via
+    #   plasmapy (pyproject.toml)
     #   jupyterlab-server
     #   sphinx
 rfc3339-validator==0.1.4
@@ -348,11 +379,15 @@ rpds-py==0.18.1
     #   jsonschema
     #   referencing
 scipy==1.13.0
-    # via lmfit
+    # via
+    #   plasmapy (pyproject.toml)
+    #   lmfit
 send2trash==1.8.3
     # via jupyter-server
 setuptools==69.5.1
-    # via nodeenv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   nodeenv
 six==1.16.0
     # via
     #   asttokens
@@ -370,6 +405,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   plasmapy (pyproject.toml)
     #   nbsphinx
     #   numpydoc
     #   sphinx-changelog
@@ -387,22 +423,35 @@ sphinx==7.3.7
     #   sphinxcontrib-globalsubs
     #   sphinxcontrib-jquery
 sphinx-changelog==1.5.0
+    # via plasmapy (pyproject.toml)
 sphinx-codeautolink==0.15.1
+    # via plasmapy (pyproject.toml)
 sphinx-collapse==0.1.3
+    # via plasmapy (pyproject.toml)
 sphinx-copybutton==0.5.2
+    # via plasmapy (pyproject.toml)
 sphinx-gallery==0.16.0
+    # via plasmapy (pyproject.toml)
 sphinx-hoverxref==1.3.0
+    # via plasmapy (pyproject.toml)
 sphinx-issues==4.1.0
+    # via plasmapy (pyproject.toml)
 sphinx-notfound-page==1.0.0
+    # via plasmapy (pyproject.toml)
 sphinx-reredirects==0.1.3
+    # via plasmapy (pyproject.toml)
 sphinx-rtd-theme==2.0.0
+    # via plasmapy (pyproject.toml)
 sphinx-tabs==3.4.5
+    # via plasmapy (pyproject.toml)
 sphinxcontrib-applehelp==1.0.8
     # via sphinx
 sphinxcontrib-bibtex==2.6.2
+    # via plasmapy (pyproject.toml)
 sphinxcontrib-devhelp==1.0.6
     # via sphinx
 sphinxcontrib-globalsubs==0.1.1
+    # via plasmapy (pyproject.toml)
 sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-jquery==4.1
@@ -426,6 +475,7 @@ terminado==0.18.1
 tinycss2==1.3.0
     # via nbconvert
 tomli==2.0.1
+    # via plasmapy (pyproject.toml)
 tornado==6.4
     # via
     #   ipykernel
@@ -433,11 +483,17 @@ tornado==6.4
     #   jupyter-server
     #   terminado
 towncrier==23.11.0
-    # via sphinx-changelog
+    # via
+    #   plasmapy (pyproject.toml)
+    #   sphinx-changelog
 tox==4.15.0
-    # via tox-uv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   tox-uv
 tox-uv==1.8.2
+    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
+    # via plasmapy (pyproject.toml)
 traitlets==5.14.3
     # via
     #   comm
@@ -461,18 +517,20 @@ tzdata==2024.1
 uncertainties==3.1.7
     # via lmfit
 unidecode==1.3.8
+    # via plasmapy (pyproject.toml)
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.1
     # via requests
-uv==0.1.42
+uv==0.1.44
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit
     #   tox
 voila==0.5.6
+    # via plasmapy (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==1.13
@@ -488,4 +546,6 @@ websockets==12.0
 widgetsnbextension==4.0.10
     # via ipywidgets
 wrapt==1.16.0
+    # via plasmapy (pyproject.toml)
 xarray==2024.5.0
+    # via plasmapy (pyproject.toml)

--- a/ci_requirements/docs-3.12.txt
+++ b/ci_requirements/docs-3.12.txt
@@ -15,6 +15,7 @@ arrow==1.3.0
 asteval==0.9.32
     # via lmfit
 astropy==6.1.0
+    # via plasmapy (pyproject.toml)
 astropy-iers-data==0.2024.5.13.0.30.12
     # via astropy
 asttokens==2.4.1
@@ -69,6 +70,7 @@ distlib==0.3.8
     # via virtualenv
 docutils==0.20.1
     # via
+    #   plasmapy (pyproject.toml)
     #   nbsphinx
     #   pybtex-docutils
     #   sphinx
@@ -90,6 +92,7 @@ fqdn==1.5.1
 future==1.0.0
     # via uncertainties
 h5py==3.11.0
+    # via plasmapy (pyproject.toml)
 idna==3.7
     # via
     #   anyio
@@ -100,17 +103,20 @@ imagesize==1.4.1
 incremental==22.10.0
     # via towncrier
 ipykernel==6.29.4
+    # via plasmapy (pyproject.toml)
 ipython==8.24.0
     # via
     #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.2
+    # via plasmapy (pyproject.toml)
 isoduration==20.11.0
     # via jsonschema
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
+    #   plasmapy (pyproject.toml)
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
@@ -164,11 +170,13 @@ latexcodec==3.0.0
 llvmlite==0.42.0
     # via numba
 lmfit==1.3.1
+    # via plasmapy (pyproject.toml)
 markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
 matplotlib==3.8.4
+    # via plasmapy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -176,6 +184,7 @@ matplotlib-inline==0.1.7
 mistune==3.0.2
     # via nbconvert
 mpmath==1.3.0
+    # via plasmapy (pyproject.toml)
 nbclient==0.7.4
     # via
     #   nbconvert
@@ -192,12 +201,16 @@ nbformat==5.10.4
     #   nbconvert
     #   nbsphinx
 nbsphinx==0.9.4
+    # via plasmapy (pyproject.toml)
 nest-asyncio==1.6.0
     # via ipykernel
 nox==2024.4.15
+    # via plasmapy (pyproject.toml)
 numba==0.59.1
+    # via plasmapy (pyproject.toml)
 numpy==1.26.4
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   contourpy
     #   h5py
@@ -209,10 +222,12 @@ numpy==1.26.4
     #   scipy
     #   xarray
 numpydoc==1.7.0
+    # via plasmapy (pyproject.toml)
 overrides==7.7.0
     # via jupyter-server
 packaging==24.0
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   ipykernel
     #   jupyter-server
@@ -226,7 +241,9 @@ packaging==24.0
     #   tox-uv
     #   xarray
 pandas==2.2.2
-    # via xarray
+    # via
+    #   plasmapy (pyproject.toml)
+    #   xarray
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -235,6 +252,7 @@ pexpect==4.9.0
     # via ipython
 pillow==10.3.0
     # via
+    #   plasmapy (pyproject.toml)
     #   matplotlib
     #   sphinx-gallery
 platformdirs==4.2.1
@@ -268,6 +286,7 @@ pyerfa==2.0.1.4
     # via astropy
 pygments==2.18.0
     # via
+    #   plasmapy (pyproject.toml)
     #   ipython
     #   nbconvert
     #   sphinx
@@ -303,6 +322,7 @@ referencing==0.35.1
     #   jupyter-events
 requests==2.31.0
     # via
+    #   plasmapy (pyproject.toml)
     #   jupyterlab-server
     #   sphinx
 rfc3339-validator==0.1.4
@@ -318,10 +338,13 @@ rpds-py==0.18.1
     #   jsonschema
     #   referencing
 scipy==1.13.0
-    # via lmfit
+    # via
+    #   plasmapy (pyproject.toml)
+    #   lmfit
 send2trash==1.8.3
     # via jupyter-server
 setuptools==69.5.1
+    # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
     #   asttokens
@@ -337,6 +360,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   plasmapy (pyproject.toml)
     #   nbsphinx
     #   numpydoc
     #   sphinx-changelog
@@ -354,22 +378,35 @@ sphinx==7.3.7
     #   sphinxcontrib-globalsubs
     #   sphinxcontrib-jquery
 sphinx-changelog==1.5.0
+    # via plasmapy (pyproject.toml)
 sphinx-codeautolink==0.15.1
+    # via plasmapy (pyproject.toml)
 sphinx-collapse==0.1.3
+    # via plasmapy (pyproject.toml)
 sphinx-copybutton==0.5.2
+    # via plasmapy (pyproject.toml)
 sphinx-gallery==0.16.0
+    # via plasmapy (pyproject.toml)
 sphinx-hoverxref==1.3.0
+    # via plasmapy (pyproject.toml)
 sphinx-issues==4.1.0
+    # via plasmapy (pyproject.toml)
 sphinx-notfound-page==1.0.0
+    # via plasmapy (pyproject.toml)
 sphinx-reredirects==0.1.3
+    # via plasmapy (pyproject.toml)
 sphinx-rtd-theme==2.0.0
+    # via plasmapy (pyproject.toml)
 sphinx-tabs==3.4.5
+    # via plasmapy (pyproject.toml)
 sphinxcontrib-applehelp==1.0.8
     # via sphinx
 sphinxcontrib-bibtex==2.6.2
+    # via plasmapy (pyproject.toml)
 sphinxcontrib-devhelp==1.0.6
     # via sphinx
 sphinxcontrib-globalsubs==0.1.1
+    # via plasmapy (pyproject.toml)
 sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-jquery==4.1
@@ -399,11 +436,17 @@ tornado==6.4
     #   jupyter-server
     #   terminado
 towncrier==23.11.0
-    # via sphinx-changelog
+    # via
+    #   plasmapy (pyproject.toml)
+    #   sphinx-changelog
 tox==4.15.0
-    # via tox-uv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   tox-uv
 tox-uv==1.8.2
+    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
+    # via plasmapy (pyproject.toml)
 traitlets==5.14.3
     # via
     #   comm
@@ -427,17 +470,19 @@ tzdata==2024.1
 uncertainties==3.1.7
     # via lmfit
 unidecode==1.3.8
+    # via plasmapy (pyproject.toml)
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.1
     # via requests
-uv==0.1.42
+uv==0.1.44
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   tox
 voila==0.5.6
+    # via plasmapy (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==1.13
@@ -453,4 +498,6 @@ websockets==12.0
 widgetsnbextension==4.0.10
     # via ipywidgets
 wrapt==1.16.0
+    # via plasmapy (pyproject.toml)
 xarray==2024.5.0
+    # via plasmapy (pyproject.toml)

--- a/ci_requirements/tests-3.10-lowest-direct.txt
+++ b/ci_requirements/tests-3.10-lowest-direct.txt
@@ -14,6 +14,7 @@ argon2-cffi-bindings==21.2.0
 asteval==0.9.32
     # via lmfit
 astropy==5.1
+    # via plasmapy (pyproject.toml)
 asttokens==2.4.1
     # via stack-data
 attrs==23.2.0
@@ -78,7 +79,9 @@ fonttools==4.51.0
 future==1.0.0
     # via uncertainties
 h5py==3.7.0
+    # via plasmapy (pyproject.toml)
 hypothesis==6.97.4
+    # via plasmapy (pyproject.toml)
 identify==2.5.36
     # via pre-commit
 idna==3.7
@@ -89,6 +92,7 @@ iniconfig==2.0.0
     # via pytest
 ipykernel==6.8.0
     # via
+    #   plasmapy (pyproject.toml)
     #   ipywidgets
     #   nbclassic
     #   notebook
@@ -102,6 +106,7 @@ ipython-genutils==0.2.0
     #   nbclassic
     #   notebook
 ipywidgets==7.7.0
+    # via plasmapy (pyproject.toml)
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
@@ -154,11 +159,13 @@ kiwisolver==1.4.5
 llvmlite==0.40.1
     # via numba
 lmfit==1.1.0
+    # via plasmapy (pyproject.toml)
 markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
 matplotlib==3.5.1
+    # via plasmapy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -166,6 +173,7 @@ matplotlib-inline==0.1.7
 mistune==3.0.2
     # via nbconvert
 mpmath==1.2.1
+    # via plasmapy (pyproject.toml)
 nbclassic==1.0.0
     # via notebook
 nbclient==0.7.4
@@ -199,9 +207,12 @@ notebook==6.5.7
 notebook-shim==0.2.4
     # via nbclassic
 nox==2024.4.15
+    # via plasmapy (pyproject.toml)
 numba==0.57.0
+    # via plasmapy (pyproject.toml)
 numpy==1.23.0
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   h5py
     #   lmfit
@@ -213,6 +224,7 @@ numpy==1.23.0
     #   xarray
 packaging==23.2
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   jupyter-server
     #   jupyterlab-server
@@ -226,7 +238,9 @@ packaging==23.2
     #   tox-uv
     #   xarray
 pandas==1.4.0
-    # via xarray
+    # via
+    #   plasmapy (pyproject.toml)
+    #   xarray
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -245,6 +259,7 @@ pluggy==1.5.0
     #   pytest
     #   tox
 pre-commit==3.6.0
+    # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
     # via
     #   jupyter-server
@@ -272,17 +287,22 @@ pyproject-api==1.6.1
     # via tox
 pytest==8.0.2
     # via
+    #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
+    # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
+    # via plasmapy (pyproject.toml)
 pytest-rerunfailures==13.0
+    # via plasmapy (pyproject.toml)
 pytest-xdist==3.5.0
+    # via plasmapy (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   jupyter-client
@@ -306,20 +326,26 @@ referencing==0.35.1
     #   jsonschema
     #   jsonschema-specifications
 requests==2.28.0
-    # via jupyterlab-server
+    # via
+    #   plasmapy (pyproject.toml)
+    #   jupyterlab-server
 rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.8.0
-    # via lmfit
+    # via
+    #   plasmapy (pyproject.toml)
+    #   lmfit
 send2trash==1.8.3
     # via
     #   jupyter-server
     #   nbclassic
     #   notebook
 setuptools==61.2.0
-    # via nodeenv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   nodeenv
 six==1.16.0
     # via
     #   asttokens
@@ -342,6 +368,7 @@ tinycss2==1.3.0
     # via nbconvert
 tomli==2.0.1
     # via
+    #   plasmapy (pyproject.toml)
     #   coverage
     #   nox
     #   pyproject-api
@@ -356,9 +383,13 @@ tornado==6.4
     #   notebook
     #   terminado
 tox==4.14.0
-    # via tox-uv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   tox-uv
 tox-uv==1.7.0
+    # via plasmapy (pyproject.toml)
 tqdm==4.60.0
+    # via plasmapy (pyproject.toml)
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -380,14 +411,15 @@ uncertainties==3.1.7
     # via lmfit
 urllib3==1.26.18
     # via requests
-uv==0.1.42
+uv==0.1.44
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit
     #   tox
 voila==0.4.0
+    # via plasmapy (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
@@ -401,4 +433,6 @@ websockets==12.0
 widgetsnbextension==3.6.6
     # via ipywidgets
 wrapt==1.14.0
+    # via plasmapy (pyproject.toml)
 xarray==2022.3.0
+    # via plasmapy (pyproject.toml)

--- a/ci_requirements/tests-3.10.txt
+++ b/ci_requirements/tests-3.10.txt
@@ -13,6 +13,7 @@ arrow==1.3.0
 asteval==0.9.32
     # via lmfit
 astropy==6.1.0
+    # via plasmapy (pyproject.toml)
 astropy-iers-data==0.2024.5.13.0.30.12
     # via astropy
 asttokens==2.4.1
@@ -87,7 +88,9 @@ fqdn==1.5.1
 future==1.0.0
     # via uncertainties
 h5py==3.11.0
+    # via plasmapy (pyproject.toml)
 hypothesis==6.102.1
+    # via plasmapy (pyproject.toml)
 identify==2.5.36
     # via pre-commit
 idna==3.7
@@ -98,11 +101,13 @@ idna==3.7
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.4
+    # via plasmapy (pyproject.toml)
 ipython==8.24.0
     # via
     #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.2
+    # via plasmapy (pyproject.toml)
 isoduration==20.11.0
     # via jsonschema
 jedi==0.19.1
@@ -157,11 +162,13 @@ kiwisolver==1.4.5
 llvmlite==0.42.0
     # via numba
 lmfit==1.3.1
+    # via plasmapy (pyproject.toml)
 markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
 matplotlib==3.8.4
+    # via plasmapy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -169,6 +176,7 @@ matplotlib-inline==0.1.7
 mistune==3.0.2
     # via nbconvert
 mpmath==1.3.0
+    # via plasmapy (pyproject.toml)
 nbclient==0.7.4
     # via
     #   nbconvert
@@ -187,9 +195,12 @@ nest-asyncio==1.6.0
 nodeenv==1.8.0
     # via pre-commit
 nox==2024.4.15
+    # via plasmapy (pyproject.toml)
 numba==0.59.1
+    # via plasmapy (pyproject.toml)
 numpy==1.26.4
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   contourpy
     #   h5py
@@ -204,6 +215,7 @@ overrides==7.7.0
     # via jupyter-server
 packaging==24.0
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   ipykernel
     #   jupyter-server
@@ -218,7 +230,9 @@ packaging==24.0
     #   tox-uv
     #   xarray
 pandas==2.2.2
-    # via xarray
+    # via
+    #   plasmapy (pyproject.toml)
+    #   xarray
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -237,6 +251,7 @@ pluggy==1.5.0
     #   pytest
     #   tox
 pre-commit==3.7.1
+    # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.43
@@ -263,17 +278,22 @@ pyproject-api==1.6.1
     # via tox
 pytest==8.2.0
     # via
+    #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
+    # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
+    # via plasmapy (pyproject.toml)
 pytest-rerunfailures==14.0
+    # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
+    # via plasmapy (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   arrow
@@ -301,7 +321,9 @@ referencing==0.35.1
     #   jsonschema-specifications
     #   jupyter-events
 requests==2.31.0
-    # via jupyterlab-server
+    # via
+    #   plasmapy (pyproject.toml)
+    #   jupyterlab-server
 rfc3339-validator==0.1.4
     # via
     #   jsonschema
@@ -315,11 +337,15 @@ rpds-py==0.18.1
     #   jsonschema
     #   referencing
 scipy==1.13.0
-    # via lmfit
+    # via
+    #   plasmapy (pyproject.toml)
+    #   lmfit
 send2trash==1.8.3
     # via jupyter-server
 setuptools==69.5.1
-    # via nodeenv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   nodeenv
 six==1.16.0
     # via
     #   asttokens
@@ -342,6 +368,7 @@ tinycss2==1.3.0
     # via nbconvert
 tomli==2.0.1
     # via
+    #   plasmapy (pyproject.toml)
     #   coverage
     #   nox
     #   pyproject-api
@@ -354,9 +381,13 @@ tornado==6.4
     #   jupyter-server
     #   terminado
 tox==4.15.0
-    # via tox-uv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   tox-uv
 tox-uv==1.8.2
+    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
+    # via plasmapy (pyproject.toml)
 traitlets==5.14.3
     # via
     #   comm
@@ -386,14 +417,15 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.1
     # via requests
-uv==0.1.42
+uv==0.1.44
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit
     #   tox
 voila==0.5.6
+    # via plasmapy (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==1.13
@@ -409,4 +441,6 @@ websockets==12.0
 widgetsnbextension==4.0.10
     # via ipywidgets
 wrapt==1.16.0
+    # via plasmapy (pyproject.toml)
 xarray==2024.5.0
+    # via plasmapy (pyproject.toml)

--- a/ci_requirements/tests-3.11-lowest-direct.txt
+++ b/ci_requirements/tests-3.11-lowest-direct.txt
@@ -14,6 +14,7 @@ argon2-cffi-bindings==21.2.0
 asteval==0.9.32
     # via lmfit
 astropy==5.1
+    # via plasmapy (pyproject.toml)
 asttokens==2.4.1
     # via stack-data
 attrs==23.2.0
@@ -72,7 +73,9 @@ fonttools==4.51.0
 future==1.0.0
     # via uncertainties
 h5py==3.7.0
+    # via plasmapy (pyproject.toml)
 hypothesis==6.97.4
+    # via plasmapy (pyproject.toml)
 identify==2.5.36
     # via pre-commit
 idna==3.7
@@ -83,6 +86,7 @@ iniconfig==2.0.0
     # via pytest
 ipykernel==6.8.0
     # via
+    #   plasmapy (pyproject.toml)
     #   ipywidgets
     #   nbclassic
     #   notebook
@@ -96,6 +100,7 @@ ipython-genutils==0.2.0
     #   nbclassic
     #   notebook
 ipywidgets==7.7.0
+    # via plasmapy (pyproject.toml)
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
@@ -148,11 +153,13 @@ kiwisolver==1.4.5
 llvmlite==0.40.1
     # via numba
 lmfit==1.1.0
+    # via plasmapy (pyproject.toml)
 markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
 matplotlib==3.5.1
+    # via plasmapy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -160,6 +167,7 @@ matplotlib-inline==0.1.7
 mistune==3.0.2
     # via nbconvert
 mpmath==1.2.1
+    # via plasmapy (pyproject.toml)
 nbclassic==1.0.0
     # via notebook
 nbclient==0.7.4
@@ -193,9 +201,12 @@ notebook==6.5.7
 notebook-shim==0.2.4
     # via nbclassic
 nox==2024.4.15
+    # via plasmapy (pyproject.toml)
 numba==0.57.0
+    # via plasmapy (pyproject.toml)
 numpy==1.23.0
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   h5py
     #   lmfit
@@ -207,6 +218,7 @@ numpy==1.23.0
     #   xarray
 packaging==23.2
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   jupyter-server
     #   jupyterlab-server
@@ -220,7 +232,9 @@ packaging==23.2
     #   tox-uv
     #   xarray
 pandas==1.4.0
-    # via xarray
+    # via
+    #   plasmapy (pyproject.toml)
+    #   xarray
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -239,6 +253,7 @@ pluggy==1.5.0
     #   pytest
     #   tox
 pre-commit==3.6.0
+    # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
     # via
     #   jupyter-server
@@ -266,17 +281,22 @@ pyproject-api==1.6.1
     # via tox
 pytest==8.0.2
     # via
+    #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
+    # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
+    # via plasmapy (pyproject.toml)
 pytest-rerunfailures==13.0
+    # via plasmapy (pyproject.toml)
 pytest-xdist==3.5.0
+    # via plasmapy (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   jupyter-client
@@ -300,20 +320,26 @@ referencing==0.35.1
     #   jsonschema
     #   jsonschema-specifications
 requests==2.28.0
-    # via jupyterlab-server
+    # via
+    #   plasmapy (pyproject.toml)
+    #   jupyterlab-server
 rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.9.0
-    # via lmfit
+    # via
+    #   plasmapy (pyproject.toml)
+    #   lmfit
 send2trash==1.8.3
     # via
     #   jupyter-server
     #   nbclassic
     #   notebook
 setuptools==61.2.0
-    # via nodeenv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   nodeenv
 six==1.16.0
     # via
     #   asttokens
@@ -335,6 +361,7 @@ terminado==0.18.1
 tinycss2==1.3.0
     # via nbconvert
 tomli==2.0.1
+    # via plasmapy (pyproject.toml)
 tornado==6.4
     # via
     #   ipykernel
@@ -344,9 +371,13 @@ tornado==6.4
     #   notebook
     #   terminado
 tox==4.14.0
-    # via tox-uv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   tox-uv
 tox-uv==1.7.0
+    # via plasmapy (pyproject.toml)
 tqdm==4.60.0
+    # via plasmapy (pyproject.toml)
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -368,14 +399,15 @@ uncertainties==3.1.7
     # via lmfit
 urllib3==1.26.18
     # via requests
-uv==0.1.42
+uv==0.1.44
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit
     #   tox
 voila==0.4.0
+    # via plasmapy (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
@@ -389,4 +421,6 @@ websockets==12.0
 widgetsnbextension==3.6.6
     # via ipywidgets
 wrapt==1.14.0
+    # via plasmapy (pyproject.toml)
 xarray==2022.3.0
+    # via plasmapy (pyproject.toml)

--- a/ci_requirements/tests-3.11.txt
+++ b/ci_requirements/tests-3.11.txt
@@ -13,6 +13,7 @@ arrow==1.3.0
 asteval==0.9.32
     # via lmfit
 astropy==6.1.0
+    # via plasmapy (pyproject.toml)
 astropy-iers-data==0.2024.5.13.0.30.12
     # via astropy
 asttokens==2.4.1
@@ -81,7 +82,9 @@ fqdn==1.5.1
 future==1.0.0
     # via uncertainties
 h5py==3.11.0
+    # via plasmapy (pyproject.toml)
 hypothesis==6.102.1
+    # via plasmapy (pyproject.toml)
 identify==2.5.36
     # via pre-commit
 idna==3.7
@@ -92,11 +95,13 @@ idna==3.7
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.4
+    # via plasmapy (pyproject.toml)
 ipython==8.24.0
     # via
     #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.2
+    # via plasmapy (pyproject.toml)
 isoduration==20.11.0
     # via jsonschema
 jedi==0.19.1
@@ -151,11 +156,13 @@ kiwisolver==1.4.5
 llvmlite==0.42.0
     # via numba
 lmfit==1.3.1
+    # via plasmapy (pyproject.toml)
 markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
 matplotlib==3.8.4
+    # via plasmapy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -163,6 +170,7 @@ matplotlib-inline==0.1.7
 mistune==3.0.2
     # via nbconvert
 mpmath==1.3.0
+    # via plasmapy (pyproject.toml)
 nbclient==0.7.4
     # via
     #   nbconvert
@@ -181,9 +189,12 @@ nest-asyncio==1.6.0
 nodeenv==1.8.0
     # via pre-commit
 nox==2024.4.15
+    # via plasmapy (pyproject.toml)
 numba==0.59.1
+    # via plasmapy (pyproject.toml)
 numpy==1.26.4
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   contourpy
     #   h5py
@@ -198,6 +209,7 @@ overrides==7.7.0
     # via jupyter-server
 packaging==24.0
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   ipykernel
     #   jupyter-server
@@ -212,7 +224,9 @@ packaging==24.0
     #   tox-uv
     #   xarray
 pandas==2.2.2
-    # via xarray
+    # via
+    #   plasmapy (pyproject.toml)
+    #   xarray
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -231,6 +245,7 @@ pluggy==1.5.0
     #   pytest
     #   tox
 pre-commit==3.7.1
+    # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.43
@@ -257,17 +272,22 @@ pyproject-api==1.6.1
     # via tox
 pytest==8.2.0
     # via
+    #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
+    # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
+    # via plasmapy (pyproject.toml)
 pytest-rerunfailures==14.0
+    # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
+    # via plasmapy (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   arrow
@@ -295,7 +315,9 @@ referencing==0.35.1
     #   jsonschema-specifications
     #   jupyter-events
 requests==2.31.0
-    # via jupyterlab-server
+    # via
+    #   plasmapy (pyproject.toml)
+    #   jupyterlab-server
 rfc3339-validator==0.1.4
     # via
     #   jsonschema
@@ -309,11 +331,15 @@ rpds-py==0.18.1
     #   jsonschema
     #   referencing
 scipy==1.13.0
-    # via lmfit
+    # via
+    #   plasmapy (pyproject.toml)
+    #   lmfit
 send2trash==1.8.3
     # via jupyter-server
 setuptools==69.5.1
-    # via nodeenv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   nodeenv
 six==1.16.0
     # via
     #   asttokens
@@ -335,6 +361,7 @@ terminado==0.18.1
 tinycss2==1.3.0
     # via nbconvert
 tomli==2.0.1
+    # via plasmapy (pyproject.toml)
 tornado==6.4
     # via
     #   ipykernel
@@ -342,9 +369,13 @@ tornado==6.4
     #   jupyter-server
     #   terminado
 tox==4.15.0
-    # via tox-uv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   tox-uv
 tox-uv==1.8.2
+    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
+    # via plasmapy (pyproject.toml)
 traitlets==5.14.3
     # via
     #   comm
@@ -372,14 +403,15 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.1
     # via requests
-uv==0.1.42
+uv==0.1.44
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit
     #   tox
 voila==0.5.6
+    # via plasmapy (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==1.13
@@ -395,4 +427,6 @@ websockets==12.0
 widgetsnbextension==4.0.10
     # via ipywidgets
 wrapt==1.16.0
+    # via plasmapy (pyproject.toml)
 xarray==2024.5.0
+    # via plasmapy (pyproject.toml)

--- a/ci_requirements/tests-3.12-lowest-direct.txt
+++ b/ci_requirements/tests-3.12-lowest-direct.txt
@@ -14,6 +14,7 @@ argon2-cffi-bindings==21.2.0
 asteval==0.9.32
     # via lmfit
 astropy==5.1
+    # via plasmapy (pyproject.toml)
 asttokens==2.4.1
     # via stack-data
 attrs==23.2.0
@@ -72,7 +73,9 @@ fonttools==4.51.0
 future==1.0.0
     # via uncertainties
 h5py==3.7.0
+    # via plasmapy (pyproject.toml)
 hypothesis==6.97.4
+    # via plasmapy (pyproject.toml)
 identify==2.5.36
     # via pre-commit
 idna==3.7
@@ -83,6 +86,7 @@ iniconfig==2.0.0
     # via pytest
 ipykernel==6.8.0
     # via
+    #   plasmapy (pyproject.toml)
     #   ipywidgets
     #   nbclassic
     #   notebook
@@ -96,6 +100,7 @@ ipython-genutils==0.2.0
     #   nbclassic
     #   notebook
 ipywidgets==7.7.0
+    # via plasmapy (pyproject.toml)
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
@@ -148,11 +153,13 @@ kiwisolver==1.4.5
 llvmlite==0.40.1
     # via numba
 lmfit==1.1.0
+    # via plasmapy (pyproject.toml)
 markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
 matplotlib==3.5.1
+    # via plasmapy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -160,6 +167,7 @@ matplotlib-inline==0.1.7
 mistune==3.0.2
     # via nbconvert
 mpmath==1.2.1
+    # via plasmapy (pyproject.toml)
 nbclassic==1.0.0
     # via notebook
 nbclient==0.7.4
@@ -193,9 +201,12 @@ notebook==6.5.7
 notebook-shim==0.2.4
     # via nbclassic
 nox==2024.4.15
+    # via plasmapy (pyproject.toml)
 numba==0.57.0
+    # via plasmapy (pyproject.toml)
 numpy==1.23.0
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   h5py
     #   lmfit
@@ -207,6 +218,7 @@ numpy==1.23.0
     #   xarray
 packaging==23.2
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   jupyter-server
     #   jupyterlab-server
@@ -220,7 +232,9 @@ packaging==23.2
     #   tox-uv
     #   xarray
 pandas==1.4.0
-    # via xarray
+    # via
+    #   plasmapy (pyproject.toml)
+    #   xarray
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -239,6 +253,7 @@ pluggy==1.5.0
     #   pytest
     #   tox
 pre-commit==3.6.0
+    # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
     # via
     #   jupyter-server
@@ -266,17 +281,22 @@ pyproject-api==1.6.1
     # via tox
 pytest==8.0.2
     # via
+    #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
+    # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
+    # via plasmapy (pyproject.toml)
 pytest-rerunfailures==13.0
+    # via plasmapy (pyproject.toml)
 pytest-xdist==3.5.0
+    # via plasmapy (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   jupyter-client
@@ -300,20 +320,26 @@ referencing==0.35.1
     #   jsonschema
     #   jsonschema-specifications
 requests==2.28.0
-    # via jupyterlab-server
+    # via
+    #   plasmapy (pyproject.toml)
+    #   jupyterlab-server
 rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.9.2
-    # via lmfit
+    # via
+    #   plasmapy (pyproject.toml)
+    #   lmfit
 send2trash==1.8.3
     # via
     #   jupyter-server
     #   nbclassic
     #   notebook
 setuptools==61.2.0
-    # via nodeenv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   nodeenv
 six==1.16.0
     # via
     #   asttokens
@@ -335,6 +361,7 @@ terminado==0.18.1
 tinycss2==1.3.0
     # via nbconvert
 tomli==2.0.1
+    # via plasmapy (pyproject.toml)
 tornado==6.4
     # via
     #   ipykernel
@@ -344,9 +371,13 @@ tornado==6.4
     #   notebook
     #   terminado
 tox==4.14.0
-    # via tox-uv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   tox-uv
 tox-uv==1.7.0
+    # via plasmapy (pyproject.toml)
 tqdm==4.60.0
+    # via plasmapy (pyproject.toml)
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -366,14 +397,15 @@ uncertainties==3.1.7
     # via lmfit
 urllib3==1.26.18
     # via requests
-uv==0.1.42
+uv==0.1.44
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit
     #   tox
 voila==0.4.0
+    # via plasmapy (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
@@ -387,4 +419,6 @@ websockets==12.0
 widgetsnbextension==3.6.6
     # via ipywidgets
 wrapt==1.14.0
+    # via plasmapy (pyproject.toml)
 xarray==2022.3.0
+    # via plasmapy (pyproject.toml)

--- a/ci_requirements/tests-3.12.txt
+++ b/ci_requirements/tests-3.12.txt
@@ -13,6 +13,7 @@ arrow==1.3.0
 asteval==0.9.32
     # via lmfit
 astropy==6.1.0
+    # via plasmapy (pyproject.toml)
 astropy-iers-data==0.2024.5.13.0.30.12
     # via astropy
 asttokens==2.4.1
@@ -81,7 +82,9 @@ fqdn==1.5.1
 future==1.0.0
     # via uncertainties
 h5py==3.11.0
+    # via plasmapy (pyproject.toml)
 hypothesis==6.102.1
+    # via plasmapy (pyproject.toml)
 identify==2.5.36
     # via pre-commit
 idna==3.7
@@ -92,11 +95,13 @@ idna==3.7
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.4
+    # via plasmapy (pyproject.toml)
 ipython==8.24.0
     # via
     #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.2
+    # via plasmapy (pyproject.toml)
 isoduration==20.11.0
     # via jsonschema
 jedi==0.19.1
@@ -151,11 +156,13 @@ kiwisolver==1.4.5
 llvmlite==0.42.0
     # via numba
 lmfit==1.3.1
+    # via plasmapy (pyproject.toml)
 markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
 matplotlib==3.8.4
+    # via plasmapy (pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -163,6 +170,7 @@ matplotlib-inline==0.1.7
 mistune==3.0.2
     # via nbconvert
 mpmath==1.3.0
+    # via plasmapy (pyproject.toml)
 nbclient==0.7.4
     # via
     #   nbconvert
@@ -181,9 +189,12 @@ nest-asyncio==1.6.0
 nodeenv==1.8.0
     # via pre-commit
 nox==2024.4.15
+    # via plasmapy (pyproject.toml)
 numba==0.59.1
+    # via plasmapy (pyproject.toml)
 numpy==1.26.4
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   contourpy
     #   h5py
@@ -198,6 +209,7 @@ overrides==7.7.0
     # via jupyter-server
 packaging==24.0
     # via
+    #   plasmapy (pyproject.toml)
     #   astropy
     #   ipykernel
     #   jupyter-server
@@ -212,7 +224,9 @@ packaging==24.0
     #   tox-uv
     #   xarray
 pandas==2.2.2
-    # via xarray
+    # via
+    #   plasmapy (pyproject.toml)
+    #   xarray
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -231,6 +245,7 @@ pluggy==1.5.0
     #   pytest
     #   tox
 pre-commit==3.7.1
+    # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.43
@@ -257,17 +272,22 @@ pyproject-api==1.6.1
     # via tox
 pytest==8.2.0
     # via
+    #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==5.0.0
+    # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
 pytest-regressions==2.5.0
+    # via plasmapy (pyproject.toml)
 pytest-rerunfailures==14.0
+    # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
+    # via plasmapy (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   arrow
@@ -295,7 +315,9 @@ referencing==0.35.1
     #   jsonschema-specifications
     #   jupyter-events
 requests==2.31.0
-    # via jupyterlab-server
+    # via
+    #   plasmapy (pyproject.toml)
+    #   jupyterlab-server
 rfc3339-validator==0.1.4
     # via
     #   jsonschema
@@ -309,11 +331,15 @@ rpds-py==0.18.1
     #   jsonschema
     #   referencing
 scipy==1.13.0
-    # via lmfit
+    # via
+    #   plasmapy (pyproject.toml)
+    #   lmfit
 send2trash==1.8.3
     # via jupyter-server
 setuptools==69.5.1
-    # via nodeenv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   nodeenv
 six==1.16.0
     # via
     #   asttokens
@@ -335,6 +361,7 @@ terminado==0.18.1
 tinycss2==1.3.0
     # via nbconvert
 tomli==2.0.1
+    # via plasmapy (pyproject.toml)
 tornado==6.4
     # via
     #   ipykernel
@@ -342,9 +369,13 @@ tornado==6.4
     #   jupyter-server
     #   terminado
 tox==4.15.0
-    # via tox-uv
+    # via
+    #   plasmapy (pyproject.toml)
+    #   tox-uv
 tox-uv==1.8.2
+    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
+    # via plasmapy (pyproject.toml)
 traitlets==5.14.3
     # via
     #   comm
@@ -370,14 +401,15 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.1
     # via requests
-uv==0.1.42
+uv==0.1.44
     # via tox-uv
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   nox
     #   pre-commit
     #   tox
 voila==0.5.6
+    # via plasmapy (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==1.13
@@ -393,4 +425,6 @@ websockets==12.0
 widgetsnbextension==4.0.10
     # via ipywidgets
 wrapt==1.16.0
+    # via plasmapy (pyproject.toml)
 xarray==2024.5.0
+    # via plasmapy (pyproject.toml)

--- a/noxfile.py
+++ b/noxfile.py
@@ -63,6 +63,11 @@ def requirements(session):
         for resolution in ("highest", "lowest-direct")
     ]
 
+    category_version_resolution += [
+        ("docs", maxpython, "highest"),
+        ("all", maxpython, "highest"),
+    ]
+
     category_flags: dict[str, tuple[str, ...]] = {
         "all": ("--all-extras",),
         "docs": ("--extra", "docs"),

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,7 +55,7 @@ def get_requirements_filepath(
 def requirements(session):
     """Regenerate pinned requirements files."""
 
-    session.install("uv >= 0.1.39")
+    session.install("uv >= 0.1.44")
 
     category_version_resolution: list[tuple[str, str, str]] = [
         ("tests", version, resolution)


### PR DESCRIPTION
I recently accidentally removed the code that regenerated the `docs` and `all` requirements files in the `requirements session of `noxfile.py`.  This PR adds them back, and regenerates the requirements files.  

This PR also makes it so that Read the Docs builds the docs using the requirements file generated by doing `nox -s requirements`.