### PR TITLE
Automatically merge dependabot PRs

### DIFF
--- a/.github/workflows/merge-dependabot.yml
+++ b/.github/workflows/merge-dependabot.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+    - name: Fetch metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Approve PR
+      run: gh pr review --approve "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+    - name: Enable auto-merge
+      run: gh pr merge --auto --merge "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
As part of the discussion on the role of `requirements.txt` in #2647 @namurphy mentioned it would be convenient to implement a workflow that automatically merges dependabot pull requests should all of the necessary CI tests pass.

This is accomplished using the workflow outlined [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request). The default behavior of auto-merge is to hold off on merging if CIs fail, which is exactly the behavior we're looking for.

I'm not quite sure what the best way to test this is. Maybe I could make my own repository and link my results here