### PR TITLE
Update the configuration for labeling pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,30 +17,30 @@ bugfix:
 CI:
   - changed-files:
     - any-glob-to-any-file: [
-      '.github/workflows/*test*.yml',
+      '.github/workflows/ci.yml',
+      '.github/workflows/linkcheck.yml',
+      '.github/workflows/weekly.yml',
       '.pre-commit-config.yaml',
       '.readthedocs.yml',
       'codecov.yaml',
       'mypy.ini',
-      'noxfile.py',
-      'tox.ini',
-      '*azure*',
-      '*appveyor*',
     ]
 
 'contributor guide':
   - changed-files:
     - any-glob-to-any-file: [
+      '.github/contributing.md',
       'changelog/README.rst',
-      'docs/contributing/**'
+      'CONTRIBUTING.md',
+      'docs/contributing/**',
     ]
 
 requirements:
   - changed-files:
     - any-glob-to-any-file: [
       '**/*req*.txt',
-      '**/environment.y*ml',
-      '*requirements*/**/*.txt'
+      '**/pylock.toml',
+      '**/uv.lock',
     ]
 
 'deprecation or planned removal':
@@ -62,6 +62,8 @@ docs:
 'documentation infrastructure':
   - changed-files:
     - any-glob-to-any-file: [
+      '.github/workflows/changelog.yml',
+      '.github/workflows/check-author-included.yml',
       '.github/workflows/linkcheck.yml',
       '.readthedocs.yml',
       'docs/**/*.css',
@@ -84,27 +86,22 @@ feature:
 linters:
   - changed-files:
     - any-glob-to-any-file: [
-      '**/*flake8*',
-      '*lint*',
-      '*pep8speaks*',
-      '*style*',
       '.editorconfig',
       '.pre-commit*.yaml',
-      '.sourcery.yaml'
+      '.sourcery.yaml',
+      '_typos.toml',
     ]
 
 maintenance:
   - changed-files:
     - any-glob-to-any-file: [
-      '**/CONTRIBUTING.md',
-      '**/README.*',
       '.git-blame-ignore-revs',
       '.gitattributes',
       '.gitignore',
       '.mailmap',
       'changelog/*.internal*.rst',
       'CODEOWNERS',
-      'licenses/**'
+      'licenses/**',
     ]
 
 notebooks:
@@ -129,7 +126,7 @@ packaging:
       '.github/workflows/*pypi*',
       '.github/workflows/*release*',
       'MANIFEST.in',
-      'pyproject.toml'
+      'pyproject.toml',
     ]
 
 'physical data':
@@ -161,10 +158,7 @@ plasmapy.formulary.quantum:
 
 plasmapy.particles:
   - changed-files:
-    - any-glob-to-any-file: [
-      '**/atomic/**',
-      '**/particles/**'
-    ]
+    - any-glob-to-any-file: '**/particles/**'
 
 plasmapy.plasma:
   - changed-files:
@@ -185,6 +179,7 @@ python:
 release:
   - changed-files:
     - any-glob-to-any-file: [
+      '.github/content/*release*',
       '.github/workflows/*publish*',
       '.github/workflows/*pypi*',
       '.github/workflows/*release*'
@@ -202,21 +197,14 @@ testing:
   - changed-files:
     - any-glob-to-any-file: [
       '**/*coverage*',
+      '**/*pytest*.*',
       '**/conftest.py',
       '**/test*.py',
       '**/tests/**',
-      '*.sh',
       '*codecov.y*ml',
-      '.github/workflows/*tests*.yml',
       '.github/workflows/ci.yml',
-      'noxfile.py',
-      'pytest.ini',
-      'tox.ini'
     ]
 
 tools:
   - changed-files:
-    - any-glob-to-any-file: [
-      '**/scripts/**',
-      '**/tools/**'
-    ]
+    - any-glob-to-any-file: '**/tools/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -56,7 +56,7 @@ docs:
       'docs/**/*.md',
       'docs/**/*.png',
       'docs/**/*.rst',
-      'docs/**/*.svg'
+      'docs/**/*.svg',
     ]
 
 'documentation infrastructure':
@@ -72,7 +72,7 @@ docs:
       'docs/**/make.bat',
       'docs/**/Makefile',
       'docs/**/plasmapy_sphinx/**',
-      'docs/**/robots.txt'
+      'docs/**/robots.txt',
     ]
 
 feature:
@@ -110,7 +110,7 @@ notebooks:
       '**/*.ipynb',
       '**/binder/**',
       '.jupyter/**',
-      'docs/notebooks/**'
+      'docs/notebooks/**',
     ]
 
 nox:
@@ -133,7 +133,7 @@ packaging:
   - changed-files:
     - any-glob-to-any-file: [
       '**/particles/data/**',
-      '**/tools/export_ionization_energy.py'
+      '**/tools/export_ionization_energy.py',
     ]
 
 plasmapy.analysis:
@@ -182,7 +182,7 @@ release:
       '.github/content/*release*',
       '.github/workflows/*publish*',
       '.github/workflows/*pypi*',
-      '.github/workflows/*release*'
+      '.github/workflows/*release*',
     ]
 
 'static type checking':
@@ -190,7 +190,7 @@ release:
     - any-glob-to-any-file: [
       '**/*mypy*',
       '**/py.typed',
-      '**/type_stubs/**'
+      '**/type_stubs/**',
     ]
 
 testing:

--- a/changelog/2984.trivial.rst
+++ b/changelog/2984.trivial.rst
@@ -1,0 +1,1 @@
+Updated the configuration to automatically label pull requests on GitHub.


### PR DESCRIPTION
This PR makes some updates to `.github/labeler.yml`, which is the file that specifies which labels get add for each file that gets added to a pull request.  I remembered that we needed to update this to include `uv.lock`, and then noticed that there were a few things that were out-of-date. In particular, we renamed a few GitHub workflows, and haven't had any files related to Azure pipelines or Appveyor for a long time.