### PR TITLE
Modify version in latest docs to be based on current date and git hash

### DIFF
--- a/changelog/2775.doc.rst
+++ b/changelog/2775.doc.rst
@@ -1,0 +1,1 @@
+Based the version of PlasmaPy that gets included in development documentation builds on the current date and most recent git hash.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ if "dev" in version:
     # version for non-releases, so base it on the date and git hash
     # instead.
     git_hash = version.split("dev")[-1].split("+")[-1].split(".")[0]
-    version = f"{now.year}.{now.month}.{now.day}.dev+{git_hash}"
+    version = f"{now.year}.{now.month}.0.dev+{git_hash}"
     version_info_message = f"Setting {version = !r}"
     logging.info(version_info_message)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,14 +50,18 @@ author = "PlasmaPy Community"
 copyright = f"2015–{now.year}, {author}"  # noqa: A001
 language = "en"
 
-if "dev" in version or version.startswith("0"):
+if "dev" in version:
     # We've had some problems with setuptools_scm providing an incorrect
     # version for non-releases, so base it on the date and git hash
     # instead.
     git_hash = version.split("dev")[-1].split("+")[-1].split(".")[0]
     version = f"{now.year}.{now.month}.{now.day}.dev+{git_hash}"
-    msg = f"Setting {version = !r}"
-    logging.info(msg)
+    version_info_message = f"Setting {version = !r}"
+    logging.info(version_info_message)
+
+if version.startswith("0"):
+    version_warning_message = f"Incorrect {version = !r}"
+    logging.warning(version_warning_message)
 
 release = version
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ Sphinx extensions (built-in):
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
+import logging
 import os
 import sys
 import warnings
@@ -29,7 +30,7 @@ from datetime import datetime, timezone
 
 from sphinx.application import Sphinx
 
-from plasmapy import __version__
+from plasmapy import __version__ as version
 
 # isort: off
 sys.path.insert(0, os.path.abspath(".."))  # noqa: PTH100
@@ -40,17 +41,25 @@ import _author_list_from_cff
 import _changelog_index
 import _global_substitutions
 
+now = datetime.now(timezone.utc)
+
 # Project metadata
 
 project = "PlasmaPy"
 author = "PlasmaPy Community"
-copyright = f"2015–{datetime.now(timezone.utc).year}, {author}"  # noqa: A001
+copyright = f"2015–{now.year}, {author}"  # noqa: A001
 language = "en"
-release = __version__
-version = __version__
 
-if release.startswith("0"):
-    warnings.warn(f"Incorrect version in documentation build ({release = })")
+if "dev" in version or version.startswith("0"):
+    # We've had some problems with setuptools_scm providing an incorrect
+    # version for non-releases, so base it on the date and git hash
+    # instead.
+    git_hash = version.split("dev")[-1].split("+")[-1].split(".")[0]
+    version = f"{now.year}.{now.month}.{now.day}.dev+{git_hash}"
+    msg = f"Setting {version = !r}"
+    logging.info(msg)
+
+release = version
 
 # Define global substitutions in docs/_global_substitutions.py
 


### PR DESCRIPTION
We've been getting incorrect versions in our documentation builds. Sometimes it's starts with `2023.1.0dev...` (where it gets the version from the most recent git hash) and other times it starts with `0.1...`.  This PR changes it so that the version that appears in the documentation includes the current date and the git hash.

I haven't been able to figure out what the problem has been with the version, so this is probably best considered as a temporary quasi-fix.

Closes #2632.