### PR TITLE
Enable `pytest-doctestplus` and update minimum versions in the `tests` dependency set

### DIFF
--- a/changelog/2913.internal.rst
+++ b/changelog/2913.internal.rst
@@ -1,0 +1,1 @@
+Added ``pytest-doctestplus`` as a testing extension.

--- a/ci_requirements/all-3.13-linux.txt
+++ b/ci_requirements/all-3.13-linux.txt
@@ -238,6 +238,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   sphinx
@@ -301,6 +302,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -309,6 +311,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -370,6 +374,7 @@ send2trash==1.8.3
 setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
     #   sphinxcontrib-bibtex
 six==1.16.0
     # via

--- a/ci_requirements/all-3.13-linux.txt
+++ b/ci_requirements/all-3.13-linux.txt
@@ -14,9 +14,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -51,9 +51,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -84,13 +84,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -124,7 +124,7 @@ jinja2==3.1.4
     #   nbsphinx
     #   sphinx
     #   towncrier
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -285,7 +285,7 @@ pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -313,7 +313,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -367,7 +367,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
     #   sphinxcontrib-bibtex
@@ -415,7 +415,7 @@ sphinx-copybutton==0.5.2
     # via plasmapy (pyproject.toml)
 sphinx-gallery==0.18.0
     # via plasmapy (pyproject.toml)
-sphinx-hoverxref==1.4.1
+sphinx-hoverxref==1.4.2
     # via plasmapy (pyproject.toml)
 sphinx-issues==5.0.0
     # via plasmapy (pyproject.toml)
@@ -423,7 +423,7 @@ sphinx-notfound-page==1.0.4
     # via plasmapy (pyproject.toml)
 sphinx-reredirects==0.1.5
     # via plasmapy (pyproject.toml)
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via plasmapy (pyproject.toml)
 sphinx-tabs==3.4.7
     # via plasmapy (pyproject.toml)
@@ -459,7 +459,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -519,7 +519,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/all-3.13-macos.txt
+++ b/ci_requirements/all-3.13-macos.txt
@@ -240,6 +240,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   sphinx
@@ -303,6 +304,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -311,6 +313,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -372,6 +376,7 @@ send2trash==1.8.3
 setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
     #   sphinxcontrib-bibtex
 six==1.16.0
     # via

--- a/ci_requirements/all-3.13-macos.txt
+++ b/ci_requirements/all-3.13-macos.txt
@@ -16,9 +16,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -53,9 +53,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -86,13 +86,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -126,7 +126,7 @@ jinja2==3.1.4
     #   nbsphinx
     #   sphinx
     #   towncrier
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -287,7 +287,7 @@ pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -315,7 +315,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -369,7 +369,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
     #   sphinxcontrib-bibtex
@@ -417,7 +417,7 @@ sphinx-copybutton==0.5.2
     # via plasmapy (pyproject.toml)
 sphinx-gallery==0.18.0
     # via plasmapy (pyproject.toml)
-sphinx-hoverxref==1.4.1
+sphinx-hoverxref==1.4.2
     # via plasmapy (pyproject.toml)
 sphinx-issues==5.0.0
     # via plasmapy (pyproject.toml)
@@ -425,7 +425,7 @@ sphinx-notfound-page==1.0.4
     # via plasmapy (pyproject.toml)
 sphinx-reredirects==0.1.5
     # via plasmapy (pyproject.toml)
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via plasmapy (pyproject.toml)
 sphinx-tabs==3.4.7
     # via plasmapy (pyproject.toml)
@@ -461,7 +461,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -521,7 +521,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/all-3.13-windows.txt
+++ b/ci_requirements/all-3.13-windows.txt
@@ -14,9 +14,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -59,9 +59,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -92,13 +92,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -132,7 +132,7 @@ jinja2==3.1.4
     #   nbsphinx
     #   sphinx
     #   towncrier
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -287,7 +287,7 @@ pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -315,7 +315,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -376,7 +376,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
     #   sphinxcontrib-bibtex
@@ -424,7 +424,7 @@ sphinx-copybutton==0.5.2
     # via plasmapy (pyproject.toml)
 sphinx-gallery==0.18.0
     # via plasmapy (pyproject.toml)
-sphinx-hoverxref==1.4.1
+sphinx-hoverxref==1.4.2
     # via plasmapy (pyproject.toml)
 sphinx-issues==5.0.0
     # via plasmapy (pyproject.toml)
@@ -432,7 +432,7 @@ sphinx-notfound-page==1.0.4
     # via plasmapy (pyproject.toml)
 sphinx-reredirects==0.1.5
     # via plasmapy (pyproject.toml)
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via plasmapy (pyproject.toml)
 sphinx-tabs==3.4.7
     # via plasmapy (pyproject.toml)
@@ -468,7 +468,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -528,7 +528,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/all-3.13-windows.txt
+++ b/ci_requirements/all-3.13-windows.txt
@@ -246,6 +246,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   sphinx
@@ -303,6 +304,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -311,6 +313,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -379,6 +383,7 @@ send2trash==1.8.3
 setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
     #   sphinxcontrib-bibtex
 six==1.16.0
     # via

--- a/ci_requirements/docs-3.13-linux.txt
+++ b/ci_requirements/docs-3.13-linux.txt
@@ -14,9 +14,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -48,7 +48,7 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
@@ -77,7 +77,7 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -111,7 +111,7 @@ jinja2==3.1.4
     #   nbsphinx
     #   sphinx
     #   towncrier
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -259,7 +259,7 @@ pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -318,7 +318,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
     #   sphinxcontrib-bibtex
@@ -364,7 +364,7 @@ sphinx-copybutton==0.5.2
     # via plasmapy (pyproject.toml)
 sphinx-gallery==0.18.0
     # via plasmapy (pyproject.toml)
-sphinx-hoverxref==1.4.1
+sphinx-hoverxref==1.4.2
     # via plasmapy (pyproject.toml)
 sphinx-issues==5.0.0
     # via plasmapy (pyproject.toml)
@@ -372,7 +372,7 @@ sphinx-notfound-page==1.0.4
     # via plasmapy (pyproject.toml)
 sphinx-reredirects==0.1.5
     # via plasmapy (pyproject.toml)
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via plasmapy (pyproject.toml)
 sphinx-tabs==3.4.7
     # via plasmapy (pyproject.toml)
@@ -462,7 +462,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/docs-3.13-macos.txt
+++ b/ci_requirements/docs-3.13-macos.txt
@@ -16,9 +16,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -50,7 +50,7 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
@@ -79,7 +79,7 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -113,7 +113,7 @@ jinja2==3.1.4
     #   nbsphinx
     #   sphinx
     #   towncrier
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -261,7 +261,7 @@ pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -320,7 +320,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
     #   sphinxcontrib-bibtex
@@ -366,7 +366,7 @@ sphinx-copybutton==0.5.2
     # via plasmapy (pyproject.toml)
 sphinx-gallery==0.18.0
     # via plasmapy (pyproject.toml)
-sphinx-hoverxref==1.4.1
+sphinx-hoverxref==1.4.2
     # via plasmapy (pyproject.toml)
 sphinx-issues==5.0.0
     # via plasmapy (pyproject.toml)
@@ -374,7 +374,7 @@ sphinx-notfound-page==1.0.4
     # via plasmapy (pyproject.toml)
 sphinx-reredirects==0.1.5
     # via plasmapy (pyproject.toml)
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via plasmapy (pyproject.toml)
 sphinx-tabs==3.4.7
     # via plasmapy (pyproject.toml)
@@ -464,7 +464,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/docs-3.13-windows.txt
+++ b/ci_requirements/docs-3.13-windows.txt
@@ -14,9 +14,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -55,7 +55,7 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
@@ -84,7 +84,7 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -118,7 +118,7 @@ jinja2==3.1.4
     #   nbsphinx
     #   sphinx
     #   towncrier
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -260,7 +260,7 @@ pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -326,7 +326,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via
     #   plasmapy (pyproject.toml)
     #   sphinxcontrib-bibtex
@@ -372,7 +372,7 @@ sphinx-copybutton==0.5.2
     # via plasmapy (pyproject.toml)
 sphinx-gallery==0.18.0
     # via plasmapy (pyproject.toml)
-sphinx-hoverxref==1.4.1
+sphinx-hoverxref==1.4.2
     # via plasmapy (pyproject.toml)
 sphinx-issues==5.0.0
     # via plasmapy (pyproject.toml)
@@ -380,7 +380,7 @@ sphinx-notfound-page==1.0.4
     # via plasmapy (pyproject.toml)
 sphinx-reredirects==0.1.5
     # via plasmapy (pyproject.toml)
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via plasmapy (pyproject.toml)
 sphinx-tabs==3.4.7
     # via plasmapy (pyproject.toml)
@@ -470,7 +470,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.11-linux-lowest-direct.txt
+++ b/ci_requirements/tests-3.11-linux-lowest-direct.txt
@@ -35,9 +35,9 @@ charset-normalizer==2.0.12
     # via requests
 colorlog==6.9.0
     # via nox
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -57,11 +57,11 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 h5py==3.8.0
     # via plasmapy (pyproject.toml)
-hypothesis==6.108.2
+hypothesis==6.110.0
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -137,7 +137,7 @@ mistune==0.8.4
     # via nbconvert
 mpmath==1.3.0
     # via plasmapy (pyproject.toml)
-mypy==1.11.0
+mypy==1.13.0
     # via plasmapy (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
@@ -170,7 +170,7 @@ notebook==6.5.7
     # via widgetsnbextension
 notebook-shim==0.2.4
     # via nbclassic
-nox==2024.4.15
+nox==2024.10.9
     # via plasmapy (pyproject.toml)
 numpy==1.24.0
     # via
@@ -214,7 +214,7 @@ platformdirs==4.3.6
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.6.0
+pre-commit==4.0.1
     # via plasmapy (pyproject.toml)
 prometheus-client==0.21.0
     # via
@@ -230,7 +230,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -238,7 +238,7 @@ pygments==2.18.0
     #   nbconvert
 pyparsing==3.2.0
     # via matplotlib
-pytest==8.3.1
+pytest==8.3.3
     # via
     #   plasmapy (pyproject.toml)
     #   pytest-cov
@@ -247,7 +247,7 @@ pytest==8.3.1
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
@@ -255,7 +255,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -314,7 +314,7 @@ terminado==0.18.1
     #   notebook
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.1
+tomli==2.1.0
     # via
     #   plasmapy (pyproject.toml)
     #   coverage

--- a/ci_requirements/tests-3.11-linux-lowest-direct.txt
+++ b/ci_requirements/tests-3.11-linux-lowest-direct.txt
@@ -137,7 +137,7 @@ mistune==0.8.4
     # via nbconvert
 mpmath==1.3.0
     # via plasmapy (pyproject.toml)
-mypy==1.13.0
+mypy==1.11.0
     # via plasmapy (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
@@ -193,6 +193,7 @@ packaging==22.0
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -243,6 +244,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -251,6 +253,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -295,7 +299,9 @@ send2trash==1.8.3
     #   jupyter-server
     #   notebook
 setuptools==66.0.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.11-linux.txt
+++ b/ci_requirements/tests-3.11-linux.txt
@@ -12,9 +12,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -43,9 +43,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -67,13 +67,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -101,7 +101,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -244,7 +244,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -269,7 +269,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -321,7 +321,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -342,7 +342,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   plasmapy (pyproject.toml)
     #   coverage
@@ -399,7 +399,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.11-linux.txt
+++ b/ci_requirements/tests-3.11-linux.txt
@@ -207,6 +207,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -257,6 +258,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -265,6 +267,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -322,7 +326,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.11-macos-lowest-direct.txt
+++ b/ci_requirements/tests-3.11-macos-lowest-direct.txt
@@ -37,9 +37,9 @@ charset-normalizer==2.0.12
     # via requests
 colorlog==6.9.0
     # via nox
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -59,11 +59,11 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 h5py==3.8.0
     # via plasmapy (pyproject.toml)
-hypothesis==6.108.2
+hypothesis==6.110.0
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -139,7 +139,7 @@ mistune==0.8.4
     # via nbconvert
 mpmath==1.3.0
     # via plasmapy (pyproject.toml)
-mypy==1.11.0
+mypy==1.13.0
     # via plasmapy (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
@@ -172,7 +172,7 @@ notebook==6.5.7
     # via widgetsnbextension
 notebook-shim==0.2.4
     # via nbclassic
-nox==2024.4.15
+nox==2024.10.9
     # via plasmapy (pyproject.toml)
 numpy==1.24.0
     # via
@@ -216,7 +216,7 @@ platformdirs==4.3.6
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.6.0
+pre-commit==4.0.1
     # via plasmapy (pyproject.toml)
 prometheus-client==0.21.0
     # via
@@ -232,7 +232,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -240,7 +240,7 @@ pygments==2.18.0
     #   nbconvert
 pyparsing==3.2.0
     # via matplotlib
-pytest==8.3.1
+pytest==8.3.3
     # via
     #   plasmapy (pyproject.toml)
     #   pytest-cov
@@ -249,7 +249,7 @@ pytest==8.3.1
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
@@ -257,7 +257,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -316,7 +316,7 @@ terminado==0.18.1
     #   notebook
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.1
+tomli==2.1.0
     # via
     #   plasmapy (pyproject.toml)
     #   coverage

--- a/ci_requirements/tests-3.11-macos-lowest-direct.txt
+++ b/ci_requirements/tests-3.11-macos-lowest-direct.txt
@@ -139,7 +139,7 @@ mistune==0.8.4
     # via nbconvert
 mpmath==1.3.0
     # via plasmapy (pyproject.toml)
-mypy==1.13.0
+mypy==1.11.0
     # via plasmapy (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
@@ -195,6 +195,7 @@ packaging==22.0
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -245,6 +246,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -253,6 +255,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -297,7 +301,9 @@ send2trash==1.8.3
     #   jupyter-server
     #   notebook
 setuptools==66.0.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.11-macos.txt
+++ b/ci_requirements/tests-3.11-macos.txt
@@ -209,6 +209,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -259,6 +260,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -267,6 +269,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -324,7 +328,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.11-macos.txt
+++ b/ci_requirements/tests-3.11-macos.txt
@@ -14,9 +14,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -45,9 +45,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -69,13 +69,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -103,7 +103,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -246,7 +246,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -271,7 +271,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -323,7 +323,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -344,7 +344,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   plasmapy (pyproject.toml)
     #   coverage
@@ -401,7 +401,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.11-windows-lowest-direct.txt
+++ b/ci_requirements/tests-3.11-windows-lowest-direct.txt
@@ -143,7 +143,7 @@ mistune==0.8.4
     # via nbconvert
 mpmath==1.3.0
     # via plasmapy (pyproject.toml)
-mypy==1.13.0
+mypy==1.11.0
     # via plasmapy (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
@@ -199,6 +199,7 @@ packaging==22.0
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -243,6 +244,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -251,6 +253,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -301,7 +305,9 @@ send2trash==1.8.3
     #   jupyter-server
     #   notebook
 setuptools==66.0.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.11-windows-lowest-direct.txt
+++ b/ci_requirements/tests-3.11-windows-lowest-direct.txt
@@ -41,9 +41,9 @@ colorama==0.4.6
     #   tqdm
 colorlog==6.9.0
     # via nox
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -63,11 +63,11 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 h5py==3.8.0
     # via plasmapy (pyproject.toml)
-hypothesis==6.108.2
+hypothesis==6.110.0
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -143,7 +143,7 @@ mistune==0.8.4
     # via nbconvert
 mpmath==1.3.0
     # via plasmapy (pyproject.toml)
-mypy==1.11.0
+mypy==1.13.0
     # via plasmapy (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
@@ -176,7 +176,7 @@ notebook==6.5.7
     # via widgetsnbextension
 notebook-shim==0.2.4
     # via nbclassic
-nox==2024.4.15
+nox==2024.10.9
     # via plasmapy (pyproject.toml)
 numpy==1.24.0
     # via
@@ -218,7 +218,7 @@ platformdirs==4.3.6
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.6.0
+pre-commit==4.0.1
     # via plasmapy (pyproject.toml)
 prometheus-client==0.21.0
     # via
@@ -230,7 +230,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -238,7 +238,7 @@ pygments==2.18.0
     #   nbconvert
 pyparsing==3.2.0
     # via matplotlib
-pytest==8.3.1
+pytest==8.3.3
     # via
     #   plasmapy (pyproject.toml)
     #   pytest-cov
@@ -247,7 +247,7 @@ pytest==8.3.1
     #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
@@ -255,7 +255,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -320,7 +320,7 @@ terminado==0.18.1
     #   notebook
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.1
+tomli==2.1.0
     # via
     #   plasmapy (pyproject.toml)
     #   coverage

--- a/ci_requirements/tests-3.11-windows.txt
+++ b/ci_requirements/tests-3.11-windows.txt
@@ -213,6 +213,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -257,6 +258,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -265,6 +267,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -329,7 +333,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.11-windows.txt
+++ b/ci_requirements/tests-3.11-windows.txt
@@ -12,9 +12,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -49,9 +49,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -73,13 +73,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -107,7 +107,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -244,7 +244,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -269,7 +269,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -328,7 +328,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -349,7 +349,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   plasmapy (pyproject.toml)
     #   coverage
@@ -406,7 +406,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.12-linux.txt
+++ b/ci_requirements/tests-3.12-linux.txt
@@ -207,6 +207,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -257,6 +258,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -265,6 +267,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -322,7 +326,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.12-linux.txt
+++ b/ci_requirements/tests-3.12-linux.txt
@@ -12,9 +12,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -43,9 +43,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -67,13 +67,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -101,7 +101,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -244,7 +244,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -269,7 +269,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -321,7 +321,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -342,7 +342,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -395,7 +395,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.12-macos.txt
+++ b/ci_requirements/tests-3.12-macos.txt
@@ -209,6 +209,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -259,6 +260,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -267,6 +269,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -324,7 +328,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.12-macos.txt
+++ b/ci_requirements/tests-3.12-macos.txt
@@ -14,9 +14,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -45,9 +45,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -69,13 +69,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -103,7 +103,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -246,7 +246,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -271,7 +271,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -323,7 +323,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -344,7 +344,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -397,7 +397,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.12-windows.txt
+++ b/ci_requirements/tests-3.12-windows.txt
@@ -213,6 +213,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -257,6 +258,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -265,6 +267,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -329,7 +333,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.12-windows.txt
+++ b/ci_requirements/tests-3.12-windows.txt
@@ -12,9 +12,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -49,9 +49,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -73,13 +73,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -107,7 +107,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -244,7 +244,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -269,7 +269,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -328,7 +328,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -349,7 +349,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -402,7 +402,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.13-linux.txt
+++ b/ci_requirements/tests-3.13-linux.txt
@@ -207,6 +207,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -257,6 +258,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -265,6 +267,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -322,7 +326,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.13-linux.txt
+++ b/ci_requirements/tests-3.13-linux.txt
@@ -12,9 +12,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -43,9 +43,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -67,13 +67,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -101,7 +101,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -244,7 +244,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -269,7 +269,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -321,7 +321,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -342,7 +342,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -395,7 +395,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.13-macos.txt
+++ b/ci_requirements/tests-3.13-macos.txt
@@ -209,6 +209,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -259,6 +260,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -267,6 +269,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -324,7 +328,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.13-macos.txt
+++ b/ci_requirements/tests-3.13-macos.txt
@@ -14,9 +14,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -45,9 +45,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -69,13 +69,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -103,7 +103,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -246,7 +246,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -271,7 +271,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -323,7 +323,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -344,7 +344,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -397,7 +397,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/ci_requirements/tests-3.13-windows.txt
+++ b/ci_requirements/tests-3.13-windows.txt
@@ -213,6 +213,7 @@ packaging==24.2
     #   nbconvert
     #   nox
     #   pytest
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-rerunfailures
     #   xarray
@@ -257,6 +258,7 @@ pytest==8.3.3
     #   plasmapy (pyproject.toml)
     #   pytest-cov
     #   pytest-datadir
+    #   pytest-doctestplus
     #   pytest-filter-subpackage
     #   pytest-regressions
     #   pytest-rerunfailures
@@ -265,6 +267,8 @@ pytest-cov==6.0.0
     # via plasmapy (pyproject.toml)
 pytest-datadir==1.5.0
     # via pytest-regressions
+pytest-doctestplus==1.2.1
+    # via plasmapy (pyproject.toml)
 pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
@@ -329,7 +333,9 @@ scipy==1.14.1
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.6.0
-    # via plasmapy (pyproject.toml)
+    # via
+    #   plasmapy (pyproject.toml)
+    #   pytest-doctestplus
 six==1.16.0
     # via
     #   asttokens

--- a/ci_requirements/tests-3.13-windows.txt
+++ b/ci_requirements/tests-3.13-windows.txt
@@ -12,9 +12,9 @@ arrow==1.3.0
     # via isoduration
 asteval==1.0.5
     # via lmfit
-astropy==6.1.5
+astropy==6.1.6
     # via plasmapy (pyproject.toml)
-astropy-iers-data==0.2024.11.11.0.32.38
+astropy-iers-data==0.2024.11.18.0.35.2
     # via astropy
 asttokens==2.4.1
     # via stack-data
@@ -49,9 +49,9 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-coverage==7.6.4
+coverage==7.6.7
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -73,13 +73,13 @@ fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
     # via virtualenv
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.118.7
+hypothesis==6.119.3
     # via plasmapy (pyproject.toml)
 identify==2.6.2
     # via pre-commit
@@ -107,7 +107,7 @@ jinja2==3.1.4
     #   jupyter-server
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.27
+json5==0.9.28
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -244,7 +244,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pygments==2.18.0
     # via
@@ -269,7 +269,7 @@ pytest-filter-subpackage==0.2.0
     # via plasmapy (pyproject.toml)
 pytest-regressions==2.5.0
     # via plasmapy (pyproject.toml)
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via plasmapy (pyproject.toml)
 pytest-xdist==3.6.1
     # via plasmapy (pyproject.toml)
@@ -328,7 +328,7 @@ scipy==1.14.1
     #   lmfit
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.3.0
+setuptools==75.6.0
     # via plasmapy (pyproject.toml)
 six==1.16.0
     # via
@@ -349,7 +349,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via plasmapy (pyproject.toml)
 tornado==6.4.1
     # via
@@ -402,7 +402,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==14.0
+websockets==14.1
     # via voila
 widgetsnbextension==4.0.13
     # via ipywidgets

--- a/noxfile.py
+++ b/noxfile.py
@@ -172,7 +172,11 @@ pytest_command: tuple[str, ...] = (
     "--dist=loadfile",
 )
 
-with_doctests: tuple[str, ...] = ("--doctest-modules", "--doctest-continue-on-failure")
+with_doctests: tuple[str, ...] = (
+    "--doctest-plus",
+    "--doctest-rst",
+    "--doctest-continue-on-failure",
+)
 
 with_coverage: tuple[str, ...] = (
     "--cov=plasmapy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ docs = [
 # requirements to ensure that tests are run in consistent environments.
 tests = [
   "hypothesis >= 6.109.3",
-  "mypy >= 1.13.0",
+  "mypy >= 1.11.0",
   "nox >= 2024.10.9",
   "pre-commit >= 4.0.1",
   "pytest >= 8.3.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,17 +110,17 @@ docs = [
 # Test dependencies are not user-facing, so we can set stricter
 # requirements to ensure that tests are run in consistent environments.
 tests = [
-  "hypothesis >= 6.108.2",
-  "mypy >= 1.11.0",
-  "nox >= 2024.4.15",
-  "pre-commit >= 3.6.0",
-  "pytest >= 8.3.1",
-  "pytest-cov >= 5.0.0",
+  "hypothesis >= 6.109.3",
+  "mypy >= 1.13.0",
+  "nox >= 2024.10.9",
+  "pre-commit >= 4.0.1",
+  "pytest >= 8.3.3",
+  "pytest-cov >= 6.0.0",
   "pytest-filter-subpackage >= 0.2.0",
   "pytest-regressions >= 2.5.0",
-  "pytest-rerunfailures >= 14.0",
+  "pytest-rerunfailures >= 15.0",
   "pytest-xdist >= 3.6.1",
-  "tomli >= 2.0.1",
+  "tomli >= 2.1.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ tests = [
   "pre-commit >= 4.0.1",
   "pytest >= 8.3.3",
   "pytest-cov >= 6.0.0",
+  "pytest-doctestplus >= 1.2.1",
   "pytest-filter-subpackage >= 0.2.0",
   "pytest-regressions >= 2.5.0",
   "pytest-rerunfailures >= 15.0",


### PR DESCRIPTION
This PR enables `pytest-doctestplus` as a pytest extension. See #2912 for the motivation. Closes #2912.

Doctests are only run on the most recent version of Python (currently 3.13).

I'm starting this now so I don't forget, but I'll come back to this probably in December after a forthcoming proposal deadline.

