### PR TITLE
Remove GitHub-style admonition that does not get recognized on PyPI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,9 @@ To install PlasmaPy on macOS or Linux, open a terminal and run:
 python -m pip install plasmapy
 ```
 
-> [!NOTE]
-> On some systems, it might be necessary to specify the Python version
-> number, for example by using `python3` or `python3.13` instead of
-> `python`.
+On some systems, it might be necessary to specify the Python version
+number, for example by using `python3` or `python3.13` instead of
+`python`.
 
 To install PlasmaPy on Windows, open a terminal and run
 ```Shell


### PR DESCRIPTION
While GitHub has new syntax for admonitions, other sites do not (yet) recognize it.  Hence, I'm removing it here for the `README.md` file. The weird formatting can (or could) be seen on [PlasmaPy's PyPI page](https://pypi.org/project/plasmapy).  

The top-level `README.md` is the primary Markdown file that shows up on different sites, so it should be no problem to use it in other places.