### PR TITLE
Use `autotyping` to add type hint annotations

### DIFF
--- a/src/plasmapy/simulation/particle_integrators.py
+++ b/src/plasmapy/simulation/particle_integrators.py
@@ -46,7 +46,7 @@ class BorisIntegrator(AbstractIntegrator):
     """The explicit Boris pusher."""
 
     @property
-    def is_relativistic(self):
+    def is_relativistic(self) -> bool:
         r"""
         The explicit Boris pusher is not relativistic.
         """
@@ -186,7 +186,7 @@ class RelativisticBorisIntegrator(AbstractIntegrator):
     """The explicit Boris pusher, including relativistic corrections."""
 
     @property
-    def is_relativistic(self):
+    def is_relativistic(self) -> bool:
         r"""
         The push implementation of the Boris push algorithm includes relativistic
         corrections.

--- a/src/plasmapy/simulation/particle_tracker/particle_tracker.py
+++ b/src/plasmapy/simulation/particle_tracker/particle_tracker.py
@@ -154,9 +154,9 @@ class ParticleTracker:
         particle_integrator: type[AbstractIntegrator] | None = None,
         dt=None,
         dt_range=None,
-        field_weighting="volume averaged",
+        field_weighting: str = "volume averaged",
         req_quantities=None,
-        verbose=True,
+        verbose: bool = True,
     ) -> None:
         # Instantiate the integrator object for use in the _push() method
         self._integrator: AbstractIntegrator = (

--- a/src/plasmapy/simulation/particle_tracker/particle_tracker.py
+++ b/src/plasmapy/simulation/particle_tracker/particle_tracker.py
@@ -866,7 +866,7 @@ class ParticleTracker:
 
         return dt
 
-    def _update_position(self, summed_field_values):
+    def _update_position(self, summed_field_values) -> None:
         r"""
         Update the positions and velocities of the simulated particles using the
         integrator provided at instantiation.
@@ -901,7 +901,7 @@ class ParticleTracker:
             v_results,
         )
 
-    def _update_velocity_stopping(self, summed_field_values):
+    def _update_velocity_stopping(self, summed_field_values) -> None:
         r"""
         Apply stopping to the simulated particles using the provided stopping
         routine. The stopping is applied to the simulation by calculating the

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -1015,7 +1015,7 @@ def test_NIST_particle_stopping(
     material: str,
     density: u.Quantity[u.kg / u.m**3],
     energy_projected_range_list: list[tuple[u.Quantity[u.J], u.Quantity[u.m]]],
-):
+) -> None:
     r"""
     Test to ensure that the simulated stopping range matches the SRIM output
     for various proton energies.

--- a/tests/formulary/collisions/test_collisions_misc.py
+++ b/tests/formulary/collisions/test_collisions_misc.py
@@ -40,7 +40,7 @@ check_database_connection = pytest.mark.skipif(
         )
     ],
 )
-def test_Bethe_stopping(material, rho, I, n_e, T2):  # noqa: E741
+def test_Bethe_stopping(material, rho, I, n_e, T2) -> None:  # noqa: E741
     """
     The NIST PSTAR and ASTAR databases should have stopping powers similar
     to those calculated by the Bethe formula beyond a material-dependent

--- a/tests/simulation/test_particle_tracker.py
+++ b/tests/simulation/test_particle_tracker.py
@@ -579,8 +579,14 @@ class TestParticleTrajectory:
         )
 
     @classmethod
-    def ExB_trajectory_case_one(
-        cls, t, E, B, q=const.e.si, m=const.m_p.si, is_relativistic=True
+    def ExB_trajectory_case_one(  # noqa: ANN206
+        cls,
+        t,
+        E,
+        B,
+        q=const.e.si,
+        m=const.m_p.si,
+        is_relativistic: bool = True,
     ):
         """
         Calculates the relativistically-correct ExB drift trajectory for a

--- a/tests/simulation/test_particle_tracker.py
+++ b/tests/simulation/test_particle_tracker.py
@@ -656,7 +656,7 @@ class TestParticleTrajectory:
             (0.9, Particle("e-")),
         ],
     )
-    def test_relativistic_Boris_integrator_fitting(cls, regime, particle):
+    def test_relativistic_Boris_integrator_fitting(cls, regime, particle) -> None:
         """
         Fit the results of the relativistic Boris integrator using
         relativistic models developed in https://www.sciencedirect.com/science/article/pii/S163107211400148X
@@ -774,7 +774,7 @@ class TestParticleTrajectory:
             (0.1, Particle("e-")),
         ],
     )
-    def test_classical_Boris_integrator_fitting(cls, regime, particle):
+    def test_classical_Boris_integrator_fitting(cls, regime, particle) -> None:
         """
         Fit the results of the non-relativistic Boris integrator using
         relativistic models developed in https://www.sciencedirect.com/science/article/pii/S163107211400148X
@@ -871,7 +871,7 @@ class TestParticleTrajectory:
             (0.9, Particle("e-")),
         ],
     )
-    def test_relativity_warning(cls, regime, particle):
+    def test_relativity_warning(cls, regime, particle) -> None:
         """
         Fit the results of the non-relativistic Boris integrator using
         relativistic models developed in https://www.sciencedirect.com/science/article/pii/S163107211400148X


### PR DESCRIPTION
For this PR, I ran `nox -s 'autotyping(safe)'` followed by `nox -s 'autotyping(aggressive)'` to automatically add type hint annotations ahead of the 2024.7.0 release.