### PR TITLE
Minor fix of labeler action

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -3,8 +3,7 @@ name: Label PR
 # The labels to be added are defined in .github/labeler.yml
 
 on:
-  pull_request_target:
-    types: [opened, edited, reopened]
+- pull_request_target
 
 jobs:
   labeler:


### PR DESCRIPTION
Quick follow-up of #2690, to fix when the labeler action is run.

(I started the title of this PR with "Minor" to test some changes to the workflow to add the "no changelog entry needed" label.)