### PR TITLE
Build documentation with Python 3.13

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ formats:
 build:
   os: ubuntu-24.04
   tools:
-    python: '3.12'
+    python: '3.13'
   apt_packages:
   - graphviz
   jobs:
@@ -23,4 +23,4 @@ python:
   install:
   - method: pip
     path: .
-  - requirements: ci_requirements/docs-3.12-linux.txt
+  - requirements: ci_requirements/docs-3.13-linux.txt

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,7 @@ current_python = f"{sys.version_info.major}.{sys.version_info.minor}"
 # the Docs. Because Read the Docs takes some time to support new
 # releases of Python, we should not link docpython to maxpython.
 
-docpython = "3.12"
+docpython = "3.13"
 
 nox.options.sessions: list[str] = [f"tests-{current_python}(skipslow)"]
 nox.options.default_venv_backend = "uv|virtualenv"


### PR DESCRIPTION
Read the Docs now appears to allow documentation to be built with Python 3.13, so this PR adjusts PlasmaPy's doc build configuration accordingly.

Closes #2874. Potential overlap with #2937.
