### PR TITLE
Extend `@particle_input` to `ParticleListLike` annotations

### DIFF
--- a/src/plasmapy/particles/decorators.py
+++ b/src/plasmapy/particles/decorators.py
@@ -586,6 +586,14 @@ class _ParticleInput:
             if not hasattr(argument, "__len__") or len(argument) != 2:
                 raise ValueError(f"The length of {argument} must be 2.")
             return Particle(argument[0]), Particle(argument[1])
+        elif annotation in [ParticleList, ParticleListLike]:
+            # Apply casting to arguments annotated with ParticleList and ParticleListLike
+            # If the argument is already an iterable, it will be cast to a ParticleList
+            # otherwise, cast it to a list
+            if not isinstance(argument, ParticleList) and not isinstance(
+                argument, Iterable
+            ):
+                argument = [argument]
 
         if annotation in _basic_particle_input_annotations and argument is None:
             raise TypeError(f"{parameter} may not be None.")

--- a/src/plasmapy/particles/decorators.py
+++ b/src/plasmapy/particles/decorators.py
@@ -590,9 +590,10 @@ class _ParticleInput:
             # Apply casting to arguments annotated with ParticleList and ParticleListLike
             # If the argument is already an iterable, it will be cast to a ParticleList
             # otherwise, cast it to a list
-            if not isinstance(argument, ParticleList) and not isinstance(
-                argument, Iterable
-            ):
+            if (
+                not isinstance(argument, ParticleList)
+                and (not isinstance(argument, Iterable) or isinstance(argument, str))
+            ):  # TODO: figure out the python hierarchy for arrays like this so we can find the difference Iterable \ str
                 argument = [argument]
 
         if annotation in _basic_particle_input_annotations and argument is None:


### PR DESCRIPTION
Currently, the `@particle_input` decorator *supports* `ParticleList` annotations but does not provide robust support for casting for `ParticleListLike` objects. This PR will implement support for casting of iterables and strings to `ParticleList` objects for parameters annotated with `ParticleListLike`.