### PR TITLE
Fix problem with installation step in Nox sessions to build documentation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -283,7 +283,7 @@ def docs(session: nox.Session) -> None:
     """
     if running_on_ci:
         session.debug(doc_troubleshooting_message)
-    session.install("-r", docs_requirements, ".")
+    session.install("-r", docs_requirements, ".[docs]")
     session.run(*sphinx_commands, *build_html, *session.posargs)
     landing_page = (
         pathlib.Path(session.invoked_from) / "docs" / "build" / "html" / "index.html"
@@ -337,8 +337,7 @@ def linkcheck(session: nox.Session) -> None:
     """Check hyperlinks in documentation."""
     if running_on_ci:
         session.debug(LINKCHECK_TROUBLESHOOTING)
-    session.install("-r", docs_requirements)
-    session.install(".")
+    session.install("-r", docs_requirements, ".[docs]")
     session.run(*sphinx_commands, *check_hyperlinks, *session.posargs)
 
 
@@ -463,12 +462,9 @@ def changelog(session: nox.Session, final: str) -> None:
             "and PATCH is a non-negative integer."
         )
 
-    session.install(".")
-    session.install("towncrier")
+    session.install(".", "towncrier")
 
     options = ("--yes",) if final else ("--draft", "--keep")
-
-    session.install("towncrier")
 
     session.run(
         "towncrier",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ docs = [
   "numpydoc >= 1.7.0",
   "pillow >= 10.4.0",
   "pygments >= 2.18.0",
-  "sphinx >= 7.4.7",
+  "sphinx == 7.3.7",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.2",
   "sphinx-copybutton >= 0.5.2",


### PR DESCRIPTION
Previously, we included a line in the Nox sessions to build documentation like:
```python
session.install("-r", docs_requirements, ".")
```
The problem is that this does not explicitly include the `docs` dependency set, which has the consequence of hiding errors resulting from inconsistencies between the requirements file and `docs` requirements set.

🔧 This PR makes it so that the installation step explicitly includes the `docs` dependency set via `.[docs]`. 

I'm also repinning `sphinx==7.3.7` (sigh!) since the problem with the `docs` Nox session masked the warnings that we were trying to fix (see also #2762 and #2764).  