### PR TITLE
Require `particle` for `ParticleTracker.load_particles`

### DIFF
--- a/changelog/2746.breaking.rst
+++ b/changelog/2746.breaking.rst
@@ -1,0 +1,1 @@
+Convert ``particle`` to a required argument of the ``~plasmapy.simulation.particle_tracker.particle_tracker.ParticleTracker.load_particles`` method.

--- a/src/plasmapy/simulation/particle_tracker/particle_tracker.py
+++ b/src/plasmapy/simulation/particle_tracker/particle_tracker.py
@@ -394,7 +394,7 @@ class ParticleTracker:
         self,
         x,
         v,
-        particle: Particle = Particle("p+"),  # noqa: B008
+        particle: Particle,
     ) -> None:
         r"""
         Load arrays of particle positions and velocities.
@@ -407,9 +407,9 @@ class ParticleTracker:
         v : `~astropy.units.Quantity`, shape (N,3)
             Velocities for N particles
 
-        particle : |particle-like|, optional
+        particle : |particle-like|
             Representation of the particle species as either a |Particle| object
-            or a string representation. The default particle is protons.
+            or a string representation.
         """
         # Raise an error if the run method has already been called.
         self._enforce_order()

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -10,7 +10,7 @@ from scipy.special import erf
 from plasmapy.diagnostics.charged_particle_radiography import (
     synthetic_radiography as cpr,
 )
-from plasmapy.particles import Particle
+from plasmapy.particles.particle_class import Particle
 from plasmapy.plasma.grids import CartesianGrid
 
 

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -10,6 +10,7 @@ from scipy.special import erf
 from plasmapy.diagnostics.charged_particle_radiography import (
     synthetic_radiography as cpr,
 )
+from plasmapy.particles import Particle
 from plasmapy.plasma.grids import CartesianGrid
 
 
@@ -444,8 +445,9 @@ def test_load_particles() -> None:
     # Test adding unequal numbers of particles
     x = np.zeros([100, 3]) * u.m
     v = np.ones([150, 3]) * u.m / u.s
+    particle = Particle("p+")
     with pytest.raises(ValueError):
-        sim.load_particles(x, v)
+        sim.load_particles(x, v, particle)
 
     # Test creating particles with explicit keywords
     x = sim.x * u.m
@@ -453,7 +455,7 @@ def test_load_particles() -> None:
 
     # Try setting particles going the wrong direction
     with pytest.warns(RuntimeWarning):
-        sim.load_particles(x, -v)
+        sim.load_particles(x, -v, particle)
 
     # Try specifying a larger ion (not a proton or electron)
     sim.load_particles(x, v, particle="C-12 +3")

--- a/tests/simulation/test_particle_tracker.py
+++ b/tests/simulation/test_particle_tracker.py
@@ -12,7 +12,7 @@ from scipy.optimize import fsolve
 
 from plasmapy.formulary.frequencies import gyrofrequency
 from plasmapy.formulary.lengths import gyroradius
-from plasmapy.particles import CustomParticle, Particle
+from plasmapy.particles.particle_class import CustomParticle, Particle
 from plasmapy.plasma import Plasma
 from plasmapy.plasma.grids import CartesianGrid
 from plasmapy.simulation.particle_tracker.particle_tracker import ParticleTracker

--- a/tests/simulation/test_particle_tracker.py
+++ b/tests/simulation/test_particle_tracker.py
@@ -159,7 +159,9 @@ def test_particle_tracker_load_particles_shape_error(
     simulation = ParticleTracker(grid, no_particles_on_grids_instantiated)
 
     with pytest.raises(ValueError):
-        simulation.load_particles([[0, 0, 0]] * u.m, [[0, 0, 0], [0, 0, 0]] * u.m / u.s)
+        simulation.load_particles(
+            [[0, 0, 0]] * u.m, [[0, 0, 0], [0, 0, 0]] * u.m / u.s, Particle("p+")
+        )
 
 
 class TestParticleTrackerGyroradius:


### PR DESCRIPTION
Implements `particle` as a required argument for the load particle method of the particle tracker.

Resolves #2725