### PR TITLE
Update docstrings in `plasmapy.formulary.collisions`

### DIFF
--- a/changelog/2736.doc.rst
+++ b/changelog/2736.doc.rst
@@ -1,0 +1,1 @@
+Updated docstrings in `plasmapy.formulary.collisions`.

--- a/src/plasmapy/formulary/braginskii.py
+++ b/src/plasmapy/formulary/braginskii.py
@@ -651,7 +651,7 @@ class ClassicalTransport:
         Calculate the ion viscosity.
 
         .. todo::
-            The ion viscosity (:math:`\eta`) of a plasma is defined by...
+            The ion viscosity (:math:`η`) of a plasma is defined by...
 
         Notes
         -----
@@ -699,7 +699,7 @@ class ClassicalTransport:
         Calculate the electron viscosity.
 
         .. todo::
-            The electron viscosity (:math:`\eta`) of a plasma is defined by...
+            The electron viscosity (:math:`η`) of a plasma is defined by...
 
         Notes
         -----
@@ -1069,7 +1069,7 @@ def ion_viscosity(
     Calculate the ion viscosity.
 
     .. todo::
-        The ion viscosity (:math:`\eta`) of a plasma is defined by...
+        The ion viscosity (:math:`η`) of a plasma is defined by...
 
     Notes
     -----
@@ -1126,7 +1126,7 @@ def electron_viscosity(
     Calculate the electron viscosity.
 
     .. todo::
-        The electron viscosity (:math:`\eta`) of a plasma is defined by...
+        The electron viscosity (:math:`η`) of a plasma is defined by...
 
     Notes
     -----

--- a/src/plasmapy/formulary/collisions/coulomb.py
+++ b/src/plasmapy/formulary/collisions/coulomb.py
@@ -149,7 +149,7 @@ def Coulomb_logarithm(
 
     .. math::
 
-        \ln{Λ} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+        \ln{Λ} ≡ \ln\left( \frac{b_{max}}{b_{min}} \right)
 
     Options 5–7 are hyperbolic Landau-Spitzer (``"hls..."``) methods in
     which the trajectory of a Coulomb collision is modeled as a
@@ -158,7 +158,7 @@ def Coulomb_logarithm(
 
     .. math::
 
-        \ln{Λ} \equiv \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
+        \ln{Λ} ≡ \frac{1}{2} \ln\left(1 + \frac{b_{max}^2}{b_{min}^2} \right)
 
     For all 7 methods, :math:`b_{min}` and :math:`b_{max}` are the inner
     impact parameter and the outer impact parameter, respectively, for
@@ -193,21 +193,21 @@ def Coulomb_logarithm(
 
         .. math::
 
-            \ln{Λ} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+            \ln{Λ} ≡ \ln\left( \frac{b_{max}}{b_{min}} \right)
 
         .. math::
 
-            b_{min} \equiv
+            b_{min} ≡
             \left\{
                 \begin{array}{ll}
-                           λ_{de Broglie} & \mbox{if } λ_{de Broglie} \geq ρ_⟂ \\
-                           ρ_⟂         & \mbox{if } ρ_⟂ \geq λ_{de Broglie}
+                           λ_{de Broglie} & \mbox{if } λ_{de Broglie} ≥ ρ_⟂ \\
+                           ρ_⟂         & \mbox{if } ρ_⟂ ≥ λ_{de Broglie}
                 \end{array}
             \right.
 
         .. math::
 
-            b_{max} \equiv λ_{Debye}
+            b_{max} ≡ λ_{Debye}
 
         The inner impact parameter (:math:`b_{min}`) is the higher of
         :math:`λ_{de Broglie}` and :math:`ρ_⟂` because for impact
@@ -243,15 +243,15 @@ def Coulomb_logarithm(
 
         .. math::
 
-            \ln{Λ} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+            \ln{Λ} ≡ \ln\left( \frac{b_{max}}{b_{min}} \right)
 
         .. math::
 
-            b_{min} \equiv \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
+            b_{min} ≡ \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
 
         .. math::
 
-            b_{max} \equiv λ_{Debye}
+            b_{max} ≡ λ_{Debye}
 
         This method is invalid if :math:`\ln{Λ} < 0`, which may be true
         if the coupling parameter is high (such as for nonideal, dense,
@@ -272,15 +272,15 @@ def Coulomb_logarithm(
 
         .. math::
 
-            \ln{Λ} \equiv \ln\left( \frac{b_{max}}{b_{min}} \right)
+            \ln{Λ} ≡ \ln\left( \frac{b_{max}}{b_{min}} \right)
 
         .. math::
 
-            b_{min} \equiv \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
+            b_{min} ≡ \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
 
         .. math::
 
-            b_{max} \equiv \sqrt{λ_{Debye}^2 + a_i^2}
+            b_{max} ≡ \sqrt{λ_{Debye}^2 + a_i^2}
 
         This method is invalid if :math:`\ln{Λ} < 0`, which may be true
         if the coupling parameter is high (such as for nonideal, dense,
@@ -303,24 +303,24 @@ def Coulomb_logarithm(
 
         .. math::
 
-            \ln{Λ} \equiv
+            \ln{Λ} ≡
             \left\{
                \begin{array}{ll}
                   \ln\left(\frac{b_{max}}{b_{min}} \right)
                      & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}}\right)
-                  \geq 2 \\
+                  ≥ 2 \\
                   2 & \mbox{if } \ln\left( \frac{b_{max}}{b_{min}} \right)
-                  \leq 2
+                  ≤ 2
                 \end{array}
             \right.
 
         .. math::
 
-            b_{min} \equiv \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
+            b_{min} ≡ \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
 
         .. math::
 
-            b_{max} \equiv λ_{Debye}
+            b_{max} ≡ λ_{Debye}
 
         This method is valid for any plasma because it is impossible for
         :math:`\ln{Λ} < 0` by this method, even if the coupling
@@ -340,16 +340,16 @@ def Coulomb_logarithm(
 
         .. math::
 
-            \ln{Λ} \equiv \frac{1}{2} \ln\left(1 +
+            \ln{Λ} ≡ \frac{1}{2} \ln\left(1 +
             \frac{b_{max}^2}{b_{min}^2} \right)
 
         .. math::
 
-            b_{min} \equiv \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
+            b_{min} ≡ \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
 
         .. math::
 
-            b_{max} \equiv λ_{Debye}
+            b_{max} ≡ λ_{Debye}
 
         This method is valid for any plasma because it is impossible for
         :math:`\ln{Λ} < 0` by this method, even if the coupling
@@ -368,16 +368,16 @@ def Coulomb_logarithm(
 
         .. math::
 
-            \ln{Λ} \equiv \frac{1}{2} \ln\left(1 +
+            \ln{Λ} ≡ \frac{1}{2} \ln\left(1 +
             \frac{b_{max}^2}{b_{min}^2} \right)
 
         .. math::
 
-            b_{min} \equiv ρ_⟂
+            b_{min} ≡ ρ_⟂
 
         .. math::
 
-            b_{max} \equiv \sqrt{λ_{Debye}^2 + a_i^2}
+            b_{max} ≡ \sqrt{λ_{Debye}^2 + a_i^2}
 
         This method is valid for any plasma because it is impossible for
         :math:`\ln{Λ} < 0` by this method, even if the coupling
@@ -402,16 +402,16 @@ def Coulomb_logarithm(
 
         .. math::
 
-            \ln{Λ} \equiv \frac{1}{2} \ln\left(1 +
+            \ln{Λ} ≡ \frac{1}{2} \ln\left(1 +
             \frac{b_{max}^2}{b_{min}^2} \right)
 
         .. math::
 
-            b_{min} \equiv \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
+            b_{min} ≡ \sqrt{λ_{de Broglie}^2 + ρ_⟂^2}
 
         .. math::
 
-            b_{max} \equiv \sqrt{λ_{Debye}^2 + a_i^2}
+            b_{max} ≡ \sqrt{λ_{Debye}^2 + a_i^2}
 
         This method is valid for any plasma because it is impossible for
         :math:`\ln{Λ} < 0` by this method, even if the coupling

--- a/src/plasmapy/formulary/collisions/frequencies.py
+++ b/src/plasmapy/formulary/collisions/frequencies.py
@@ -92,7 +92,7 @@ class SingleParticleCollisionFrequencies:
         + ψ' \left( x^{α \backslash β} \right) \right]
         ν_0^{α \backslash β}`
 
-        parallel diffusion: :math:`ν_{||}^{α \backslash β}
+        parallel diffusion: :math:`ν_{∥}^{α \backslash β}
         = \left[ \frac{ψ \left( x^{α \backslash β} \right)
         }{x^{α \backslash β}} \right] ν_{0}^{α \backslash β}`
 

--- a/src/plasmapy/formulary/collisions/helio/collisional_analysis.py
+++ b/src/plasmapy/formulary/collisions/helio/collisional_analysis.py
@@ -35,60 +35,60 @@ def temp_ratio(  # noqa: C901
     verbose: bool = False,
 ):
     r"""
-    Calculate the thermalization ratio for a plasma in transit, taken
-    from :cite:t:`maruca:2013` and :cite:t:`johnson:2023a`. This
-    function allows the thermalization of a plasma to be modeled,
-    predicting the temperature ratio for different ion species
-    within a plasma at a different point in space.
+    Calculate the thermalization ratio for a plasma in transit.
+
+    This function allows the thermalization of a plasma to be modeled,
+    predicting the temperature ratio for different ion species within a
+    plasma at a different point in space. Taken from
+    :cite:t:`maruca:2013` and :cite:t:`johnson:2023a`.
 
     Parameters
     ----------
     r_0 : `~astropy.units.Quantity`, |keyword-only|
-        Starting position of the plasma in units convertible
-        to astronomical units.
+        Starting position of the plasma in units convertible to
+        astronomical units.
 
-    r_n : `~astropy.units.Quantity`
-        Final position of the plasma in units convertible
-        to astronomical units.
+    r_n : `~astropy.units.Quantity`, |keyword-only|
+        Final position of the plasma in units convertible to
+        astronomical units.
 
-    n_1 : `~astropy.units.Quantity`
-        The primary ion number density in units convertible
-        to m\ :sup:`-3`.
+    n_1 : `~astropy.units.Quantity`, |keyword-only|
+        The primary ion number density in units convertible to
+        m\ :sup:`-3`.
 
-    n_2 : `~astropy.units.Quantity`
-        The secondary ion number density in units convertible
-        to m\ :sup:`-3`.
+    n_2 : `~astropy.units.Quantity`, |keyword-only|
+        The secondary ion number density in units convertible to
+        m\ :sup:`-3`.
 
-    v_1 : `~astropy.units.Quantity`
+    v_1 : `~astropy.units.Quantity`, |keyword-only|
         The primary ion speed in units convertible to km s\ :sup:`-1`.
 
-    T_1 : `~astropy.units.Quantity`
-        Temperature of the primary ion in units convertible to
-        temperature K.
+    T_1 : `~astropy.units.Quantity`, |keyword-only|
+        Temperature of the primary ion in units convertible to kelvin.
 
-    T_2 : `~astropy.units.Quantity`
+    T_2 : `~astropy.units.Quantity`, |keyword-only|
         Temperature of the secondary ion in units convertible to
-        temperature K.
+        kelvin.
 
-    ions : |particle-list-like|, default: ``("p+, "He-4 2+")``
-        Particle list containing two (2) particles, primary ion of
-        interest is entered first, followed by the secondary ion.
+    ions : |particle-list-like|, |keyword-only|, default: ``("p+, "He-4 2+")``
+        Particle list containing two particles, with the primary ion
+        first and the secondary ion second.
 
-    n_step : positive integer
-        The number of intervals used in solving a differential
-        equation via the Euler method.
+    n_step : `int`, |keyword-only|
+        The number of intervals used in solving a differential equation
+        via the Euler method. Must be positive.
 
-    density_scale : real number, default: -1.8
+    density_scale : `float`, |keyword-only|, default: ``-1.8``
         The value used as the scaling parameter for the primary ion
         density. The default value is taken from
         :cite:t:`hellinger:2011`.
 
-    velocity_scale : `float`, default: -0.2
+    velocity_scale : `float`, |keyword-only|, default: ``-0.2``
         The value used as the scaling parameter for the primary ion
         velocity. The default value is taken from
         :cite:t:`hellinger:2011`.
 
-    temperature_scale : `float`, default: -0.74
+    temperature_scale : `float`, |keyword-only|, default: ``-0.74``
         The value used as the scaling parameter for the primary ion
         temperature. The default value is taken from
         :cite:t:`hellinger:2011`.
@@ -96,8 +96,8 @@ def temp_ratio(  # noqa: C901
     Returns
     -------
     theta : `float`
-        The dimensionless ion temperature ratio prediction
-        for the distance provided.
+        The dimensionless ion temperature ratio prediction for the
+        distance provided.
 
     Raises
     ------
@@ -118,55 +118,55 @@ def temp_ratio(  # noqa: C901
 
     .. math::
 
-        \theta_{21} = \frac{T_{2}}{T_{1}} \, ,
+        θ_{21} = \frac{T_2}{T_1} \, ,
 
-    where :math:`T_{1}` and :math:`T_{2}` are the scalar temperatures
-    for the primary ion of interest and the secondary ion, respectively.
-    The scalar temperature defined as:
+    where :math:`T_1` and :math:`T_2` are the scalar temperatures for
+    the primary ion of interest and the secondary ion, respectively. The
+    scalar temperature defined as:
 
     .. math::
 
-        T_{\rm i} = \frac{2T_{{\rm i}, \perp} + T_{{\rm i}, \parallel}}{3} \, ,
+        T_{\rm i} = \frac{2T_{{\rm i}, ⟂} + T_{{\rm i}, ∥}}{3} \, ,
 
-    where :math:`T_{{\rm i}, \perp}` and :math:`T_{{\rm i}, \parallel}`
-    are the temperature of the :math:`{\rm i}`-particles along the
+    where :math:`T_{{\rm i}, ⟂}` and :math:`T_{{\rm i}, ∥}`
+    are the temperature of the :math:`\mathrm{i}`-particles along the
     axes perpendicular and parallel to the ambient magnetic field.
 
     In order to determine how extensively an individual parcel of
-    plasma has been processed by Coulomb collisions :cite:p:`maruca:2013`
-    introduced an approached called collisional analysis. This paper seeks
-    to quantify how collisions affect the plasma's departures from
-    LTE, the equation for collisional thermalization
-    from :cite:t:`maruca:2013` is given below:
+    plasma has been processed by Coulomb collisions, :cite:t:`maruca:2013`
+    introduced an approached called collisional analysis. This paper
+    quantifies how collisions affect the plasma's departures from LTE.
+    The equation for collisional thermalization :cite:p:`maruca:2013`
+    is:
 
      .. math::
 
-        \frac{d \theta_{21}}{dr} = A \left (
-        \frac{n_1}{v_1 T_1^{3/2}} \right ) \frac{\left( \mu_{1} \mu_{2}
-        \right )^{1/2} Z_{1} Z_{2} \left( 1 - \theta_{21} \right )
-        \left(1 + \eta_{21}\theta_{21} \right )}{\left(
-        \frac{\mu_{2}}{\mu_{1}} + \theta_{21} \right )^{3/2}} \lambda_{21}
+        \frac{d θ_{21}}{dr} = A \left (
+        \frac{n_1}{v_1 T_1^{3/2}} \right ) \frac{\left( μ_1 μ_2
+        \right )^{1/2} Z_1 Z_2 \left( 1 - θ_{21} \right )
+        \left(1 + η_{21}θ_{21} \right )}{\left(
+        \frac{μ_2}{μ_1} + θ_{21} \right )^{3/2}} λ_{21}
 
     and
 
     .. math::
 
-         \lambda_{21} = 9 + \ln \left| B \left ( \frac{T^{3}_{1}}{n_{1}}
-         \right )^{1/2} \left( \frac{Z_{1}Z_{2}(\mu_{1} + \mu_{2}) }{\theta_{21} +
-         \frac{\mu_{2}}{\mu_1}} \right )
-         \left( \frac{n_{2}Z_{2}^{2}}{n_{1}Z_{1}^{2}} + \theta_{21}
+         λ_{21} = 9 + \ln \left| B \left ( \frac{T^3_1}{n_1}
+         \right )^{1/2} \left( \frac{Z_1Z_2(μ_1 + μ_2) }{θ_{21} +
+         \frac{μ_2}{μ_1}} \right )
+         \left( \frac{n_2 Z_2^2}{n_1 Z_1^2} + θ_{21}
          \right)^{1/2}\right |
 
-    With :math:`\eta = \frac{n_{2}}{n_{1}}`, :math:`\theta =
-    \frac{T_{2}}{T_{1}}`, :math:`A = 2.60 \times 10^{7} \, {\rm cm}^{3}
+    With :math:`η = \frac{n_2}{n_1}`, :math:`θ =
+    \frac{T_2}{T_1}`, :math:`A = 2.60 × 10^{7} \, {\rm cm}^3
     \, {\rm km} \, {\rm K}^{3/2} \, {\rm s}^{-1} \, {\rm au}^{-1}`,
-    and :math:`B = 1 \, {\rm cm}^{-3/2}{\rm K}^{-3/2}`.
+    and :math:`B = 1 \, {\rm cm}^{-3/2}{~\rm K}^{-3/2}`.
 
     The thermalization is from Coulomb collisions, which assumes
     "soft", small-angle deflections mediated by the electrostatic
-    force :cite:t:`baumjohann:1997`. It is assumed that there is no
+    force :cite:p:`baumjohann:1997`. It is assumed that there is no
     relative drift between the ion species and that it is a mixed ion
-    collision, the Coulomb logarithm for a mixed ion collision is
+    collision, and the Coulomb logarithm for a mixed ion collision is
     given by :cite:t:`nrlformulary:2019`.
 
     The density, velocity and temperature of the primary ion can be

--- a/src/plasmapy/formulary/collisions/lengths.py
+++ b/src/plasmapy/formulary/collisions/lengths.py
@@ -76,12 +76,12 @@ def impact_parameter_perp(
 
     Notes
     -----
-    The distance of closest approach, impact_parameter_perp, is given by
-    (see Ch. 5 of :cite:t:`chen:2016`):
+    The distance of closest approach, ``impact_parameter_perp``, is
+    given by (see Ch. 5 of :cite:t:`chen:2016`):
 
     .. math::
 
-        b_⟂ = \frac{Z_1 Z_2}{4 π \epsilon_0 m v^2}
+        b_⟂ = \frac{Z_1 Z_2}{4 π ε_0 m v^2}
 
     Examples
     --------
@@ -197,8 +197,8 @@ def impact_parameter(  # noqa: C901
     length.
 
     For quantum plasmas the maximum impact parameter can be the
-    quadratic sum of the debye length and ion radius (Wigner_Seitz)
-    :cite:p:`gericke:2002`
+    quadratic sum of the debye length and ion radius
+    (``Wigner_Seitz_radius``) :cite:p:`gericke:2002`:
 
     .. math::
 


### PR DESCRIPTION
This PR makes some minor updates to docstrings in `plasmapy.formulary.collisions`.

Changes include:
 - Using unicode characters instead of LaTeX symbols (which makes docstrings more readable when using `help()`)
 - Removing extra brackets in equations (which makes it easier to keep track of brackets)
 - Justifying docstring text
