### PR TITLE
Make pytest ignore the `tools` directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ norecursedirs = [
   'docs',
   'licenses',
   'node_modules',
+  'tools',
   'venv',
   '.venv',
 ]

--- a/src/plasmapy/__init__.py
+++ b/src/plasmapy/__init__.py
@@ -67,6 +67,9 @@ except Exception:  # coverage: ignore  # noqa: BLE001
 
     del warnings
 
+__version__  # noqa: B018
+"""PlasmaPy's version."""
+
 __citation__ = (
     "Instructions on how to cite and acknowledge PlasmaPy are provided "
     "in the online documentation at: "

--- a/src/plasmapy/__init__.py
+++ b/src/plasmapy/__init__.py
@@ -67,9 +67,6 @@ except Exception:  # coverage: ignore  # noqa: BLE001
 
     del warnings
 
-__version__  # noqa: B018
-"""PlasmaPy's version."""
-
 __citation__ = (
     "Instructions on how to cite and acknowledge PlasmaPy are provided "
     "in the online documentation at: "


### PR DESCRIPTION
We've been getting an occasional test collection error in `tools/export_ionization_energy.py`. However, we don't have any tests in `tools/` that we should run, so this PR makes pytest skip looking for tests in the `tools/` directory.