### PR TITLE
Apply autofixes from ruff rule PLR6201 

### DIFF
--- a/src/plasmapy/dispersion/analytical/mhd_waves_.py
+++ b/src/plasmapy/dispersion/analytical/mhd_waves_.py
@@ -118,7 +118,7 @@ class AbstractMHDWave(ABC):
         """Validate and return wavenumber and angle."""
         # validate argument k
         k = k.squeeze()
-        if k.ndim not in [0, 1]:
+        if k.ndim not in {0, 1}:
             raise ValueError(
                 f"Argument 'k' needs to be a single-valued or 1D array astropy Quantity,"
                 f" got array of shape {k.shape}."
@@ -128,7 +128,7 @@ class AbstractMHDWave(ABC):
 
         # validate argument theta
         theta = theta.squeeze()
-        if theta.ndim not in [0, 1]:
+        if theta.ndim not in {0, 1}:
             raise ValueError(
                 f"Argument 'theta' needs to be a single-valued or 1D array astropy "
                 f"Quantity, got array of shape {k.shape}."

--- a/src/plasmapy/dispersion/analytical/stix_.py
+++ b/src/plasmapy/dispersion/analytical/stix_.py
@@ -189,7 +189,7 @@ def stix(  # noqa: C901, PLR0912, PLR0915
         )
 
     # Validate n_i argument
-    if n_i.ndim not in (0, 1):
+    if n_i.ndim not in {0, 1}:
         raise ValueError(
             "Argument 'n_i' must be a single valued or a 1D array of "
             f"size 1 or {len(ions)}, instead got shape of {n_i.shape}"
@@ -221,7 +221,7 @@ def stix(  # noqa: C901, PLR0912, PLR0915
 
     # Validate w argument and dimension
     w = w.value.squeeze()
-    if w.ndim not in (0, 1):
+    if w.ndim not in {0, 1}:
         raise ValueError(
             "Argument 'w' needs to be a single value or a 1D array "
             f" astropy Quantity, got a value of shape {w.shape}."
@@ -231,7 +231,7 @@ def stix(  # noqa: C901, PLR0912, PLR0915
 
     # Validate theta value
     theta = theta.value.squeeze()
-    if theta.ndim not in (0, 1):
+    if theta.ndim not in {0, 1}:
         raise TypeError(
             "Argument 'theta' needs to be a single value or 1D array "
             f" astropy Quantity, got array of shape {theta.shape}."

--- a/src/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/src/plasmapy/dispersion/analytical/two_fluid_.py
@@ -255,7 +255,7 @@ def two_fluid(
 
     # validate argument k
     k = k.squeeze()
-    if k.ndim not in (0, 1):
+    if k.ndim not in {0, 1}:
         raise ValueError(
             f"Argument 'k' needs to be a single valued or 1D array astropy Quantity,"
             f" got array of shape {k.shape}."
@@ -265,7 +265,7 @@ def two_fluid(
 
     # validate argument theta
     theta = theta.squeeze()
-    if theta.ndim not in (0, 1):
+    if theta.ndim not in {0, 1}:
         raise ValueError(
             f"Argument 'theta' needs to be a single valued or 1D array astropy "
             f"Quantity, got array of shape {k.shape}."

--- a/src/plasmapy/dispersion/numerical/hollweg_.py
+++ b/src/plasmapy/dispersion/numerical/hollweg_.py
@@ -238,7 +238,7 @@ def hollweg(  # noqa: C901, PLR0912, PLR0915
 
     # validate argument k
     k = k.squeeze()
-    if k.ndim not in (0, 1):
+    if k.ndim not in {0, 1}:
         raise ValueError(
             f"Argument 'k' needs to be single valued or a 1D array "
             f"astropy Quantity, got array of shape {k.shape}."
@@ -248,7 +248,7 @@ def hollweg(  # noqa: C901, PLR0912, PLR0915
 
     # validate argument theta
     theta = theta.squeeze()
-    if theta.ndim not in (0, 1):
+    if theta.ndim not in {0, 1}:
         raise ValueError(
             f"Argument 'theta' needs to be a single valued or 1D array astropy "
             f"Quantity, got array of shape {theta.shape}."

--- a/src/plasmapy/dispersion/numerical/kinetic_alfven_.py
+++ b/src/plasmapy/dispersion/numerical/kinetic_alfven_.py
@@ -195,7 +195,7 @@ def kinetic_alfven(  # noqa: C901, PLR0912
 
     # Validate argument k
     k = k.value.squeeze()
-    if k.ndim not in (0, 1):
+    if k.ndim not in {0, 1}:
         raise ValueError(
             "Argument 'k' needs to be a single valued or 1D array "
             f"astropy Quantity, instead got array of shape {k.shape}."
@@ -207,7 +207,7 @@ def kinetic_alfven(  # noqa: C901, PLR0912
 
     # Validate argument theta
     theta = theta.value.squeeze()
-    if theta.ndim not in (0, 1):
+    if theta.ndim not in {0, 1}:
         raise ValueError(
             "Argument 'theta' needs to be a single valued or 1D array "
             f"astropy Quantity, instead got array of shape {theta.shape}."

--- a/src/plasmapy/formulary/braginskii.py
+++ b/src/plasmapy/formulary/braginskii.py
@@ -1175,7 +1175,7 @@ def _nondim_thermal_conductivity(
     be ions.
     """
     if _is_electron(particle):
-        if model in ("spitzer-harm", "spitzer"):
+        if model in {"spitzer-harm", "spitzer"}:
             kappa_hat = _nondim_tc_e_spitzer(Z)
         elif model == "braginskii":
             kappa_hat = _nondim_tc_e_braginskii(hall, Z, field_orientation)
@@ -1189,7 +1189,7 @@ def _nondim_thermal_conductivity(
         kappa_hat = _nondim_tc_i_braginskii(hall, field_orientation)
     elif model == "ji-held":
         kappa_hat = _nondim_tc_i_ji_held(hall, Z, mu, theta, field_orientation)
-    elif model in ("spitzer-harm", "spitzer"):
+    elif model in {"spitzer-harm", "spitzer"}:
         raise NotImplementedError(
             "Ion thermal conductivity is not implemented in the Spitzer model."
         )
@@ -1228,7 +1228,7 @@ def _nondim_viscosity(
         eta_hat = _nondim_visc_i_braginskii(hall)
     elif model == "ji-held":
         eta_hat = _nondim_visc_i_ji_held(hall, Z, mu, theta)
-    elif model in ("spitzer-harm", "spitzer"):
+    elif model in {"spitzer-harm", "spitzer"}:
         raise NotImplementedError(
             "Ion viscosity is not implemented in the Spitzer model."
         )
@@ -1244,7 +1244,7 @@ def _nondim_resistivity(hall, Z, particle, model, field_orientation):  # noqa: A
     This function is a switchboard / wrapper that calls the appropriate
     model-specific functions depending on which model is specified.
     """
-    if model in ("spitzer-harm", "spitzer"):
+    if model in {"spitzer-harm", "spitzer"}:
         alpha_hat = _nondim_resist_spitzer(Z, field_orientation)
     elif model == "braginskii":
         alpha_hat = _nondim_resist_braginskii(hall, Z, field_orientation)
@@ -1268,7 +1268,7 @@ def _nondim_te_conductivity(
     This function is a switchboard / wrapper that calls the appropriate
     model-specific functions depending on which model is specified.
     """
-    if model in ("spitzer-harm", "spitzer"):
+    if model in {"spitzer-harm", "spitzer"}:
         beta_hat = _nondim_tec_spitzer(Z)
     elif model == "braginskii":
         beta_hat = _nondim_tec_braginskii(hall, Z, field_orientation)
@@ -1340,12 +1340,12 @@ def _nondim_resist_spitzer(Z, field_orientation):
     in Physics of Fully Ionized Gases, Spitzer.
     """
     alpha_perp = 1
-    if field_orientation in ("perpendicular", "perp"):
+    if field_orientation in {"perpendicular", "perp"}:
         return alpha_perp
 
     (gamma_E, gamma_T, delta_E, delta_T) = _get_spitzer_harm_coeffs(Z)
     alpha_par = (3 * np.pi / 32) * (1 / gamma_E)
-    if field_orientation in ("parallel", "par"):
+    if field_orientation in {"parallel", "par"}:
         return alpha_par
     #        alpha_par = 0.5064 # Z = 1
 
@@ -1388,11 +1388,11 @@ def _nondim_tc_e_braginskii(hall, Z, field_orientation):
     gamma_0 = gamma_0_prime[Z_idx] / delta_0[Z_idx]
     Delta = hall**4 + delta_1[Z_idx] * hall**2 + delta_0[Z_idx]
 
-    if field_orientation in ("parallel", "par"):
+    if field_orientation in {"parallel", "par"}:
         kappa_par = gamma_0
         return kappa_par
 
-    if field_orientation in ("perpendicular", "perp"):
+    if field_orientation in {"perpendicular", "perp"}:
         kappa_perp = (gamma_1_prime[Z_idx] * hall**2 + gamma_0_prime[Z_idx]) / Delta
         return kappa_perp
 
@@ -1424,7 +1424,7 @@ def _nondim_tc_i_braginskii(hall, field_orientation):
     # instead of an int
     hall = float(hall)
 
-    if field_orientation in ("parallel", "par"):
+    if field_orientation in {"parallel", "par"}:
         kappa_par_coeff_0 = 3.906
         kappa_par = kappa_par_coeff_0
         return kappa_par
@@ -1433,7 +1433,7 @@ def _nondim_tc_i_braginskii(hall, field_orientation):
     delta_0 = 0.677
     Delta = hall**4 + delta_1 * hall**2 + delta_0
 
-    if field_orientation in ("perpendicular", "perp"):
+    if field_orientation in {"perpendicular", "perp"}:
         kappa_perp_coeff_2 = 2.0
         kappa_perp_coeff_0 = 2.645
         kappa_perp = (kappa_perp_coeff_2 * hall**2 + kappa_perp_coeff_0) / Delta
@@ -1561,11 +1561,11 @@ def _nondim_resist_braginskii(hall, Z, field_orientation):
     alpha_0 = 1 - alpha_0_prime[Z_idx] / delta_0[Z_idx]
     Delta = hall**4 + delta_1[Z_idx] * hall**2 + delta_0[Z_idx]
 
-    if field_orientation in ("parallel", "par"):
+    if field_orientation in {"parallel", "par"}:
         alpha_par = alpha_0
         return alpha_par
 
-    if field_orientation in ("perpendicular", "perp"):
+    if field_orientation in {"perpendicular", "perp"}:
         alpha_perp = 1 - (alpha_1_prime[Z_idx] * hall**2 + alpha_0_prime[Z_idx]) / Delta
         return alpha_perp
 
@@ -1610,11 +1610,11 @@ def _nondim_tec_braginskii(hall, Z, field_orientation):
     beta_0 = beta_0_prime[Z_idx] / delta_0[Z_idx]
     #    beta_0 = 0.7110
 
-    if field_orientation in ("parallel", "par"):
+    if field_orientation in {"parallel", "par"}:
         beta_par = beta_0
         return beta_par
 
-    if field_orientation in ("perpendicular", "perp"):
+    if field_orientation in {"perpendicular", "perp"}:
         beta_perp = (beta_1_prime[Z_idx] * hall**2 + beta_0_prime[Z_idx]) / Delta
         return beta_perp
 
@@ -2093,7 +2093,7 @@ def _nondim_tc_i_ji_held(hall, Z, mu, theta: float, field_orientation, K: int = 
     elif K == 3:
         Delta_par_i1 = 1 + 26.90 * zeta + 187.5 * zeta**2 + 346.9 * zeta**3
         kappa_par_i = (5.586 + 101.7 * zeta + 289.1 * zeta**2) / Delta_par_i1
-    if field_orientation in ("parallel", "par"):
+    if field_orientation in {"parallel", "par"}:
         return kappa_par_i / np.sqrt(2)
 
     if K == 3:
@@ -2118,7 +2118,7 @@ def _nondim_tc_i_ji_held(hall, Z, mu, theta: float, field_orientation, K: int = 
         kappa_perp_i = (
             (np.sqrt(2) + 15 / 2 * zeta) * r**2 + 0.1693 * kappa_par_i * Delta_par_i1**2
         ) / Delta_perp_i1
-    if field_orientation in ("perpendicular", "perp"):
+    if field_orientation in {"perpendicular", "perp"}:
         return kappa_perp_i / np.sqrt(2)
 
     if K == 2:

--- a/src/plasmapy/formulary/collisions/coulomb.py
+++ b/src/plasmapy/formulary/collisions/coulomb.py
@@ -440,30 +440,30 @@ def Coulomb_logarithm(
         T=T, n_e=n_e, species=species, z_mean=z_mean, V=V, method=method
     )
 
-    if method in (
+    if method in {
         "classical",
         "ls",
         "ls_min_interp",
         "GMS-1",
         "ls_full_interp",
         "GMS-2",
-    ):
+    }:
         ln_Lambda = np.log(bmax / bmin)
-    elif method in ("ls_clamp_mininterp", "GMS-3"):
+    elif method in {"ls_clamp_mininterp", "GMS-3"}:
         ln_Lambda = np.log(bmax / bmin)
         if np.any(ln_Lambda < 2):
             if np.isscalar(ln_Lambda.value):
                 ln_Lambda = 2 * u.dimensionless_unscaled
             else:
                 ln_Lambda[ln_Lambda < 2] = 2 * u.dimensionless_unscaled
-    elif method in (
+    elif method in {
         "hls_min_interp",
         "GMS-4",
         "hls_max_interp",
         "GMS-5",
         "hls_full_interp",
         "GMS-6",
-    ):
+    }:
         ln_Lambda = 0.5 * np.log(1 + bmax**2 / bmin**2)
     else:
         raise ValueError(
@@ -478,14 +478,14 @@ def Coulomb_logarithm(
 
     min_ln_Lambda = np.nanmin(ln_Lambda)
 
-    if min_ln_Lambda < 2 and method in (
+    if min_ln_Lambda < 2 and method in {
         "classical",
         "ls",
         "ls_min_interp",
         "GMS-1",
         "ls_full_interp",
         "GMS-2",
-    ):
+    }:
         warnings.warn(
             f"The calculation of the Coulomb logarithm has found a value of "
             f"min(ln Λ) = {min_ln_Lambda:.4f} which is likely to be inaccurate "

--- a/src/plasmapy/formulary/collisions/frequencies.py
+++ b/src/plasmapy/formulary/collisions/frequencies.py
@@ -754,7 +754,7 @@ def collision_frequency(
     # reduced mass
     V_reduced = V_r
 
-    if species[0] in ("e", "e-") and species[1] in ("e", "e-"):
+    if species[0] in {"e", "e-"} and species[1] in {"e", "e-"}:
         # electron-electron collision
         # if a velocity was passed, we use that instead of the reduced
         # thermal velocity
@@ -765,7 +765,7 @@ def collision_frequency(
         )
         # impact parameter for 90° collision
         bPerp = lengths.impact_parameter_perp(T=T, species=species, V=V_reduced)
-    elif species[0] in ("e", "e-") or species[1] in ("e", "e-"):
+    elif species[0] in {"e", "e-"} or species[1] in {"e", "e-"}:
         # electron-ion collision
         # Need to manually pass electron thermal velocity to obtain
         # correct perpendicular collision radius

--- a/src/plasmapy/formulary/collisions/lengths.py
+++ b/src/plasmapy/formulary/collisions/lengths.py
@@ -230,14 +230,14 @@ def impact_parameter(  # noqa: C901
     )
     # catching error where mean charge state is not given for non-classical
     # methods that require the ion density
-    if method in (
+    if method in {
         "ls_full_interp",
         "GMS-2",
         "hls_max_interp",
         "GMS-5",
         "hls_full_interp",
         "GMS-6",
-    ) and np.isnan(z_mean):
+    } and np.isnan(z_mean):
         raise ValueError(
             'Must provide a z_mean for "ls_full_interp", '
             '"hls_max_interp", and "hls_full_interp" methods.'
@@ -251,7 +251,7 @@ def impact_parameter(  # noqa: C901
 
     # obtaining minimum and maximum impact parameters depending on which
     # method is requested
-    if method in ("classical", "ls"):
+    if method in {"classical", "ls"}:
         bmax = lambdaDe
         # Coulomb-style collisions will not happen for impact parameters
         # shorter than either of these two impact parameters, so we choose
@@ -267,14 +267,14 @@ def impact_parameter(  # noqa: C901
         except ValueError:  # both lambdaBroglie and bPerp are arrays
             bmin = lambdaBroglie
             bmin[bPerp > lambdaBroglie] = bPerp[bPerp > lambdaBroglie]
-    elif method in ("ls_min_interp", "GMS-1"):
+    elif method in {"ls_min_interp", "GMS-1"}:
         # 1st method listed in Table 1 of reference [1]
         # This is just another form of the classical Landau-Spitzer
         # approach, but bmin is interpolated between the de Broglie
         # wavelength and distance of the closest approach.
         bmax = lambdaDe
         bmin = (lambdaBroglie**2 + bPerp**2) ** (1 / 2)
-    elif method in ("ls_full_interp", "GMS-2"):
+    elif method in {"ls_full_interp", "GMS-2"}:
         # 2nd method listed in Table 1 of reference [1]
         # Another Landau-Spitzer like approach, but now bmax is also
         # being interpolated. The interpolation is between the Debye
@@ -286,17 +286,17 @@ def impact_parameter(  # noqa: C901
         ionRadius = Wigner_Seitz_radius(n_i)
         bmax = (lambdaDe**2 + ionRadius**2) ** (1 / 2)
         bmin = (lambdaBroglie**2 + bPerp**2) ** (1 / 2)
-    elif method in ("ls_clamp_mininterp", "GMS-3"):
+    elif method in {"ls_clamp_mininterp", "GMS-3"}:
         # 3rd method listed in Table 1 of reference [1]
         # same as GMS-1, but not Lambda has a clamp at Lambda_min = 2
         # where Lambda is the argument to the Coulomb logarithm.
         bmax = lambdaDe
         bmin = (lambdaBroglie**2 + bPerp**2) ** (1 / 2)
-    elif method in ("hls_min_interp", "GMS-4"):
+    elif method in {"hls_min_interp", "GMS-4"}:
         # 4th method listed in Table 1 of reference [1]
         bmax = lambdaDe
         bmin = (lambdaBroglie**2 + bPerp**2) ** (1 / 2)
-    elif method in ("hls_max_interp", "GMS-5"):
+    elif method in {"hls_max_interp", "GMS-5"}:
         # 5th method listed in Table 1 of reference [1]
         # Mean ion density.
         n_i = n_e / z_mean
@@ -304,7 +304,7 @@ def impact_parameter(  # noqa: C901
         ionRadius = Wigner_Seitz_radius(n_i)
         bmax = (lambdaDe**2 + ionRadius**2) ** (1 / 2)
         bmin = bPerp
-    elif method in ("hls_full_interp", "GMS-6"):
+    elif method in {"hls_full_interp", "GMS-6"}:
         # 6th method listed in Table 1 of reference [1]
         # Mean ion density.
         n_i = n_e / z_mean

--- a/src/plasmapy/particles/atomic.py
+++ b/src/plasmapy/particles/atomic.py
@@ -1135,7 +1135,7 @@ def _is_electron(arg: Any) -> bool:
     # TODO: Remove _is_electron from all parts of code.
 
     return (
-        arg in ("e", "e-") or arg.lower() == "electron"
+        arg in {"e", "e-"} or arg.lower() == "electron"
         if isinstance(arg, str)
         else False
     )
@@ -1207,7 +1207,7 @@ def stopping_power(
             raise NotImplementedError(
                 "Stopping calculations for electrons have not been implemented yet!"
             )
-        elif incident_particle in [Particle("H+"), Particle("p+")]:
+        elif incident_particle in {Particle("H+"), Particle("p+")}:
             group_name = "protons"
         else:
             raise ValueError(

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -731,7 +731,7 @@ class Particle(AbstractPhysicalParticle):
                 f"use: Particle({attributes['particle']!r})"
             )
 
-        if mass_numb not in (1, None) or Z not in (1, None):
+        if mass_numb not in {1, None} or Z not in {1, None}:
             raise InvalidParticleError(
                 "Cannot create a Particle representing a proton for a "
                 "mass number or charge number not equal to 1."

--- a/src/plasmapy/utils/decorators/checks.py
+++ b/src/plasmapy/utils/decorators/checks.py
@@ -238,10 +238,10 @@ class CheckValues(CheckBase):
             # e.g. in foo(x, y, *args, d=None, **kwargs) variable arguments
             #      *args and **kwargs will NOT be checked
             #
-            if param.kind in (
+            if param.kind in {
                 inspect.Parameter.VAR_KEYWORD,
                 inspect.Parameter.VAR_POSITIONAL,
-            ):
+            }:
                 continue
 
             # grab the checks dictionary for the desired parameter
@@ -565,10 +565,10 @@ class CheckUnits(CheckBase):
             # e.g. in foo(x, y, *args, d=None, **kwargs) variable arguments
             #      *args and **kwargs will NOT be checked
             #
-            if param.kind in (
+            if param.kind in {
                 inspect.Parameter.VAR_KEYWORD,
                 inspect.Parameter.VAR_POSITIONAL,
-            ):
+            }:
                 continue
 
             # grab the checks dictionary for the desired parameter

--- a/tests/formulary/test_transport.py
+++ b/tests/formulary/test_transport.py
@@ -969,9 +969,9 @@ class Test__nondim_visc_e_braginskii:
         beta_hat = _nondim_visc_e_braginskii(self.big_hall, Z)
         if idx == 0:
             assert np.isclose(beta_hat[idx], expected, atol=1e-2)
-        elif idx in (1, 2):
+        elif idx in {1, 2}:
             assert np.isclose(beta_hat[idx] * self.big_hall**2, expected, atol=1e-2)
-        elif idx in (3, 4):
+        elif idx in {3, 4}:
             assert np.isclose(beta_hat[idx] * self.big_hall, expected, atol=1e-1)
 
 
@@ -987,7 +987,7 @@ def test__nondim_tc_e_spitzer(Z) -> None:
     if Z == 1:
         kappa_check = 3.203
         rtol = 1e-3
-    elif Z in (2, 4):
+    elif Z in {2, 4}:
         kappa_check = _nondim_tc_e_braginskii(0, Z, "par")
         rtol = 2e-2
     elif Z == 16:
@@ -1006,7 +1006,7 @@ def test__nondim_resist_spitzer(Z) -> None:
     if Z == 1:
         alpha_check = 0.5064
         rtol = 1e-3
-    elif Z in (2, 4, np.inf):
+    elif Z in {2, 4, np.inf}:
         alpha_check = _nondim_resist_braginskii(0, Z, "par")
         rtol = 2e-2
     elif Z == 16:
@@ -1022,7 +1022,7 @@ def test__nondim_tec_spitzer(Z) -> None:
     if Z == 1:
         beta_check = 0.699
         rtol = 1e-3
-    elif Z in (2, 4, np.inf):
+    elif Z in {2, 4, np.inf}:
         beta_check = _nondim_tec_braginskii(0, Z, "par")
         rtol = 2e-2
     elif Z == 16:

--- a/tests/particles/test_special_particles.py
+++ b/tests/particles/test_special_particles.py
@@ -19,7 +19,7 @@ def test_particle_antiparticle_pairs(particle_antiparticle_pair) -> None:
     if "nu" not in particle:
         identical_keys.append("mass")
 
-    if particle in ("e-", "mu-", "tau-") or "nu" in particle:
+    if particle in {"e-", "mu-", "tau-"} or "nu" in particle:
         identical_keys.append("generation")
 
     opposite_keys = ["charge number", "lepton number", "baryon number"]
@@ -36,7 +36,7 @@ def test_particle_antiparticle_pairs(particle_antiparticle_pair) -> None:
             == -data_about_special_particles[antiparticle][key]
         ), f"{particle} and {antiparticle} do not have exact opposite {key}."
 
-    if particle not in ("e-", "n"):
+    if particle not in {"e-", "n"}:
         assert data_about_special_particles[particle][
             "name"
         ] == data_about_special_particles[antiparticle]["name"].replace(


### PR DESCRIPTION
This PR applies autofixes from ruff rule [PLR6201](https://docs.astral.sh/ruff/rules/literal-membership/), which makes it so that sets are used when testing for membership because:

> When testing for membership in a static sequence, prefer a set literal over a list or tuple, as Python optimizes set membership tests.

This particular ruff rule is in preview and not currently enabled in our ruff setup, but might be enabled at some point in the future so it's worth getting it out of the way now.

I'm also using this as a test PR to see if it gets any errors from the "Add no changelog label" workflow which was grumpy in #2755.  And, it's working here, so yay!
