### PR TITLE
Added `__str__` method to `CustomParticle` class.

### DIFF
--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -2283,6 +2283,10 @@ class CustomParticle(AbstractPhysicalParticle):
             else f"CustomParticle(mass={self.mass}, charge={self.charge}, symbol={self.symbol})"
         )
 
+    def __str__(self) -> str:
+        """Return the particle's symbol if provided, otherwise the |repr|."""
+        return self.symbol
+
     @property
     def json_dict(self) -> dict[str, Any]:
         """

--- a/tests/particles/test_particle_class.py
+++ b/tests/particles/test_particle_class.py
@@ -1102,6 +1102,25 @@ def test_customized_particle_repr(cls, kwargs, expected_repr) -> None:
         )
 
 
+custom_particle_str_table = [
+    (
+        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C},
+        "CustomParticle(mass=5.12 kg, charge=6.2 C)",
+    ),
+    (
+        {"mass": 5.12 * u.kg, "charge": 6.2 * u.C, "symbol": "I2"},
+        "I2",
+    ),
+]
+
+
+@pytest.mark.parametrize(("kwargs", "expected_str"), custom_particle_str_table)
+def test_custom_particle_str(kwargs, expected_str) -> None:
+    """Test the string representation of a custom particle."""
+    instance = CustomParticle(**kwargs)
+    assert str(instance) == expected_str
+
+
 @pytest.mark.parametrize("cls", [CustomParticle, DimensionlessParticle])
 @pytest.mark.parametrize("not_a_str", [1, u.kg])
 def test_typeerror_redefining_symbol(cls, not_a_str) -> None:


### PR DESCRIPTION

## Description

Adds the method `__str__` that calls the symbol getter of the `CustomParticle` class.




## Motivation and context

This makes the behavior of custom particle instances consistent with that of other particle objects, With a fallback to the repr if no symbol was provided.



## Related issues

Closes #2701