### PR TITLE
Unpin sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,7 @@ docs = [
   "numpydoc >= 1.7.0",
   "pillow >= 10.4.0",
   "pygments >= 2.18.0",
-  # See #2764
-  "sphinx == 7.3.7",
+  "sphinx >= 7.4.7",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.2",
   "sphinx-copybutton >= 0.5.2",


### PR DESCRIPTION
Previously a bug on sphinx-doc's side caused builds to fail. This bug has been fixed in subsequent releases, meaning we can unpin sphinx.

Resolves #2764