### PR TITLE
Add a Nox session to set up a virtual environment

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -64,6 +64,12 @@ running_on_rtd = os.environ.get("READTHEDOCS") == "True"
 uv_requirement = "uv >= 0.6.5"
 
 
+@nox.session(python=current_python)
+def dev(session: nox.Session) -> None:
+    """Set up a development environment."""
+    session.run("uv", "venv", "--python", maxpython, "--no-progress")
+    session.run("uv", "sync", "--frozen", "--all-extras", "--no-progress")
+
 def _create_requirements_pr_message(uv_output: str, session: nox.Session) -> None:
     """
     Create the pull request message during requirements updates.


### PR DESCRIPTION
The purpose of this PR is to simplify the process of setting up and syncing a virtual environment for contributing to PlasmaPy.  In particular, I want it to create a virtual environment (if one doesn't exist) and then sync it with `uv.lock`.

The Nox cookbook has a recipe to [set up a dev environment for a project](https://nox.thea.codes/en/stable/cookbook.html#instant-dev-environment).  Their example uses `virtualenv`, so I am in the process of adapting it to use a virtual environment set up by `uv`.

I'm going to need to play around with this to make sure it works, but I'm hoping this will let us simplify the instructions on getting ready to contribute to PlasmaPy to be (1) install `uv` and (2) run `nox -s dev`.