### PR TITLE
Use `typing.Self` in type hint annotations for `particle_class.py`

### DIFF
--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 __all__ = [
     "AbstractParticle",
@@ -105,7 +105,7 @@ See Also
 """
 
 
-def _category_errmsg(particle: str | Particle, category: str) -> str:
+def _category_errmsg(particle: str | Self, category: str) -> str:
     """
     Return an error message when an attribute raises an
     `~plasmapy.particles.exceptions.InvalidElementError`,
@@ -379,7 +379,7 @@ class AbstractPhysicalParticle(AbstractParticle):
 
         return require <= self.categories
 
-    def __add__(self, other: str | Particle | ParticleList) -> ParticleList:
+    def __add__(self, other: str | Self | ParticleList) -> ParticleList:
         return self._as_particle_list + other
 
     def __radd__(self, other: str) -> ParticleList:
@@ -966,7 +966,7 @@ class Particle(AbstractPhysicalParticle):
         """
         return hash(self.__repr__())
 
-    def __invert__(self) -> Particle:
+    def __invert__(self) -> Self:
         """
         Return the corresponding antiparticle, or raise an
         `~plasmapy.particles.exceptions.ParticleError` if the particle
@@ -1023,7 +1023,7 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["symbol"]
 
     @property
-    def antiparticle(self) -> Particle:
+    def antiparticle(self) -> Self:
         """
         The antiparticle corresponding to the particle.
 
@@ -1083,7 +1083,7 @@ class Particle(AbstractPhysicalParticle):
         return self._attributes["isotope"]
 
     @property
-    def nucleus(self) -> Particle:
+    def nucleus(self) -> Self:
         """
         Return the nucleus of an atom.
 
@@ -1795,7 +1795,7 @@ class Particle(AbstractPhysicalParticle):
 
     def ionize(
         self, n: int | Literal[np.inf] = 1, inplace: bool = False
-    ) -> Particle | None:
+    ) -> Self | None:
         """
         Create a new |Particle| instance corresponding to the current
         |Particle| after being ionized ``n`` times.
@@ -1887,7 +1887,7 @@ class Particle(AbstractPhysicalParticle):
         else:
             return Particle(base_particle, Z=new_charge_number)
 
-    def recombine(self, n: int = 1, inplace: bool = False) -> Particle | None:
+    def recombine(self, n: int = 1, inplace: bool = False) -> Self | None:
         """
         Create a new |Particle| instance corresponding to the current
         |Particle| after undergoing recombination ``n`` times.
@@ -2338,7 +2338,7 @@ class CustomParticle(AbstractPhysicalParticle):
         *quantities,
         symbol: str | None = None,
         Z: float | None = None,
-    ) -> CustomParticle:
+    ) -> Self:
         """
         An alternate constructor for |CustomParticle| objects where the
         positional arguments correspond to the mass and/or charge in
@@ -2633,7 +2633,7 @@ class CustomParticle(AbstractPhysicalParticle):
         return hash(self.__repr__())
 
 
-def molecule(symbol: str, Z: int | None = None) -> Particle | CustomParticle:
+def molecule(symbol: str, Z: int | None = None) -> Self | CustomParticle:
     r"""
     Parse a molecule symbol into a |CustomParticle| or |Particle|.
 


### PR DESCRIPTION
Once we drop support for Python 3.10, we can use new typing features like [`typing.Self`](https://typing.readthedocs.io/en/latest/spec/generics.html#self)!  This PR applies this to some type hint annotations in `Particle` and `CustomParticle`.

We still need to do `from __future__ import annotations` for delayed evaluation of type hints because we use `ParticleLike` in some annotations before it is actually defined.

This PR will need to wait until after #2880 is merged.