### PR TITLE
Update caching and cache invalidation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         path: |
           .nox
         # Changing pyproject.toml or requirements invalidates the cache
-        key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'ci_requirements/all-3.13-linux.txt') }}
+        key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 
     - name: Run Nox session
       run: nox -s '${{ matrix.nox_session }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,6 @@ jobs:
         # Changing pyproject.toml or requirements invalidates the cache
         key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 
-    # Adding this temporarily to see the contents of the cache
-    - name: Find all directories in cache
-      run: find ${{ runner.tool_cache }} -type d
-
     - name: Run Nox session
       run: nox -s '${{ matrix.nox_session }}'
 
@@ -118,7 +114,3 @@ jobs:
         fail_ci_if_error: false
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-    # Adding this temporarily to see the contents of the cache
-    - name: Find all directories in cache
-      run: find ${{ runner.tool_cache }} -type d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
         # Changing pyproject.toml or requirements invalidates the cache
         key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 
+    # Adding this temporarily to see the contents of the cache
+    - name: Find all directories in cache
+      run: find ${{ runner.tool_cache }} -type d
+
     - name: Run Nox session
       run: nox -s '${{ matrix.nox_session }}'
 
@@ -114,3 +118,7 @@ jobs:
         fail_ci_if_error: false
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+    # Adding this temporarily to see the contents of the cache
+    - name: Find all directories in cache
+      run: find ${{ runner.tool_cache }} -type d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
         path: |
           .nox
           .venv
+          .cache/uv
+          cache/uv
         # Changing pyproject.toml or requirements invalidates the cache
         key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
       with:
         path: |
           .nox
+          .venv
         # Changing pyproject.toml or requirements invalidates the cache
         key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -166,6 +166,8 @@ jobs:
         path: |
           .nox
           .venv
+          .cache/uv
+          cache/uv
         # Changing pyproject.toml or requirements invalidates the cache
         key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -165,8 +165,9 @@ jobs:
       with:
         path: |
           .nox
+          .venv
         # Changing pyproject.toml or requirements invalidates the cache
-        key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'ci_requirements/all-3.12-linux.txt') }}
+        key: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 
     - name: Run Nox session
       run: nox -s '${{ matrix.nox_session }}'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,7 +35,7 @@ docs/plasmapy_sphinx/ @rocco8773
 
 # project files
 
-ci_requirements/ @namurphy
+uv.lock @namurphy
 mypy.ini @namurphy
 pyproject.toml @namurphy
 type_stubs/ @namurphy

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@
 # distribution (sdist) of PlasmaPy.
 
 graft changelog
-graft ci_requirements
 graft docs
 graft licenses
 graft src

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,9 +71,11 @@ def requirements(session) -> None:
     """
     session.install(uv_requirement)
 
-    # If it becomes possible to exclude the current project when using
-    # `uv lock`, we should do so here. That would allow us to add a Nox
-    # session to validate the requirements back in.
+    # If we start using a different file to pin dependencies besides
+    # uv.lock, we will need to update the GitHub workflows so that the
+    # cache gets invalidated when the different file changes instead of
+    # uv.lock.
+
     session.run("uv", "lock", "--upgrade", "--no-progress")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dynamic = ["version"]
 # alongside other packages, such as in the heliopythoniverse.
 
 # When updating dependencies, run `nox -s requirements` to update the
-# pinned requirements files. See also `ci_requirements/README.txt`.
+# pinned environments.
 
 dependencies = [
   # astropy upper limit described in https://github.com/PlasmaPy/PlasmaPy/issues/2883

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dynamic = ["version"]
 # alongside other packages, such as in the heliopythoniverse.
 
 # When updating dependencies, run `nox -s requirements` to update the
-# pinned environments.
+# pinned environments in `uv.lock`.
 
 dependencies = [
   # astropy upper limit described in https://github.com/PlasmaPy/PlasmaPy/issues/2883


### PR DESCRIPTION
This PR is a direct follow-up to #2937, which switched us from using requirements files in `ci_requirements` to `uv.lock` to pin requirements for use by Nox and in CI.  

 - I updated the cache key in our GitHub workflow so that the cache gets invalidated when `uv.lock` changes.
 - Now `.venv` gets cached along with `.nox`. 
 - Switch `ci_requirements` → `uv.lock` in `CODEOWNERS` so that I get assigned to PRs where it changes
 - Updated some comments.

I still need to:

 - [ ] Verify that `.venv` is where the the virtual environment is stored, 

