### PR TITLE
Update `.mailmap`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,122 +1,31 @@
-Aditya Magarde <adityamagarde26@gmail.com>
-Afzal Rao <50012451+thecasuist@users.noreply.github.com>
-Alexis Jeandet <alexis.jeandet@member.fsf.org>
-Alf Köhn-Seemann <alf.koehn@posteo.net>
-Andrew <apsandeman@gmail.com>
-Angad Singh <angad88@hotmail.com>
-Ankit Singh <Griffintaur@users.noreply.github.com>
-Ankur Chattopadhyay <39518771+chttrjeankr@users.noreply.github.com>
-Anna Lanteri <88714459+alanteriBW@users.noreply.github.com>
-Anthony Vo <voxxx266@umn.edu>
-Antoine T <antoine.tavant@lpp.polytechnique.fr>
-Apoorv Choubey <theapoorvs1@gmail.com>
-Armando Salcido <39717342+aksalcido@users.noreply.github.com>
-BH4 <brycefore4@gmail.com>
-Brigitta Sipocz <bsipocz@gmail.com> <b.sipocz@gmail.com>
-bryancfoo <68606269+bryancfoo@users.noreply.github.com>
-Carlos A. Cartagena-Sanchez <ccartagena@brynmawr.edu>
-Carol Zhang <carol.zhang@mail.mcgill.ca>
-cclauss <cclauss@bluewin.ch>
-Chengcai Shen <chengcaishen@cfa.harvard.edu>
-Chris Hoang <hoadh-23@rhodes.edu>
-Christopher Arran <30498857+ChrisArran@users.noreply.github.com>
-Colby Haggerty <colbych@udel.edu>
-Cora Schneck <22159116+cyschneck@users.noreply.github.com>
-DarkAEther <30438425+DarkAEther@users.noreply.github.com>
-David Stansby <dstansby@gmail.com>
-Dawa Nurbu Sherpa <dawa@Dawas-MacBook-Pro.local>
-dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
-Dhawal Modi <utsavmodi10@gmail.com>
+# Use .mailmap to prevent commands like `git shortlog` from showing duplicate names
+#
+# The syntax is:
+#
+#    Preferred Name <preferred email> Other Name <Other Email>
+#
+# You can skip "Other Name" if it is the same as the one that should be used, and is unique.
+#
+# This file is up-to-date if the command `git log --format="%aN <%aE>" | sort -u` yields no duplicates.
+
+Brigitta Sipőcz <bsipocz@gmail.com>
+Brigitta Sipőcz <bsipocz@gmail.com> <b.sipocz@gmail.com>
+Bzero <B_0@posteo.net> <lolo-b@posteo.net>
 Diego Diaz <diego7319@users.noreply.github.com>
-Dominik Stańczak <stanczakdominik@gmail.com>
-Drew Leonard <andy.j.leonard@gmail.com>
-Drozdov David <36568373+davemus@users.noreply.github.com>
+Dominik Stańczak-Marikin <stanczakdominik@gmail.com>
+Elliot Johnson <ejohn@udel.edu>
 Elliot Johnson <ejohn@udel.edu> <77989826+ejohnson-96@users.noreply.github.com>
-FinMacDov <fmackenziedover1@sheffield.ac.uk>
-flaixman <biel_nadal@hotmail.com>
-Francisco Silva Pavon <silvapav@usc.edu>
-goodab <goodab@uw.edu>
-Graham Goudeau <grahamgoudeau@gmail.com>
-Gregor Decristoforo <gregor.decristoforo@gmail.com>
-Haman Bagherianlemraski <70356097+haman80@users.noreply.github.com>
-hzxusx <hzxusx@gmail.com>
-Isaias <jota33@users.noreply.github.com>
-Jacob Deal <38059243+Jac0bDeal@users.noreply.github.com>
-Jakub Polak <44603152+Ishinomori@users.noreply.github.com>
-James Kent <james-kent@uiowa.edu>
-jams2 <me@joshuamunn.com>
+Elliot Johnson <ejohn@udel.edu> <77989826+etjohnson@users.noreply.github.com>
+Erik Everson <eteverson@gmail.com>
 Jasper Beckers <j.p.beckers@student.tue.nl>
 Jayden Roberts <109694185+JaydenR2305@users.noreply.github.com>
-Joao Victor Martinelli <jvmartinellis@gmail.com>
-Julia <56553398+JuliaGuimiot@users.noreply.github.com>
 Julien Hillairet <julien.hillaire@cea.fr> <julien.hillairet@gmail.com>
-Justin Bergeron <bergeron.just@gmail.com>
-Kevin Montes <kjmontes1@gmail.com>
-Khalil Bryant <35078079+KhalilBryant@users.noreply.github.com>
-Leah <leaheinhorn@Leahs-MacBook-Air.local> <leaheinhorn@yahoo.com>
-Leo Murphy <85201894+LeoMurphyWM24@users.noreply.github.com>
-lgoenner <lgoenner@users.noreply.github.com>
-LucianoGSilvestri <53919258+lucianogsilvestri@users.noreply.github.com>
-Ludovico_Bessi <ludovicobessi@gmail.com>
-Manas Bedmutha <manasbedmutha98@gmail.com>
-Marcin Kastek <37458996+MKastek@users.noreply.github.com>
-Marco Gorelli <marcogorelli@protonmail.com>
-Michael Fischer <michael.fischer.13@cnu.edu>
-misupova <marija.isupova@gmail.com>
-Mohammad Haque <124110016+mohawk811@users.noreply.github.com>
-Muhammad Masood <102393324+MuhammadHMasood@users.noreply.github.com>
-mysakli <65419770+mysakli@users.noreply.github.com>
-Nabil Humphrey <nabilhumphrey@internode.on.net>
-namurphy <namurphy@users.noreply.github.com>
-Neil Patel <neil123@gmail.com>
-Nick Murphy <namurphy@cfa.harvard.edu> <namurphy@users.noreply.github.com>
-Nicolas Lequette <49229457+Quettle@users.noreply.github.com>
-Nismirno <daemonik92@yahoo.com>
-nrb1324 <nrb1324@hotmail.com>
-Pawel Marek Kozlowski <pawel@pmkozlowski.com>
-Peter Heuer <pvheuer@gmail.com>
-Piotr Kuszaj <peterkuszaj@gmail.com>
-PlasmaPy Release Bot <team@plasmapy.org>
-plasmapy-requirements-bot[bot] <134649236+plasmapy-requirements-bot[bot]@users.noreply.github.com>
-P. L. Lim <2090236+pllim@users.noreply.github.com>
+Leah <leaheinhorn@yahoo.com> <leaheinhorn@Leahs-MacBook-Air.local>
+Nick Murphy <namurphy@plasmapy.org> <namurphy@cfa.harvard.edu>
+Nick Murphy <namurphy@plasmapy.org> <namurphy@users.noreply.github.com>
+Pawel Kozlowski <pawel@pmkozlowski.com>
 Poh Zi How <poh.zihow@gmail.com>
-pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-Quettle <49229457+Quettle@users.noreply.github.com>
-Raajit Raj <raajit.raj@gmail.com>
-RAJAGOPALAN-GANGADHARAN <g.raju2000@gmail.com>
-Ramiz Qudsi <ahmadr@udel.edu>
-Raymon Skjørten Hansen <raymon.s.hansen@gmail.com>
-Reynaldo R <reynaldo.rz.26@gmail.com>
+Rajagopalan Gangadharan <g.raju2000@gmail.com>
 Ritiek Malhotra <ritiekmalhotra123@gmail.com>
-Roberto Díaz Pérez <r.r.1994a@gmail.com>
-rocco8773 <eteverson@gmail.com>
-Samaiyah I. Farid <38890767+samaiyahfarid@users.noreply.github.com>
-samurai688 <sam.langendorf@gmail.com>
-Sarthak Choudhary <csarthak@vmware.com>
-savcheva <43857770+savcheva@users.noreply.github.com>
-Sean Carroll <seanwilliamcarroll@gmail.com>
-Sean Chambers <schambers80@gmail.com>
-seanjunheng2 <66832639+seanjunheng2@users.noreply.github.com>
-Shane Brown <ssjbrown@udel.edu>
-Siddharth <think.siddharth@gmail.com>
-singhankit <ankitsingh135@gmail.com>
-Sjbrownian <84342922+Sjbrownian@users.noreply.github.com>
-Sobeskes <55936504+Sobeskes@users.noreply.github.com>
-sourcery-ai[bot] <58596630+sourcery-ai[bot]@users.noreply.github.com>
-Steve Richardson <arichar6@gmail.com>
-Stuart Mumford <stuart@cadair.com>
-suzannenie <58891198+suzannenie@users.noreply.github.com>
-svincena <vincena@gmail.com>
-syip1 <44428342+syip1@users.noreply.github.com>
-Thomas Fan <thomasjpfan@gmail.com>
-Thomas Ulrich <tmulrich1@gmail.com>
-Thomas Varnish <5612615+tvarnish@users.noreply.github.com>
 Tiger Du <56400881+Tiger-Du@users.noreply.github.com>
-Tomás Stinson <14tstinson@gmail.com>
-tranqver <60008217+tranqver@users.noreply.github.com>
-Trestan Simon <trestansimon@gmail.com>
-Volken <the.shadow.anonyme@gmail.com>
-W. Cody Skinner <cody@codyskinner.net>
-winedarkmoon <127571479+winedarkmoon@users.noreply.github.com>
 Wu Tingfeng <wutingfeng@outlook.com> <wu.tingfeng@u.nus.edu>
-Yi-Min Huang <yopology@yahoo.com>


### PR DESCRIPTION
This PR updates and fine-tunes `.mailmap`. While the `.mailmap` file has previously included most or all contributors, this PR pares it down to only the entries that are needed. I also adapted some explanatory comments from NumPy's `.mailmap` file.

The purpose of a `.mailmap` file is to prevent commands like `git shortlog` from showing duplicate names (see also the docs for [`gitmailmap`](https://git-scm.com/docs/gitmailmap). 

