### PR TITLE
Enable new ruff rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   - id: check-yaml
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.31.1
+  rev: 0.31.2
   hooks:
   - id: check-github-workflows
 
@@ -79,13 +79,13 @@ repos:
     - tomli
 
 - repo: https://github.com/crate-ci/typos
-  rev: typos-dict-v0.12.4
+  rev: v1.29.9
   hooks:
   - id: typos
     name: typos (add false positives to _typos.toml)
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.4
+  rev: v0.9.7
   hooks:
   - id: ruff
     name: ruff (see https://docs.astral.sh/ruff/rules)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,8 +342,14 @@ extend-select = [
   "RUF018", # assignment-in-assert
   "RUF019", # unnecessary-key-check
   "RUF020", # never-union
+  "RUF021", # parenthesize-chained-operators
+  "RUF023", # unsorted-dunder-slots
   "RUF024", # mutable-fromkeys-value
   "RUF026", # default-factory-kwarg
+  "RUF030", # assert-with-print-message
+  "RUF032", # decimal-from-float-literal
+  "RUF033", # post-init-default
+  "RUF034", # useless-if-else
   "RUF100", # unused-noqa
   "RUF101", # redirected-noqa
   "RUF200", # invalid-pyproject-toml

--- a/src/plasmapy/particles/ionization_state.py
+++ b/src/plasmapy/particles/ionization_state.py
@@ -413,16 +413,12 @@ class IonizationState:
 
         min_tol = np.min([self.tol, other.tol])
 
-        same_T_e = (
-            np.isnan(self.T_e)
-            and np.isnan(other.T_e)
-            or u.allclose(self.T_e, other.T_e, rtol=min_tol, atol=0 * u.K)
+        same_T_e = (np.isnan(self.T_e) and np.isnan(other.T_e)) or u.allclose(
+            self.T_e, other.T_e, rtol=min_tol, atol=0 * u.K
         )
 
-        same_n_elem = (
-            np.isnan(self.n_elem)
-            and np.isnan(other.n_elem)
-            or u.allclose(self.n_elem, other.n_elem, rtol=min_tol, atol=0 * u.m**-3)
+        same_n_elem = (np.isnan(self.n_elem) and np.isnan(other.n_elem)) or u.allclose(
+            self.n_elem, other.n_elem, rtol=min_tol, atol=0 * u.m**-3
         )
 
         # For the next line, recall that np.nan == np.nan is False


### PR DESCRIPTION
This PR enables a few more of the [`RUF`](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf) rule set for ruff that have come out of preview and are now suitable for production. The changes are pretty straightforward.