### PR TITLE
Improve handling of unexpected lines of `uv lock` output in Nox session to update requirements

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -64,7 +64,7 @@ running_on_rtd = os.environ.get("READTHEDOCS") == "True"
 uv_requirement = "uv >= 0.6.5"
 
 
-def _create_requirements_pr_message(uv_output: str) -> None:
+def _create_requirements_pr_message(uv_output: str, session: nox.Session) -> None:
     """
     Create the pull request message during requirements updates.
 
@@ -134,7 +134,7 @@ def requirements(session: nox.Session) -> None:
 
     if running_on_ci:
         session.log(uv_output)
-        _create_requirements_pr_message(uv_output)
+        _create_requirements_pr_message(uv_output=uv_output, session=session)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -92,10 +92,16 @@ def _create_requirements_pr_message(uv_output: str, session: nox.Session) -> Non
     ]
 
     for package_update in uv_output.splitlines():
-        if package_update.startswith("Resolved"):
+        if not package_update.startswith("Updated"):
+            session.debug(f"Line not added to table: {package_update}")
             continue
 
-        # The formats are like "Updated nbsphinx v0.9.6 -> v0.9.7"
+        try:
+            # An example line is "Updated nbsphinx v0.9.6 -> v0.9.7"
+            _, package_, old_version_, _, new_version_ = package_update.split()
+        except ValueError:
+            session.debug(f"Line not added to table: {package_update}:")
+            continue
 
         _, package, old_version_, _, new_version_ = package_update.split()
         old_version = f"{old_version_.removeprefix('v')}"

--- a/noxfile.py
+++ b/noxfile.py
@@ -103,13 +103,13 @@ def _create_requirements_pr_message(uv_output: str, session: nox.Session) -> Non
             session.debug(f"Line not added to table: {package_update}:")
             continue
 
-        _, package, old_version_, _, new_version_ = package_update.split()
         old_version = f"{old_version_.removeprefix('v')}"
         new_version = f"{new_version_.removeprefix('v')}"
-        pypi_link = f"https://pypi.org/project/{package}/{new_version}"
-        package_link = f"[`{package}`]({pypi_link})"
 
-        lines.append(f"| {package_link} | `{old_version}` | `{new_version}` |")
+        pypi_link = f"https://pypi.org/project/{package_}/{new_version}"
+        package = f"[`{package_}`]({pypi_link})"
+
+        lines.append(f"| {package} | `{old_version}` | `{new_version}` |")
 
     with pr_message.open(mode="a") as file:
         file.write("\n".join(lines))


### PR DESCRIPTION
This PR is a quick follow-up to #2964, since it failed when I tried to run the requirements workflow.