### PR TITLE
Update docstrings for `plasmapy.dispersion` and `plasmapy.plasma.grids`

### DIFF
--- a/changelog/2735.doc.rst
+++ b/changelog/2735.doc.rst
@@ -1,0 +1,1 @@
+Updated docstrings in `plasmapy.dispersion`.

--- a/src/plasmapy/dispersion/analytical/mhd_waves_.py
+++ b/src/plasmapy/dispersion/analytical/mhd_waves_.py
@@ -252,9 +252,9 @@ class AbstractMHDWave(ABC):
 
         .. math::
 
-        \mathbf{v}_g = \frac{d\omega}{d\mathbf{k}}
-            = \hat{\mathbf{k}} \frac{\partial\omega}{\partial k}
-                + \hat{\mathbf{\theta}} \frac{\partial v_{ph}}{\partial\theta}
+        \mathbf{v}_g = \frac{dω}{d\mathbf{k}}
+            = \hat{\mathbf{k}} \frac{∂ω}{∂ k}
+                + \hat{\mathbf{θ}} \frac{∂ v_{ph}}{∂θ}
 
         where :math:`ω` is the angular frequency, :math:`\mathbf{k}` is
         the wavevector, :math:`θ` is the angle between :math:`\mathbf{k}`
@@ -484,7 +484,7 @@ class AlfvenWave(AbstractMHDWave):
         -------
         group_velocity : `~astropy.units.Quantity` of shape ``(2, N, M)``
             An array of group_velocities in units m/s with shape
-            :math:`2 \times N \times M`. The first dimension maps to the
+            :math:`2 × N × M`. The first dimension maps to the
             two coordinate arrays in the direction of ``k`` and in
             the direction of increasing ``theta``, the second
             dimension maps to the ``k`` array, and the third dimension
@@ -514,8 +514,8 @@ class AlfvenWave(AbstractMHDWave):
 
         .. math::
 
-        \mathbf{v}_g = \frac{d\omega}{d\mathbf{k}}
-            = \pm \hat{\mathbf{B}} v_{A}
+        \mathbf{v}_g = \frac{dω}{d\mathbf{k}}
+            = ± \hat{\mathbf{B}} v_{A}
 
         where :math:`\hat{\mathbf{B}}` is the unit vector in the
         direction of the unperturbed magnetic field and :math:`v_A` is
@@ -725,7 +725,7 @@ class FastMagnetosonicWave(AbstractMHDWave):
         -------
         group_velocity : `~astropy.units.Quantity` of shape ``(2, N, M)``
             An array of group_velocities in units m/s with shape
-            :math:`2 \times N \times M`. The first dimension maps to the
+            :math:`2 × N × M`. The first dimension maps to the
             two coordinate arrays in the direction of ``k`` and in
             the direction of increasing ``theta``, the second
             dimension maps to the ``k`` array, and the third dimension
@@ -755,9 +755,9 @@ class FastMagnetosonicWave(AbstractMHDWave):
 
         .. math::
 
-        \mathbf{v}_g = \frac{d\omega}{d\mathbf{k}}
+        \mathbf{v}_g = \frac{dω}{d\mathbf{k}}
             = \hat{\mathbf{k}} v_{ph}
-                + \hat{\mathbf{\theta}} \frac{\partial v_{ph}}{\partial\theta}
+                + \hat{\mathbf{θ}} \frac{∂ v_{ph}}{∂θ}
 
         where :math:`ω` is the angular frequency, :math:`\mathbf{k}` is
         the wavevector, :math:`θ` is the angle between :math:`\mathbf{k}`
@@ -968,7 +968,7 @@ class SlowMagnetosonicWave(AbstractMHDWave):
         -------
         group_velocity : `~astropy.units.Quantity` of shape ``(2, N, M)``
             An array of group_velocities in units m/s with shape
-            :math:`2 \times N \times M`. The first dimension maps to the
+            :math:`2 × N × M`. The first dimension maps to the
             two coordinate arrays in the direction of ``k`` and in
             the direction of increasing ``theta``, the second
             dimension maps to the ``k`` array, and the third dimension
@@ -998,9 +998,9 @@ class SlowMagnetosonicWave(AbstractMHDWave):
 
         .. math::
 
-        \mathbf{v}_g = \frac{d\omega}{d\mathbf{k}}
+        \mathbf{v}_g = \frac{dω}{d\mathbf{k}}
             = \hat{\mathbf{k}} v_{ph}
-                + \hat{\mathbf{\theta}} \frac{\partial v_{ph}}{\partial\theta}
+                + \hat{\mathbf{θ}} \frac{∂ v_{ph}}{∂θ}
 
         where :math:`ω` is the angular frequency, :math:`\mathbf{k}` is
         the wavevector, :math:`θ` is the angle between :math:`\mathbf{k}`

--- a/src/plasmapy/dispersion/analytical/stix_.py
+++ b/src/plasmapy/dispersion/analytical/stix_.py
@@ -64,7 +64,7 @@ def stix(  # noqa: C901, PLR0912, PLR0915
     -------
     k : `~astropy.units.Quantity` of shape ``(N, M, 4)``
         An array of wavenubmers in units rad/m (shape
-        :math:`N \times M \times 4`).  The first dimension maps to the
+        :math:`N × M × 4`).  The first dimension maps to the
         ``w`` array, the second dimension maps to the ``theta`` array,
         and the third dimension maps to the four roots of the Stix
         polynomial.
@@ -106,35 +106,35 @@ def stix(  # noqa: C901, PLR0912, PLR0915
     :cite:t:`bellan:2012` in equation 8) to be
 
     .. math::
-        (S\sin^{2}(\theta) + P\cos^{2}(\theta))(ck/\omega)^{4}
+        (S\sin^{2}(θ) + P\cos^{2}(θ))(ck/ω)^{4}
             - [
-                RL\sin^{2}(\theta) + PS(1 + \cos^{2}(\theta))
-            ](ck/\omega)^{2} + PRL = 0
+                RL\sin^{2}(θ) + PS(1 + \cos^{2}(θ))
+            ](ck/ω)^{2} + PRL = 0
 
     where,
 
     .. math::
         \mathbf{B_o} &= B_{o} \mathbf{\hat{z}} \\
-        \cos \theta &= \frac{k_z}{k} \\
+        \cos θ &= \frac{k_z}{k} \\
         \mathbf{k} &= k_{\rm x} \hat{x} + k_{\rm z} \hat{z}
 
     .. math::
-        S &= 1 - \sum_{s} \frac{\omega^{2}_{p,s}}{\omega^{2} -
-            \omega^{2}_{c,s}}\\
-        P &= 1 - \sum_{s} \frac{\omega^{2}_{p,s}}{\omega^{2}}\\
+        S &= 1 - \sum_{s} \frac{ω^{2}_{p,s}}{ω^{2} -
+            ω^{2}_{c,s}}\\
+        P &= 1 - \sum_{s} \frac{ω^{2}_{p,s}}{ω^{2}}\\
         D &= \sum_{s}
-            \frac{\omega_{c,s}}{\omega}
-            \frac{\omega^{2}_{p,s}}{\omega^{2} -
-            \omega_{c,s}^{2}}
+            \frac{ω_{c,s}}{ω}
+            \frac{ω^{2}_{p,s}}{ω^{2} -
+            ω_{c,s}^{2}}
 
     .. math::
         R = S + D \hspace{1cm} L = S - D
 
-    :math:`\omega` is the wave frequency, :math:`k` is the wavenumber,
-    :math:`\theta` is the wave propagation angle with respect to the
+    :math:`ω` is the wave frequency, :math:`k` is the wavenumber,
+    :math:`θ` is the wave propagation angle with respect to the
     background magntic field :math:`\mathbf{B_o}`, :math:`s` corresponds
-    to plasma species :math:`s`, :math:`\omega_{p,s}` is the plasma
-    frequency of species :math:`s`, and :math:`\omega_{c,s}` is the
+    to plasma species :math:`s`, :math:`ω_{p,s}` is the plasma
+    frequency of species :math:`s`, and :math:`ω_{c,s}` is the
     gyrofrequency of species :math:`s`. The derivation of this
     dispersion relation assumed:
 
@@ -147,16 +147,16 @@ def stix(  # noqa: C901, PLR0912, PLR0915
       electric-field, magnetic field, particle speeds, etc.) are
       constant in time and space
     * first-order perturbations in plasma parameters vary like
-      :math:`\sim e^{\left [ i (\textbf{k}\cdot\textbf{r} - \omega t)\right ]}`
+      :math:`\sim e^{\left [ i (\textbf{k}\cdot\textbf{r} - ω t)\right ]}`
 
     Due to the cold plasma assumption, this equation is valid for all
-    :math:`\omega` and :math:`k` given
-    :math:`\frac{\omega}{k_{z}} \gg v_{Th}` for all thermal speeds
+    :math:`ω` and :math:`k` given
+    :math:`\frac{ω}{k_{z}} \gg v_{Th}` for all thermal speeds
     :math:`v_{Th}` of all plasma species and :math:`k_{x} r_{L} \ll 1`
     for all gyroradii :math:`r_{L}` of all plasma species.
 
     The relation predicts :math:`k \to 0` when any one of P, R or L
-    vanish (cutoffs) and :math:`k \to \infty` for perpendicular
+    vanish (cutoffs) and :math:`k \to ∞` for perpendicular
     propagation during wave resonance :math:`S \to 0`.
 
     Examples

--- a/src/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/src/plasmapy/dispersion/analytical/two_fluid_.py
@@ -183,7 +183,7 @@ def two_fluid(
                 \frac{1}{3} \cos^{-1}\left(
                     \frac{3q}{2p} \sqrt{-\frac{3}{p}}
                 \right)
-                - \frac{2 \pi}{3}j
+                - \frac{2π}{3}j
             \right)
             + \frac{Λ A}{3}
         }

--- a/src/plasmapy/dispersion/numerical/kinetic_alfven_.py
+++ b/src/plasmapy/dispersion/numerical/kinetic_alfven_.py
@@ -149,8 +149,8 @@ def kinetic_alfven(  # noqa: C901, PLR0912
 
     With :math:`c_{\rm s}` being the wave speed and :math:`ω_{\rm ci}`
     as the gyrofrequency of the respective ion.  The regions in which
-    this is valid are :math:`ω ≪ ω_{\rm ci}` and :math:`\nu_{\rm Te} ≫
-    \frac{ω}{k_{z}} ≫ \nu_{\rm Ti}`, with :math:`\nu_{\rm Ti}`
+    this is valid are :math:`ω ≪ ω_{\rm ci}` and :math:`ν_{\rm Te} ≫
+    \frac{ω}{k_{z}} ≫ ν_{\rm Ti}`, with :math:`ν_{\rm Ti}`
     standing for the thermal speed of the respective ion. There is no
     restriction on propagation angle.
 


### PR DESCRIPTION
This PR makes some minor updates to docstrings in `plasmapy.dispersion`.

Changes include:
 - Using unicode characters instead of LaTeX symbols (which makes docstrings more readable when using `help()`)
 - Removing extra brackets in equations (which makes it easier to keep track of brackets)
 - Justifying docstring text