### PR TITLE
Fix minor test failure from change to `astropy.units` namespace

### DIFF
--- a/tests/dispersion/analytical/test_mhd_wave_class.py
+++ b/tests/dispersion/analytical/test_mhd_wave_class.py
@@ -1,5 +1,4 @@
 import astropy.units as u
-import astropy.units.core
 import numpy as np
 import pytest
 
@@ -56,7 +55,7 @@ class TestMHDWave:
             ),
             ({"k": 0 * u.rad / u.m, "theta": 45 * u.deg}, ValueError),
             ({"k": -1.0 * u.rad / u.m, "theta": 45 * u.deg}, ValueError),
-            ({"k": 1e-5 * u.eV, "theta": 45 * u.deg}, astropy.units.core.UnitTypeError),
+            ({"k": 1e-5 * u.eV, "theta": 45 * u.deg}, u.UnitTypeError),
             ({"k": 1e-5 * u.rad / u.m, "theta": np.ones((3, 2)) * u.deg}, ValueError),
             ({"k": 1e-5 * u.rad / u.m, "theta": 5 * u.eV}, u.UnitTypeError),
         ],


### PR DESCRIPTION
There was a change to the namespace in `astropy.units` so that `astropy.units.core.UnitTypeError` no longer exists (https://github.com/astropy/astropy/pull/16868). 

Based on the discussion in that issue, it sounds better to import something directly from `astropy.units` rather than the specific modules (i.e., use `u.UnitTypeError` vs `astropy.units.core.UnitTypeError`). Fortunately, this pattern is what we usually do anyway. 

Note: there's still another error in the development version of `astropy.units` that this PR doesn't fix.
