### PR TITLE
Update pre-commit configuration after new releases of `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
     - tomli
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1
+  rev: v1.30.2
   hooks:
   - id: typos
     name: typos (add false positives to _typos.toml)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   - id: check-yaml
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.31.2
+  rev: 0.31.3
   hooks:
   - id: check-github-workflows
 
@@ -79,13 +79,13 @@ repos:
     - tomli
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1.30.0
+  rev: v1
   hooks:
   - id: typos
     name: typos (add false positives to _typos.toml)
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.9
+  rev: v0.11.0
   hooks:
   - id: ruff
     name: ruff (see https://docs.astral.sh/ruff/rules)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,11 +348,11 @@ extend-select = [
   "RUF032", # decimal-from-float-literal
   "RUF033", # post-init-default
   "RUF034", # useless-if-else
-  "RUF040",
-  "RUF041",
-  "RUF046",
-  "RUF048",
-  "RUF051",
+  "RUF040", # invalid-assert-message-literal-argument
+  "RUF041", # unnecessary-nested-literal
+  "RUF046", # unnecessary-cast-to-int
+  "RUF048", # map-int-version-parsing
+  "RUF051", # if-key-in-dict-del
   "RUF100", # unused-noqa
   "RUF101", # redirected-noqa
   "RUF200", # invalid-pyproject-toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,6 +348,11 @@ extend-select = [
   "RUF032", # decimal-from-float-literal
   "RUF033", # post-init-default
   "RUF034", # useless-if-else
+  "RUF040",
+  "RUF041",
+  "RUF046",
+  "RUF048",
+  "RUF051",
   "RUF100", # unused-noqa
   "RUF101", # redirected-noqa
   "RUF200", # invalid-pyproject-toml

--- a/src/plasmapy/particles/ionization_state_collection.py
+++ b/src/plasmapy/particles/ionization_state_collection.py
@@ -689,7 +689,7 @@ class IonizationStateCollection:
         ionization states are being tracked.
         """
         if abundances_dict is None:
-            self._pars["abundances"] = {elem: np.nan for elem in self.base_particles}
+            self._pars["abundances"] = dict.fromkeys(self.base_particles, np.nan)
         elif not isinstance(abundances_dict, dict):
             raise TypeError(
                 "The abundances attribute must be a dict with "


### PR DESCRIPTION
I noticed from an Astropy PR that ruff v0.11.0 came out a few days ago.  This PR runs `pre-commit autoupdate`, enables a few more rules in the `RUF` rule set, and applies changes with `pre-commit run --all-files`.  

I kept the old version of `pre-commit-search-and-replace`, and specified the exact version of `typos` (since exact versions like `1.30.2` are more secure than abbreviated versions like `v1`).  