### PR TITLE
Update versions of Python used in tests, doc builds, and other CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,29 +52,29 @@ jobs:
           python: '3.10'
           nox_session: tests-3.10(lowest-direct)
 
-        - name: Documentation, Python 3.12, Ubuntu
+        - name: Documentation, Python 3.13, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: docs
 
-        - name: Static type checking with mypy, Python 3.12, Ubuntu
+        - name: Static type checking with mypy, Python 3.13, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: mypy
 
-        - name: Packaging, Python 3.12, Ubuntu
+        - name: Packaging, Python 3.13, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: build
 
         - name: Validate CITATION.cff
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: cff
 
         - name: Check consistency of pinned & project requirements
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: validate_requirements
 
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -54,94 +54,94 @@ jobs:
           python: '3.10'
           nox_session: tests-3.10(lowest-direct)
 
-        - name: Tests, Python 3.12, astropy-dev, Ubuntu
+        - name: Tests, Python 3.13, astropy-dev, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: run_tests_with_dev_version_of(astropy)
 
-        - name: Tests, Python 3.12, numpy-dev, Ubuntu
+        - name: Tests, Python 3.13, numpy-dev, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: run_tests_with_dev_version_of(numpy)
 
-        - name: Tests, Python 3.12, xarray-dev, Ubuntu
+        - name: Tests, Python 3.13, xarray-dev, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: run_tests_with_dev_version_of(xarray)
 
-        - name: Tests, Python 3.12, pandas-dev, Ubuntu
+        - name: Tests, Python 3.13, pandas-dev, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: run_tests_with_dev_version_of(pandas)
 
-        - name: Tests, Python 3.12, lmfit-dev, Ubuntu
+        - name: Tests, Python 3.13, lmfit-dev, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: run_tests_with_dev_version_of(lmfit)
 
-        - name: Documentation, Python 3.12, Ubuntu
+        - name: Documentation, Python 3.13, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: docs
 
-        - name: Documentation, Python 3.12, sphinx-dev, Ubuntu
+        - name: Documentation, Python 3.13, sphinx-dev, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: build_docs_with_dev_version_of(sphinx)
 
-        - name: Documentation, Python 3.12, sphinx_rtd_theme-dev, Ubuntu
+        - name: Documentation, Python 3.13, sphinx_rtd_theme-dev, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: build_docs_with_dev_version_of(sphinx_rtd_theme)
 
-        - name: Documentation, Python 3.12, nbsphinx-dev, Ubuntu
+        - name: Documentation, Python 3.13, nbsphinx-dev, Ubuntu
           os: ubuntu-latest
           python: '3.12'
           nox_session: build_docs_with_dev_version_of(nbsphinx)
 
-        - name: Static type checking with mypy, Python 3.12, Windows
+        - name: Static type checking with mypy, Python 3.13, Windows
           os: windows-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: mypy
 
-        - name: Packaging, Python 3.12, Windows
+        - name: Packaging, Python 3.13, Windows
           os: windows-latest
+          python: '3.13'
+          nox_session: build
+
+        - name: Packaging, Python 3.12, Ubuntu
+          os: ubuntu-latest
           python: '3.12'
           nox_session: build
 
-        - name: Packaging, Python 3.11, Ubuntu
-          os: ubuntu-latest
+        - name: Packaging, Python 3.11, macOS
+          os: macos-latest
           python: '3.11'
           nox_session: build
 
-        - name: Packaging, Python 3.10, macOS
+        - name: Import PlasmaPy, Python 3.13, macOS
           os: macos-latest
-          python: '3.10'
-          nox_session: build
+          python: '3.13'
+          nox_session: import
 
-        - name: Import PlasmaPy, Python 3.12, macOS
-          os: macos-latest
+        - name: Import PlasmaPy, Python 3.12, Ubuntu
+          os: ubuntu-latest
           python: '3.12'
           nox_session: import
 
-        - name: Import PlasmaPy, Python 3.11, Ubuntu
-          os: ubuntu-latest
-          python: '3.11'
-          nox_session: import
-
-        - name: Import PlasmaPy, Python 3.10, Windows
+        - name: Import PlasmaPy, Python 3.11, Windows
           os: windows-latest
-          python: '3.10'
+          python: '3.11'
           nox_session: import
 
         - name: Check MANIFEST.in
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: manifest
 
         - name: Lint
           os: ubuntu-latest
-          python: '3.12'
+          python: '3.13'
           nox_session: lint
 
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,17 +7,17 @@ formats:
 - htmlzip
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: '3.12'
+    python: '3.13'
   apt_packages:
   - graphviz
   jobs:
     post_build:
-    - echo $'\n'For help deciphering documentation build error messages, see:$'\n\n'\ \ https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
+    - echo $'\n'⚠️ For help deciphering documentation build error messages, see:$'\n\n'\ \ https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
 python:
   install:
   - method: pip
     path: .
-  - requirements: ci_requirements/docs-3.12-linux.txt
+  - requirements: ci_requirements/docs-3.13-linux.txt

--- a/noxfile.py
+++ b/noxfile.py
@@ -274,7 +274,7 @@ PlasmaPy's documentation guide at:
 """
 
 
-@nox.session(python="3.12")
+@nox.session(python=maxpython)
 def docs(session: nox.Session) -> None:
     """
     Build documentation with Sphinx.


### PR DESCRIPTION
This PR follows up on #2869 by updating the versions of Python used in Nox sessions, GitHub workflows, and on Read the Docs.