### PR TITLE
Add back code review checklist

### DIFF
--- a/.github/content/code-review-checklist.md
+++ b/.github/content/code-review-checklist.md
@@ -1,0 +1,23 @@
+[changelog guide]: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html
+[coding guide]: https://docs.plasmapy.org/en/latest/contributing/coding_guide.html
+[doc guide]: https://docs.plasmapy.org/en/latest/contributing/doc_guide.html
+[testing guide]: https://docs.plasmapy.org/en/latest/contributing/testing_guide.html
+
+Thank you for contributing to PlasmaPy! The project's future depends deeply on contributors like you, so we deeply appreciate it! 🌱 The following checklist will be used by the code reviewer to help guide the code review process.
+
+- Overall
+  - [ ] Does the PR do what it intends to do?
+  - [ ] Except for very minor changes, is a changelog entry included and consistent with the [changelog guide]?
+  - [ ] Are the continuous integration checks passing? (Most linter problems can be automagically fixed by commenting on this PR with `pre-commit.ci autofix`.)
+- Code
+  - [ ] Is new/updated code understandable and consistent with the [coding guide]?
+  - [ ] Are there ways to greatly simplify the implementation?
+  - [ ] Are there any large functions that should be split up into shorter functions?
+- Tests
+  - [ ] Are tests added/updated as required, and consistent with the [testing guide]?
+  - [ ] Are the tests understandable?
+  - [ ] Do the tests cover all important cases?
+- Docs
+  - [ ] Are docs added/updated as required, and consistent with the [doc guide]?
+  - [ ] Are the docs understandable?
+  - [ ] Do the docs show up correctly in the preview, including Jupyter notebooks?


### PR DESCRIPTION
Having a checklist for reviewers is generally considered a recommended practice for doing code reviews.

Up until ∼early 2023, we had a code review checklist that got posted to every pull request. We ended up deleting that in favor of posting a [welcome message](https://github.com/PlasmaPy/PlasmaPy/blob/8be53601b14f35af34c054cfbb856a57fb74fa96/.github/workflows/comment-on-pr.yml#L23) without a checklist. We did that because we ended up not using the checklist as much as we probably should have.

This PR adds back the code review checklist ahead of the summer school.

It would be great to make it so that there are sections of the checklist that are collapsible, like in the [dependabot pull requests](https://github.com/PlasmaPy/PlasmaPy/pull/2706#issue-2324431924). That way, if a PR doesn't modify documentation, then the documentation checklist items can be hidden.

At the moment, I haven't yet added the GitHub workflow that does the actual posting.  I want to make it so that what gets posted is in a Markdown file of its own (instead of in the GitHub workflow YAML file, which is quite difficult to read). I don't know how do that, so I'll probably ask ChatGPT to do it for me. That sometimes works! 🙃 