### PR TITLE
Add discussion in testing guide of how to reduce chances of getting test collection errors

### DIFF
--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -150,7 +150,7 @@ Writing Tests
 
 Every code contribution that adds new functionality requires both tests
 and documentation in order to be merged. Here we describe the process of
-write a test.
+writing a test.
 
 Assertions
 ----------

--- a/docs/contributing/testing_guide.rst
+++ b/docs/contributing/testing_guide.rst
@@ -107,19 +107,10 @@ are located in |tests/formulary|_ and tests of
 `plasmapy.formulary.speeds` are located in
 |tests/formulary/test_speeds.py|_.
 
-.. _writing-tests:
-
-Writing Tests
-=============
-
-Every code contribution that adds new functionality requires both tests
-and documentation in order to be merged. Here we describe the process of
-write a test.
-
 .. _locating-tests:
 
 Locating tests
---------------
+==============
 
 Tests are located in the top-level |tests|_ directory. The directory
 structure of |tests|_ largely mirrors that of |src/plasmapy|_, which
@@ -151,6 +142,15 @@ actual printed output matches the output included in the docstring.
 
 More information on test organization, naming, and collection is
 provided in pytest_'s documentation on `test discovery conventions`_.
+
+.. _writing-tests:
+
+Writing Tests
+=============
+
+Every code contribution that adds new functionality requires both tests
+and documentation in order to be merged. Here we describe the process of
+write a test.
 
 Assertions
 ----------


### PR DESCRIPTION
When using pytest, I've noticed that it's harder to diagnose test collection errors than test failures (most recently in #2869 & #2870).  Test collection errors don't result in good tracebacks, at least with the pytest settings from `pyproject.toml`. Test collection errors also prevent pytest from running the full test suite by default, which means we often get incomplete information.

In this PR, I'm planning to add some tips to the testing guide on how to avoid getting test collection errors.  In particular, if a test file contains code that has a chance of failing, that code should be put into either a fixture or an actual test.  Pretty much I want to avoid situations like...

```python
# test_file.py

x = 0 / 0   # causes a ZeroDivisionError in the test collection phase

def test_something():
    assert True
```

I may also look into ways to improve the reporting of test collection errors.

Just wanted to start this PR now as a placeholder since it might take me a month or three to get to it.