### PR TITLE
Drop `|tox|` global substitution and adjust changelog formatting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,12 +113,11 @@ Internal Changes and Refactorings
 - Removed :file:`setup.py`. (:pr:`2558`)
 - Added ``sphinx-lint`` as a |pre-commit| hook to find
   reStructuredText errors. (:pr:`2561`)
-- Enabled the `tox-uv <https://github.com/tox-dev/tox-uv>`_ plugin to tox,
-  so that package installation, caching, and the creation of virtual
-  environments will
-  be handled by |uv| instead of |pip|. This change makes it faster to run
-  tests both locally and via |GitHub Actions|. (:pr:`2584`)
-- Changed the project structure to an `src
+- Enabled the ``tox-uv`` plugin to tox, so that package installation,
+  caching, and the creation of virtual environments will be handled by
+  |uv| instead of |pip|. This change makes it faster to run tests both
+  locally and via |GitHub Actions|. (:pr:`2584`)
+  - Changed the project structure to an `src
   layout
   <https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/>`__
   to follow the updated recommendation from the Python Packaging
@@ -131,18 +130,16 @@ Internal Changes and Refactorings
   the source code of `plasmapy.formulary` is now located in
   :file:`src/plasmapy/formulary/` and the tests for `plasmapy.formulary`
   are now in :file:`tests/formulary/`. (:pr:`2598`)
-- Reconfigured the auto-generated requirements files used during continuous
-  integration
-  and for documentation builds, while adding corresponding documentation.
-  (:pr:`2650`)
-- Added :file:`noxfile.py` as a configuration file for |Nox|. This file
-  initially contains
-  environments for building documentation, checking hyperlinks, and performing
-  static
-  type checking with |mypy| (:pr:`2654`)
+- Reconfigured the auto-generated requirements files used during
+  continuous integration and for documentation builds, while adding
+  corresponding documentation.  (:pr:`2650`)
+- Added :file:`noxfile.py` as a configuration file for |Nox|. This
+  file initially contains environments for building documentation,
+  checking hyperlinks, and performing static type checking with |mypy|
+  (:pr:`2654`)
 - Began using |Nox| for some testing environments in |GitHub Actions|,
-  including for the
-  documentation build and static type checking. (:pr:`2656`)
+  including for the documentation build and static type
+  checking. (:pr:`2656`)
 
 
 Additional Changes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,10 +36,10 @@ Documentation Improvements
 - Fix typo in description of `~plasmapy.formulary.densities.mass_density`.
   (:pr:`2588`)
 - Updated the |testing guide| to reflect recent performance improvements with
-  |tox|
+  tox
   via the ``tox-uv`` extension, and the |documentation guide| to reflect that
   the
-  documentation is now built with |Nox| instead of |tox| (:pr:`2590`)
+  documentation is now built with |Nox| instead of tox (:pr:`2590`)
 - Add examples to the docstring for
   `~plasmapy.formulary.radiation.thermal_bremsstrahlung`. (:pr:`2618`)
 - Update the dependency version support policy in the |coding guide|.
@@ -90,7 +90,7 @@ Internal Changes and Refactorings
 - Changed type hint annotations that used `numbers.Integral`, `numbers.Real`,
   or `numbers.Complex` to instead use `int`, `float`, or `complex`,
   respectively. (:pr:`2520`)
-- Created a |tox| environment for regenerating requirements files used
+- Created a tox environment for regenerating requirements files used
   in continuous integration (CI) and by integrated development environments
   (IDEs). This environment is now what is being used in the automated pull
   requests to regenerate requirements files. Switching from ``pip-compile``
@@ -105,7 +105,7 @@ Internal Changes and Refactorings
 - Applied caching through |GitHub Actions| to speed up continuous
   integration tests and documentation builds. Because the Python environments
   used
-  by |tox| to run tests no longer need to be recreated every time tests are
+  by tox to run tests no longer need to be recreated every time tests are
   run,
   caching speeds up several continuous integration tests by ∼2–3 minutes.
   See :issue:`2585` to learn more about recent efforts to drastically
@@ -113,7 +113,7 @@ Internal Changes and Refactorings
 - Removed :file:`setup.py`. (:pr:`2558`)
 - Added ``sphinx-lint`` as a |pre-commit| hook to find
   reStructuredText errors. (:pr:`2561`)
-- Enabled the `tox-uv <https://github.com/tox-dev/tox-uv>`_ plugin to |tox|,
+- Enabled the `tox-uv <https://github.com/tox-dev/tox-uv>`_ plugin to tox,
   so that package installation, caching, and the creation of virtual
   environments will
   be handled by |uv| instead of |pip|. This change makes it faster to run
@@ -160,7 +160,7 @@ Additional Changes
   field components, since one of these is often not explicitly provided.
   (:pr:`2519`)
 - Removed |pytest| as a runtime dependency. (:pr:`2525`)
-- Removed the unused ``py310-conda`` |tox| environment. (:pr:`2526`)
+- Removed the unused ``py310-conda`` tox environment. (:pr:`2526`)
 - Exposed `~plasmapy.formulary.dielectric.StixTensorElements`
   and `~plasmapy.formulary.dielectric.RotatingTensorElements`
   to the public API. (:pr:`2543`)
@@ -241,7 +241,7 @@ Trivial/Internal Changes
   (:pr:`2402`)
 - Added an initial configuration for |mypy| that temporarily ignores existing
   errors. (:pr:`2424`)
-- Added a |tox| environment for running |mypy|. (:pr:`2431`)
+- Added a tox environment for running |mypy|. (:pr:`2431`)
 - Added |mypy| to the suite of continuous integration checks. (:pr:`2432`)
 - Used ``autotyping`` to implement |type hint annotations| for special
   methods like ``__init__`` and ``__str__``, and changed ``-> typing.NoReturn``
@@ -1034,7 +1034,7 @@ Trivial/Internal Changes
 - Made ``pytest`` an ``install`` requirement instead of a ``testing``
   requirement. (:pr:`1749`)
 - Added a step to validate :file:`CITATION.cff` as part of the ``linters``
-  |tox| testing environment. (:pr:`1771`)
+  tox testing environment. (:pr:`1771`)
 - Added ``cffconvert`` to the ``testing`` requirements. (:pr:`1771`)
 - Deleted :file:`codemeta.json`, which recorded project metadata using
   the `CodeMeta <https://codemeta.github.io>`__ metadata
@@ -1344,9 +1344,9 @@ Improved Documentation
 - Added an example notebook that calculates plasma parameters associated
   with the Magnetospheric Multiscale Mission (MMS). (`#1568 <https://github.com/plasmapy/plasmapy/pull/1568>`__)
 - Added an example notebook that discusses Coulomb collisions. (`#1569 <https://github.com/plasmapy/plasmapy/pull/1569>`__)
-- Increased the strictness of the ``build_docs`` |tox| environment so that
+- Increased the strictness of the ``build_docs`` tox environment so that
   broken |reStructuredText| links now emit warnings which are then treated as errors,
-  fixed the new errors, removed the ``build_docs_nitpicky`` |tox|
+  fixed the new errors, removed the ``build_docs_nitpicky`` tox
   environment, and updated the |documentation guide| accordingly. (`#1587 <https://github.com/plasmapy/plasmapy/pull/1587>`__)
 - Renamed the :file:`magnetic_statics.ipynb` notebook to
   :file:`magnetostatics.ipynb`, and made some minor edits to its text
@@ -1463,7 +1463,7 @@ Trivial/Internal Changes
 - Added a test that ``import plasmapy`` does not raise an exception. (`#1501 <https://github.com/plasmapy/plasmapy/pull/1501>`__)
 - Added a GitHub Action for `codespell
   <https://github.com/codespell-project/codespell>`__, and updated the
-  corresponding |tox| environment to print out contextual information. (`#1530 <https://github.com/plasmapy/plasmapy/pull/1530>`__)
+  corresponding tox environment to print out contextual information. (`#1530 <https://github.com/plasmapy/plasmapy/pull/1530>`__)
 - Added :file:`plasmapy/utils/units_definitions.py` to precompute units
   which were applied to optimize functionality in
   :file:`plasmapy/formulary/distribution.py`. (`#1531 <https://github.com/plasmapy/plasmapy/pull/1531>`__)
@@ -1692,7 +1692,7 @@ Improved Documentation
   so that the release of PlasmaPy on |PyPI| gets installed when opening
   example notebooks from the stable and release branches of the online
   documentation. (`#1205 <https://github.com/plasmapy/plasmapy/pull/1205>`__)
-- Updated the documentation guide to include updates to |tox| environments
+- Updated the documentation guide to include updates to tox environments
   for building the documentation. (`#1206 <https://github.com/plasmapy/plasmapy/pull/1206>`__)
 - Fixed numerous broken |reStructuredText| links in prior changelogs. (`#1207 <https://github.com/plasmapy/plasmapy/pull/1207>`__)
 - Improve the docstring for `plasmapy.online_help`. (`#1213 <https://github.com/plasmapy/plasmapy/pull/1213>`__)
@@ -1763,10 +1763,10 @@ Trivial/Internal Changes
   now determines the default detector size to be the smallest detector
   plane centered on the origin that includes all particles. (`#1134 <https://github.com/plasmapy/plasmapy/pull/1134>`__)
 - Added ion velocity input to the :file:`thomson.ipynb` diagnostics notebook. (`#1171 <https://github.com/plasmapy/plasmapy/pull/1171>`__)
-- Added |tox| and removed `pytest` as extra requirements. (`#1195 <https://github.com/plasmapy/plasmapy/pull/1195>`__)
-- Updated |tox| test environments for building the documentation. Added the
+- Added tox and removed `pytest` as extra requirements. (`#1195 <https://github.com/plasmapy/plasmapy/pull/1195>`__)
+- Updated tox test environments for building the documentation. Added the
   ``build_docs_nitpicky`` environment to check for broken |reStructuredText| links. (`#1206 <https://github.com/plasmapy/plasmapy/pull/1206>`__)
-- Added the ``--keep-going`` flag to the ``build_docs*`` |tox| environments with
+- Added the ``--keep-going`` flag to the ``build_docs*`` tox environments with
   the ``-W`` option so that test failures will not stop after the first warning
   (that is treated as an error). (`#1206 <https://github.com/plasmapy/plasmapy/pull/1206>`__)
 - Make queries to `plasmapy.online_help` for ``"quantity"`` or ``"quantities"`` redirect to the
@@ -1787,7 +1787,7 @@ Trivial/Internal Changes
 - Switched usage of `str.format` to formatted string literals (f-strings)
   in several files. (`#1281 <https://github.com/plasmapy/plasmapy/pull/1281>`__)
 - Added `flake8-absolute-import <https://github.com/bskinn/flake8-absolute-import>`_
-  to the ``linters`` |tox| environment. (`#1283 <https://github.com/plasmapy/plasmapy/pull/1283>`__)
+  to the ``linters`` tox environment. (`#1283 <https://github.com/plasmapy/plasmapy/pull/1283>`__)
 - Removed unused imports, and changed several imports from relative to absolute. (`#1283 <https://github.com/plasmapy/plasmapy/pull/1283>`__)
 - Added |pre-commit| hooks to auto-format :file:`.ini`,
   :file:`.toml`, and :file:`.yaml` files, and applied changes from

--- a/changelog/2664.internal.rst
+++ b/changelog/2664.internal.rst
@@ -1,2 +1,2 @@
-Converted the |tox| environment for regenerating the requirements files
+Converted the tox environment for regenerating the requirements files
 used in continuous integration checks to |Nox|.

--- a/changelog/2685.internal.rst
+++ b/changelog/2685.internal.rst
@@ -1,2 +1,2 @@
-Switched the GitHub workflows for running tests from using |tox| environments
+Switched the GitHub workflows for running tests from using tox environments
 to using |Nox| sessions.

--- a/changelog/2693.feature.1.rst
+++ b/changelog/2693.feature.1.rst
@@ -1,6 +1,3 @@
 Added electron binding energy data, relying on ionization energy data from NIST, to the |Particle| class.
 This can now be accessed using the `~plasmapy.particles.particle_class.Particle.electron_binding_energy` attribute
 from the |Particle| class.
-
-Renamed `~plasmapy.particles.particle_class.Particle.binding_energy` to `~plasmapy.particles.particle_class.Particle.nuclear_binding_energy`
-to avoid confusion with `~plasmapy.particles.particle_class.Particle.electron_binding_energy`.

--- a/changelog/2693.feature.2.rst
+++ b/changelog/2693.feature.2.rst
@@ -1,0 +1,1 @@
+Renamed the `~plasmapy.particles.particle_class.Particle.binding_energy` attribute of |Particle| to `~plasmapy.particles.particle_class.Particle.nuclear_binding_energy` to avoid confusion with `~plasmapy.particles.particle_class.Particle.electron_binding_energy`.

--- a/changelog/2694.internal.2.rst
+++ b/changelog/2694.internal.2.rst
@@ -1,1 +1,1 @@
-Switched over weekly tests to use |Nox| sessions rather than |tox| environments.
+Switched over weekly tests to use |Nox| sessions rather than tox environments.

--- a/changelog/2694.internal.3.rst
+++ b/changelog/2694.internal.3.rst
@@ -1,2 +1,2 @@
-Deleted :file:`tox.ini`, since all |tox| environments defined therein
+Deleted :file:`tox.ini`, since all tox environments defined therein
 have been converted to |Nox| sessions.

--- a/changelog/2694.internal.4.rst
+++ b/changelog/2694.internal.4.rst
@@ -1,3 +1,3 @@
 Removed :file:`requirements.txt`, along with the requirements files
-in :file:`ci_requirements/` that were used in |tox| environments
+in :file:`ci_requirements/` that were used in tox environments
 that have since been replaced with |Nox| sessions.

--- a/changelog/2704.trivial.rst
+++ b/changelog/2704.trivial.rst
@@ -1,1 +1,1 @@
-Refactor `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` to use |ParticleTracker|
+Refactored `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` to use |ParticleTracker|.

--- a/ci_requirements/all-3.12.txt
+++ b/ci_requirements/all-3.12.txt
@@ -12,7 +12,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asteval==0.9.33
+asteval==1.0.0
     # via lmfit
 astropy==6.1.1
     # via plasmapy (pyproject.toml)
@@ -35,22 +35,16 @@ beautifulsoup4==4.12.3
     #   sphinx-codeautolink
 bleach==6.1.0
     # via nbconvert
-cachetools==5.3.3
-    # via tox
 certifi==2024.6.2
     # via requests
 cffi==1.16.0
     # via argon2-cffi-bindings
 cfgv==3.4.0
     # via pre-commit
-chardet==5.2.0
-    # via tox
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via towncrier
-colorama==0.4.6
-    # via tox
 colorlog==6.8.2
     # via nox
 comm==0.2.2
@@ -89,9 +83,7 @@ executing==2.0.1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
-    # via
-    #   tox
-    #   virtualenv
+    # via virtualenv
 fonttools==4.53.0
     # via matplotlib
 fqdn==1.5.1
@@ -113,7 +105,7 @@ incremental==22.10.0
     # via towncrier
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.4
+ipykernel==6.29.5
     # via plasmapy (pyproject.toml)
 ipython==8.26.0
     # via
@@ -252,13 +244,10 @@ packaging==24.1
     #   matplotlib
     #   nbconvert
     #   nox
-    #   pyproject-api
     #   pytest
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   sphinx
-    #   tox
-    #   tox-uv
     #   xarray
 pandas==2.2.2
     # via
@@ -278,12 +267,9 @@ pillow==10.4.0
 platformdirs==4.2.2
     # via
     #   jupyter-core
-    #   tox
     #   virtualenv
 pluggy==1.5.0
-    # via
-    #   pytest
-    #   tox
+    # via pytest
 pre-commit==3.7.1
     # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
@@ -317,8 +303,6 @@ pygments==2.18.0
     #   sphinx-tabs
 pyparsing==3.1.2
     # via matplotlib
-pyproject-api==1.7.1
-    # via tox
 pytest==8.2.2
     # via
     #   plasmapy (pyproject.toml)
@@ -390,7 +374,7 @@ scipy==1.14.0
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==70.1.1
+setuptools==70.2.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -490,12 +474,6 @@ towncrier==23.11.0
     # via
     #   plasmapy (pyproject.toml)
     #   sphinx-changelog
-tox==4.15.1
-    # via
-    #   plasmapy (pyproject.toml)
-    #   tox-uv
-tox-uv==1.9.1
-    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
     # via plasmapy (pyproject.toml)
 traitlets==5.14.3
@@ -528,13 +506,10 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2
     # via requests
-uv==0.2.18
-    # via tox-uv
 virtualenv==20.26.3
     # via
     #   nox
     #   pre-commit
-    #   tox
 voila==0.5.7
     # via plasmapy (pyproject.toml)
 wcwidth==0.2.13

--- a/ci_requirements/docs-3.12.txt
+++ b/ci_requirements/docs-3.12.txt
@@ -12,7 +12,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asteval==0.9.33
+asteval==1.0.0
     # via lmfit
 astropy==6.1.1
     # via plasmapy (pyproject.toml)
@@ -34,20 +34,14 @@ beautifulsoup4==4.12.3
     #   sphinx-codeautolink
 bleach==6.1.0
     # via nbconvert
-cachetools==5.3.3
-    # via tox
 certifi==2024.6.2
     # via requests
 cffi==1.16.0
     # via argon2-cffi-bindings
-chardet==5.2.0
-    # via tox
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via towncrier
-colorama==0.4.6
-    # via tox
 colorlog==6.8.2
     # via nox
 comm==0.2.2
@@ -82,9 +76,7 @@ executing==2.0.1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
-    # via
-    #   tox
-    #   virtualenv
+    # via virtualenv
 fonttools==4.53.0
     # via matplotlib
 fqdn==1.5.1
@@ -100,7 +92,7 @@ imagesize==1.4.1
     # via sphinx
 incremental==22.10.0
     # via towncrier
-ipykernel==6.29.4
+ipykernel==6.29.5
     # via plasmapy (pyproject.toml)
 ipython==8.26.0
     # via
@@ -233,10 +225,7 @@ packaging==24.1
     #   matplotlib
     #   nbconvert
     #   nox
-    #   pyproject-api
     #   sphinx
-    #   tox
-    #   tox-uv
     #   xarray
 pandas==2.2.2
     # via
@@ -256,10 +245,7 @@ pillow==10.4.0
 platformdirs==4.2.2
     # via
     #   jupyter-core
-    #   tox
     #   virtualenv
-pluggy==1.5.0
-    # via tox
 prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.47
@@ -291,8 +277,6 @@ pygments==2.18.0
     #   sphinx-tabs
 pyparsing==3.1.2
     # via matplotlib
-pyproject-api==1.7.1
-    # via tox
 python-dateutil==2.9.0.post0
     # via
     #   arrow
@@ -341,7 +325,7 @@ scipy==1.14.0
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==70.1.1
+setuptools==70.2.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -437,12 +421,6 @@ towncrier==23.11.0
     # via
     #   plasmapy (pyproject.toml)
     #   sphinx-changelog
-tox==4.15.1
-    # via
-    #   plasmapy (pyproject.toml)
-    #   tox-uv
-tox-uv==1.9.1
-    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
     # via plasmapy (pyproject.toml)
 traitlets==5.14.3
@@ -473,12 +451,8 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2
     # via requests
-uv==0.2.18
-    # via tox-uv
 virtualenv==20.26.3
-    # via
-    #   nox
-    #   tox
+    # via nox
 voila==0.5.7
     # via plasmapy (pyproject.toml)
 wcwidth==0.2.13

--- a/ci_requirements/tests-3.10-lowest-direct.txt
+++ b/ci_requirements/tests-3.10-lowest-direct.txt
@@ -10,7 +10,7 @@ argon2-cffi==23.1.0
     #   notebook
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
-asteval==0.9.33
+asteval==1.0.0
     # via lmfit
 astropy==5.1
     # via plasmapy (pyproject.toml)
@@ -25,20 +25,14 @@ beautifulsoup4==4.12.3
     # via nbconvert
 bleach==6.1.0
     # via nbconvert
-cachetools==5.3.3
-    # via tox
 certifi==2024.6.2
     # via requests
 cffi==1.16.0
     # via argon2-cffi-bindings
 cfgv==3.4.0
     # via pre-commit
-chardet==5.2.0
-    # via tox
 charset-normalizer==2.0.12
     # via requests
-colorama==0.4.6
-    # via tox
 colorlog==6.8.2
     # via nox
 coverage==7.5.4
@@ -66,9 +60,7 @@ executing==2.0.1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
-    # via
-    #   tox
-    #   virtualenv
+    # via virtualenv
 fonttools==4.53.0
     # via matplotlib
 h5py==3.7.0
@@ -200,7 +192,7 @@ numpy==1.23.0
     #   pyerfa
     #   scipy
     #   xarray
-packaging==23.2
+packaging==22.0
     # via
     #   plasmapy (pyproject.toml)
     #   astropy
@@ -208,12 +200,9 @@ packaging==23.2
     #   matplotlib
     #   nbconvert
     #   nox
-    #   pyproject-api
     #   pytest
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
-    #   tox
-    #   tox-uv
     #   xarray
 pandas==1.4.0
     # via
@@ -230,12 +219,9 @@ pillow==10.4.0
 platformdirs==4.2.2
     # via
     #   jupyter-core
-    #   tox
     #   virtualenv
 pluggy==1.5.0
-    # via
-    #   pytest
-    #   tox
+    # via pytest
 pre-commit==3.6.0
     # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
@@ -260,8 +246,6 @@ pygments==2.18.0
     #   nbconvert
 pyparsing==3.1.2
     # via matplotlib
-pyproject-api==1.6.1
-    # via tox
 pytest==8.0.2
     # via
     #   plasmapy (pyproject.toml)
@@ -345,9 +329,7 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   nox
-    #   pyproject-api
     #   pytest
-    #   tox
 tornado==6.4.1
     # via
     #   ipykernel
@@ -355,12 +337,6 @@ tornado==6.4.1
     #   jupyter-server
     #   notebook
     #   terminado
-tox==4.14.0
-    # via
-    #   plasmapy (pyproject.toml)
-    #   tox-uv
-tox-uv==1.7.0
-    # via plasmapy (pyproject.toml)
 tqdm==4.60.0
     # via plasmapy (pyproject.toml)
 traitlets==5.14.3
@@ -384,13 +360,10 @@ uncertainties==3.2.1
     # via lmfit
 urllib3==1.26.19
     # via requests
-uv==0.2.18
-    # via tox-uv
 virtualenv==20.26.3
     # via
     #   nox
     #   pre-commit
-    #   tox
 voila==0.2.7
     # via plasmapy (pyproject.toml)
 wcwidth==0.2.13

--- a/ci_requirements/tests-3.10.txt
+++ b/ci_requirements/tests-3.10.txt
@@ -10,7 +10,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asteval==0.9.33
+asteval==1.0.0
     # via lmfit
 astropy==6.1.1
     # via plasmapy (pyproject.toml)
@@ -29,20 +29,14 @@ beautifulsoup4==4.12.3
     # via nbconvert
 bleach==6.1.0
     # via nbconvert
-cachetools==5.3.3
-    # via tox
 certifi==2024.6.2
     # via requests
 cffi==1.16.0
     # via argon2-cffi-bindings
 cfgv==3.4.0
     # via pre-commit
-chardet==5.2.0
-    # via tox
 charset-normalizer==3.3.2
     # via requests
-colorama==0.4.6
-    # via tox
 colorlog==6.8.2
     # via nox
 comm==0.2.2
@@ -78,9 +72,7 @@ executing==2.0.1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
-    # via
-    #   tox
-    #   virtualenv
+    # via virtualenv
 fonttools==4.53.0
     # via matplotlib
 fqdn==1.5.1
@@ -98,7 +90,7 @@ idna==3.7
     #   requests
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.4
+ipykernel==6.29.5
     # via plasmapy (pyproject.toml)
 ipython==8.26.0
     # via
@@ -225,12 +217,9 @@ packaging==24.1
     #   matplotlib
     #   nbconvert
     #   nox
-    #   pyproject-api
     #   pytest
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
-    #   tox
-    #   tox-uv
     #   xarray
 pandas==2.2.2
     # via
@@ -247,12 +236,9 @@ pillow==10.4.0
 platformdirs==4.2.2
     # via
     #   jupyter-core
-    #   tox
     #   virtualenv
 pluggy==1.5.0
-    # via
-    #   pytest
-    #   tox
+    # via pytest
 pre-commit==3.7.1
     # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
@@ -277,8 +263,6 @@ pygments==2.18.0
     #   nbconvert
 pyparsing==3.1.2
     # via matplotlib
-pyproject-api==1.7.1
-    # via tox
 pytest==8.2.2
     # via
     #   plasmapy (pyproject.toml)
@@ -348,7 +332,7 @@ scipy==1.14.0
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==70.1.1
+setuptools==70.2.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -376,21 +360,13 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   nox
-    #   pyproject-api
     #   pytest
-    #   tox
 tornado==6.4.1
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
     #   terminado
-tox==4.15.1
-    # via
-    #   plasmapy (pyproject.toml)
-    #   tox-uv
-tox-uv==1.9.1
-    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
     # via plasmapy (pyproject.toml)
 traitlets==5.14.3
@@ -423,13 +399,10 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2
     # via requests
-uv==0.2.18
-    # via tox-uv
 virtualenv==20.26.3
     # via
     #   nox
     #   pre-commit
-    #   tox
 voila==0.5.7
     # via plasmapy (pyproject.toml)
 wcwidth==0.2.13

--- a/ci_requirements/tests-3.11.txt
+++ b/ci_requirements/tests-3.11.txt
@@ -10,7 +10,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asteval==0.9.33
+asteval==1.0.0
     # via lmfit
 astropy==6.1.1
     # via plasmapy (pyproject.toml)
@@ -29,20 +29,14 @@ beautifulsoup4==4.12.3
     # via nbconvert
 bleach==6.1.0
     # via nbconvert
-cachetools==5.3.3
-    # via tox
 certifi==2024.6.2
     # via requests
 cffi==1.16.0
     # via argon2-cffi-bindings
 cfgv==3.4.0
     # via pre-commit
-chardet==5.2.0
-    # via tox
 charset-normalizer==3.3.2
     # via requests
-colorama==0.4.6
-    # via tox
 colorlog==6.8.2
     # via nox
 comm==0.2.2
@@ -72,9 +66,7 @@ executing==2.0.1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
-    # via
-    #   tox
-    #   virtualenv
+    # via virtualenv
 fonttools==4.53.0
     # via matplotlib
 fqdn==1.5.1
@@ -92,7 +84,7 @@ idna==3.7
     #   requests
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.4
+ipykernel==6.29.5
     # via plasmapy (pyproject.toml)
 ipython==8.26.0
     # via
@@ -219,12 +211,9 @@ packaging==24.1
     #   matplotlib
     #   nbconvert
     #   nox
-    #   pyproject-api
     #   pytest
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
-    #   tox
-    #   tox-uv
     #   xarray
 pandas==2.2.2
     # via
@@ -241,12 +230,9 @@ pillow==10.4.0
 platformdirs==4.2.2
     # via
     #   jupyter-core
-    #   tox
     #   virtualenv
 pluggy==1.5.0
-    # via
-    #   pytest
-    #   tox
+    # via pytest
 pre-commit==3.7.1
     # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
@@ -271,8 +257,6 @@ pygments==2.18.0
     #   nbconvert
 pyparsing==3.1.2
     # via matplotlib
-pyproject-api==1.7.1
-    # via tox
 pytest==8.2.2
     # via
     #   plasmapy (pyproject.toml)
@@ -342,7 +326,7 @@ scipy==1.14.0
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==70.1.1
+setuptools==70.2.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -372,12 +356,6 @@ tornado==6.4.1
     #   jupyter-client
     #   jupyter-server
     #   terminado
-tox==4.15.1
-    # via
-    #   plasmapy (pyproject.toml)
-    #   tox-uv
-tox-uv==1.9.1
-    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
     # via plasmapy (pyproject.toml)
 traitlets==5.14.3
@@ -409,13 +387,10 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2
     # via requests
-uv==0.2.18
-    # via tox-uv
 virtualenv==20.26.3
     # via
     #   nox
     #   pre-commit
-    #   tox
 voila==0.5.7
     # via plasmapy (pyproject.toml)
 wcwidth==0.2.13

--- a/ci_requirements/tests-3.12.txt
+++ b/ci_requirements/tests-3.12.txt
@@ -10,7 +10,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asteval==0.9.33
+asteval==1.0.0
     # via lmfit
 astropy==6.1.1
     # via plasmapy (pyproject.toml)
@@ -29,20 +29,14 @@ beautifulsoup4==4.12.3
     # via nbconvert
 bleach==6.1.0
     # via nbconvert
-cachetools==5.3.3
-    # via tox
 certifi==2024.6.2
     # via requests
 cffi==1.16.0
     # via argon2-cffi-bindings
 cfgv==3.4.0
     # via pre-commit
-chardet==5.2.0
-    # via tox
 charset-normalizer==3.3.2
     # via requests
-colorama==0.4.6
-    # via tox
 colorlog==6.8.2
     # via nox
 comm==0.2.2
@@ -72,9 +66,7 @@ executing==2.0.1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
-    # via
-    #   tox
-    #   virtualenv
+    # via virtualenv
 fonttools==4.53.0
     # via matplotlib
 fqdn==1.5.1
@@ -92,7 +84,7 @@ idna==3.7
     #   requests
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.4
+ipykernel==6.29.5
     # via plasmapy (pyproject.toml)
 ipython==8.26.0
     # via
@@ -219,12 +211,9 @@ packaging==24.1
     #   matplotlib
     #   nbconvert
     #   nox
-    #   pyproject-api
     #   pytest
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
-    #   tox
-    #   tox-uv
     #   xarray
 pandas==2.2.2
     # via
@@ -241,12 +230,9 @@ pillow==10.4.0
 platformdirs==4.2.2
     # via
     #   jupyter-core
-    #   tox
     #   virtualenv
 pluggy==1.5.0
-    # via
-    #   pytest
-    #   tox
+    # via pytest
 pre-commit==3.7.1
     # via plasmapy (pyproject.toml)
 prometheus-client==0.20.0
@@ -271,8 +257,6 @@ pygments==2.18.0
     #   nbconvert
 pyparsing==3.1.2
     # via matplotlib
-pyproject-api==1.7.1
-    # via tox
 pytest==8.2.2
     # via
     #   plasmapy (pyproject.toml)
@@ -342,7 +326,7 @@ scipy==1.14.0
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==70.1.1
+setuptools==70.2.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -372,12 +356,6 @@ tornado==6.4.1
     #   jupyter-client
     #   jupyter-server
     #   terminado
-tox==4.15.1
-    # via
-    #   plasmapy (pyproject.toml)
-    #   tox-uv
-tox-uv==1.9.1
-    # via plasmapy (pyproject.toml)
 tqdm==4.66.4
     # via plasmapy (pyproject.toml)
 traitlets==5.14.3
@@ -407,13 +385,10 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2
     # via requests
-uv==0.2.18
-    # via tox-uv
 virtualenv==20.26.3
     # via
     #   nox
     #   pre-commit
-    #   tox
 voila==0.5.7
     # via plasmapy (pyproject.toml)
 wcwidth==0.2.13

--- a/docs/_global_substitutions.py
+++ b/docs/_global_substitutions.py
@@ -159,7 +159,6 @@ links_to_become_subs: dict[str, str] = {
     "Sphinx": "https://www.sphinx-doc.org",
     "static type checking": "https://realpython.com/lessons/python-type-checking-overview",
     "towncrier": "https://github.com/twisted/towncrier",
-    "tox": "https://tox.wiki/en/latest",
     "type hint annotations": "https://peps.python.org/pep-0484",
     "xarray": "https://docs.xarray.dev",
     "Zenodo": "https://zenodo.org",

--- a/docs/changelog/0.7.0.rst
+++ b/docs/changelog/0.7.0.rst
@@ -222,7 +222,7 @@ Improved Documentation
   so that the release of PlasmaPy on |PyPI| gets installed when opening
   example notebooks from the stable and release branches of the online
   documentation. (`#1205 <https://github.com/plasmapy/plasmapy/pull/1205>`__)
-- Updated the |documentation guide| to include updates to |tox| environments
+- Updated the |documentation guide| to include updates to tox environments
   for building the documentation. (`#1206 <https://github.com/plasmapy/plasmapy/pull/1206>`__)
 - Fixed numerous broken |reStructuredText| links in prior changelogs. (`#1207 <https://github.com/plasmapy/plasmapy/pull/1207>`__)
 - Improve the docstring for `plasmapy.online_help`. (`#1213 <https://github.com/plasmapy/plasmapy/pull/1213>`__)
@@ -293,10 +293,10 @@ Trivial/Internal Changes
   now determines the default detector size to be the smallest detector
   plane centered on the origin that includes all particles. (`#1134 <https://github.com/plasmapy/plasmapy/pull/1134>`__)
 - Added ion velocity input to the :file:`thomson.ipynb` diagnostics notebook. (`#1171 <https://github.com/plasmapy/plasmapy/pull/1171>`__)
-- Added |tox| and removed `pytest` as extra requirements. (`#1195 <https://github.com/plasmapy/plasmapy/pull/1195>`__)
-- Updated |tox| test environments for building the documentation. Added the
+- Added tox and removed `pytest` as extra requirements. (`#1195 <https://github.com/plasmapy/plasmapy/pull/1195>`__)
+- Updated tox test environments for building the documentation. Added the
   ``build_docs_nitpicky`` environment to check for broken |reStructuredText| links. (`#1206 <https://github.com/plasmapy/plasmapy/pull/1206>`__)
-- Added the ``--keep-going`` flag to the ``build_docs*`` |tox| environments with
+- Added the ``--keep-going`` flag to the ``build_docs*`` tox environments with
   the ``-W`` option so that test failures will not stop after the first warning
   (that is treated as an error). (`#1206 <https://github.com/plasmapy/plasmapy/pull/1206>`__)
 - Make queries to `plasmapy.online_help` for ``"quantity"`` or ``"quantities"`` redirect to the
@@ -317,7 +317,7 @@ Trivial/Internal Changes
 - Switched usage of `str.format` to formatted string literals (f-strings)
   in several files. (`#1281 <https://github.com/plasmapy/plasmapy/pull/1281>`__)
 - Added `flake8-absolute-import <https://github.com/bskinn/flake8-absolute-import>`_
-  to the ``linters`` |tox| environment. (`#1283 <https://github.com/plasmapy/plasmapy/pull/1283>`__)
+  to the ``linters`` tox environment. (`#1283 <https://github.com/plasmapy/plasmapy/pull/1283>`__)
 - Removed unused imports, and changed several imports from relative to absolute. (`#1283 <https://github.com/plasmapy/plasmapy/pull/1283>`__)
 - Added |pre-commit| hooks to auto-format :file:`.ini`,
   :file:`.toml`, and :file:`.yaml` files, and applied changes from

--- a/docs/changelog/0.8.1.rst
+++ b/docs/changelog/0.8.1.rst
@@ -464,10 +464,10 @@ Improved Documentation
   <https://github.com/plasmapy/plasmapy/pull/1568>`__)
 - Added an example notebook that discusses Coulomb collisions. (`#1569
   <https://github.com/plasmapy/plasmapy/pull/1569>`__)
-- Increased the strictness of the ``build_docs`` |tox| environment so
+- Increased the strictness of the ``build_docs`` tox environment so
   that broken |reStructuredText| links now emit warnings which are then treated as
   errors, fixed the new errors, removed the ``build_docs_nitpicky``
-  |tox| environment, and updated the |documentation guide|
+  tox environment, and updated the |documentation guide|
   accordingly. (`#1587
   <https://github.com/plasmapy/plasmapy/pull/1587>`__)
 - Renamed the :file:`magnetic_statics.ipynb` notebook to
@@ -632,7 +632,7 @@ Trivial/Internal Changes
   <https://github.com/plasmapy/plasmapy/pull/1501>`__)
 - Added a GitHub Action for `codespell
   <https://github.com/codespell-project/codespell>`__, and updated the
-  corresponding |tox| environment to print out contextual
+  corresponding tox environment to print out contextual
   information. (`#1530
   <https://github.com/plasmapy/plasmapy/pull/1530>`__)
 - Added :file:`plasmapy/utils/units_definitions.py` to precompute

--- a/docs/changelog/0.9.0.rst
+++ b/docs/changelog/0.9.0.rst
@@ -256,7 +256,7 @@ Trivial/Internal Changes
 - Made ``pytest`` an ``install`` requirement instead of a ``testing``
   requirement. (:pr:`1749`)
 - Added a step to validate :file:`CITATION.cff` as part of the ``linters``
-  |tox| testing environment. (:pr:`1771`)
+  tox testing environment. (:pr:`1771`)
 - Added ``cffconvert`` to the ``testing`` requirements. (:pr:`1771`)
 - Deleted :file:`codemeta.json`, which recorded project metadata using
   the `CodeMeta <https://codemeta.github.io>`__ metadata

--- a/docs/changelog/0.9.1.rst
+++ b/docs/changelog/0.9.1.rst
@@ -4,5 +4,5 @@ PlasmaPy v0.9.1 (2022-11-15)
 Trivial/Internal Changes
 ------------------------
 
-- Removed a test of requirement file consistency to allow tests to pass on
-  conda-forge.
+- Removed a test of requirement file consistency to allow tests to
+  pass on conda-forge.

--- a/docs/changelog/2023.1.0.rst
+++ b/docs/changelog/2023.1.0.rst
@@ -94,8 +94,8 @@ Trivial/Internal Changes
   (``pip install plasmapy[all]`` and ``[extras]`` are gone).  (:pr:`1758`)
 - Added `blacken-docs <https://github.com/adamchainz/blacken-docs>`__
   to the |pre-commit| configuration. (:pr:`1807`)
-- Removed ``pytest-xdist`` from the testing requirements (see also
-  :issue:`750`). (:pr:`1822`)
+- Removed ``pytest-xdist`` from the testing requirements. (:pr:`1822`;
+  see also :issue:`750`)
 - Refactored tests of `~plasmapy.formulary.relativity.Lorentz_factor`
   and
   `~plasmapy.formulary.relativity.relativistic_energy`. (:pr:`1844`)

--- a/docs/changelog/2023.1.0.rst
+++ b/docs/changelog/2023.1.0.rst
@@ -4,31 +4,34 @@ PlasmaPy v2023.1.0 (2023-01-13)
 Backwards Incompatible Changes
 ------------------------------
 
-- Moved the charged particle radiography analysis codes into a new module
-  `~plasmapy.diagnostics.charged_particle_radiography` containing synthetic
-  radiography tools in
+- Moved the charged particle radiography analysis codes into a new
+  module `~plasmapy.diagnostics.charged_particle_radiography`
+  containing synthetic radiography tools in
   `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography`
   and detector stack calculation tools in
   `~plasmapy.diagnostics.charged_particle_radiography.detector_stacks`.
   (:pr:`1274`)
-- Changed the `~plasmapy.formulary.lengths.gyroradius` function so that it
-  takes relativistic effects into account by default. (:pr:`1813`)
+- Changed the `~plasmapy.formulary.lengths.gyroradius` function so
+  that it takes relativistic effects into account by
+  default. (:pr:`1813`)
 
 
 Deprecations and Removals
 -------------------------
 
-- Changed the `~plasmapy.formulary.lengths.gyroradius` function so it no
-  longer accepts deprecated ``T_i``. (:pr:`1824`)
+- Changed the `~plasmapy.formulary.lengths.gyroradius` function so it
+  no longer accepts deprecated ``T_i``. (:pr:`1824`)
 - Removed ``plasmapy.formulary.parameters``, which was deprecated in
-  the ``0.7.0`` release.  The functionality in that module had previously
-  been migrated to modules that are broken down by physical type, such as:
-  `plasmapy.formulary.densities`, `plasmapy.formulary.dimensionless`,
+  the ``0.7.0`` release.  The functionality in that module had
+  previously been migrated to modules that are broken down by physical
+  type, such as: `plasmapy.formulary.densities`,
+  `plasmapy.formulary.dimensionless`,
   `plasmapy.formulary.frequencies`, `plasmapy.formulary.lengths`,
-  `plasmapy.formulary.misc`, and `plasmapy.formulary.speeds`. (:pr:`1833`)
+  `plasmapy.formulary.misc`, and
+  `plasmapy.formulary.speeds`. (:pr:`1833`)
 - Deprecated providing a real number to the ``charge`` parameter of
-  |CustomParticle| to represent the |charge number|. Use ``Z`` instead.
-  (:pr:`1866`)
+  |CustomParticle| to represent the |charge number|. Use ``Z``
+  instead.  (:pr:`1866`)
 
 
 Features
@@ -37,8 +40,8 @@ Features
 - Added the
   `~plasmapy.diagnostics.charged_particle_radiography.detector_stacks.Stack`
   and |Layer| objects to the
-  `~plasmapy.diagnostics.charged_particle_radiography` module, which represent
-  a stack of detector media layers. The
+  `~plasmapy.diagnostics.charged_particle_radiography` module, which
+  represent a stack of detector media layers. The
   `~plasmapy.diagnostics.charged_particle_radiography.detector_stacks.Stack.deposition_curves`
   and
   `~plasmapy.diagnostics.charged_particle_radiography.detector_stacks.Stack.energy_bands`
@@ -46,32 +49,34 @@ Features
   `~plasmapy.diagnostics.charged_particle_radiography.detector_stacks.Stack`
   calculate the particle energies deposited in each detector layer.
   (:pr:`1274`)
--
-  `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker`
-  now supports multiple field grids, provided as an iterable. (:pr:`1799`)
+- `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker`
+  now supports multiple field grids, provided as an
+  iterable. (:pr:`1799`)
 - Added the `plasmapy.analysis.time_series.running_moments` module
   including two functions for calculating running moments of time
   series. (:pr:`1803`)
-- Added ``lorentzfactor`` as an optional keyword-only argument
-  to `~plasmapy.formulary.lengths.gyroradius`. Also added ``relativistic``
-  as an optional keyword-only argument which can be set to `False` for the
-  non-relativistic approximation. (:pr:`1813`)
-- Modified |Particle| attributes to return |nan| in the appropriate units
-  when undefined rather than raising exceptions. (:pr:`1825`)
+- Added ``lorentzfactor`` as an optional keyword-only argument to
+  `~plasmapy.formulary.lengths.gyroradius`. Also added
+  ``relativistic`` as an optional keyword-only argument which can be
+  set to `False` for the non-relativistic approximation. (:pr:`1813`)
+- Modified |Particle| attributes to return |nan| in the appropriate
+  units when undefined rather than raising exceptions. (:pr:`1825`)
 - Added the `~plasmapy.particles.particle_class.CustomParticle.charge_number`
   attribute to |CustomParticle|. (:pr:`1866`)
-- Added ``Z`` as a |keyword-only| |parameter| representing the
-  |charge number| to |CustomParticle|. (:pr:`1866`)
+- Added ``Z`` as a |keyword-only| |parameter| representing the |charge
+  number| to |CustomParticle|. (:pr:`1866`)
 
 
 Improved Documentation
 ----------------------
 
-- Updated docstrings and annotations in `plasmapy.diagnostics.thomson`.
-  (:pr:`1756`)
-- Updated the discussion on type descriptions and parameter descriptions
-  for docstrings in the |documentation guide|. (:pr:`1757`)
-- Updated troubleshooting sections of the |documentation guide|. (:pr:`1817`)
+- Updated docstrings and annotations in
+  `plasmapy.diagnostics.thomson`.  (:pr:`1756`)
+- Updated the discussion on type descriptions and parameter
+  descriptions for docstrings in the |documentation guide|.
+  (:pr:`1757`)
+- Updated troubleshooting sections of the |documentation guide|.
+  (:pr:`1817`)
 - Added a summary section to the |testing guide|. (:pr:`1823`)
 - Updated the |changelog guide|. (:pr:`1826`)
 - Reorganized the |coding guide|. (:pr:`1856`)
@@ -83,23 +88,24 @@ Trivial/Internal Changes
 
 - Updated warning messages in
   `~plasmapy.formulary.collisions.coulomb.Coulomb_logarithm`. (:pr:`1586`)
-- Transferred most of the contents of :file:`setup.py` and :file:`setup.cfg` to
-  :file:`pyproject.toml` (see :pep:`518` and :pep:`621`). Simplified ``extras``
-  requirements (``pip install plasmapy[all]`` and ``[extras]`` are gone).
-  (:pr:`1758`)
-- Added `blacken-docs <https://github.com/adamchainz/blacken-docs>`__ to
-  the |pre-commit| configuration. (:pr:`1807`)
+- Transferred most of the contents of :file:`setup.py` and
+  :file:`setup.cfg` to :file:`pyproject.toml` (see :pep:`518` and
+  :pep:`621`). Simplified ``extras`` requirements
+  (``pip install plasmapy[all]`` and ``[extras]`` are gone).  (:pr:`1758`)
+- Added `blacken-docs <https://github.com/adamchainz/blacken-docs>`__
+  to the |pre-commit| configuration. (:pr:`1807`)
 - Removed ``pytest-xdist`` from the testing requirements (see also
   :issue:`750`). (:pr:`1822`)
 - Refactored tests of `~plasmapy.formulary.relativity.Lorentz_factor`
-  and `~plasmapy.formulary.relativity.relativistic_energy`. (:pr:`1844`)
+  and
+  `~plasmapy.formulary.relativity.relativistic_energy`. (:pr:`1844`)
 - Applied refactorings from |ruff| and ``refurb`` to `plasmapy.utils`.
   (:pr:`1845`)
 - Applied changes from ``refurb`` to `plasmapy.particles`. (:pr:`1846`)
 - Applied changes from ``refurb`` to `plasmapy.formulary`. (:pr:`1847`)
 - Apply changes from |ruff| and ``refurb`` to `plasmapy.analysis`,
-  `plasmapy.diagnostics`, `plasmapy.dispersion`, and `plasmapy.plasma`.
-  (:pr:`1853`)
+  `plasmapy.diagnostics`, `plasmapy.dispersion`, and
+  `plasmapy.plasma`.  (:pr:`1853`)
 - Added |ruff| to the ``pre-commit`` configuration. (:pr:`1854`)
 - Added the ``strict`` and ``allowed_physical_types`` parameters to
   ``plasmapy.utils._units_helpers._get_physical_type_dict``. (:pr:`1880`)

--- a/docs/changelog/2023.10.0.rst
+++ b/docs/changelog/2023.10.0.rst
@@ -4,110 +4,115 @@ PlasmaPy v2023.10.0 (2023-10-20)
 Backwards Incompatible Changes
 ------------------------------
 
-- Renamed the ``plasmapy.dispersion.dispersionfunction`` module
-  to `plasmapy.dispersion.dispersion_functions`. Both
-  of ``plasma_dispersion_func`` and ``plasma_dispersion_func_deriv``
-  are temporarily still available, but will issue
-  a `~plasmapy.utils.exceptions.PlasmaPyFutureWarning` and will be
+- Renamed the ``plasmapy.dispersion.dispersionfunction`` module to
+  `plasmapy.dispersion.dispersion_functions`. Both of
+  ``plasma_dispersion_func`` and ``plasma_dispersion_func_deriv`` are
+  temporarily still available, but will issue a
+  `~plasmapy.utils.exceptions.PlasmaPyFutureWarning` and will be
   removed in a subsequent release. (:pr:`2271`)
-- Removed the |lite-functions|
-  for `~plasmapy.dispersion.dispersion_functions.plasma_dispersion_func`
-  and `~plasmapy.dispersion.dispersion_functions.plasma_dispersion_func_deriv`.
+- Removed the |lite-functions| for
+  `~plasmapy.dispersion.dispersion_functions.plasma_dispersion_func`
+  and
+  `~plasmapy.dispersion.dispersion_functions.plasma_dispersion_func_deriv`.
   Instead, the performance of the original functions has been improved
-  by using a :py:`try` and :py:`except` block instead of having multiple
-  :py:`if` statements to check for preconditions. (:pr:`2361`)
-- Providing a real number to the ``charge`` parameter in |CustomParticle|
-  will now result in a |InvalidParticleError| instead of a deprecation warning.
-  Now,
-  ``charge`` must be a |Quantity| with units of electrical charge. To
-  express the charge as a multiple of the elementary charge, provide a
-  real number to the ``Z`` parameter instead. (:pr:`2369`)
+  by using a :py:`try` and :py:`except` block instead of having
+  multiple :py:`if` statements to check for
+  preconditions. (:pr:`2361`)
+- Providing a real number to the ``charge`` parameter in
+  |CustomParticle| will now result in a |InvalidParticleError| instead
+  of a deprecation warning.  Now, ``charge`` must be a |Quantity| with
+  units of electrical charge. To express the charge as a multiple of
+  the elementary charge, provide a real number to the ``Z`` parameter
+  instead. (:pr:`2369`)
 
 
 Features
 --------
 
-- Added the `~plasmapy.plasma.equilibria1d.HarrisSheet` class to calculate
-  magnetic field, current density, and plasma pressure for 1D Harris sheets.
-  (:pr:`2068`)
-- Added module `plasmapy.dispersion.analytical.mhd_waves_`
-  with classes for storing and calculating parameters of
+- Added the `~plasmapy.plasma.equilibria1d.HarrisSheet` class to
+  calculate magnetic field, current density, and plasma pressure for
+  1D Harris sheets.  (:pr:`2068`)
+- Added module `plasmapy.dispersion.analytical.mhd_waves_` with
+  classes for storing and calculating parameters of
   magnetohydrodynamic waves. (:pr:`2206`)
-- Added the `plasmapy.analysis.time_series.conditional_averaging` module
-  including the
+- Added the `plasmapy.analysis.time_series.conditional_averaging`
+  module including the
   `~plasmapy.analysis.time_series.conditional_averaging.ConditionalEvents`
-  class for calculating the conditional average and variance of time series.
-  (:pr:`2275`)
-- Added the `~plasmapy.plasma.cylindrical_equilibria.ForceFreeFluxRope`
-  class to calculate magnetic field for the Lundquist solution for
-  force-free cylindrical equilibria. (:pr:`2289`)
+  class for calculating the conditional average and variance of time
+  series.  (:pr:`2275`)
+- Added the
+  `~plasmapy.plasma.cylindrical_equilibria.ForceFreeFluxRope` class to
+  calculate magnetic field for the Lundquist solution for force-free
+  cylindrical equilibria. (:pr:`2289`)
 
 
 Bug Fixes
 ---------
 
-- Fixed a bug that had been causing incorrect results
-  in `~plasmapy.formulary.collisions.helio.collisional_analysis.temp_ratio`.
+- Fixed a bug that had been causing incorrect results in
+  `~plasmapy.formulary.collisions.helio.collisional_analysis.temp_ratio`.
   (:pr:`2248`)
 - Enabled the ``time_step`` parameter in
-  `~plasmapy.analysis.time_series.excess_statistics.ExcessStatistics` class to
-  be a |Quantity| with a unit. (:pr:`2300`)
+  `~plasmapy.analysis.time_series.excess_statistics.ExcessStatistics`
+  class to be a |Quantity| with a unit. (:pr:`2300`)
 
 
 Improved Documentation
 ----------------------
 
-- Updated the |code contribution workflow| in the |contributor guide| to
-  describe how to use ``git pull``. (:pr:`2193`)
+- Updated the |code contribution workflow| in the |contributor guide|
+  to describe how to use ``git pull``. (:pr:`2193`)
 - Expanded the troubleshooting section of the |documentation guide| to
   describe how to resolve warnings related to documents not being
   included in any toctrees. (:pr:`2257`)
-- Added a step to the |code contribution workflow| about using ``git status``
-  to verify that there have been no changes to tracked files before
-  creating and switching to a new branch. (:pr:`2263`)
-- Added a page to the |contributor guide| about |pre-commit|, including
-  how to troubleshoot test failures. (:pr:`2265`)
+- Added a step to the |code contribution workflow| about using ``git
+  status`` to verify that there have been no changes to tracked files
+  before creating and switching to a new branch. (:pr:`2263`)
+- Added a page to the |contributor guide| about |pre-commit|,
+  including how to troubleshoot test failures. (:pr:`2265`)
 - Added :file:`CONTRIBUTING.md` to PlasmaPy's GitHub repository.  This
   page refers contributors to PlasmaPy's |contributor guide|. (:pr:`2266`)
-- Enabled the `sphinx.ext.duration` extension to show the times required
-  to process different pages during documentation builds. (:pr:`2268`)
+- Enabled the `sphinx.ext.duration` extension to show the times
+  required to process different pages during documentation
+  builds. (:pr:`2268`)
 - Enabled the `sphinx.ext.viewcode` extension for adding links in the
   documentation to pages containing the source code. (:pr:`2269`)
-- Moved definitions of certain |reStructuredText| substitutions
-  from :file:`docs/common_links.rst` to the
-  file :file:`docs/contributing/doc_guide.rst` in order to speed up the
+- Moved definitions of certain |reStructuredText| substitutions from
+  :file:`docs/common_links.rst` to the file
+  :file:`docs/contributing/doc_guide.rst` in order to speed up the
   documentation build (see :issue:`2277`\ ). (:pr:`2272`)
 - Implemented ``sphinxcontrib-globalsubs`` to enable global
-  |reStructuredText| substitutions to be used throughout the documentation,
-  and moved the definition of substitutions from :file:`docs/common_links.rst`
-  to the ``global_substitutions`` `dict` in
-  :file:`docs/_global_substitutions.py`. (:pr:`2281`)
-- Changed :py:`from astropy import units as u` to :py:`import astropy.units as
-  u`
-  and :py:`from astropy import constants as const`
-  to :py:`import astropy.constants as const` throughout the code in order to
-  increase consistency of import statements. (:pr:`2282`)
-- Added and applied ``nbqa-ruff`` to our suite of |pre-commit| hooks so
-  that |ruff| can perform code quality checks on our example notebooks.
-  (:pr:`2302`)
-- Renamed :file:`docs/cff_to_rst.py` to :file:`docs/_cff_to_rst.py`, and
-  updated the functionality contained within that file for converting
-  author information in :file:`CITATION.cff` into a |reStructuredText|
-  author list to be included in the documentation. (:pr:`2307`)
+  |reStructuredText| substitutions to be used throughout the
+  documentation, and moved the definition of substitutions from
+  :file:`docs/common_links.rst` to the ``global_substitutions`` `dict`
+  in :file:`docs/_global_substitutions.py`. (:pr:`2281`)
+- Changed :py:`from astropy import units as u` to
+  :py:`import astropy.units as u` and
+  :py:`from astropy import constants as const` to
+  :py:`import astropy.constants as const` throughout the code in order
+  to increase consistency of import statements. (:pr:`2282`)
+- Added and applied ``nbqa-ruff`` to our suite of |pre-commit| hooks
+  so that |ruff| can perform code quality checks on our example
+  notebooks.  (:pr:`2302`)
+- Renamed :file:`docs/cff_to_rst.py` to :file:`docs/_cff_to_rst.py`,
+  and updated the functionality contained within that file for
+  converting author information in :file:`CITATION.cff` into a
+  |reStructuredText| author list to be included in the
+  documentation. (:pr:`2307`)
 - Fixed broken hyperlinks and |reStructuredText| references. (:pr:`2308`)
 - Replaced :py:`from plasmapy.particles import *` in
-  :file:`docs/notebooks/getting_started/particles.ipynb` with imports of
-  the actual functions and classes that were used. (:pr:`2311`)
+  :file:`docs/notebooks/getting_started/particles.ipynb` with imports
+  of the actual functions and classes that were used. (:pr:`2311`)
 - Applied minor refactorings and formatting improvements to
   :file:`docs/notebooks/dispersion/stix_dispersion.ipynb`. (:pr:`2312`)
 - Updated the |coding guide| by discussing when to use aliases and
-  applied the ``:py:`` role so that in-line code gets formatted the same
-  as Python code blocks. (:pr:`2324`)
+  applied the ``:py:`` role so that in-line code gets formatted the
+  same as Python code blocks. (:pr:`2324`)
 - Updated the docstrings and type hint annotations in
   `plasmapy.formulary.lengths`. (:pr:`2356`)
 - Refactored :file:`docs/conf.py` to improve organization. (:pr:`2363`)
-- Updated the narrative documentation on particle objects to
-  include |CustomParticle|, |DimensionlessParticle|, and |ParticleList|
+- Updated the narrative documentation on particle objects to include
+  |CustomParticle|, |DimensionlessParticle|, and |ParticleList|
   objects. (:pr:`2377`)
 
 
@@ -116,37 +121,39 @@ Trivial/Internal Changes
 
 - Modernized :file:`MANIFEST.in`. (:pr:`2189`)
 - Applied automated refactorings from Sourcery. (:pr:`2219`)
-- Distributions defined in the `~plasmapy.formulary.distribution` module
-  will now raise a `ValueError` for an improper ``units`` parameter.
-  (:pr:`2229`)
+- Distributions defined in the `~plasmapy.formulary.distribution`
+  module will now raise a `ValueError` for an improper ``units``
+  parameter.  (:pr:`2229`)
 - Added "decorators" section to the |coding guide|. (:pr:`2231`)
 - Improved the error message issued by
-  `~plasmapy.formulary.speeds.Alfven_speed`
-  when the argument provided to ``density`` has a physical type of
-  number density and ``ion`` is not provided. (:pr:`2262`)
-- Exposed `plasmapy.dispersion.analytical` and `plasmapy.dispersion.numerical`
-  to the `plasmapy.dispersion` namespace. (:pr:`2271`)
+  `~plasmapy.formulary.speeds.Alfven_speed` when the argument provided
+  to ``density`` has a physical type of number density and ``ion`` is
+  not provided. (:pr:`2262`)
+- Exposed `plasmapy.dispersion.analytical` and
+  `plasmapy.dispersion.numerical` to the `plasmapy.dispersion`
+  namespace. (:pr:`2271`)
 - Expanded the |ruff| settings to include more linter rules. (:pr:`2295`)
 - Add |ruff| linter rules that check for `print` and :py:`pprint`, as
   the `logging` library is generally preferred for production code.
   (:pr:`2296`)
 - Updated and corrected author information in :file:`CITATION.cff`.
   (:pr:`2307`)
-- Reduced the number of warnings emitted by `plasmapy.particles` during
-  tests by decorating test functions with `pytest.mark.filterwarnings`.
-  (:pr:`2314`)
-- Fixed a `pytest` deprecation warning that had been issued
-  by ``plasmapy.utils._pytest_helpers/pytest_helpers.run_test``
-  so that `None` is no longer passed to the `pytest.warns` context
+- Reduced the number of warnings emitted by `plasmapy.particles`
+  during tests by decorating test functions with
+  `pytest.mark.filterwarnings`.  (:pr:`2314`)
+- Fixed a `pytest` deprecation warning that had been issued by
+  ``plasmapy.utils._pytest_helpers/pytest_helpers.run_test`` so that
+  `None` is no longer passed to the `pytest.warns` context
   manager. (:pr:`2314`)
-- Changed the default configuration for `pytest` so that if a test is marked
-  as expected to fail actually passes, then that test will issue an error
-  to indicate that the `pytest.mark.xfail` mark can be removed. (:pr:`2315`)
+- Changed the default configuration for `pytest` so that if a test is
+  marked as expected to fail actually passes, then that test will
+  issue an error to indicate that the `pytest.mark.xfail` mark can be
+  removed. (:pr:`2315`)
 - Added a weekly linkcheck test that verifies that hyperlinks in the
   documentation are up-to-date. (:pr:`2328`)
 - Enabled |validate_quantities| to accept annotations of the form
-  :py:`u.Quantity[u.m]`, where we have previously run :py:`import astropy.units
-  as u`. (:pr:`2346`)
+  :py:`u.Quantity[u.m]`, where we have previously run :py:`import
+  astropy.units as u`. (:pr:`2346`)
 - Both `~plasmapy.dispersion.dispersion_functions.plasma_dispersion_func`
   and `~plasmapy.dispersion.dispersion_functions.plasma_dispersion_func_deriv`
   now allow |inf| and |nan| arguments without raising a `ValueError`.

--- a/docs/changelog/2023.5.0.rst
+++ b/docs/changelog/2023.5.0.rst
@@ -5,86 +5,92 @@ Backwards Incompatible Changes
 ------------------------------
 
 - The signature of `~plasmapy.formulary.relativity.relativistic_energy`
-  has changed. The parameter ``m`` has been replaced with ``particle``,
-  which now accepts a broader variety of |particle-like| arguments,
-  including but not limited to a |Quantity| representing mass. The
-  parameter ``v`` has been replaced with ``V`` for consistency with other
-  functionality. (:pr:`1871`)
+  has changed. The parameter ``m`` has been replaced with
+  ``particle``, which now accepts a broader variety of |particle-like|
+  arguments, including but not limited to a |Quantity| representing
+  mass. The parameter ``v`` has been replaced with ``V`` for
+  consistency with other functionality. (:pr:`1871`)
 - Changed the minimum required version of Python from 3.8 to 3.9.
-  Accordingly, increased the minimum versions of ``numpy`` to ``1.21.0``,
-  ``pandas`` to
-  ``1.2.0``, ``h5py`` to ``3.1.0``, ``scipy`` to ``1.6.0``, ``voila`` to
-  ``0.3.0``, and ``xarray`` to ``0.17.0``. (:pr:`1885`)
+  Accordingly, increased the minimum versions of ``numpy`` to
+  ``1.21.0``, ``pandas`` to ``1.2.0``, ``h5py`` to ``3.1.0``,
+  ``scipy`` to ``1.6.0``, ``voila`` to ``0.3.0``, and ``xarray`` to
+  ``0.17.0``. (:pr:`1885`)
 - Made |ParticleList| raise a `TypeError` when provided with a string.
   This change was made to avoid potentially ambiguous situations like
   :py:`ParticleList("He")` which was previously equivalent to
-  :py:`ParticleList(["H", "e"])` instead of the possibly expected value of
-  :py:`ParticleList(["He"])`. (:pr:`1892`)
+  :py:`ParticleList(["H", "e"])` instead of the possibly expected
+  value of :py:`ParticleList(["He"])`. (:pr:`1892`)
 - In `~plasmapy.dispersion.analytical.two_fluid_.two_fluid`,
   `~plasmapy.dispersion.numerical.hollweg_.hollweg`, and
-  `~plasmapy.dispersion.numerical.kinetic_alfven_.kinetic_alfven`
-  in `plasmapy.dispersion`, providing the |charge number| as a keyword
-  argument (now ``Z``, formerly ``z_mean``) will no longer override the
-  charge number provided in ``ion``. (:pr:`2022`, :pr:`2181`, :pr:`2182`)
+  `~plasmapy.dispersion.numerical.kinetic_alfven_.kinetic_alfven` in
+  `plasmapy.dispersion`, providing the |charge number| as a keyword
+  argument (now ``Z``, formerly ``z_mean``) will no longer override
+  the charge number provided in ``ion``. (:pr:`2022`, :pr:`2181`,
+  :pr:`2182`)
 - |particle_input| no longer enforces that |parameters| named
   ``ionic_level`` are ions or neutral atoms. For equivalent behavior,
   name the parameter ``ion`` instead. (:pr:`2034`)
-- Removed ``plasmapy.utils.pytest_helpers`` from PlasmaPy's public API. It is
-  still available as ``plasmapy.utils._pytest_helpers``, but might be removed
-  in the future. (:pr:`2114`)
+- Removed ``plasmapy.utils.pytest_helpers`` from PlasmaPy's public
+  API. It is still available as ``plasmapy.utils._pytest_helpers``,
+  but might be removed in the future. (:pr:`2114`)
 - Removed ``plasmapy.tests.helpers`` from PlasmaPy's public API. It is
-  still available as ``plasmapy.tests._helpers``, but might be removed in
-  the future. (:pr:`2114`)
+  still available as ``plasmapy.tests._helpers``, but might be removed
+  in the future. (:pr:`2114`)
 - The ``ion_species`` |parameter| to
-  `~plasmapy.formulary.radiation.thermal_bremsstrahlung` has been renamed to
-  ``ion`` in order to provide a more consistent API to functions that accept
-  ions as arguments. (:pr:`2135`)
+  `~plasmapy.formulary.radiation.thermal_bremsstrahlung` has been
+  renamed to ``ion`` in order to provide a more consistent API to
+  functions that accept ions as arguments. (:pr:`2135`)
 
 
 Deprecations and Removals
 -------------------------
 
-- In `plasmapy.dispersion`, the ``z_mean`` parameter
-  to `~plasmapy.dispersion.analytical.two_fluid_.two_fluid`,
+- In `plasmapy.dispersion`, the ``z_mean`` parameter to
+  `~plasmapy.dispersion.analytical.two_fluid_.two_fluid`,
   `~plasmapy.dispersion.numerical.hollweg_.hollweg`, and
   `~plasmapy.dispersion.numerical.kinetic_alfven_.kinetic_alfven` has
   been deprecated. Provide the |charge number| to ``Z`` instead.
   (:pr:`2022`, :pr:`2181`, :pr:`2182`)
 - When a function decorated with |particle_input| is provided with
-  ``z_mean`` as a keyword |argument|, it will change ``z_mean`` to ``Z``
-  and issue a `~plasmapy.utils.exceptions.PlasmaPyDeprecationWarning` if
-  the decorated function accepts ``Z`` as a parameter. This capability
-  is intended to temporarily preserve the current behavior of several
-  functions in `plasmapy.dispersion` and `plasmapy.formulary` as they get
-  decorated with |particle_input| over the next few releases. (:pr:`2027`)
-- The ``z_mean`` parameter to `~plasmapy.formulary.speeds.ion_sound_speed`
-  and `~plasmapy.formulary.speeds.Alfven_speed` has been deprecated and
-  may be removed in a future release. Use ``Z`` instead. (:pr:`2134`, :pr:`2179`)
+  ``z_mean`` as a keyword |argument|, it will change ``z_mean`` to
+  ``Z`` and issue a
+  `~plasmapy.utils.exceptions.PlasmaPyDeprecationWarning` if the
+  decorated function accepts ``Z`` as a parameter. This capability is
+  intended to temporarily preserve the current behavior of several
+  functions in `plasmapy.dispersion` and `plasmapy.formulary` as they
+  get decorated with |particle_input| over the next few
+  releases. (:pr:`2027`)
+- The ``z_mean`` parameter to
+  `~plasmapy.formulary.speeds.ion_sound_speed` and
+  `~plasmapy.formulary.speeds.Alfven_speed` has been deprecated and
+  may be removed in a future release. Use ``Z`` instead. (:pr:`2134`,
+  :pr:`2179`)
 
 
 Features
 --------
 
-- Added `~plasmapy.dispersion.numerical.kinetic_alfven_.kinetic_alfven`,
-  which numerically solves dispersion relations for kinetic Alfvén waves.
-  (:pr:`1665`)
-- Added the :file:`stix_dispersion.ipynb` notebook
-  which contains Stix cold-plasma dispersion examples. (:pr:`1693`)
-- Added the `~plasmapy.formulary.frequencies.Buchsbaum_frequency` function.
-  (:pr:`1828`)
+- Added
+  `~plasmapy.dispersion.numerical.kinetic_alfven_.kinetic_alfven`,
+  which numerically solves dispersion relations for kinetic Alfvén
+  waves.  (:pr:`1665`)
+- Added the :file:`stix_dispersion.ipynb` notebook which contains Stix
+  cold-plasma dispersion examples. (:pr:`1693`)
+- Added the `~plasmapy.formulary.frequencies.Buchsbaum_frequency`
+  function.  (:pr:`1828`)
 - Decorated `~plasmapy.formulary.frequencies.gyrofrequency` with
   |particle_input| so that it can accept a broader variety of
   |particle-like| arguments. (:pr:`1869`)
 - After having been decorated with |particle_input|, the
   `~plasmapy.formulary.relativity.relativistic_energy` function now
-  accepts a broader variety of |particle-like| objects rather than only
-  |Quantity| objects representing mass. (:pr:`1871`)
+  accepts a broader variety of |particle-like| objects rather than
+  only |Quantity| objects representing mass. (:pr:`1871`)
 - After having been decorated with |particle_input|, |RelativisticBody|
   now accepts a broader variety of |particle-like| objects. (:pr:`1871`)
-- Enabled |particle_input| to accept values of the |charge number| that
-  are real numbers but not integers. This capability can now be used by
-  many of the functions in `plasmapy.formulary` and elsewhere that are
-  decorated with |particle_input|. (:pr:`1884`)
+- Enabled |particle_input| to accept values of the |charge number|
+  that are real numbers but not integers. This capability can now be
+  used by many of the functions in `plasmapy.formulary` and elsewhere
+  that are decorated with |particle_input|. (:pr:`1884`)
 - Decorated `~plasmapy.particles.atomic.reduced_mass` with
   |particle_input| so that it can now accept a broader variety of
   |particle-like| arguments. (:pr:`1921`)
@@ -96,9 +102,9 @@ Features
   (:pr:`1986`)
 - Enabled |ParticleList| to accept |Quantity| objects of physical type
   mass or electrical charge. (:pr:`1987`)
-- The following functions have been decorated with |particle_input| and
-  now accept a broader variety of |particle-like| arguments (see also
-  :issue:`341`):
+- The following functions have been decorated with |particle_input|
+  and now accept a broader variety of |particle-like| arguments (see
+  also :issue:`341`):
 
   - `~plasmapy.dispersion.analytical.two_fluid_.two_fluid` (:pr:`2022`)
   - `~plasmapy.formulary.frequencies.plasma_frequency` (:pr:`2026`)
@@ -108,24 +114,25 @@ Features
   - `~plasmapy.dispersion.numerical.hollweg_.hollweg` (:pr:`2181`)
   - `~plasmapy.dispersion.numerical.kinetic_alfven_.kinetic_alfven` (:pr:`2182`)
 
-- Refactored `~plasmapy.formulary.lengths.gyroradius` to reduce cognitive
-  complexity and increase readability. (:pr:`2031`)
+- Refactored `~plasmapy.formulary.lengths.gyroradius` to reduce
+  cognitive complexity and increase readability. (:pr:`2031`)
 - Added ``mass_numb`` and ``Z`` as parameters to functions decorated
-  with |particle_input| in `plasmapy.formulary.lengths`
-  and `plasmapy.formulary.distribution`. (:pr:`2140`)
+  with |particle_input| in `plasmapy.formulary.lengths` and
+  `plasmapy.formulary.distribution`. (:pr:`2140`)
 
 
 Bug Fixes
 ---------
 
 - When attempting to create a |Particle| object representing a proton,
-  calls like :py:`Particle("H", Z=1, mass_numb=1)` no longer incorrectly
-  issue a |ParticleWarning| for redundant particle information. (:pr:`1992`)
+  calls like :py:`Particle("H", Z=1, mass_numb=1)` no longer
+  incorrectly issue a |ParticleWarning| for redundant particle
+  information. (:pr:`1992`)
 - Updated the docstring of
   `~plasmapy.dispersion.numerical.kinetic_alfven_.kinetic_alfven`. (:pr:`2016`)
 - Fixed a slight error in `~plasmapy.formulary.frequencies.plasma_frequency`
-  and `~plasmapy.formulary.speeds.Alfven_speed` when the charge number was
-  provided via ``z_mean`` (or now ``Z``) and inconsistent with the
+  and `~plasmapy.formulary.speeds.Alfven_speed` when the charge number
+  was provided via ``z_mean`` (or now ``Z``) and inconsistent with the
   charge number provided to ``particle`` (or zero, if ``particle``
   represented an element or isotope with no charge
   information. Previously, if we represented a proton with
@@ -134,17 +141,20 @@ Bug Fixes
   hydrogen atom rather than the mass of a proton. However, using
   :py:`particle="p+"` would have produced the correct mass. This
   behavior has been corrected by decorating this function with
-  |particle_input|. See also :issue:`2178` and :pr:`2179`. (:pr:`2026`)
-- The ``plasmapy.analysis.nullpoint._vector_space`` function now returns a
-  list for its delta values instead of an array. (:pr:`2133`)
+  |particle_input|. See also :issue:`2178` and
+  :pr:`2179`. (:pr:`2026`)
+- The ``plasmapy.analysis.nullpoint._vector_space`` function now
+  returns a list for its delta values instead of an array.
+  (:pr:`2133`)
 
 
 Improved Documentation
 ----------------------
 
 - Enabled `sphinx-codeautolink
-  <https://sphinx-codeautolink.readthedocs.io/en/latest/>`_ to make code
-  examples clickable and give quick access to API documentation. (:pr:`1410`)
+  <https://sphinx-codeautolink.readthedocs.io/en/latest/>`_ to make
+  code examples clickable and give quick access to API
+  documentation. (:pr:`1410`)
 - Added an example notebook on ionization states in the solar wind.
   (:pr:`1513`)
 - Moved the location of the changelog pages for past releases from
@@ -153,11 +163,11 @@ Improved Documentation
 - Removed outdated instructions on installing the development version
   of PlasmaPy contained in :file:`docs/contributing/install_dev.rst`.
   (:pr:`1656`)
-- Converted :file:`docs/CONTRIBUTING.rst` to :file:`.github/contributing.md`.
-  (:pr:`1656`)
+- Converted :file:`docs/CONTRIBUTING.rst` to
+  :file:`.github/contributing.md`.  (:pr:`1656`)
 - Added a new page to the |contributor guide| on the
-  |code contribution workflow|, replacing content previously contained in
-  the |coding guide|. (:pr:`1656`)
+  |code contribution workflow|, replacing content previously contained
+  in the |coding guide|. (:pr:`1656`)
 - Added a page to the |contributor guide| on |getting ready to contribute|.
   (:pr:`1656`)
 - Updated docstrings in `plasmapy.formulary.collisions.frequencies`.
@@ -165,10 +175,11 @@ Improved Documentation
 - Updated the docstring for |particle_input|. (:pr:`1883`)
 - Updated the introductory paragraphs to the |contributor guide|. (:pr:`2014`)
 - Moved PlasmaPy's `vision statement
-  <https://doi.org/10.5281/zenodo.7734998>`__
-  from the online documentation to a Zenodo record. (:pr:`2017`)
-- Restructured the |documentation guide| by putting information on writing
-  documentation prior to instructions for building documentation. (:pr:`2038`)
+  <https://doi.org/10.5281/zenodo.7734998>`__ from the online
+  documentation to a Zenodo record. (:pr:`2017`)
+- Restructured the |documentation guide| by putting information on
+  writing documentation prior to instructions for building
+  documentation. (:pr:`2038`)
 - Restructured the |testing guide| by putting information on writing
   tests prior to instructions for running tests. (:pr:`2041`)
 - Updated the introduction on the documentation landing page and the
@@ -176,46 +187,48 @@ Improved Documentation
 - Updated the |changelog guide|. (:pr:`2059`)
 - Added admonitions for functionality that is under development and for
   which backwards incompatible changes might occur in the future. (:pr:`2112`)
-- Updated the code contribution workflow instructions in the |contributor
-  guide|
-  to reflect that first-time contributors should add themselves to the author
-  list in :file:`CITATION.cff` instead of in ``docs/about/credits.rst``. (:pr:`2155`)
-- Added functionality to automatically generate the author list included
-  in ``docs/about/credits.rst`` directly from :file:`CITATION.cff`. The script
-  is located at :file:`docs/cff_to_rst.py`. (:pr:`2156`)
+- Updated the code contribution workflow instructions in the
+  |contributor guide| to reflect that first-time contributors should
+  add themselves to the author list in :file:`CITATION.cff` instead of
+  in ``docs/about/credits.rst``. (:pr:`2155`)
+- Added functionality to automatically generate the author list
+  included in ``docs/about/credits.rst`` directly from
+  :file:`CITATION.cff`. The script is located at
+  :file:`docs/cff_to_rst.py`. (:pr:`2156`)
 
 
 Trivial/Internal Changes
 ------------------------
 
 - Included Python 3.11 in continuous integration tests. (:pr:`1775`)
-- Turned the root-level :file:`requirements.txt` into a lockfile for continuous
-  integration purposes. (:pr:`1864`)
+- Turned the root-level :file:`requirements.txt` into a lockfile for
+  continuous integration purposes. (:pr:`1864`)
 - Enabled the particle creation factory in
   ``plasmapy.particles._factory`` used by |particle_input| to create
-  |CustomParticle| instances of an element or isotope with a
-  |charge number| that is a real number but not an integer. (:pr:`1884`)
+  |CustomParticle| instances of an element or isotope with a |charge
+  number| that is a real number but not an integer. (:pr:`1884`)
 - Implemented the new private |CustomParticle| constructor from
   :pr:`1881` into the private particle creation factory used by
   |particle_input|. (:pr:`1884`)
 - Dropped ``dlint`` from the tests requirements, as it is no longer
   being maintained. (:pr:`1906`)
-- Modified |particle_input| to allow |CustomParticle|\ -like objects with
-  a defined charge to be passed through to decorated functions when a
-  |parameter| to that function annotated with |ParticleLike| is named
-  ``ion``. Previously, only |Particle| objects representing ions or
-  neutral atoms were allowed to pass through when the parameter was named
-  ``ion``. (:pr:`2034`)
+- Modified |particle_input| to allow |CustomParticle|\ -like objects
+  with a defined charge to be passed through to decorated functions
+  when a |parameter| to that function annotated with |ParticleLike| is
+  named ``ion``. Previously, only |Particle| objects representing ions
+  or neutral atoms were allowed to pass through when the parameter was
+  named ``ion``. (:pr:`2034`)
 - Updated package metadata in :file:`pyproject.toml`. (:pr:`2075`)
 - Set minimum versions for all explicitly listed dependencies. (:pr:`2075`)
 - Enabled and applied changes for additional rule sets for |ruff|, and
   removed corresponding ``flake8`` extensions. (:pr:`2080`)
-- Changed from ``indexserver`` to ``PIP_INDEX_URL`` to index nightly `numpy`
-  builds (:pr:`2138`)
+- Changed from ``indexserver`` to ``PIP_INDEX_URL`` to index nightly
+  `numpy` builds (:pr:`2138`)
 - Updated the function and docstring of
   `~plasmapy.formulary.collisions.helio.collisional_analysis`. (:pr:`2151`)
-- Dropped ``flake8`` and its extensions as linters. Instead, |ruff| is now used as
-  the primary linter. (:pr:`2170`)
-- Expanded the variety of arguments that could be provided to a function
-  decorated by `~plasmapy.utils.decorators.converter.angular_freq_to_hz`,
-  and refactored this decorator to use ``wrapt``. (:pr:`2175`)
+- Dropped ``flake8`` and its extensions as linters. Instead, |ruff| is
+  now used as the primary linter. (:pr:`2170`)
+- Expanded the variety of arguments that could be provided to a
+  function decorated by
+  `~plasmapy.utils.decorators.converter.angular_freq_to_hz`, and
+  refactored this decorator to use ``wrapt``. (:pr:`2175`)

--- a/docs/changelog/2024.2.0.rst
+++ b/docs/changelog/2024.2.0.rst
@@ -69,7 +69,7 @@ Trivial/Internal Changes
   (:pr:`2402`)
 - Added an initial configuration for |mypy| that temporarily ignores existing
   errors. (:pr:`2424`)
-- Added a |tox| environment for running |mypy|. (:pr:`2431`)
+- Added a tox environment for running |mypy|. (:pr:`2431`)
 - Added |mypy| to the suite of continuous integration checks. (:pr:`2432`)
 - Used ``autotyping`` to implement |type hint annotations| for special
   methods like ``__init__`` and ``__str__``, and changed ``-> typing.NoReturn``

--- a/docs/changelog/2024.2.0.rst
+++ b/docs/changelog/2024.2.0.rst
@@ -8,9 +8,9 @@ Backwards Incompatible Changes
   object for general particle pushing simulations involving
   electromagnetic fields. The tracker replaces the old
   ``~plasmapy.simulation.particletracker.ParticleTracker``. (:pr:`2245`)
-- Imports of classes and functions from `plasmapy.utils` must now be made
-  directly from the subpackages and modules, rather than from `plasmapy.utils`
-  itself. (:pr:`2403`)
+- Imports of classes and functions from `plasmapy.utils` must now be
+  made directly from the subpackages and modules, rather than from
+  `plasmapy.utils` itself. (:pr:`2403`)
 - Moved ``mass_density`` and its alias ``rho_`` from `plasmapy.formulary.misc`
   to `plasmapy.formulary.densities`. (:pr:`2410`)
 
@@ -19,31 +19,30 @@ Features
 --------
 
 - Added a ``notch`` argument to
-  `~plasmapy.diagnostics.thomson.spectral_density`,
-  which allows users to output spectrum over one or multiple wavelength
-  ranges to correspond to a notch filter commonly applied to experimentally
+  `~plasmapy.diagnostics.thomson.spectral_density`, which allows users
+  to output spectrum over one or multiple wavelength ranges to
+  correspond to a notch filter commonly applied to experimentally
   measured Thomson scattering spectra. Changed the
-  `~plasmapy.diagnostics.thomson.spectral_density_model` function to allow
-  ``notch`` to be applied during fitting. (:pr:`2058`)
-- Changed unit annotations to |Quantity| type hint annotations. (:pr:`2421`)
+  `~plasmapy.diagnostics.thomson.spectral_density_model` function to
+  allow ``notch`` to be applied during fitting. (:pr:`2058`)
+- Changed unit annotations to |Quantity| type hint
+  annotations. (:pr:`2421`)
 - Enabled |particle_input| to decorate functions which have variadic
-  positional arguments followed by keyword arguments. See :issue:`2150`.
-  (:pr:`2428`)
-- Added a ``random_seed`` keyword in
-  the
+  positional arguments followed by keyword arguments. See
+  :issue:`2150`.  (:pr:`2428`)
+- Added a ``random_seed`` keyword in the
   `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker.create_particles`
   method of the
   `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker`
-  class
-  to make the function deterministic to resolve intermittent test failures.
-  (:pr:`2487`)
+  class to make the function deterministic to resolve intermittent
+  test failures.  (:pr:`2487`)
 
 
 Bug Fixes
 ---------
 
-- Enabled |particle_input| to be compatible with postponed evaluation of
-  annotations (see :pep:`563`). (:pr:`2479`)
+- Enabled |particle_input| to be compatible with postponed evaluation
+  of annotations (see :pep:`563`). (:pr:`2479`)
 
 
 Improved Documentation
@@ -58,37 +57,41 @@ Improved Documentation
 Trivial/Internal Changes
 ------------------------
 
-- Added Python 3.12 to the suite of continuous integration tests. (:pr:`2368`)
+- Added Python 3.12 to the suite of continuous integration
+  tests. (:pr:`2368`)
 - Added a GitHub Action that will create an issue containing a release
   checklist, which will largely supersede the release process outlined
   in the |contributor guide|. (:pr:`2376`)
 - Separated the GitHub Action for checking hyperlinks in the
   documentation into its own GitHub Action. (:pr:`2392`)
-- Replaced |black| with |ruff| in the |pre-commit| configuration. (:pr:`2394`)
-- Modified the ``__exit__`` method of ``HDF5Reader`` for context management.
-  (:pr:`2402`)
-- Added an initial configuration for |mypy| that temporarily ignores existing
-  errors. (:pr:`2424`)
+- Replaced |black| with |ruff| in the |pre-commit|
+  configuration. (:pr:`2394`)
+- Modified the ``__exit__`` method of ``HDF5Reader`` for context
+  management.  (:pr:`2402`)
+- Added an initial configuration for |mypy| that temporarily ignores
+  existing errors. (:pr:`2424`)
 - Added a tox environment for running |mypy|. (:pr:`2431`)
-- Added |mypy| to the suite of continuous integration checks. (:pr:`2432`)
+- Added |mypy| to the suite of continuous integration
+  checks. (:pr:`2432`)
 - Used ``autotyping`` to implement |type hint annotations| for special
-  methods like ``__init__`` and ``__str__``, and changed ``-> typing.NoReturn``
-  annotations to ``-> None``. (:pr:`2437`)
-- Used ``autotyping`` to add :py:`-> None` return annotations to functions
-  and methods with no :py:`return` statement. (:pr:`2439`)
+  methods like ``__init__`` and ``__str__``, and changed ``->
+  typing.NoReturn`` annotations to ``-> None``. (:pr:`2437`)
+- Used ``autotyping`` to add :py:`-> None` return annotations to
+  functions and methods with no :py:`return` statement. (:pr:`2439`)
 - Added a stub file containing |type hint annotations| for
   ``@wrapt.decorator``. (:pr:`2442`)
-- Improved |type hint annotations| for `plasmapy.particles.decorators`,
-  which includes |particle_input|, and the corresponding tests. (:pr:`2443`)
-- Dropped the |pre-commit| hook for ``isort`` and enabled all ``isort``
-  rules in |ruff|. (:pr:`2453`)
+- Improved |type hint annotations| for
+  `plasmapy.particles.decorators`, which includes |particle_input|,
+  and the corresponding tests. (:pr:`2443`)
+- Dropped the |pre-commit| hook for ``isort`` and enabled all
+  ``isort`` rules in |ruff|. (:pr:`2453`)
 - Added a :file:`py.typed` marker to indicate that PlasmaPy contains
   type hint annotations as per :pep:`561`. (:pr:`2473`)
-- Changed ``_nearest_neighbor_interpolator`` method in `~plasmapy.plasma.grids`
-  to interpolate quantities array instead of producing an intermediate index.
-  (:pr:`2475`)
-- Enabled the ``sphinx`` linkchecker in quiet mode to make it easier to find
-  problem links from the console output. (:pr:`2476`)
+- Changed ``_nearest_neighbor_interpolator`` method in
+  `~plasmapy.plasma.grids` to interpolate quantities array instead of
+  producing an intermediate index.  (:pr:`2475`)
+- Enabled the ``sphinx`` linkchecker in quiet mode to make it easier
+  to find problem links from the console output. (:pr:`2476`)
 - Bumped the minimum versions of dependencies to drop support for
   minor releases older than two years old. In particular, the minimum
   version of NumPy was bumped to ``1.23.0``. (:pr:`2488`)

--- a/docs/changelog/2024.2.0.rst
+++ b/docs/changelog/2024.2.0.rst
@@ -4,10 +4,10 @@ PlasmaPy v2024.2.0 (2024-02-06)
 Backwards Incompatible Changes
 ------------------------------
 
-- Created new ``~plasmapy.simulation.particle_tracker.ParticleTracker``
+- Created new ``plasmapy.simulation.particle_tracker.ParticleTracker``
   object for general particle pushing simulations involving
   electromagnetic fields. The tracker replaces the old
-  ``~plasmapy.simulation.particletracker.ParticleTracker``. (:pr:`2245`)
+  ``plasmapy.simulation.particletracker.ParticleTracker``. (:pr:`2245`)
 - Imports of classes and functions from `plasmapy.utils` must now be
   made directly from the subpackages and modules, rather than from
   `plasmapy.utils` itself. (:pr:`2403`)
@@ -28,8 +28,8 @@ Features
 - Changed unit annotations to |Quantity| type hint
   annotations. (:pr:`2421`)
 - Enabled |particle_input| to decorate functions which have variadic
-  positional arguments followed by keyword arguments. See
-  :issue:`2150`.  (:pr:`2428`)
+  positional arguments followed by keyword arguments. (:pr:`2428`; see
+  also :issue:`2150`)
 - Added a ``random_seed`` keyword in the
   `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker.create_particles`
   method of the
@@ -74,8 +74,8 @@ Trivial/Internal Changes
 - Added |mypy| to the suite of continuous integration
   checks. (:pr:`2432`)
 - Used ``autotyping`` to implement |type hint annotations| for special
-  methods like ``__init__`` and ``__str__``, and changed ``->
-  typing.NoReturn`` annotations to ``-> None``. (:pr:`2437`)
+  methods like ``__init__`` and ``__str__``, and changed
+  :py:`-> typing.NoReturn` annotations to :py:`-> None`. (:pr:`2437`)
 - Used ``autotyping`` to add :py:`-> None` return annotations to
   functions and methods with no :py:`return` statement. (:pr:`2439`)
 - Added a stub file containing |type hint annotations| for
@@ -85,8 +85,8 @@ Trivial/Internal Changes
   and the corresponding tests. (:pr:`2443`)
 - Dropped the |pre-commit| hook for ``isort`` and enabled all
   ``isort`` rules in |ruff|. (:pr:`2453`)
-- Added a :file:`py.typed` marker to indicate that PlasmaPy contains
-  type hint annotations as per :pep:`561`. (:pr:`2473`)
+- Added a :file:`py.typed` marker file to indicate that PlasmaPy
+  contains type hint annotations as per :pep:`561`. (:pr:`2473`)
 - Changed ``_nearest_neighbor_interpolator`` method in
   `~plasmapy.plasma.grids` to interpolate quantities array instead of
   producing an intermediate index.  (:pr:`2475`)

--- a/docs/changelog/2024.5.0.rst
+++ b/docs/changelog/2024.5.0.rst
@@ -36,10 +36,10 @@ Documentation Improvements
 - Fix typo in description of `~plasmapy.formulary.densities.mass_density`.
   (:pr:`2588`)
 - Updated the |testing guide| to reflect recent performance improvements with
-  |tox|
+  tox
   via the ``tox-uv`` extension, and the |documentation guide| to reflect that
   the
-  documentation is now built with |Nox| instead of |tox| (:pr:`2590`)
+  documentation is now built with |Nox| instead of tox (:pr:`2590`)
 - Add examples to the docstring for
   `~plasmapy.formulary.radiation.thermal_bremsstrahlung`. (:pr:`2618`)
 - Update the dependency version support policy in the |coding guide|.
@@ -90,7 +90,7 @@ Internal Changes and Refactorings
 - Changed type hint annotations that used `numbers.Integral`, `numbers.Real`,
   or `numbers.Complex` to instead use `int`, `float`, or `complex`,
   respectively. (:pr:`2520`)
-- Created a |tox| environment for regenerating requirements files used
+- Created a tox environment for regenerating requirements files used
   in continuous integration (CI) and by integrated development environments
   (IDEs). This environment is now what is being used in the automated pull
   requests to regenerate requirements files. Switching from ``pip-compile``
@@ -105,7 +105,7 @@ Internal Changes and Refactorings
 - Applied caching through |GitHub Actions| to speed up continuous
   integration tests and documentation builds. Because the Python environments
   used
-  by |tox| to run tests no longer need to be recreated every time tests are
+  by tox to run tests no longer need to be recreated every time tests are
   run,
   caching speeds up several continuous integration tests by ∼2–3 minutes.
   See :issue:`2585` to learn more about recent efforts to drastically
@@ -113,7 +113,7 @@ Internal Changes and Refactorings
 - Removed :file:`setup.py`. (:pr:`2558`)
 - Added ``sphinx-lint`` as a |pre-commit| hook to find
   reStructuredText errors. (:pr:`2561`)
-- Enabled the `tox-uv <https://github.com/tox-dev/tox-uv>`_ plugin to |tox|,
+- Enabled the `tox-uv <https://github.com/tox-dev/tox-uv>`_ plugin to tox,
   so that package installation, caching, and the creation of virtual
   environments will
   be handled by |uv| instead of |pip|. This change makes it faster to run
@@ -160,7 +160,7 @@ Additional Changes
   field components, since one of these is often not explicitly provided.
   (:pr:`2519`)
 - Removed |pytest| as a runtime dependency. (:pr:`2525`)
-- Removed the unused ``py310-conda`` |tox| environment. (:pr:`2526`)
+- Removed the unused ``py310-conda`` tox environment. (:pr:`2526`)
 - Exposed `~plasmapy.formulary.dielectric.StixTensorElements`
   and `~plasmapy.formulary.dielectric.RotatingTensorElements`
   to the public API. (:pr:`2543`)

--- a/docs/changelog/2024.5.0.rst
+++ b/docs/changelog/2024.5.0.rst
@@ -4,42 +4,41 @@ PlasmaPy v2024.5.0 (2024-05-08)
 New Features
 ------------
 
-- Added the `~plasmapy.particles.particle_class.Particle.nucleus` attribute of
-  |Particle|. (:pr:`2538`)
-- Replaced ``plasmapy.utils.data.downloader.get_file`` with a
-  new class `~plasmapy.utils.data.downloader.Downloader` with a
-  method `~plasmapy.utils.data.downloader.Downloader.get_file` which
-  downloads resource files from |PlasmaPy's data repository|. (:pr:`2570`)
-- Added support for new ``background``, ``ion_mu`` and ``ion_z`` fitting
-  parameters to the `~plasmapy.diagnostics.thomson.spectral_density_model`
+- Added the `~plasmapy.particles.particle_class.Particle.nucleus`
+  attribute of |Particle|. (:pr:`2538`)
+- Replaced ``plasmapy.utils.data.downloader.get_file`` with a new
+  class `~plasmapy.utils.data.downloader.Downloader` with a method
+  `~plasmapy.utils.data.downloader.Downloader.get_file` which
+  downloads resource files from |PlasmaPy's data
+  repository|. (:pr:`2570`)
+- Added support for new ``background``, ``ion_mu`` and ``ion_z``
+  fitting parameters to the
+  `~plasmapy.diagnostics.thomson.spectral_density_model`
   function. (:pr:`2636`)
 
 
 Documentation Improvements
 --------------------------
 
-- Added the ``internal`` category for changelog entries, which will be used to
-  denote
-  refactorings with minimal impact on the API, and updated the |changelog
-  guide| to
-  reflect these changes. (:pr:`2441`)
+- Added the ``internal`` category for changelog entries, which will be
+  used to denote refactorings with minimal impact on the API, and
+  updated the |changelog guide| to reflect these changes. (:pr:`2441`)
 - Updated the docstring of |particle_input| to indicate that annotations
   for optional parameters should now be :py:`ParticleLike | None` or
   :py:`ParticleListLike | None`. (:pr:`2505`)
 - Added known limitations of |particle_input| to its docstring. (:pr:`2516`)
-- Removed references to PlasmaPy's Twitter account, which is no longer used.
-  (:pr:`2522`)
-- Updated the docstring for `~plasmapy.formulary.lengths.gyroradius` to finish
-  an unfinished sentence. (:pr:`2560`)
-- Updated the instructions in the |documentation guide| on how to build
-  PlasmaPy's documentation locally. (:pr:`2565`)
-- Fix typo in description of `~plasmapy.formulary.densities.mass_density`.
-  (:pr:`2588`)
-- Updated the |testing guide| to reflect recent performance improvements with
-  tox
-  via the ``tox-uv`` extension, and the |documentation guide| to reflect that
-  the
-  documentation is now built with |Nox| instead of tox (:pr:`2590`)
+- Removed references to PlasmaPy's Twitter account, which is no longer
+  used.  (:pr:`2522`)
+- Updated the docstring for `~plasmapy.formulary.lengths.gyroradius`
+  to finish an unfinished sentence. (:pr:`2560`)
+- Updated the instructions in the |documentation guide| on how to
+  build PlasmaPy's documentation locally. (:pr:`2565`)
+- Fix typo in description of
+  `~plasmapy.formulary.densities.mass_density`.  (:pr:`2588`)
+- Updated the |testing guide| to reflect recent performance
+  improvements with tox via the ``tox-uv`` extension, and the
+  |documentation guide| to reflect that the documentation is now built
+  with |Nox| instead of tox (:pr:`2590`)
 - Add examples to the docstring for
   `~plasmapy.formulary.radiation.thermal_bremsstrahlung`. (:pr:`2618`)
 - Update the dependency version support policy in the |coding guide|.
@@ -49,100 +48,100 @@ Documentation Improvements
 Backwards Incompatible Changes
 ------------------------------
 
-- Changed the minimum required version of Python from 3.9 to 3.10. (:pr:`2501`)
+- Changed the minimum required version of Python from 3.9 to
+  3.10. (:pr:`2501`)
 - Modified `~plasmapy.particles.atomic.common_isotopes`,
-  `~plasmapy.particles.atomic.known_isotopes`,
-  and `~plasmapy.particles.atomic.known_isotopes` to each return a
+  `~plasmapy.particles.atomic.known_isotopes`, and
+  `~plasmapy.particles.atomic.known_isotopes` to each return a
   |ParticleList|. (:pr:`2559`)
 - Added a new keyword ``particlewise`` to the method
-  `~plasmapy.particles.particle_collections.ParticleList.is_category` of
-  |ParticleList|,
-  which now causes the function to return a `bool` for the whole list by
-  default.  The old functionality is still available
-  by setting ``particlewise`` to `True`. (:pr:`2648`)
+  `~plasmapy.particles.particle_collections.ParticleList.is_category`
+  of |ParticleList|, which now causes the function to return a `bool`
+  for the whole list by default.  The old functionality is still
+  available by setting ``particlewise`` to `True`. (:pr:`2648`)
 
 
 Bug Fixes
 ---------
 
-- Fixed an error when :py:`lorentzfactor` and multiple particles are provided
-  to `~plasmapy.formulary.lengths.gyroradius`. (:pr:`2542`)
+- Fixed an error when :py:`lorentzfactor` and multiple particles are
+  provided to `~plasmapy.formulary.lengths.gyroradius`. (:pr:`2542`)
 - Required UTF-8 encoding to be used for generating citation output.
   (:pr:`2578`)
-- Fixed a bug in |particle_input| where particle categorization criteria
-  had not been applied to arguments that became a |ParticleList|. (:pr:`2594`)
-- Made `~plasmapy.diagnostics.thomson.spectral_density_model` compatible with
-  the
-  new version of ``lmfit==1.3.0``. (:pr:`2623`)
-- Fixed a bug when `~plasmapy.formulary.radiation.thermal_bremsstrahlung`
-  is given multiple input density values. (:pr:`2627`)
-- Fixed the requirements file used by binder to open notebooks. (:pr:`2672`)
+- Fixed a bug in |particle_input| where particle categorization
+  criteria had not been applied to arguments that became a
+  |ParticleList|. (:pr:`2594`)
+- Made `~plasmapy.diagnostics.thomson.spectral_density_model`
+  compatible with the new version of ``lmfit==1.3.0``. (:pr:`2623`)
+- Fixed a bug when
+  `~plasmapy.formulary.radiation.thermal_bremsstrahlung` is given
+  multiple input density values. (:pr:`2627`)
+- Fixed the requirements file used by binder to open
+  notebooks. (:pr:`2672`)
 
 
 Internal Changes and Refactorings
 ---------------------------------
 
-- Changed type hint annotations to be consistent with :pep:`604`. Most type
-  unions are now made using the ``|`` operator rather than with
+- Changed type hint annotations to be consistent with :pep:`604`. Most
+  type unions are now made using the ``|`` operator rather than with
   `typing.Union`. (:pr:`2504`)
-- Refactored, parametrized, and expanded the tests
-  for `~plasmapy.formulary.lengths.Debye_length`. (:pr:`2509`)
-- Changed type hint annotations that used `numbers.Integral`, `numbers.Real`,
-  or `numbers.Complex` to instead use `int`, `float`, or `complex`,
-  respectively. (:pr:`2520`)
+- Refactored, parametrized, and expanded the tests for
+  `~plasmapy.formulary.lengths.Debye_length`. (:pr:`2509`)
+- Changed type hint annotations that used `numbers.Integral`,
+  `numbers.Real`, or `numbers.Complex` to instead use `int`, `float`,
+  or `complex`, respectively. (:pr:`2520`)
 - Created a tox environment for regenerating requirements files used
-  in continuous integration (CI) and by integrated development environments
-  (IDEs). This environment is now what is being used in the automated pull
-  requests to regenerate requirements files. Switching from ``pip-compile``
-  to ``uv pip compile`` now allows requirements files to be created for
-  multiple
-  versions of Python, as well as for minimal versions of dependencies.
+  in continuous integration (CI) and by integrated development
+  environments (IDEs). This environment is now what is being used in
+  the automated pull requests to regenerate requirements
+  files. Switching from ``pip-compile`` to ``uv pip compile`` now
+  allows requirements files to be created for multiple versions of
+  Python, as well as for minimal versions of dependencies.
   (:pr:`2523`)
-- Reduced the :wikipedia:`cognitive complexity`
-  of `~plasmapy.formulary.lengths.gyroradius`. (:pr:`2542`)
+- Reduced the :wikipedia:`cognitive complexity` of
+  `~plasmapy.formulary.lengths.gyroradius`. (:pr:`2542`)
 - Added and updated type hint annotations within `plasmapy.formulary`.
   (:pr:`2543`)
 - Applied caching through |GitHub Actions| to speed up continuous
-  integration tests and documentation builds. Because the Python environments
-  used
-  by tox to run tests no longer need to be recreated every time tests are
-  run,
-  caching speeds up several continuous integration tests by ∼2–3 minutes.
-  See :issue:`2585` to learn more about recent efforts to drastically
-  speed up PlasmaPy's continuous integraiton checks. (:pr:`2552`)
+  integration tests and documentation builds. Because the Python
+  environments used by tox to run tests no longer need to be recreated
+  every time tests are run, caching speeds up several continuous
+  integration tests by ∼2–3 minutes.  See :issue:`2585` to learn more
+  about recent efforts to drastically speed up PlasmaPy's continuous
+  integraiton checks. (:pr:`2552`)
 - Removed :file:`setup.py`. (:pr:`2558`)
 - Added ``sphinx-lint`` as a |pre-commit| hook to find
   reStructuredText errors. (:pr:`2561`)
-- Enabled the `tox-uv <https://github.com/tox-dev/tox-uv>`_ plugin to tox,
-  so that package installation, caching, and the creation of virtual
-  environments will
-  be handled by |uv| instead of |pip|. This change makes it faster to run
-  tests both locally and via |GitHub Actions|. (:pr:`2584`)
+- Enabled the `tox-uv <https://github.com/tox-dev/tox-uv>`_ plugin to
+  tox, so that package installation, caching, and the creation of
+  virtual environments will be handled by |uv| instead of |pip|. This
+  change makes it faster to run tests both locally and via |GitHub
+  Actions|. (:pr:`2584`)
 - Changed the project structure to an `src
   layout
   <https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/>`__
   to follow the updated recommendation from the Python Packaging
   Authority's `packaging guide <https://packaging.python.org/>`__. The
-  motivation for this change is described in :issue:`2581`. Source code
-  previously in :file:`plasmapy/` is now located in |src/plasmapy/| and
-  tests are now in a separate |tests/| directory. Tests previously in
-  :file:`plasmapy/**/tests/` are now in :file:`tests/**/`, where
-  :file:`**` refers to an arbitrary number of subdirectories. For example,
-  the source code of `plasmapy.formulary` is now located in
-  :file:`src/plasmapy/formulary/` and the tests for `plasmapy.formulary`
-  are now in :file:`tests/formulary/`. (:pr:`2598`)
-- Reconfigured the auto-generated requirements files used during continuous
-  integration
-  and for documentation builds, while adding corresponding documentation.
-  (:pr:`2650`)
-- Added :file:`noxfile.py` as a configuration file for |Nox|. This file
-  initially contains
-  environments for building documentation, checking hyperlinks, and performing
-  static
-  type checking with |mypy| (:pr:`2654`)
+  motivation for this change is described in :issue:`2581`. Source
+  code previously in :file:`plasmapy/` is now located in
+  |src/plasmapy/| and tests are now in a separate |tests/|
+  directory. Tests previously in :file:`plasmapy/**/tests/` are now in
+  :file:`tests/**/`, where :file:`**` refers to an arbitrary number of
+  subdirectories. For example, the source code of `plasmapy.formulary`
+  is now located in :file:`src/plasmapy/formulary/` and the tests for
+  `plasmapy.formulary` are now in
+  :file:`tests/formulary/`. (:pr:`2598`)
+- Reconfigured the auto-generated requirements files used during
+  continuous integration and for documentation builds, while adding
+  corresponding documentation.  (:pr:`2650`)
+- Added :file:`noxfile.py` as a configuration file for |Nox|. This
+  file initially contains environments for building documentation,
+  checking hyperlinks, and performing static type checking with |mypy|
+  (:pr:`2654`)
 - Began using |Nox| for some testing environments in |GitHub Actions|,
-  including for the
-  documentation build and static type checking. (:pr:`2656`)
+  including for the documentation build and static type
+  checking. (:pr:`2656`)
 
 
 Additional Changes
@@ -153,18 +152,17 @@ Additional Changes
   defined in :file:`pyproject.toml`, and applied it to a test that
   experiences intermittent failures. (:pr:`2483`)
 - Added a flag to `~plasmapy.plasma.grids.AbstractGrid.require_quantities`
-  to silence warnings when a quantity is not provided and is assumed to be
-  zero everywhere. Modified
-  ``plasmapy.simulation.particle_tracker.ParticleTracker`` to
-  not display this warning for the :math:`\mathbf{E}` and :math:`\mathbf{B}`
-  field components, since one of these is often not explicitly provided.
-  (:pr:`2519`)
+  to silence warnings when a quantity is not provided and is assumed
+  to be zero everywhere. Modified
+  ``plasmapy.simulation.particle_tracker.ParticleTracker`` to not
+  display this warning for the :math:`\mathbf{E}` and
+  :math:`\mathbf{B}` field components, since one of these is often not
+  explicitly provided.  (:pr:`2519`)
 - Removed |pytest| as a runtime dependency. (:pr:`2525`)
 - Removed the unused ``py310-conda`` tox environment. (:pr:`2526`)
-- Exposed `~plasmapy.formulary.dielectric.StixTensorElements`
-  and `~plasmapy.formulary.dielectric.RotatingTensorElements`
-  to the public API. (:pr:`2543`)
-- Added tests to verify correctness of two properties
-  in
+- Exposed `~plasmapy.formulary.dielectric.StixTensorElements` and
+  `~plasmapy.formulary.dielectric.RotatingTensorElements` to the
+  public API. (:pr:`2543`)
+- Added tests to verify correctness of two properties in
   `~plasmapy.formulary.collisions.frequencies.MaxwellianCollisionFrequencies`.
   (:pr:`2614`)

--- a/docs/changelog/2024.5.0.rst
+++ b/docs/changelog/2024.5.0.rst
@@ -33,15 +33,15 @@ Documentation Improvements
   to finish an unfinished sentence. (:pr:`2560`)
 - Updated the instructions in the |documentation guide| on how to
   build PlasmaPy's documentation locally. (:pr:`2565`)
-- Fix typo in description of
+- Fixed a typo in description of
   `~plasmapy.formulary.densities.mass_density`.  (:pr:`2588`)
 - Updated the |testing guide| to reflect recent performance
   improvements with tox via the ``tox-uv`` extension, and the
   |documentation guide| to reflect that the documentation is now built
   with |Nox| instead of tox (:pr:`2590`)
-- Add examples to the docstring for
+- Added examples to the docstring for
   `~plasmapy.formulary.radiation.thermal_bremsstrahlung`. (:pr:`2618`)
-- Update the dependency version support policy in the |coding guide|.
+- Updated the dependency version support policy in the |coding guide|.
   (:pr:`2670`)
 
 

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -42,11 +42,6 @@ PlasmaPy and run:
 This command will invoke `pytest` to run PlasmaPy's tests, excluding the
 tests marked as slow.
 
-.. important::
-
-   PlasmaPy is in the process of switching its test runner from |tox| to
-   |Nox|. |tox| is still used for defining weekly tests.
-
 Writing tests
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,6 @@ docs = [
   "sphinxcontrib-bibtex >= 2.6.2",
   "sphinxcontrib-globalsubs >= 0.1.1",
   "towncrier >= 23.11.0",
-  "tox >= 4.12.1",
-  "tox-uv >= 1.7.0",
   "unidecode >= 1.3.8",
 ]
 
@@ -122,8 +120,6 @@ tests = [
   "pytest-rerunfailures >= 13.0",
   "pytest-xdist >= 3.5.0",
   "tomli >= 2.0.1",
-  "tox >= 4.12.1",
-  "tox-uv >= 1.7.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
We recently completed our switch from tox → Nox as our test runner. This is a quick follow-up PR to drop usage of the `|tox|` global substitution (mostly in the changelog) since we no longer need to refer to it, and to drop `tox` and `tox-uv` from the requirements. While I was at it, I also did some minor justifying of text in changelog files (since it sometimes gets formatted awkwardly).  