### PR TITLE
Add type hints to `plasmapy.utils._units_helpers`

### DIFF
--- a/changelog/2734.internal.rst
+++ b/changelog/2734.internal.rst
@@ -1,0 +1,1 @@
+Added type hint annotations to ``plasmapy.utils._units_helpers``.

--- a/mypy.ini
+++ b/mypy.ini
@@ -280,9 +280,6 @@ disable_error_code = no-untyped-def,valid-type
 [mypy-plasmapy.utils._pytest_helpers.pytest_helpers]
 disable_error_code = arg-type,assignment,attr-defined,no-untyped-def,type-arg,var-annotated
 
-[mypy-plasmapy.utils._units_helpers]
-disable_error_code = type-arg
-
 [mypy-plasmapy.utils.calculator]
 disable_error_code = arg-type
 
@@ -534,6 +531,3 @@ disable_error_code = no-untyped-def,var-annotated
 
 [mypy-tests.utils.test_roman]
 disable_error_code = attr-defined,no-untyped-def
-
-[mypy-tests.utils.test_units_helpers]
-disable_error_code = name-match,no-untyped-def

--- a/src/plasmapy/utils/_units_helpers.py
+++ b/src/plasmapy/utils/_units_helpers.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def _get_physical_type_dict(
-    iterable: Iterable,
+    iterable: Iterable[object],
     *,
     only_quantities: bool | None = False,
     numbers_become_quantities: bool | None = False,

--- a/tests/utils/test_units_helpers.py
+++ b/tests/utils/test_units_helpers.py
@@ -1,6 +1,8 @@
 """Tests of `plasmapy.utils._units_helpers`."""
 
 from collections import namedtuple
+from collections.abc import Iterable
+from typing import Any
 
 import astropy.units as u
 import pytest
@@ -21,10 +23,10 @@ velocity = u.get_physical_type("velocity")
 mass = u.get_physical_type("mass")
 dimensionless = u.get_physical_type(1)
 
-test_case = namedtuple("case", ["collection", "kwargs", "expected"])
+test_case = namedtuple("test_case", ["collection", "kwargs", "expected"])
 
 
-test_cases = [
+test_cases: list[test_case] = [
     test_case(
         collection=(c, m_e),
         kwargs={},
@@ -59,12 +61,16 @@ test_cases = [
 
 
 @pytest.mark.parametrize(("collection", "kwargs", "expected"), test_cases)
-def test_get_physical_type_dict(collection, kwargs, expected) -> None:
+def test_get_physical_type_dict(
+    collection: Iterable[object],
+    kwargs: dict[str, Any],
+    expected: dict[u.PhysicalType, u.Quantity],
+) -> None:
     physical_type_dict = _get_physical_type_dict(collection, **kwargs)
     assert physical_type_dict == expected
 
 
-test_cases_exceptions = [
+test_cases_exceptions: list[test_case] = [
     test_case(
         collection=(u.m, 5 * u.m),
         kwargs={},
@@ -89,6 +95,10 @@ test_cases_exceptions = [
 
 
 @pytest.mark.parametrize(("collection", "kwargs", "expected"), test_cases_exceptions)
-def test_get_physical_type_dict_exceptions(collection, kwargs, expected) -> None:
+def test_get_physical_type_dict_exceptions(
+    collection: Iterable[object],
+    kwargs: dict[str, Any],
+    expected: type,
+) -> None:
     with pytest.raises(expected):
         _get_physical_type_dict(collection, **kwargs)


### PR DESCRIPTION
This PR adds type hint annotations to `plasmapy.utils._units_helpers`.