### PR TITLE
Enable Nox to be run as a script

### DIFF
--- a/changelog/2961.internal.rst
+++ b/changelog/2961.internal.rst
@@ -1,0 +1,1 @@
+Enabled :file:`noxfile.py` to be run as a script, in alignment with :pep:`723`.

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,6 +24,10 @@ to be installed.
 
 # Documentation: https://nox.thea.codes
 
+# /// script
+# dependencies = ["nox"]
+# ///
+
 import os
 import pathlib
 import re
@@ -568,3 +572,6 @@ def lint(session: nox.Session) -> None:
         "--show-diff-on-failure",
         *session.posargs,
     )
+
+if __name__ == "__main__":
+    nox.main()

--- a/noxfile.py
+++ b/noxfile.py
@@ -573,5 +573,6 @@ def lint(session: nox.Session) -> None:
         *session.posargs,
     )
 
+
 if __name__ == "__main__":
     nox.main()


### PR DESCRIPTION
This PR adds the capability for `nox` to be run with commands like `python noxfile.py -s session_name` or `uv run noxfile.py -s session_name` by specifying dependency information within `noxfile.py`.  

For more details, see the [Nox docs](https://nox.thea.codes/en/stable/tutorial.html#running-without-the-nox-command-or-adding-dependencies) and [PEP 723](https://peps.python.org/pep-0723/).