### PR TITLE
Migrate to new datetime API

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -736,3 +736,8 @@ authors:
   affiliation: Imperial College London
   orcid: https://orcid.org/0000-0002-1753-4223
   alias: wnguyen1312
+
+- given-names: Emmanuel
+  family-names: Ferdman
+  orcid: https://orcid.org/0009-0004-8953-0151
+  alias: emmanuel-ferdman

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -20,7 +20,7 @@ import typing
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 from numbers import Integral, Real
 from typing import TYPE_CHECKING, TypeAlias
 
@@ -170,7 +170,7 @@ class AbstractParticle(ABC):
             "plasmapy_particle": {
                 "type": type(self).__name__,
                 "module": self.__module__,
-                "date_created": datetime.utcnow().strftime(  # noqa: DTZ003
+                "date_created": datetime.now(timezone.utc).strftime(
                     "%Y-%m-%d %H:%M:%S UTC"
                 ),
                 "__init__": {"args": (), "kwargs": {}},

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -170,7 +170,7 @@ class AbstractParticle(ABC):
             "plasmapy_particle": {
                 "type": type(self).__name__,
                 "module": self.__module__,
-                "date_created": datetime.now(timezone.utc).strftime(
+                "date_created": datetime.now(timezone.utc).strftime(  # noqa: UP017
                     "%Y-%m-%d %H:%M:%S UTC"
                 ),
                 "__init__": {"args": (), "kwargs": {}},


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` deprecation warnings which you can find in the [CI logs](https://github.com/PlasmaPy/PlasmaPy/actions/runs/14848126109/job/41686437483#step:6:291):
```python
/Users/runner/work/PlasmaPy/PlasmaPy/src/plasmapy/particles/particle_class.py:173: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```
Please note that I added `noqa: UP017` because `datetime.UTC` alias (to `datetime.timezone.utc`) was introduced in Python 3.11, meaning previous versions will fail to use it.