### PR TITLE
Update release checklist

### DIFF
--- a/.github/content/release-checklist.md
+++ b/.github/content/release-checklist.md
@@ -62,11 +62,12 @@ This issue contains the procedure for releasing a new version of PlasmaPy.
    - For official releases, make sure the checkbox is selected for _Set as the latest release_. For beta releases or release candidates (e.g., `v2024.5.0rc1`), specify it as a pre-release.
    - Click on _Publish release_, which will create the GitHub release and trigger the GitHub workflow to [publish to PyPI].
    - Check the [release history] on PyPI to make sure that the release was successful.
- - [ ] [Create a pull request] to merge the tag for the release back into main. Under the box for _compare_, select _Tags_, choose the tag for this release (e.g., `v2024.7.0`), and then click on _Create pull request_.  Merge **but do not squash** this PR back into `main`.
+ - [ ] [Create a pull request] to merge the tag for the release back into main. Under the box for _compare_, select _Tags_, choose the tag for this release (e.g., `v2024.7.0`), and then click on _Create pull request_.
+ - [ ] Merge **but do not squash** this PR back into `main`.
+   - _Squashing_ this pull request can cause problems by removing the tagged release commit from the history of `main` (e.g., #2630).
 
 <!-- Creating the pull request *from the tag* prevents us from accidentally deleting the release branch. -->
-<!-- Squashing PRs from release branches back into `main` has caused problems with `setuptools_scm` being able to guess the correct next version for development installations.  See #2630. -->
-<!-- Automate pull request creation? Change it into a commit? -->
+<!-- We might be able to modify the `mint-release.yml` workflow by having it automatically create the pull request back into `main`, but we'd want to keep a note *not to squash merge* the resulting PRs. -->
 
 ### Following the release
 

--- a/.github/content/release-checklist.md
+++ b/.github/content/release-checklist.md
@@ -62,10 +62,17 @@ This issue contains the procedure for releasing a new version of PlasmaPy.
    - For official releases, make sure the checkbox is selected for _Set as the latest release_. For beta releases or release candidates (e.g., `v2024.5.0rc1`), specify it as a pre-release.
    - Click on _Publish release_, which will create the GitHub release and trigger the GitHub workflow to [publish to PyPI].
    - Check the [release history] on PyPI to make sure that the release was successful.
+ - [ ] [Create a pull request] to merge the tag for the release back into main. Under the box for _compare_, select _Tags_, choose the tag for this release (e.g., `v2024.7.0`), and then click on _Create pull request_.  Merge **but do not squash** this PR back into `main`.
+
+<!-- Creating the pull request *from the tag* prevents us from accidentally deleting the release branch. -->
+<!-- Squashing PRs from release branches back into `main` has caused problems with `setuptools_scm` being able to guess the correct next version for development installations.  See #2630. -->
+<!-- Automate pull request creation? Change it into a commit? -->
+
+### Following the release
+
  - [ ] Download a `.tar.gz` file of the tagged release from the [list of tagged versions] on GitHub, and upload it to [Zenodo].
    - [ ] Update the author list with new authors from the automatically generated release notes or [`CITATION.cff`].
    - [ ] Update the bibliography, and publish the release to Zenodo.
- - [ ] [Create a pull request] to merge the changes from the release back into `main`. Under the box for _compare_, select _Tags_, select the tag for the most recent release (e.g., `v2024.5.0`), and then click on _Create pull request_. <!-- By creating the pull request from the tag, we should not accidentally delete the release branch. --> <!-- Automate pull request creation? Change it into a commit? -->
  - [ ] Fix any problems with the automated pull request to [conda-forge feedstock], if necessary. This step should be automatic, but may take a while.
  - [ ] Update requirements in the [conda-forge feedstock] in `recipe/meta.yaml`, in particular when there is a new version of Python.
 


### PR DESCRIPTION
This PR updates the release checklist to remind us **_not to squash_ the pull request from a release branch back into `main`**. 

Squashing these PRs makes it so that the tagged version doesn't show up in the git history of `main`, which can cause problems for `setuptools_scm` when it tries to guess the next development version.

Closes #2630. (So long as we remember to do this...)