### PR TITLE
Update saving for CPR synthetic radiography

### DIFF
--- a/changelog/2868.feature.1.rst
+++ b/changelog/2868.feature.1.rst
@@ -1,3 +1,3 @@
 Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument ``output_name``
-that sets the basename of the saved file(s). `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` now 
+that sets the basename of the saved file(s). `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` now
 also accepts an ``output_name`` keyword, which is passed to the save routine.

--- a/changelog/2868.feature.1.rst
+++ b/changelog/2868.feature.1.rst
@@ -1,3 +1,3 @@
-Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument ``output_name``
+Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument ``output_basename``
 that sets the basename of the saved file(s). `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` now
-also accepts an ``output_name`` keyword, which is passed to the save routine.
+also accepts an ``output_basename`` keyword, which is passed to the save routine.

--- a/changelog/2868.feature.1.rst
+++ b/changelog/2868.feature.1.rst
@@ -1,0 +1,3 @@
+Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument ``output_name``
+that sets the basename of the saved file(s). `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` now 
+also accepts an ``output_name`` keyword, which is passed to the save routine.

--- a/changelog/2868.feature.2.rst
+++ b/changelog/2868.feature.2.rst
@@ -1,0 +1,3 @@
+`~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.synthetic_radiograph` now accepts a file path to an
+HDF5 file saved by `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` as input to create
+a synthetic radiograph.

--- a/changelog/2868.feature.rst
+++ b/changelog/2868.feature.rst
@@ -1,8 +1,8 @@
 Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument ``output_name``
 that sets the basename of the saved file(s).
 
-`~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.Tracker` now also accepts an ``output_name`` keyword.
+`~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` now also accepts an ``output_name`` keyword.
 
-`~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.synthetic_radiograph` now accepts a file path to an
-HDF5 file saved by `~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.Tracker` as input to create
+`~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.synthetic_radiograph` now accepts a file path to an
+HDF5 file saved by `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` as input to create
 a synthetic radiograph.

--- a/changelog/2868.feature.rst
+++ b/changelog/2868.feature.rst
@@ -1,8 +1,8 @@
-Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument `output_name`
+Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument ``output_name``
 that sets the basename of the saved file(s).
 
-`~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.Tracker` now also accepts an `output_name` keyword. 
+`~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.Tracker` now also accepts an ``output_name`` keyword.
 
 `~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.synthetic_radiograph` now accepts a file path to an
-HDF5 file saved by `~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.Tracker` as input to create 
+HDF5 file saved by `~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.Tracker` as input to create
 a synthetic radiograph.

--- a/changelog/2868.feature.rst
+++ b/changelog/2868.feature.rst
@@ -1,8 +1,0 @@
-Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument ``output_name``
-that sets the basename of the saved file(s).
-
-`~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` now also accepts an ``output_name`` keyword.
-
-`~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.synthetic_radiograph` now accepts a file path to an
-HDF5 file saved by `~plasmapy.diagnostics.charged_particle_radiography.synthetic_radiography.Tracker` as input to create
-a synthetic radiograph.

--- a/changelog/2868.feature.rst
+++ b/changelog/2868.feature.rst
@@ -1,0 +1,8 @@
+Save routines in `~plasmapy.simulation.particle_tracker.save_routines` now take an optional keyword argument `output_name`
+that sets the basename of the saved file(s).
+
+`~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.Tracker` now also accepts an `output_name` keyword. 
+
+`~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.synthetic_radiograph` now accepts a file path to an
+HDF5 file saved by `~plasmapy.diagnostic.charged_particle_radiography.synthetic_radiography.Tracker` as input to create 
+a synthetic radiograph.

--- a/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -76,9 +76,11 @@ def _coerce_to_cartesian_si(pos):
 
 class _SyntheticRadiographySaveRoutine(SaveOnceOnCompletion):
     def __init__(
-        self, output_directory: Path | None = None, output_name: str = "output"
+        self, output_directory: Path | None = None, output_basename: str = "output"
     ) -> None:
-        super().__init__(output_directory=output_directory, output_name=output_name)
+        super().__init__(
+            output_directory=output_directory, output_basename=output_basename
+        )
 
         self._quantities = {
             "source": (u.m, "attribute"),
@@ -100,7 +102,7 @@ class _SyntheticRadiographySaveRoutine(SaveOnceOnCompletion):
         if self.output_directory is None:
             return
 
-        output_file_path = self.output_directory / Path(f"{self.output_name}.h5")
+        output_file_path = self.output_directory / Path(f"{self.output_basename}.h5")
 
         with h5py.File(output_file_path, "w") as output_file:
             for key, (_units, data_type) in self._quantities.items():
@@ -182,7 +184,7 @@ class Tracker(ParticleTracker):
         Directory for objects that are saved to disk. If a directory is not
         specified then a memory save routine is used.
 
-    output_name : `str`, optional
+    output_basename : `str`, optional
         Optional base name for output files.
 
     fraction_exited_threshold : float, optional
@@ -207,7 +209,7 @@ class Tracker(ParticleTracker):
         ] = "volume averaged",
         detector_hdir=None,
         output_directory: Path | None = None,
-        output_name: str = "output",
+        output_basename: str = "output",
         fraction_exited_threshold: float = 0.999,
         verbose: bool = True,
     ) -> None:
@@ -215,7 +217,7 @@ class Tracker(ParticleTracker):
         # The particle tracker class ensures that the provided grid argument has the proper type and
         # that the necessary grid quantities are created if they are not already specified
         save_routine = (
-            _SyntheticRadiographySaveRoutine(output_directory, output_name)
+            _SyntheticRadiographySaveRoutine(output_directory, output_basename)
             if output_directory is not None
             else None
         )

--- a/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -75,8 +75,10 @@ def _coerce_to_cartesian_si(pos):
 
 
 class _SyntheticRadiographySaveRoutine(SaveOnceOnCompletion):
-    def __init__(self, output_directory: Path) -> None:
-        super().__init__(output_directory=output_directory)
+    def __init__(
+        self, output_directory: Path | None = None, output_name: str = "output"
+    ) -> None:
+        super().__init__(output_directory=output_directory, output_name=output_name)
 
         self._quantities = {
             "source": (u.m, "attribute"),
@@ -98,7 +100,7 @@ class _SyntheticRadiographySaveRoutine(SaveOnceOnCompletion):
         if self.output_directory is None:
             return
 
-        output_file_path = self.output_directory / "output.hdf5"
+        output_file_path = self.output_directory / f"{self.output_name}.h5"
 
         with h5py.File(output_file_path, "w") as output_file:
             for key, (_units, data_type) in self._quantities.items():
@@ -180,6 +182,9 @@ class Tracker(ParticleTracker):
         Directory for objects that are saved to disk. If a directory is not
         specified then a memory save routine is used.
 
+    output_name : `str`, optional
+        Optional base name for output files.
+
     fraction_exited_threshold : float, optional
         The fraction of particles that must leave the grids to terminate the
         simulation. This does not include particles that have never entered
@@ -201,7 +206,8 @@ class Tracker(ParticleTracker):
             "volume averaged", "nearest neighbor"
         ] = "volume averaged",
         detector_hdir=None,
-        output_file: Path | None = None,
+        output_directory: Path | None = None,
+        output_name: str = "output",
         fraction_exited_threshold: float = 0.999,
         verbose: bool = True,
     ) -> None:
@@ -209,8 +215,8 @@ class Tracker(ParticleTracker):
         # The particle tracker class ensures that the provided grid argument has the proper type and
         # that the necessary grid quantities are created if they are not already specified
         save_routine = (
-            _SyntheticRadiographySaveRoutine(output_file)
-            if output_file is not None
+            _SyntheticRadiographySaveRoutine(output_directory, output_name)
+            if output_directory is not None
             else None
         )
 

--- a/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -1157,22 +1157,21 @@ def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):
     # condition `obj` input
     if isinstance(obj, Tracker):
         # results_dict raises an error if the simulation has not been run.
-        d = obj.results_dict
+        results_dict = obj.results_dict
 
     elif isinstance(obj, dict):
-        d = obj
+        results_dict = obj
 
     elif isinstance(obj, str | Path):
-        d = {}
+        results_dict = {}
         obj = Path(obj)
         # Create a dictionary of all of the datasets and attributes in the save file
         # Equivalent to |results_dict|
         with h5py.File(obj, "r") as f:
             for k in f:
-                d[k] = f[k][...]
+                results_dict[k] = f[k][...]
             for k in f.attrs:
-                d[k] = f.attrs[k][...]
-
+                results_dict[k] = f.attrs[k][...]
     else:
         raise TypeError(
             f"Expected type `Path`, `dict` or {Tracker} for argument `obj`, but "
@@ -1188,13 +1187,13 @@ def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):
     # If ignore_grid is True, use the predicted positions in the absence of
     # simulated fields
     if ignore_grid:
-        xloc = d["x0"]
-        yloc = d["y0"]
-        v = d["v0"][:, 0]
+        xloc = results_dict["x0"]
+        yloc = results_dict["y0"]
+        v = results_dict["v0"][:, 0]
     else:
-        xloc = d["x"]
-        yloc = d["y"]
-        v = d["v"][:, 0]
+        xloc = results_dict["x"]
+        yloc = results_dict["y"]
+        v = results_dict["v"][:, 0]
 
     if size is None:
         # If a detector size is not given, choose a size based on the
@@ -1231,7 +1230,7 @@ def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):
 
     # Throw a warning if < 50% of the particles are included on the
     # histogram
-    percentage = np.sum(intensity) / d["nparticles"]
+    percentage = np.sum(intensity) / results_dict["nparticles"]
     if percentage < 0.5:
         warnings.warn(
             f"Only {percentage:.2%} of the particles are shown "

--- a/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -1103,7 +1103,7 @@ class Tracker(ParticleTracker):
 # *************************************************************************
 
 
-def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):
+def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):  # noqa: C901, PLR0912
     r"""
     Calculate a "synthetic radiograph" (particle count histogram in the
     image plane).
@@ -1168,10 +1168,10 @@ def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):
         # Create a dictionary of all of the datasets and attributes in the save file
         # Equivalent to |results_dict|
         with h5py.File(obj, "r") as f:
-            for k in f:
-                results_dict[k] = f[k][...]
-            for k in f.attrs:
-                results_dict[k] = f.attrs[k][...]
+            for key in f:
+                results_dict[key] = f[key][...]
+            for key in f.attrs:
+                results_dict[key] = f.attrs[key][...]
     else:
         raise TypeError(
             f"Expected type `Path`, `dict` or {Tracker} for argument `obj`, but "

--- a/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -100,7 +100,7 @@ class _SyntheticRadiographySaveRoutine(SaveOnceOnCompletion):
         if self.output_directory is None:
             return
 
-        output_file_path = self.output_directory / f"{self.output_name}.h5"
+        output_file_path = self.output_directory / Path(f"{self.output_name}.h5")
 
         with h5py.File(output_file_path, "w") as output_file:
             for key, (_units, data_type) in self._quantities.items():
@@ -1113,7 +1113,7 @@ def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):
 
     Parameters
     ----------
-    obj: `dict` or `Path` or |Tracker|
+    obj: `dict` or `~pathlib.Path` or |Tracker|
         Either a |Tracker|
         object that has been run, a dictionary equivalent to
         |results_dict|, or path to a saved output file

--- a/src/plasmapy/simulation/particle_tracker/save_routines.py
+++ b/src/plasmapy/simulation/particle_tracker/save_routines.py
@@ -30,6 +30,9 @@ class AbstractSaveRoutine(ABC):
         Output for objects that are saved to disk. If a directory is not specified
         then a memory save routine is used.
 
+    output_name : `str`, optional
+        Optional string basename for saved files.
+
 
     Notes
     -----
@@ -38,8 +41,11 @@ class AbstractSaveRoutine(ABC):
     Then, the hook calls `save_now` to determine whether or not the simulation state should be saved.
     """
 
-    def __init__(self, output_directory: Path | None = None) -> None:
+    def __init__(
+        self, output_directory: Path | None = None, output_name: str = "output"
+    ) -> None:
         self.output_directory = output_directory
+        self.output_name = output_name
 
         self._results = {}
         self._quantities = {
@@ -93,7 +99,10 @@ class AbstractSaveRoutine(ABC):
     def _save_to_disk(self) -> None:
         """Save a hdf5 file containing simulation positions and velocities."""
 
-        path = self.output_directory / f"{self.tracker.iteration_number}.hdf5"
+        path = (
+            self.output_directory
+            / f"{self.output_name}_iter{self.tracker.iteration_number}.h5"
+        )
 
         with h5py.File(path, "w") as output_file:
             for key, (_units, data_type) in self._quantities.items():
@@ -171,8 +180,10 @@ class SaveOnceOnCompletion(AbstractSaveRoutine):
     bypassing the ``save_now()`` criteria.
     """
 
-    def __init__(self, output_directory: Path | None = None) -> None:
-        super().__init__(output_directory)
+    def __init__(
+        self, output_directory: Path | None = None, output_name: str = "output"
+    ) -> None:
+        super().__init__(output_directory, output_name)
 
     @property
     def save_now(self) -> bool:

--- a/src/plasmapy/simulation/particle_tracker/save_routines.py
+++ b/src/plasmapy/simulation/particle_tracker/save_routines.py
@@ -30,7 +30,7 @@ class AbstractSaveRoutine(ABC):
         Output for objects that are saved to disk. If a directory is not specified
         then a memory save routine is used.
 
-    output_name : `str`, optional
+    output_basename : `str`, optional
         Optional string basename for saved files.
 
 
@@ -42,10 +42,10 @@ class AbstractSaveRoutine(ABC):
     """
 
     def __init__(
-        self, output_directory: Path | None = None, output_name: str = "output"
+        self, output_directory: Path | None = None, output_basename: str = "output"
     ) -> None:
         self.output_directory = output_directory
-        self.output_name = output_name
+        self.output_basename = output_basename
 
         self._results = {}
         self._quantities = {
@@ -101,7 +101,7 @@ class AbstractSaveRoutine(ABC):
 
         path = (
             self.output_directory
-            / f"{self.output_name}_iter{self.tracker.iteration_number}.h5"
+            / f"{self.output_basename}_iter{self.tracker.iteration_number}.h5"
         )
 
         with h5py.File(path, "w") as output_file:
@@ -181,9 +181,9 @@ class SaveOnceOnCompletion(AbstractSaveRoutine):
     """
 
     def __init__(
-        self, output_directory: Path | None = None, output_name: str = "output"
+        self, output_directory: Path | None = None, output_basename: str = "output"
     ) -> None:
-        super().__init__(output_directory, output_name)
+        super().__init__(output_directory, output_basename)
 
     @property
     def save_now(self) -> bool:

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -600,6 +600,12 @@ class TestSyntheticRadiograph:
         with pytest.warns(RuntimeWarning):
             cpr.synthetic_radiograph(sim_results)
 
+    def test_ignore_grid(self):
+        """
+        Verifies that the no grid option runs - no good tests for whether it is correct currently
+        """
+        x, y, i = cpr.synthetic_radiograph(self.sim_results, ignore_grid=True)
+
     @pytest.mark.parametrize(
         ("args", "kwargs", "expected"),
         [

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -953,7 +953,7 @@ def test_radiography_disk_save_routine(tmp_path) -> None:
         detector,
         field_weighting="nearest neighbor",
         output_directory=tmp_path,
-        output_name="test_output",
+        output_basename="test_output",
     )
     sim.create_particles(1e3, 15 * u.MeV, max_theta=8 * u.deg, random_seed=42)
     sim.run()

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -940,7 +940,11 @@ def test_radiography_disk_save_routine(tmp_path) -> None:
     detector = (0 * u.mm, 200 * u.mm, 0 * u.mm)
 
     sim = cpr.Tracker(
-        grid, source, detector, field_weighting="nearest neighbor", output_file=tmp_path
+        grid,
+        source,
+        detector,
+        field_weighting="nearest neighbor",
+        output_directory=tmp_path,
     )
     sim.create_particles(1e3, 15 * u.MeV, max_theta=8 * u.deg, random_seed=42)
     sim.run()

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -2,6 +2,8 @@
 Tests for proton radiography functions
 """
 
+from pathlib import Path
+
 import astropy.constants as const
 import astropy.units as u
 import numpy as np
@@ -945,9 +947,24 @@ def test_radiography_disk_save_routine(tmp_path) -> None:
         detector,
         field_weighting="nearest neighbor",
         output_directory=tmp_path,
+        output_name="test_output",
     )
     sim.create_particles(1e3, 15 * u.MeV, max_theta=8 * u.deg, random_seed=42)
     sim.run()
+
+    path = tmp_path / Path("test_output.h5")
+
+    # Assert the file has been saved
+    assert path.is_file()
+
+    # Make synthetic radiograph from sim object
+    h, v, i1 = cpr.synthetic_radiograph(sim)
+
+    # Load from tmppath and make synthetic radiograph
+    h, v, i2 = cpr.synthetic_radiograph(path)
+
+    # The two synthetic radiographs should be identical
+    assert np.allclose(i1, i2)
 
 
 def test_radiography_memory_save_routine() -> None:

--- a/tests/simulation/test_save_routines.py
+++ b/tests/simulation/test_save_routines.py
@@ -29,7 +29,7 @@ def time_elapsed_termination_condition_instantiated():
 @pytest.fixture
 def disk_interval_save_routine_instantiated(tmp_path):
     return IntervalSaveRoutine(
-        1 * u.s, output_directory=tmp_path, output_name="test_name"
+        1 * u.s, output_directory=tmp_path, output_basename="test_name"
     )
 
 

--- a/tests/simulation/test_save_routines.py
+++ b/tests/simulation/test_save_routines.py
@@ -28,7 +28,9 @@ def time_elapsed_termination_condition_instantiated():
 
 @pytest.fixture
 def disk_interval_save_routine_instantiated(tmp_path):
-    return IntervalSaveRoutine(1 * u.s, output_directory=tmp_path)
+    return IntervalSaveRoutine(
+        1 * u.s, output_directory=tmp_path, output_name="test_name"
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
A couple updates to how Tracker and the CPR module deal with saving, to make it a bit more convenient: 

1) `Tracker` save routines now take an optional `output_name` keyword that provides a basename for the save files. This is useful if you want your output files to have names based on context, or if you're saving multiple files. 

2) `synthetic_radiograph` now also works if you give it a path to an HDF5 file of Tracker output, which is now the default output format for Tracker. 