### PR TITLE
Organize `.gitignore` to use templates from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,14 +85,14 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile.lock
 
 # UV
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
@@ -105,7 +105,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+poetry.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.

--- a/.gitignore
+++ b/.gitignore
@@ -230,7 +230,7 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-### Adapted from https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+# Adapted from https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,13 @@ src/plasmapy/utils/data/downloads/
 docs/about/_authors.rst
 docs/changelog/index.rst
 docs/contributing/_global_substitutions_table.rst
-docs/api/
+
+# Allow contributors to create a custom requirements.txt file for
+# their own use.
+requirements.txt
+
+# Version file
+_version.py
 
 # Cython files (uncomment if we adopt Cython)
 # *.[ao]
@@ -30,14 +36,6 @@ VIRTUAL/
 *.aux
 *.bbl
 *.blg
-
-# Allow contributors to create a custom requirements.txt file for
-# their own use.
-requirements.txt
-
-# Version file
-_version.py
-tags
 
 # Miscellaneous files
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,6 @@ _version.py
 # VS code project settings
 .vscode
 
-# Auxiliary files associated with vim
-*.swp
-VIRTUAL/
-
 # LaTeX and bibtex auxiliary files
 *.aux
 *.bbl

--- a/.gitignore
+++ b/.gitignore
@@ -325,3 +325,15 @@ fabric.properties
 auto-save-list
 tramp
 .\#*
+
+# Adapted from https://github.com/github/gitignore/blob/main/Global/Vim.gitignore
+
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+Session*.vim
+.netrwhist
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,12 @@ package-lock.json
 Untitled*
 untitled*
 
-### Adapted from: https://github.com/github/gitignore/blob/main/Python.gitignore
+# Below are the contents of various .gitignore file templates, mostly
+# from https://github.com/github/gitignore. To make it easier to keep
+# track of changes in the template with `git diff`, please only copy
+# sections of templates below this line.
+
+# Adapted from: https://github.com/github/gitignore/blob/main/Python.gitignore
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ _version.py
 # *.cpp
 # *.dll
 
-# VS code project settings
+# VS Code (while a template exists, we would need a long-term VS Code
+# user to maintain appropriate settings)
 .vscode
 
 # LaTeX and bibtex auxiliary files

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,181 @@
 # Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+### Previous .gitignore
+
+# Byte-compiled / optimized / DLL files
 *$py.class
 *.a
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ docs/api/
 # *.[ch]
 # *.cpp
 # *.dll
-# *.pyd
 # cython_debug/
 # cython_version.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,87 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
+### Adapted from https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+.idea/sonarlint.xml # see https://community.sonarsource.com/t/is-the-file-idea-idea-idea-sonarlint-xml-intended-to-be-under-source-control/121119
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
 ### Previous .gitignore
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ requirements.txt
 # Version file
 _version.py
 
+# basedpyright (baseline files should be cached in CI if we adopt this tool)
+.basedpyright
+
 # Cython files (uncomment if we adopt Cython)
 # *.[ao]
 # *.[ch]

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,6 @@ docs/api/
 # *.[ch]
 # *.cpp
 # *.dll
-# cython_debug/
-# cython_version.py
 
 # VS code project settings
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,21 @@
 ### PlasmaPy custom content
 
+# The following file is created when running `nox -s requirements` in CI
+
+.github/content/update-requirements-pr-body.md
+
+# Downloaded files
+src/plasmapy/utils/data/downloads/
+
+# Documentation files
+auto_examples
+docs/about/_authors.rst
+docs/changelog/index.rst
+docs/contributing/_global_substitutions_table.rst
+docs/notebooks/*.md
+docs/api
+docs/gen_modules
+
 # Byte-compiled / optimized / DLL files
 *.a
 *.o
@@ -8,15 +24,8 @@
 # add a non-generated .c extension, use `git add -f filename.c`.
 *.c
 
-# Downloaded files
-src/plasmapy/utils/data/downloads/
-
 # Unit test / coverage reports
 *,cover
-
-# Sphinx documentation
-docs/api
-docs/gen_modules
 
 # Jupyter Notebook
 notebooks_for_proto
@@ -39,13 +48,6 @@ VIRTUAL/
 *.bbl
 *.blg
 
-# Documentation files
-auto_examples
-docs/about/_authors.rst
-docs/changelog/index.rst
-docs/contributing/_global_substitutions_table.rst
-docs/notebooks/*.md
-
 # Allow contributors to create a custom requirements.txt file for
 # their own use.
 requirements.txt
@@ -65,11 +67,6 @@ node_modules
 package-lock.json
 Untitled*
 untitled*
-
-# The following file is created when running `nox -s requirements` in CI
-
-.github/content/update-requirements-pr-body.md
-
 
 ### Adapted from: https://github.com/github/gitignore/blob/main/Python.gitignore
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,15 +35,14 @@ _version.py
 *.blg
 
 # Miscellaneous files
-
 *debuglog*
 .DS_Store
-gitlog
+.nfs*
+.Trash*
+[Uu]ntitled*
 monkeytype.sqlite3
 node_modules
 package-lock.json
-Untitled*
-untitled*
 
 # Below are the contents of various .gitignore file templates, mostly
 # from https://github.com/github/gitignore. To make it easier to keep

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ src/plasmapy/utils/data/downloads/
 
 # Generated files from documentation builds
 docs/about/_authors.rst
+docs/api/
 docs/changelog/index.rst
 docs/contributing/_global_substitutions_table.rst
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,16 +16,13 @@ docs/notebooks/*.md
 docs/api
 docs/gen_modules
 
-# Byte-compiled / optimized / DLL files
-*.a
-*.o
-
-# Ignore .c files by default to avoid including generated code. If you want to
-# add a non-generated .c extension, use `git add -f filename.c`.
-*.c
-
-# Unit test / coverage reports
-*,cover
+# Cython files (if we re-adopt Cython)
+#*.[acho]
+#*.cpp
+#*.dll
+#*.pyd
+#cython_debug/
+#cython_version.py
 
 # Jupyter Notebook
 notebooks_for_proto
@@ -57,10 +54,9 @@ _version.py
 tags
 
 # Miscellaneous files
-cython_version.py
+
 *debuglog*
 .DS_Store
-cython_debug
 gitlog
 monkeytype.sqlite3
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,76 @@
+### PlasmaPy custom content
+
+# Byte-compiled / optimized / DLL files
+*.a
+*.o
+
+# Ignore .c files by default to avoid including generated code. If you want to
+# add a non-generated .c extension, use `git add -f filename.c`.
+*.c
+
+# Downloaded files
+src/plasmapy/utils/data/downloads/
+
+# Unit test / coverage reports
+*,cover
+
+# Sphinx documentation
+docs/api
+docs/gen_modules
+
+# Jupyter Notebook
+notebooks_for_proto
+
+# VS code project settings
+.vscode
+
+# Auxiliary files associated with emacs
+*#
+*.#
+*~
+.#*
+
+# Auxiliary files associated with vim
+*.swp
+VIRTUAL/
+
+# LaTeX and bibtex auxiliary files
+*.aux
+*.bbl
+*.blg
+
+# Documentation files
+auto_examples
+docs/about/_authors.rst
+docs/changelog/index.rst
+docs/contributing/_global_substitutions_table.rst
+docs/notebooks/*.md
+
+# Allow contributors to create a custom requirements.txt file for
+# their own use.
+requirements.txt
+
+# Version file
+_version.py
+tags
+
+# Miscellaneous files
+cython_version.py
+*debuglog*
+.DS_Store
+cython_debug
+gitlog
+monkeytype.sqlite3
+node_modules
+package-lock.json
+Untitled*
+untitled*
+
+# The following file is created when running `nox -s requirements` in CI
+
+.github/content/update-requirements-pr-body.md
+
+
 ### Adapted from: https://github.com/github/gitignore/blob/main/Python.gitignore
 
 # Byte-compiled / optimized / DLL files
@@ -255,75 +328,3 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
-
-### PlasmaPy custom content
-
-# Byte-compiled / optimized / DLL files
-*.a
-*.o
-
-# Ignore .c files by default to avoid including generated code. If you want to
-# add a non-generated .c extension, use `git add -f filename.c`.
-*.c
-
-# Downloaded files
-src/plasmapy/utils/data/downloads/
-
-# Unit test / coverage reports
-*,cover
-
-# Sphinx documentation
-docs/api
-docs/gen_modules
-
-# Jupyter Notebook
-notebooks_for_proto
-
-# VS code project settings
-.vscode
-
-# Auxiliary files associated with emacs
-*#
-*.#
-*~
-.#*
-
-# Auxiliary files associated with vim
-*.swp
-VIRTUAL/
-
-# LaTeX and bibtex auxiliary files
-*.aux
-*.bbl
-*.blg
-
-# Documentation files
-auto_examples
-docs/about/_authors.rst
-docs/changelog/index.rst
-docs/contributing/_global_substitutions_table.rst
-docs/notebooks/*.md
-
-# Allow contributors to create a custom requirements.txt file for
-# their own use.
-requirements.txt
-
-# Version file
-_version.py
-tags
-
-# Miscellaneous files
-cython_version.py
-*debuglog*
-.DS_Store
-cython_debug
-gitlog
-monkeytype.sqlite3
-node_modules
-package-lock.json
-Untitled*
-untitled*
-
-# The following file is created when running `nox -s requirements` in CI
-
-.github/content/update-requirements-pr-body.md

--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,7 @@ poetry.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
+pdm.lock
 #   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
 #   in version control.
 #   https://pdm.fming.dev/latest/usage/project/#working-with-version-control

--- a/.gitignore
+++ b/.gitignore
@@ -257,118 +257,32 @@ fabric.properties
 ### Previous .gitignore
 
 # Byte-compiled / optimized / DLL files
-*$py.class
 *.a
 *.o
-*.py[cod]
-*.so
-__pycache__/
-MANIFEST
 
 # Ignore .c files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, use `git add -f filename.c`.
 *.c
 
-# Distribution / packaging
-*.egg
-*.egg-info/
-.eggs/
-.installed.cfg
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-env/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-
 # Downloaded files
 src/plasmapy/utils/data/downloads/
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-delete-this-directory.txt
-pip-log.txt
-
 # Unit test / coverage reports
 *,cover
-.cache
-.coverage
-.coverage.*
-.hypothesis/
 .pytest_cache
-.tox/
-coverage.xml
-htmlcov/
-nosetests.xml
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-
-# Flask stuff:
-.webassets-cache
-instance/
-
-# Scrapy stuff:
-.scrapy
 
 # Sphinx documentation
-docs/_build/
 docs/api
 docs/gen_modules
 
-# PyBuilder
-target/
-
 # Jupyter Notebook
-.ipynb_checkpoints
 notebooks_for_proto
 
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
-
 # dotenv
-.env
 env
-
-# virtualenv
-.venv
-ENV/
-venv/
-
-# Spyder project settings
-.spyderproject
-
-# Rope project settings
-.ropeproject
 
 # VS code project settings
 .vscode
-
-# mkdocs documentation
-/site
 
 # Auxiliary files associated with emacs
 *#
@@ -403,14 +317,12 @@ tags
 # Miscellaneous files
 cython_version.py
 *debuglog*
-.dmypy.json
 .DS_Store
 .idea/
 .mypy_cache
 .pyre
 .pytype
 cython_debug
-dmypy.json
 gitlog
 monkeytype.sqlite3
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -24,12 +24,6 @@ docs/api/
 # VS code project settings
 .vscode
 
-# Auxiliary files associated with emacs
-*#
-*.#
-*~
-.#*
-
 # Auxiliary files associated with vim
 *.swp
 VIRTUAL/
@@ -320,3 +314,14 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Adapted from https://github.com/github/gitignore/blob/main/Global/Emacs.gitignore
+
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*

--- a/.gitignore
+++ b/.gitignore
@@ -208,14 +208,14 @@ cython_debug/
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
 
 # CMake
 cmake-build-*/

--- a/.gitignore
+++ b/.gitignore
@@ -16,16 +16,14 @@ docs/notebooks/*.md
 docs/api
 docs/gen_modules
 
-# Cython files (if we re-adopt Cython)
-#*.[acho]
-#*.cpp
-#*.dll
-#*.pyd
-#cython_debug/
-#cython_version.py
-
-# Jupyter Notebook
-notebooks_for_proto
+# Cython files (uncomment if we adopt Cython)
+# *.[ao]
+# *.[ch]
+# *.cpp
+# *.dll
+# *.pyd
+# cython_debug/
+# cython_version.py
 
 # VS code project settings
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+### Adapted from: https://github.com/github/gitignore/blob/main/Python.gitignore
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -254,7 +256,7 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
-### Previous .gitignore
+### PlasmaPy custom content
 
 # Byte-compiled / optimized / DLL files
 *.a
@@ -269,7 +271,6 @@ src/plasmapy/utils/data/downloads/
 
 # Unit test / coverage reports
 *,cover
-.pytest_cache
 
 # Sphinx documentation
 docs/api
@@ -277,9 +278,6 @@ docs/gen_modules
 
 # Jupyter Notebook
 notebooks_for_proto
-
-# dotenv
-env
 
 # VS code project settings
 .vscode
@@ -318,10 +316,6 @@ tags
 cython_version.py
 *debuglog*
 .DS_Store
-.idea/
-.mypy_cache
-.pyre
-.pytype
 cython_debug
 gitlog
 monkeytype.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-### PlasmaPy custom content
+# Please put PlasmaPy-specific lines near the top of .gitignore.
 
 # The following file is created when running `nox -s requirements` in CI
 
@@ -8,13 +8,10 @@
 src/plasmapy/utils/data/downloads/
 
 # Documentation files
-auto_examples
 docs/about/_authors.rst
 docs/changelog/index.rst
 docs/contributing/_global_substitutions_table.rst
-docs/notebooks/*.md
-docs/api
-docs/gen_modules
+docs/api/
 
 # Cython files (uncomment if we adopt Cython)
 # *.[ao]

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
-# Please put PlasmaPy-specific lines near the top of .gitignore.
+# Please put PlasmaPy-specific or custom content near the top of this file.
+# The bottom part of this file is reserved for templates copied from elsewhere.
 
-# The following file is created when running `nox -s requirements` in CI
-
+# Auto-generated PR message from running `nox -s requirements` in CI
 .github/content/update-requirements-pr-body.md
 
-# Downloaded files
+# Downloaded data files
 src/plasmapy/utils/data/downloads/
 
-# Documentation files
+# Generated files from documentation builds
 docs/about/_authors.rst
 docs/changelog/index.rst
 docs/contributing/_global_substitutions_table.rst

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,3 +46,7 @@ type_stubs/ @namurphy
 .pre-commit-config.yaml @namurphy
 codecov.yml @namurphy
 noxfile.py @namurphy
+
+# PyCharm configuration
+
+.idea/ @namurphy

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,8 +26,8 @@ global-exclude _authors.rst
 global-exclude *.o *.py[cod]
 global-exclude uv.lock
 
-prune _build
-prune build
+prune **/_build
+prune **/build
 prune docs/api
 
 # The following directory is only used to get the version right for

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,6 @@ graft tests
 graft tools
 graft type_stubs
 
-include *.ini
 include *.ini *.toml *.yaml *.yml
 include *.md
 include *.py
@@ -23,10 +22,12 @@ include binder/requirements.txt
 include CITATION.cff
 include CODEOWNERS
 
-global-exclude _build build _authors.rst
+global-exclude _authors.rst
 global-exclude *.o *.py[cod]
 global-exclude uv.lock
 
+prune _build
+prune build
 prune docs/api
 
 # The following directory is only used to get the version right for

--- a/changelog/2997.internal.rst
+++ b/changelog/2997.internal.rst
@@ -1,0 +1,3 @@
+Updated :file:`.gitignore` to put content that is custom or PlasmaPy-specific
+at the top of the file, followed by content adapted from :file:`.gitignore`
+templates at the bottom.


### PR DESCRIPTION
This PR reorganizes `.gitignore` to put custom & PlasmaPy content is near the top, while having templates below.  I tried to minimally edit the templates so that it's easier to do a `git diff` later on to see what in the templates have changed.

Instead of ignoring `.idea` — the PyCharm settings folder — I put in the template from JetBrains. My hope is that we'll be able to set up certain test configurations that will be common across projects, so that it isn't necessary for everyone to set this up.  

> [!NOTE]
> I thought about including the .gitignore template specific to VS Code, but decided to keep ignoring the entirety of the configuration directory (`.vscode/`).  I plan to maintain the PyCharm configuration, but we would need someone to maintain the VS Code configuration.

I also made a few slight changes to `MANIFEST.in`.