### PR TITLE
Add sphinx-substitutions to docs dependency group, enable it in conf.…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,7 @@ extensions = [
     "sphinx_gallery.load_style",
     "sphinx_issues",
     "sphinx_reredirects",
+    "sphinx_substitution_extensions",
     "sphinx_tabs.tabs",
     "sphinx_collapse",
     "sphinxcontrib.bibtex",
@@ -214,9 +215,11 @@ nitpick_ignore_regex = [
 # build, so use them in moderation!  Use docs/_global_substitutions.py
 # to define substitutions.
 
-rst_prolog = """
+rst_prolog = f"""
 .. role:: py(code)
    :language: python
+
+.. |maxpython| replace:: {global_substitutions['maxpython']}
 """
 
 # html output options

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -73,11 +73,12 @@ installed into |uv|-managed
 `virtual environments <virtual environment_>`_ without installing |pip|.
 
 After `installing uv`_, a `virtual environment`_ with |Python| version
-3.12 can be created by opening a terminal and running:
+|maxpython| can be created by opening a terminal and running:
 
 .. code-block:: bash
+   :substitutions:
 
-   uv venv --python 3.12
+   uv venv --python |maxpython|
 
 |uv| will automatically download |Python| and link it to
 the `virtual environment`_'s directory at (by default) :file:`.venv`. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ docs = [
   "sphinx-issues >= 4.1.0",
   "sphinx-notfound-page >= 1.0.2",
   "sphinx-reredirects >= 0.1.5",
+  "sphinx-substitution-extensions >= 2024.08.06",
   "sphinx_collapse >= 0.1.3",
   "sphinx_rtd_theme >= 2.0.0",
   "sphinx_tabs >= 3.4.5",


### PR DESCRIPTION
…py, and populate maxpython into rst_prolog

The ability to dynamically use global substitutions in documentation was mentioned in [#2861](https://github.com/PlasmaPy/PlasmaPy/pull/2861#issuecomment-2394780879). This PR adds the [sphinx-substitution-extensions](https://github.com/adamtheturtle/sphinx-substitution-extensions). To demonstrate its usage, I rewrote the code block in instructions for installing plasmapy with uv (#2861 ) to use |maxpython|.

The substitution variables need to be populated into `prolog_rst`, though. So this may slow down documentation build.