### PR TITLE
Update GitHub workflows for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       uses: ts-graphviz/setup-graphviz@v2
 
     - name: Install pandoc for documentation builds
+      # This step only works on Ubuntu
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install pandoc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,13 @@ jobs:
         python-version: ${{ matrix.python }}
         cache: pip
 
-    - name: Install graphviz and pandoc for documentation builds
+    - name: Install Graphviz for documentation builds
       if: startsWith(matrix.name, 'Documentation')
-      run: sudo apt-get install graphviz pandoc
+      uses: ts-graphviz/setup-graphviz@v2
+
+    - name: Install pandoc for documentation builds
+      if: startsWith(matrix.name, 'Documentation')
+      run: sudo apt-get install pandoc
 
     - name: Install Nox and uv
       run: python -m pip install --progress-bar off --upgrade nox uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,14 +85,15 @@ jobs:
         python-version: ${{ matrix.python }}
         cache: pip
 
-    - name: Install Graphviz for documentation builds
+    - name: Install Graphviz for doc builds
       if: startsWith(matrix.name, 'Documentation')
       uses: ts-graphviz/setup-graphviz@v2
 
-    - name: Install pandoc for documentation builds
-      # This step only works on Ubuntu
+    - name: Install pandoc for doc builds (requires Ubuntu)
       if: startsWith(matrix.name, 'Documentation')
-      run: sudo apt-get install pandoc
+      run: |
+        sudo apt update
+        sudo apt-get install -y pandoc
 
     - name: Install Nox and uv
       run: python -m pip install --progress-bar off --upgrade nox uv

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -152,10 +152,14 @@ jobs:
         python-version: ${{ matrix.python }}
         cache: pip
 
-    - name: Install graphviz and pandoc for documentation builds
+    - name: Install Graphviz for documentation builds
       if: startsWith(matrix.name, 'Documentation')
-      # This step only works with Ubuntu
-      run: sudo apt-get install graphviz pandoc
+      uses: ts-graphviz/setup-graphviz@v2
+
+    - name: Install pandoc for documentation builds
+      # This step only works on Ubuntu
+      if: startsWith(matrix.name, 'Documentation')
+      run: sudo apt-get install pandoc
 
     - name: Install Nox and uv
       run: python -m pip install --progress-bar off --upgrade nox uv

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -159,7 +159,9 @@ jobs:
     - name: Install pandoc for documentation builds
       # This step only works on Ubuntu
       if: startsWith(matrix.name, 'Documentation')
-      run: sudo apt-get install pandoc
+      run: |
+        sudo apt update
+        sudo apt-get install -y pandoc
 
     - name: Install Nox and uv
       run: python -m pip install --progress-bar off --upgrade nox uv


### PR DESCRIPTION
Our documentation builds depend on Graphviz (used by `sphinx.ext.graphviz`) and pandoc (for working with Jupyter notebooks, I believe).  This PR adopts a separate action to install Graphviz, and makes a few minor updates to the pandoc installation.  The pandoc installation step only works on Ubuntu at the moment. 