### PR TITLE
Update copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2015–2024, PlasmaPy Developers.
+Copyright (c) 2015–2025, PlasmaPy Developers.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This PR updates the copyright year in `LICENSE.md`. I had forgotten to update the copyright year earlier, which is strange because I usually like to do it on Jan 1 or 2. 🤔

I'm attempting this PR to try out [CoCalc](https://cocalc.com/) for a [CRANE](https://www.cranephysics.org/) session on contributing to an open source project that I'm definitely not waiting until the last minute to prepare for. 😅  If this gets merged, then it worked!