### PR TITLE
Update docstrings in `plasmapy.diagnostics`

### DIFF
--- a/changelog/2738.doc.rst
+++ b/changelog/2738.doc.rst
@@ -1,0 +1,1 @@
+Updated docstrings for `plasmapy.diagnostics` and `plasmapy.plasma.grids`.

--- a/src/plasmapy/diagnostics/langmuir.py
+++ b/src/plasmapy/diagnostics/langmuir.py
@@ -730,7 +730,7 @@ def get_electron_density_LM(
     electron saturation current is given by
 
     .. math::
-        I_{es} = \frac{1}{4} e n_e A_p \sqrt{\frac{8 T_e}{\pi m_e}}.
+        I_{es} = \frac{1}{4} e n_e A_p \sqrt{\frac{8 T_e}{π m_e}}.
 
     Please note that the electron saturation current density is a hard
     parameter to acquire and it is usually better to measure the ion density,
@@ -1199,7 +1199,7 @@ def get_ion_density_OML(
     temperature [mott-smith.langmuir-1926]_:
 
     .. math::
-        I_i \xrightarrow[T_i = 0]{} A_p n_i e \frac{\sqrt{2}}{\pi}
+        I_i \xrightarrow[T_i = 0]{} A_p n_i e \frac{\sqrt{2}}{π}
         \sqrt{\frac{e \left( V_F - V \right)}{m_i}}
 
     References
@@ -1352,8 +1352,8 @@ def get_EEDF(probe_characteristic, visualize: bool = False):
     [druyvesteyn-1930]_:
 
     .. math::
-        N_e \left( \epsilon \right) =
-        \frac{2}{A_pe^2} \sqrt{\frac{2 m \epsilon}{e}}
+        N_e \left( ε \right) =
+        \frac{2}{A_pe^2} \sqrt{\frac{2 m ε}{e}}
         \frac{\textrm{d}^2 I}{\textrm{d} V^2}
 
     References

--- a/src/plasmapy/diagnostics/thomson.py
+++ b/src/plasmapy/diagnostics/thomson.py
@@ -807,7 +807,7 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
           sum to 1)
         - :samp:`"electron_speed_{e#}"` : Electron speed in m/s
         - :samp:`"ion_speed_{ei}"` : Ion speed in m/s
-        - :samp:`"ion_mu_{i#}"` : Ion mass number, :math:`\mu = m_i/m_p`
+        - :samp:`"ion_mu_{i#}"` : Ion mass number, :math:`μ = m_i/m_p`
         - :samp:`"ion_z_{i#}"` : Ion charge number
         - :samp:`"background"` : Background level, as fraction of max signal
 

--- a/src/plasmapy/plasma/grids.py
+++ b/src/plasmapy/plasma/grids.py
@@ -1175,7 +1175,7 @@ class CartesianGrid(AbstractGrid):
         This interpolator approximates the value of a quantity at a given
         interpolation point using a weighted sum of the values at the eight grid
         vertices that surround the point. The weighting factors are calculated by
-        defining a volume :math:`dx \\times dy \\times dz`
+        defining a volume :math:`dx × dy × dz`
         (where :math:`dx`, :math:`dy`, and :math:`dz` are the grid
         spacings in each direction) around each grid vertex and around the
         interpolation point. The contribution of each grid vertex is then


### PR DESCRIPTION
This PR makes some minor updates to docstrings in `plasmapy.dispersion`.

Changes include:
 - Using unicode characters instead of LaTeX symbols (which makes docstrings more readable when using `help()`)
 - Removing extra brackets in equations (which makes it easier to keep track of brackets)
 - Justifying docstring text