### PR TITLE
Print out the differences between environments when updating requirements

### DIFF
--- a/changelog/2964.internal.rst
+++ b/changelog/2964.internal.rst
@@ -1,0 +1,2 @@
+Updated the ``requirements`` session in :file:`noxfile.py` to print
+out the differences between the new and old environments.


### PR DESCRIPTION
In #2937, we switched to using `uv.lock` to pin dependencies for use in CI.  We had previously been using `requirements.txt` style files, which had the advantage that the diffs were more easily human readable. The purpose of this PR is to make it so that the Nox session that updates requirements for us also prints out the differences between the old and new environments.