### PR TITLE
Add a mechanism to report security vulnerabilities

### DIFF
--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,47 @@
+name: Security 🔒
+description: Report a security vulnerability
+labels: [security]
+
+body:
+
+- type: markdown
+  attributes:
+    value: ⚠️ Please report critical vulnerabilities to team@plasmapy.org.
+
+- type: textarea
+  id: description
+  attributes:
+    label: Description
+    description: What is the nature of the security vulnerability?
+  validations:
+    required: true
+
+- type: dropdown
+  attributes:
+    label: Severity
+    description: How severe is this vulnerability? (optional)
+    options:
+        - "🪛 Low: Minor vulnerability"
+        - "⚠️ Medium: Limited impact"
+        - "🔥 High: Serious risk"
+        - "💥 Critical: Requires immediate action"
+
+- type: textarea
+  id: potential-impact
+  attributes:
+    label: Potential Impact
+    description: What is the potential impact of this vulnerability? (optional)
+
+- type: textarea
+  id: mitigation
+  attributes:
+    label: Mitigation Strategy
+    description: Do you have any suggestions for how to fix this vulnerability? (optional)
+
+- type: textarea
+  id: additional-context
+  attributes:
+    label: Additional context
+    description: Please provide any additional helpful details or related issues here. (optional)
+  validations:
+    required: false


### PR DESCRIPTION
It has become increasingly important in recent years for open source software projects to have security policies and a mechanism for reporting vulnerabilities.  Having a security policy is important for trust, transparency, reliability, and compliance with expectations from the broader scientific software ecosystem. I don't expect PlasmaPy to be targeted, but we may run into issues with vulnerabilities related to PlasmaPy's dependencies.

My goals for this PR are to:

 - [ ] [Add a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)
 - [x] Add a GitHub issue template
 - [ ] Note in both that critical vulnerabilities should be reported via email rather than as a GitHub issue.
 - [ ] Describe static analysis tools that perform security checks (e.g., `zizmor` and the `flake8-bandit` rule set from `ruff` at the time of writing)

This PR goes alongside PRs to add static analysis tools to perform security checks (e.g., #2975).