### PR TITLE
Fix welcome message

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -38,7 +38,7 @@ jobs:
             > [!TIP]
             > 📚 For a documentation preview, click on *Details* next to **docs/readthedocs.org:plasmapy**. For cryptic documentation errors, see the [documentation troubleshooting guide](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting).
 
-            > [!HINT]
+            > [!TIP]
             > 🧹 Automatically fix most **pre-commit.ci** failures by commenting [\`pre-commit.ci autofix\`](https://github.com/PlasmaPy/PlasmaPy/pull/1500#issuecomment-1216865989) below. For other failures, please see the [pre-commit troubleshooting guide](https://docs.plasmapy.org/en/stable/contributing/pre-commit.html#troubleshooting-pre-commit-failures).
 
             We thank you once again! 🌌`


### PR DESCRIPTION
GitHub allows `[!TIP]` admonitions, but unlike in reStructuredText, not `[!HINT]` admonitions.  This PR changes a `[!HINT]` to a `[!TIP]`.
