### PR TITLE
Update version of ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
     name: typos (add false positives to _typos.toml)
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.1
+  rev: v0.5.3
   hooks:
   - id: ruff
     name: ruff (see https://docs.astral.sh/ruff/rules)

--- a/src/plasmapy/diagnostics/thomson.py
+++ b/src/plasmapy/diagnostics/thomson.py
@@ -561,7 +561,7 @@ def spectral_density(  # noqa: C901, PLR0912, PLR0915
         eval_w = np.linspace(-wspan, wspan, num=wavelengths.size)
         instr_func_arr = instr_func(eval_w)
 
-        if type(instr_func_arr) != np.ndarray:
+        if type(instr_func_arr) is not np.ndarray:
             raise ValueError(
                 "instr_func must be a function that returns a "
                 "np.ndarray, but the provided function returns "
@@ -966,7 +966,7 @@ def spectral_density_model(  # noqa: C901, PLR0912, PLR0915
         eval_w = np.linspace(-wspan, wspan, num=wavelengths.size)
         instr_func_arr = instr_func(eval_w * u.m)
 
-        if type(instr_func_arr) != np.ndarray:
+        if type(instr_func_arr) is not np.ndarray:
             raise ValueError(
                 "instr_func must be a function that returns a "
                 "np.ndarray, but the provided function returns "

--- a/tests/particles/test_factory.py
+++ b/tests/particles/test_factory.py
@@ -52,7 +52,7 @@ test_cases = [
 def test_physical_particle_factory(args, kwargs, expected) -> None:
     result = _physical_particle_factory(*args, **kwargs)
     assert result == expected
-    assert type(result) == type(expected)
+    assert type(result) is type(expected)
 
 
 test_cases_for_exceptions = [


### PR DESCRIPTION
<!-- If this PR will fully resolve an issue, include text like "Closes #1532" so that the issue will be automatically closed when this PR is merged. Please also check out PlasmaPy's contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html. Thank you!-->

This PR bumps the version of ruff, and changes a few type comparisons from `==` and `!=` to `is` and `is not`.