### PR TITLE
Adjust sphinx config for RTD default changes

### DIFF
--- a/changelog/2857.internal.rst
+++ b/changelog/2857.internal.rst
@@ -1,0 +1,1 @@
+Adjust Sphinx config to account for recent deprecations in ReadTheDocs.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -582,6 +582,16 @@ automodapi_group_order = (
     "variables",
 )
 
+# following https://about.readthedocs.com/blog/2024/07/addons-by-default/
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 
 def setup(app: Sphinx) -> None:
     app.add_config_value("revision", "", rebuild=True)


### PR DESCRIPTION
As per <https://about.readthedocs.com/blog/2024/07/addons-by-default/>,
RTD is currently simplifying their pipeline - they're removing "hidden"
manipulations of the `conf.py` context.

I've been getting emails about needing to add this snippet to preserve
current behavior, so there you go :)

<!-- If this PR will fully resolve an issue, include text like "Closes #1532" so that the issue will be automatically closed when this PR is merged. Please also check out PlasmaPy's contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html. Thank you!-->
