### PR TITLE
Add Nox sessions for running pre-commit and checking `MANIFEST.in`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
           python: '3.12'
           nox_session: cff
 
+        - name: Check MANIFEST.in
+          os: ubuntu-latest
+          python: '3.12'
+          nox_session: manifest
+
     steps:
 
     - name: Checkout code

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,27 +1,29 @@
+graft changelog
+graft ci_requirements
 graft docs
 graft licenses
 graft src
+graft tests
+graft tools
 graft type_stubs
 
+include *.ini
+include *.ini *.toml *.yaml *.yml
 include *.md
 include *.py
 include *.pyi
 include *.rst
 include *.txt
-include *.yaml
-include *.yml
-include changelog/README.rst
+include .editorconfig
+include .git-blame-ignore-revs
+include .jupyter/*.py
+include binder/requirements.txt
 include CITATION.cff
-include noxfile.py
-include pyproject.toml
-include tox.ini
+include CODEOWNERS
 
-global-exclude _build build _version.py
-
-global-exclude *.o
-global-exclude *.py[cod]
-
-prune docs/api
+global-exclude _build build _authors.rst _version.py
+global-exclude *.o *.py[cod]
 
 # Only for editable installs
+prune docs/api
 prune src/plasmapy/_dev

--- a/changelog/2695.internal.rst
+++ b/changelog/2695.internal.rst
@@ -1,0 +1,2 @@
+Added the ``lint`` and ``manifest`` sessions for |Nox| to run |pre-commit| on all files
+and verify :file:`MANIFEST.in` with ``check-manifest``, respectively.

--- a/noxfile.py
+++ b/noxfile.py
@@ -241,7 +241,7 @@ def build(session: nox.Session):
 def cff(session: nox.Session):
     """Validate CITATION.cff."""
     session.install("cffconvert")
-    session.run("cffconvert", "--validate")
+    session.run("cffconvert", "--validate", *session.posargs)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -246,7 +246,14 @@ def cff(session: nox.Session):
 
 @nox.session
 def manifest(session: nox.Session):
-    """Check contents of MANIFEST.in."""
+    """
+    Check contents of MANIFEST.in.
+
+    When run outside of CI, this check may report files that were
+    locally created but not included in version control. These false
+    positives can be ignored by adding file patterns and paths to
+    `ignore` under `[tool.check-manifest]` in `pyproject.toml`.
+    """
     session.install("check-manifest")
     session.run("check-manifest")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -239,7 +239,7 @@ def build(session: nox.Session):
 
 @nox.session
 def cff(session: nox.Session):
-    """Validate CITATION.cff."""
+    """Validate CITATION.cff against the metadata standard."""
     session.install("cffconvert")
     session.run("cffconvert", "--validate", *session.posargs)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -242,3 +242,17 @@ def cff(session: nox.Session):
     """Validate CITATION.cff."""
     session.install("cffconvert")
     session.run("cffconvert", "--validate")
+
+
+@nox.session
+def manifest(session: nox.Session):
+    """Check contents of MANIFEST.in."""
+    session.install("check-manifest")
+    session.run("check-manifest")
+
+
+@nox.session
+def lint(session: nox.Session):
+    """Run all pre-commit hooks on all files."""
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files")

--- a/noxfile.py
+++ b/noxfile.py
@@ -255,7 +255,7 @@ def manifest(session: nox.Session):
     `ignore` under `[tool.check-manifest]` in `pyproject.toml`.
     """
     session.install("check-manifest")
-    session.run("check-manifest")
+    session.run("check-manifest", *session.posargs)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -262,4 +262,10 @@ def manifest(session: nox.Session):
 def lint(session: nox.Session):
     """Run all pre-commit hooks on all files."""
     session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files")
+    session.run(
+        "pre-commit",
+        "run",
+        "--all-files",
+        "--show-diff-on-failure",
+        *session.posargs,
+    )

--- a/noxfile.py
+++ b/noxfile.py
@@ -238,14 +238,14 @@ def build(session: nox.Session):
 
 
 @nox.session
-def cff(session: nox.Session):
+def cff(session: nox.Session) -> None:
     """Validate CITATION.cff against the metadata standard."""
     session.install("cffconvert")
     session.run("cffconvert", "--validate", *session.posargs)
 
 
 @nox.session
-def manifest(session: nox.Session):
+def manifest(session: nox.Session) -> None:
     """
     Check contents of MANIFEST.in.
 
@@ -259,7 +259,7 @@ def manifest(session: nox.Session):
 
 
 @nox.session
-def lint(session: nox.Session):
+def lint(session: nox.Session) -> None:
     """Run all pre-commit hooks on all files."""
     session.install("pre-commit")
     session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,9 +524,17 @@ showcontent = true
 
 [tool.check-manifest]
 ignore = [
-  "docs/*build",
-  ".mailmap",
-  "*~",
   "#*#",
-  "*checkpoint*"
+  "*checkpoint*",
+  "*TEMP*",
+  "*~",
+  ".mailmap",
+  "docs/build/*",
+  "docs/build/*/*",
+  "docs/build/*/*/*",
+  "docs/build/*/*/*/*",
+  "docs/build/*/*/*/*/*",
+  "docs/build/*/*/*/*/*/*",
+  "docs/build/*/*/*/*/*/*/*",
+  "Untitled*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -521,3 +521,12 @@ showcontent = true
 directory = "trivial"
 name = "Additional Changes"
 showcontent = true
+
+[tool.check-manifest]
+ignore = [
+  "docs/*build",
+  ".mailmap",
+  "*~",
+  "#*#",
+  "*checkpoint*"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,17 +524,12 @@ showcontent = true
 
 [tool.check-manifest]
 ignore = [
-  "#*#",
+  "#*",
+  "*#",
   "*checkpoint*",
   "*TEMP*",
   "*~",
   ".mailmap",
-  "docs/build/*",
-  "docs/build/*/*",
-  "docs/build/*/*/*",
-  "docs/build/*/*/*/*",
-  "docs/build/*/*/*/*/*",
-  "docs/build/*/*/*/*/*/*",
-  "docs/build/*/*/*/*/*/*/*",
+  "docs/*build/**",
   "Untitled*",
 ]


### PR DESCRIPTION
 - I added a `lint` session for Nox as a shortcut to run `pre-commit run --all-files`.  This is mostly syntactic sugar, but does remove the need to install `pre-commit` manually.
 - I added the `manifest` session for Nox to run `check-manifest`, which checks that all appropriate files are included in `MANIFEST.in`.  
 - I added a configuration for `check-manifest` in `pyproject.toml`
 - I updated `MANIFEST.in` accordingly
