### PR TITLE
Prevent array shape mismatch due to NumPy squeeze in `mhd_waves_.py`

### DIFF
--- a/changelog/2715.bugfix.rst
+++ b/changelog/2715.bugfix.rst
@@ -1,0 +1,1 @@
+Add axes removed by ``np.squeeze`` to arrays in `~plasmapy.dispersion.analytical.mhd_waves_`

--- a/changelog/2715.bugfix.rst
+++ b/changelog/2715.bugfix.rst
@@ -1,1 +1,1 @@
-Add axes removed by ``np.squeeze`` to arrays in `~plasmapy.dispersion.analytical.mhd_waves_`
+Add axes removed by `numpy.squeeze` to arrays in `~plasmapy.dispersion.analytical.mhd_waves_`

--- a/src/plasmapy/dispersion/analytical/mhd_waves_.py
+++ b/src/plasmapy/dispersion/analytical/mhd_waves_.py
@@ -308,6 +308,12 @@ class AbstractMHDWave(ABC):
         """
         angular_frequency = self.angular_frequency(k, theta)
         theta, k = self._validate_k_theta(k, theta)
+
+        if theta.shape[1] == 1:
+            # np.squeeze will have removed this axis from angular_frequency,
+            # so it must be added back
+            angular_frequency = np.expand_dims(angular_frequency, axis=1)
+
         return np.squeeze(angular_frequency / k)
 
 
@@ -523,6 +529,12 @@ class AlfvenWave(AbstractMHDWave):
         """
         phase_velocity = self.phase_velocity(k, theta)
         theta, k = super()._validate_k_theta(k, theta)
+
+        if theta.shape[1] == 1:
+            # np.squeeze will have removed this axis from phase_velocity,
+            # so it must be added back
+            phase_velocity = np.expand_dims(phase_velocity, axis=1)
+
         return [
             phase_velocity,
             -phase_velocity * np.tan(theta),
@@ -766,6 +778,12 @@ class FastMagnetosonicWave(AbstractMHDWave):
         """
         phase_velocity = self.phase_velocity(k, theta)
         theta, k = super()._validate_k_theta(k, theta)
+
+        if theta.shape[1] == 1:
+            # np.squeeze will have removed this axis from phase_velocity,
+            # so it must be added back
+            phase_velocity = np.expand_dims(phase_velocity, axis=1)
+
         return [
             phase_velocity,
             np.squeeze(
@@ -1008,8 +1026,13 @@ class SlowMagnetosonicWave(AbstractMHDWave):
         phase velocity.
         """
         phase_velocity = self.phase_velocity(k, theta)
-
         theta, k = super()._validate_k_theta(k, theta)
+
+        if theta.shape[1] == 1:
+            # np.squeeze will have removed this axis from phase_velocity,
+            # so it must be added back
+            phase_velocity = np.expand_dims(phase_velocity, axis=1)
+
         group_velocity = np.ones(k.shape) * (0 * u.m / u.s)
         np.squeeze(
             np.divide(

--- a/src/plasmapy/dispersion/analytical/mhd_waves_.py
+++ b/src/plasmapy/dispersion/analytical/mhd_waves_.py
@@ -533,11 +533,13 @@ class AlfvenWave(AbstractMHDWave):
         if theta.shape[1] == 1:
             # np.squeeze will have removed this axis from phase_velocity,
             # so it must be added back
-            phase_velocity = np.expand_dims(phase_velocity, axis=1)
+            phase_velocity_s = np.expand_dims(phase_velocity, axis=1)
+        else:
+            phase_velocity_s = phase_velocity
 
         return [
             phase_velocity,
-            -phase_velocity * np.tan(theta),
+            np.squeeze(-phase_velocity_s * np.tan(theta)),
         ]
 
 
@@ -782,7 +784,9 @@ class FastMagnetosonicWave(AbstractMHDWave):
         if theta.shape[1] == 1:
             # np.squeeze will have removed this axis from phase_velocity,
             # so it must be added back
-            phase_velocity = np.expand_dims(phase_velocity, axis=1)
+            phase_velocity_s = np.expand_dims(phase_velocity, axis=1)
+        else:
+            phase_velocity_s = phase_velocity
 
         return [
             phase_velocity,
@@ -792,8 +796,8 @@ class FastMagnetosonicWave(AbstractMHDWave):
                 * np.sin(theta)
                 * np.cos(theta)
                 / (
-                    phase_velocity
-                    * (2 * phase_velocity**2 - self._magnetosonic_speed**2)
+                    phase_velocity_s
+                    * (2 * phase_velocity_s**2 - self._magnetosonic_speed**2)
                 )
             ),
         ]
@@ -1031,24 +1035,24 @@ class SlowMagnetosonicWave(AbstractMHDWave):
         if theta.shape[1] == 1:
             # np.squeeze will have removed this axis from phase_velocity,
             # so it must be added back
-            phase_velocity = np.expand_dims(phase_velocity, axis=1)
+            phase_velocity_s = np.expand_dims(phase_velocity, axis=1)
+        else:
+            phase_velocity_s = phase_velocity
 
         group_velocity = np.ones(k.shape) * (0 * u.m / u.s)
-        np.squeeze(
-            np.divide(
-                self._Alfven_speed**2
-                * self._sound_speed**2
-                * np.sin(theta)
-                * np.cos(theta),
-                phase_velocity * (2 * phase_velocity**2 - self._magnetosonic_speed**2),
-                out=group_velocity,
-                where=phase_velocity != 0,
-            )
+        np.divide(
+            self._Alfven_speed**2
+            * self._sound_speed**2
+            * np.sin(theta)
+            * np.cos(theta),
+            phase_velocity_s * (2 * phase_velocity_s**2 - self._magnetosonic_speed**2),
+            out=group_velocity,
+            where=phase_velocity != 0,
         )
 
         return [
             phase_velocity,
-            group_velocity,
+            np.squeeze(group_velocity),
         ]
 
 


### PR DESCRIPTION
## Description

This PR adds an if statement to prevent array shape mismatch due to `np.squeeze` in `mhd_waves_.py`.

`np.squeeze` will convert column vectors to row vectors, for example, which causes problems where the array shape is assumed to be preserved.