### PR TITLE
Unpin `pygments` and `sphinx-codeautolink` requirements

### DIFF
--- a/ci_requirements/all-3.13-linux.txt
+++ b/ci_requirements/all-3.13-linux.txt
@@ -90,7 +90,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit
@@ -406,7 +406,7 @@ sphinx==7.3.7
     #   sphinxemoji
 sphinx-changelog==1.6.0
     # via plasmapy (pyproject.toml)
-sphinx-codeautolink==0.15.2
+sphinx-codeautolink==0.16.0
     # via plasmapy (pyproject.toml)
 sphinx-collapse==0.1.3
     # via plasmapy (pyproject.toml)

--- a/ci_requirements/all-3.13-linux.txt
+++ b/ci_requirements/all-3.13-linux.txt
@@ -287,7 +287,7 @@ pycparser==2.22
     # via cffi
 pyerfa==2.0.1.5
     # via astropy
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   plasmapy (pyproject.toml)
     #   ipython

--- a/ci_requirements/all-3.13-macos.txt
+++ b/ci_requirements/all-3.13-macos.txt
@@ -289,7 +289,7 @@ pycparser==2.22
     # via cffi
 pyerfa==2.0.1.5
     # via astropy
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   plasmapy (pyproject.toml)
     #   ipython

--- a/ci_requirements/all-3.13-macos.txt
+++ b/ci_requirements/all-3.13-macos.txt
@@ -92,7 +92,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit
@@ -408,7 +408,7 @@ sphinx==7.3.7
     #   sphinxemoji
 sphinx-changelog==1.6.0
     # via plasmapy (pyproject.toml)
-sphinx-codeautolink==0.15.2
+sphinx-codeautolink==0.16.0
     # via plasmapy (pyproject.toml)
 sphinx-collapse==0.1.3
     # via plasmapy (pyproject.toml)

--- a/ci_requirements/all-3.13-windows.txt
+++ b/ci_requirements/all-3.13-windows.txt
@@ -289,7 +289,7 @@ pycparser==2.22
     # via cffi
 pyerfa==2.0.1.5
     # via astropy
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   plasmapy (pyproject.toml)
     #   ipython

--- a/ci_requirements/all-3.13-windows.txt
+++ b/ci_requirements/all-3.13-windows.txt
@@ -98,7 +98,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit
@@ -415,7 +415,7 @@ sphinx==7.3.7
     #   sphinxemoji
 sphinx-changelog==1.6.0
     # via plasmapy (pyproject.toml)
-sphinx-codeautolink==0.15.2
+sphinx-codeautolink==0.16.0
     # via plasmapy (pyproject.toml)
 sphinx-collapse==0.1.3
     # via plasmapy (pyproject.toml)

--- a/ci_requirements/docs-3.13-linux.txt
+++ b/ci_requirements/docs-3.13-linux.txt
@@ -261,7 +261,7 @@ pycparser==2.22
     # via cffi
 pyerfa==2.0.1.5
     # via astropy
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   plasmapy (pyproject.toml)
     #   ipython

--- a/ci_requirements/docs-3.13-linux.txt
+++ b/ci_requirements/docs-3.13-linux.txt
@@ -355,7 +355,7 @@ sphinx==7.3.7
     #   sphinxemoji
 sphinx-changelog==1.6.0
     # via plasmapy (pyproject.toml)
-sphinx-codeautolink==0.15.2
+sphinx-codeautolink==0.16.0
     # via plasmapy (pyproject.toml)
 sphinx-collapse==0.1.3
     # via plasmapy (pyproject.toml)

--- a/ci_requirements/docs-3.13-macos.txt
+++ b/ci_requirements/docs-3.13-macos.txt
@@ -357,7 +357,7 @@ sphinx==7.3.7
     #   sphinxemoji
 sphinx-changelog==1.6.0
     # via plasmapy (pyproject.toml)
-sphinx-codeautolink==0.15.2
+sphinx-codeautolink==0.16.0
     # via plasmapy (pyproject.toml)
 sphinx-collapse==0.1.3
     # via plasmapy (pyproject.toml)

--- a/ci_requirements/docs-3.13-macos.txt
+++ b/ci_requirements/docs-3.13-macos.txt
@@ -263,7 +263,7 @@ pycparser==2.22
     # via cffi
 pyerfa==2.0.1.5
     # via astropy
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   plasmapy (pyproject.toml)
     #   ipython

--- a/ci_requirements/docs-3.13-windows.txt
+++ b/ci_requirements/docs-3.13-windows.txt
@@ -363,7 +363,7 @@ sphinx==7.3.7
     #   sphinxemoji
 sphinx-changelog==1.6.0
     # via plasmapy (pyproject.toml)
-sphinx-codeautolink==0.15.2
+sphinx-codeautolink==0.16.0
     # via plasmapy (pyproject.toml)
 sphinx-collapse==0.1.3
     # via plasmapy (pyproject.toml)

--- a/ci_requirements/docs-3.13-windows.txt
+++ b/ci_requirements/docs-3.13-windows.txt
@@ -262,7 +262,7 @@ pycparser==2.22
     # via cffi
 pyerfa==2.0.1.5
     # via astropy
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   plasmapy (pyproject.toml)
     #   ipython

--- a/ci_requirements/tests-3.11-linux.txt
+++ b/ci_requirements/tests-3.11-linux.txt
@@ -73,7 +73,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/ci_requirements/tests-3.11-macos.txt
+++ b/ci_requirements/tests-3.11-macos.txt
@@ -75,7 +75,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/ci_requirements/tests-3.11-windows.txt
+++ b/ci_requirements/tests-3.11-windows.txt
@@ -79,7 +79,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/ci_requirements/tests-3.12-linux.txt
+++ b/ci_requirements/tests-3.12-linux.txt
@@ -73,7 +73,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/ci_requirements/tests-3.12-macos.txt
+++ b/ci_requirements/tests-3.12-macos.txt
@@ -75,7 +75,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/ci_requirements/tests-3.12-windows.txt
+++ b/ci_requirements/tests-3.12-windows.txt
@@ -79,7 +79,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/ci_requirements/tests-3.13-linux.txt
+++ b/ci_requirements/tests-3.13-linux.txt
@@ -73,7 +73,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/ci_requirements/tests-3.13-macos.txt
+++ b/ci_requirements/tests-3.13-macos.txt
@@ -75,7 +75,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/ci_requirements/tests-3.13-windows.txt
+++ b/ci_requirements/tests-3.13-windows.txt
@@ -79,7 +79,7 @@ fqdn==1.5.1
     # via jsonschema
 h5py==3.12.1
     # via plasmapy (pyproject.toml)
-hypothesis==6.123.16
+hypothesis==6.123.17
     # via plasmapy (pyproject.toml)
 identify==2.6.5
     # via pre-commit

--- a/noxfile.py
+++ b/noxfile.py
@@ -277,7 +277,7 @@ sphinx_commands: tuple[str, ...] = (
 
 build_html: tuple[str, ...] = ("--builder", "html")
 check_hyperlinks: tuple[str, ...] = ("--builder", "linkcheck")
-docs_requirements = _get_requirements_filepath(category="docs", version=maxpython)
+docs_requirements = _get_requirements_filepath(category="docs", version=docpython)
 
 doc_troubleshooting_message = """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ docs = [
   "nox >= 2024.4.15",
   "numpydoc >= 1.7.0",
   "pillow >= 10.4.0",
-  "pygments >= 2.19.1",
+  "pygments >= 2.18.1",
   "sphinx == 7.3.7",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ docs = [
   "nox >= 2024.4.15",
   "numpydoc >= 1.7.0",
   "pillow >= 10.4.0",
-  "pygments == 2.18.0",
+  "pygments >= 2.19.1",
   "sphinx == 7.3.7",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ docs = [
   "pygments >= 2.19.1",
   "sphinx == 7.3.7",
   "sphinx-changelog >= 1.5.0",
-  "sphinx-codeautolink == 0.15.2",
+  "sphinx-codeautolink >= 0.15.2",
   "sphinx-copybutton >= 0.5.2",
   "sphinx-gallery >= 0.16.0",
   "sphinx-hoverxref >= 1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ docs = [
   "nox >= 2024.4.15",
   "numpydoc >= 1.7.0",
   "pillow >= 10.4.0",
-  "pygments >= 2.18.1",
+  "pygments >= 2.18.0",
   "sphinx == 7.3.7",
   "sphinx-changelog >= 1.5.0",
   "sphinx-codeautolink >= 0.15.2",


### PR DESCRIPTION
#2933 added a strict requirements for `pygments == 2.18.0` because a change in how `pygments` handled whitespace broke `sphinx-codeautolink` (https://github.com/felix-hilden/sphinx-codeautolink/issues/152).  

We can merge this once a new version of `sphinx-codeautolink` is released.  We might need to run `nox -s requirements` if other requirements have been updated in the meantime.

`sphinx-codeautolink` is the awesome Sphinx extension that adds links to objects in code blocks in the documentation (like in [this section](https://docs.plasmapy.org/en/stable/contributing/coding_guide.html#validating-quantities)).