### PR TITLE
Move GitHub workflow steps into a reusable workflow

### DIFF
--- a/.github/workflows/run-nox-session.yml
+++ b/.github/workflows/run-nox-session.yml
@@ -1,0 +1,57 @@
+on:
+  workflow_call:
+    inputs:
+      nox_sesssion:
+        required: true
+        type: string
+      runs-on:
+        description: "The operating system"
+        default: 'ubuntu-latest'
+        type: string
+      python-version:
+        description: "The version of Python (e.g., '3.13')"
+        default: '3.13'
+        type: string
+    secrets:
+      CODECOV_TOKEN:
+        description: ""
+        required: false
+
+jobs:
+  run-nox-session:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install packages needed for documentation builds
+        if: startsWith(inputs.nox_session, 'docs')
+        uses: ts-graphviz/setup-graphviz@v2
+        run: |
+          sudo apt update
+          sudo apt-get install -y pandoc
+
+      - name: Install uv
+        with:
+          python-version: ${{ inputs.python-version }}
+          enable-cache: true
+          cache-suffix: ${{ inputs.nox_session }}-${{ inputs.python-version }}-${{ runner.os }}
+
+      - name: Run the check
+        run: uv run --python ${{ inputs.python-version }} --with nox --frozen nox -s '${{ inputs.nox_session }}'
+
+      - name: Print changes from last commit
+        run: |
+          git show
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ contains(inputs.nox_session, 'cov') }}
+        uses: codecov/codecov-action@v5
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
We currently define the steps it takes to run a Nox session in CI in both `weekly.yml` and `ci.yml`.  In #2959, this means that I need to copy code that I change in one file into the other file. Copying and pasting code is often a good indicator that it's worthwhile to create a function.  In the future, I'd like to separate out the weekly tests that try running tests & building docs with the latest versions of dependencies. 

In this PR, I'm attempting to create a reusable workflow.  It's still in the early stages. Wish me luck!

Close #1754. Inspired by #1759.
