### PR TITLE
Update the checklist for releases

### DIFF
--- a/.github/content/release-checklist.md
+++ b/.github/content/release-checklist.md
@@ -34,11 +34,6 @@ This issue contains the procedure for releasing a new version of PlasmaPy.
  - [x] [Create an issue for the release].
  - [ ] Update [milestones] for issues & pull requests (PRs). 🛣️
 
-<!-- We have had less need of a feature freeze as the package has become more mature, but we may wish to add this back in the future.
- - [ ] About three weeks before a minor or major release, announce that a feature freeze will occur one week before the anticipated release date. Only pull requests with a limited scope that do not significantly change functionality should be merged during the feature freeze.
- - [ ] Begin a code freeze about two weekdays before a release. Only bugfixes and pull requests that are directly related to the release should be merged during the code freeze.
--->
-
 ### Code quality updates
 
  - [ ] Revise changelog entries to make sure that they are understandable, necessary, and correctly categorized. Add the `no changelog entry needed` label to skip doing changelog checks. 📜
@@ -55,25 +50,20 @@ This issue contains the procedure for releasing a new version of PlasmaPy.
 
 ### Perform the release
 
- - [ ] Begin an upload to [Zenodo] for a new version of [this record], using the `team@plasmapy.org` login. Reserve a DOI.
- - [ ] Run the GitHub Action to [mint a release]. Specify the version (i.e., `2024.5.0` or `2024.5.0rc1` for a release candidate) and copy/paste the reserved DOI from Zenodo.  This action will update the DOI, build the changelog, and tag the release. 🏷️
+ - [ ] Begin an upload to [Zenodo] for a new version of [this record], using the `team@plasmapy.org` login. Reserve a DOI. 🏷️
+ - [ ] Run the GitHub Action to [mint a release] 🍬, specifying the version (i.e., `2024.10.0` or `2024.10.0rc1` for a release candidate) and copying the reserved DOI from Zenodo. This workflow will update metadata, build the changelog, create the release branch (i.e., `2024.10.x`), and tag the release.
  - [ ] [Create a release on GitHub]. 🚀
-   - Choose the newly created tag (e.g., `v2024.5.0`), and use it as the title. (The release will be performed from the tag, so it is not necessary to select the branch.) 🏷️
+   - Choose the newly created tag (e.g., `v2024.10.0`), and use it as the title. (The release will be performed from the tag, so it is not necessary to select the branch.) 🏷️
    - Select the option to automatically generate release notes. 📜
    - Select the option to create a discussion for the release under the _General_ category.
-   - For official releases, make sure the checkbox is selected for _Set as the latest release_. For beta releases or release candidates (e.g., `v2024.5.0rc1`), specify it as a pre-release.
+   - For official releases, make sure the checkbox is selected for _Set as the latest release_. For beta releases or release candidates (e.g., `v2024.10.0rc1`), specify it as a pre-release.
    - Click on _Publish release_, which will create the GitHub release and trigger the GitHub workflow to [publish to PyPI]. 🚀
    - Check the [release history] on PyPI to make sure that the release was successful. 🆕
- - [ ] [Create a pull request] to merge the tag for the release back into main. Under the box for _compare_, select _Tags_, choose the tag for this release (e.g., `v2024.7.0`), and then click on _Create pull request_.
- - [ ] Merge **but do not squash** this PR back into `main`.
+ - [ ] [Create a pull request] to merge the `v2024.10.x` branch back into main.
+ - [ ] Merge **but do not squash** this PR back into `main`, and **do not delete** the `v2024.10.x` branch.
 
 > [!CAUTION]
-> Squashing the pull request back into `main` can cause problems by removing the tagged release commit from the history of `main`.
-
-<!-- This happened in #2630. -->
-
-<!-- Creating the pull request *from the tag* prevents us from accidentally deleting the release branch. -->
-<!-- We might be able to modify the `mint-release.yml` workflow by having it automatically create the pull request back into `main`, but we'd want to keep a note *not to squash merge* the resulting PRs. -->
+> Squashing the pull request back into `main` causes problems by removing the tagged release commit from the history of `main`. For example, `plasmapy.__version__` in development installations is chosen based on the most recent tag in `main`.
 
 ### Following the release
 
@@ -86,8 +76,8 @@ This issue contains the procedure for releasing a new version of PlasmaPy.
 ### Update documentation
 
  - [ ] Delete the [`stable`] branch on GitHub, if it exists.
- - [ ] Activate the current and prior release on the [versions page on RTD], if necessary. If the documentation fails to build for a release, activate the corresponding branch (e.g., activate the `v2023.10.x` branch instead of the `v2023.10.0` tag). <!-- true example! -->
- - [ ] Check that the [documentation] builds correctly for the release branch. If the documentation build fails, create a new [`stable`] branch from the release branch (e.g., `2024.5.x`) and fix any problems with the documentation build. The [`stable`] branch is needed if the documentation build for the release fails or if we make any changes to the documentation between releases. The [stable documentation build] will point to the [`stable`] branch on GitHub if it exists. Otherwise, it will point to the most recent release on GitHub. 📚
+ - [ ] Activate the current and prior release on the [versions page on RTD], if necessary. If the documentation fails to build for a release, activate the corresponding branch (e.g., activate the `v2023.10.x` branch instead of the `v2023.10.0` tag).
+ - [ ] Check that the [documentation] builds correctly for the release branch. If the documentation build fails, create a new [`stable`] branch from the release branch (e.g., `2024.10.x`) and fix any problems with the documentation build. The [`stable`] branch is needed if the documentation build for the release fails or if we make any changes to the documentation between releases. The [stable documentation build] will point to the [`stable`] branch on GitHub if it exists. Otherwise, it will point to the most recent release on GitHub. 📚
  - [ ] Verify that the [citation page] is up-to-date and the DOI link points to the most recent release.
 
 ## Test the release

--- a/changelog/2784.internal.rst
+++ b/changelog/2784.internal.rst
@@ -1,0 +1,1 @@
+Updated the release checklist.


### PR DESCRIPTION
This PR makes some corrections to the release checklist.  More specifically, it's not currently possible to make a PR from a tag, so the checklist is from the release branch to `main`.