### PR TITLE
Repair the `weekly.yml` workflow

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -95,11 +95,6 @@ jobs:
           python: '3.12'
           nox_session: build_docs_with_dev_version_of(nbsphinx)
 
-        - name: Documentation, Python 3.12, plasmapy_sphinx-dev, Ubuntu
-          os: ubuntu-latest
-          python: '3.12'
-          nox_session: build_docs_with_dev_version_of(plasmapy_sphinx)
-
         - name: Static type checking with mypy, Python 3.13, Windows
           os: windows-latest
           python: '3.13'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -166,7 +166,7 @@ jobs:
         cache-suffix: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}
 
     - name: Run Nox session
-      run: nox -s '${{ matrix.nox_session }}'
+      run: uv run nox -s '${{ matrix.nox_session }}'
 
     - name: Upload coverage reports to Codecov
       if: ${{ contains(matrix.nox_session, 'cov') }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -95,6 +95,11 @@ jobs:
           python: '3.12'
           nox_session: build_docs_with_dev_version_of(nbsphinx)
 
+        - name: Documentation, Python 3.12, plasmapy_sphinx-dev, Ubuntu
+          os: ubuntu-latest
+          python: '3.12'
+          nox_session: build_docs_with_dev_version_of(plasmapy_sphinx)
+
         - name: Static type checking with mypy, Python 3.13, Windows
           os: windows-latest
           python: '3.13'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -171,7 +171,7 @@ jobs:
         cache-suffix: ${{ matrix.nox_session }}-${{ matrix.python }}-${{ runner.os }}
 
     - name: Run Nox session
-      run: uv run nox -s '${{ matrix.nox_session }}'
+      run: uv run --with nox nox -s '${{ matrix.nox_session }}'
 
     - name: Upload coverage reports to Codecov
       if: ${{ contains(matrix.nox_session, 'cov') }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -402,7 +402,7 @@ def build_docs_with_dev_version_of(
         *list(deps.values()),
         silent=False,
     )
-    session.install("--no-deps", "--force-install", ".")
+    session.install("--no-deps", ".")
     session.run(*sphinx_base_command, *build_html, *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -123,7 +123,7 @@ def _create_requirements_pr_message(uv_output: str, session: nox.Session) -> Non
 
 def _get_dependencies_from_pyproject_toml(extras: Optional[str] = None):
     _PYTPROJECT_TOML = (_HERE / "pyproject.toml").resolve()
-    with open(_PYTPROJECT_TOML, "rb") as file:
+    with _PYTPROJECT_TOML.open(mode="rb") as file:
         data = tomllib.load(file)
         config = data["project"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -360,7 +360,7 @@ def build_docs_with_dev_version_of(
     so that they can be fixed or updated earlier rather than later.
     """
     session.install(".[docs]")
-    session.install("--ignore-installed", f"git+https://{site}.com/{repository}")
+    session.install("--force-reinstall", f"git+https://{site}.com/{repository}")
     session.run(*sphinx_base_command, *build_html, *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -393,12 +393,16 @@ def build_docs_with_dev_version_of(
     The purpose of this session is to catch bugs and breaking changes
     so that they can be fixed or updated earlier rather than later.
     """
-    session.install(".[docs]", silent=False)
+    pkg_name = repository.split("/")[-1]
+    deps = _get_dependencies_from_pyproject_toml(extras="docs")
+    deps.pop(pkg_name, None)
+
     session.install(
-        "--force-reinstall",
         f"git+https://{site}.com/{repository}",
+        *list(deps.values()),
         silent=False,
     )
+    session.install("--no-deps", "--force-install", ".")
     session.run(*sphinx_base_command, *build_html, *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -381,7 +381,6 @@ def docs(session: nox.Session) -> None:
         nox.param("github", "sphinx-doc/sphinx", id="sphinx"),
         nox.param("github", "readthedocs/sphinx_rtd_theme", id="sphinx_rtd_theme"),
         nox.param("github", "spatialaudio/nbsphinx", id="nbsphinx"),
-        nox.param("github", "plasmapy/plasmapy_sphinx", id="plasmapy_sphinx"),
     ],
 )
 def build_docs_with_dev_version_of(

--- a/noxfile.py
+++ b/noxfile.py
@@ -393,6 +393,9 @@ def build_docs_with_dev_version_of(
     The purpose of this session is to catch bugs and breaking changes
     so that they can be fixed or updated earlier rather than later.
     """
+    # Note: Individual dependencies are install in this fashion to
+    #       avoid resolution conflicts if an upper dependency limit
+    #       had been put on the target package.
     pkg_name = repository.split("/")[-1]
     deps = _get_dependencies_from_pyproject_toml(extras="docs")
     deps.pop(pkg_name, None)

--- a/noxfile.py
+++ b/noxfile.py
@@ -359,7 +359,8 @@ def build_docs_with_dev_version_of(
     The purpose of this session is to catch bugs and breaking changes
     so that they can be fixed or updated earlier rather than later.
     """
-    session.install(f"git+https://{site}.com/{repository}", ".[docs]")
+    session.install(".[docs]")
+    session.install("--ignore-installed", f"git+https://{site}.com/{repository}")
     session.run(*sphinx_base_command, *build_html, *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -359,8 +359,12 @@ def build_docs_with_dev_version_of(
     The purpose of this session is to catch bugs and breaking changes
     so that they can be fixed or updated earlier rather than later.
     """
-    session.install(".[docs]")
-    session.install("--force-reinstall", f"git+https://{site}.com/{repository}")
+    session.install(".[docs]", silent=False)
+    session.install(
+        "--force-reinstall",
+        f"git+https://{site}.com/{repository}",
+        silent=False,
+    )
     session.run(*sphinx_base_command, *build_html, *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -347,6 +347,7 @@ def docs(session: nox.Session) -> None:
         nox.param("github", "sphinx-doc/sphinx", id="sphinx"),
         nox.param("github", "readthedocs/sphinx_rtd_theme", id="sphinx_rtd_theme"),
         nox.param("github", "spatialaudio/nbsphinx", id="nbsphinx"),
+        nox.param("github", "plasmapy/plasmapy_sphinx", id="plasmapy_sphinx"),
     ],
 )
 def build_docs_with_dev_version_of(


### PR DESCRIPTION
The `weekly.yml` workflow had been failing since `nox` was trying to be run directly while it had not been explicitly installed.  This appears to have occurred when moving to `setup-uv` in PR #2959.

This was easily resolved by running the `nox` command with `uv run --with nox`.

After solving the above issue, I noticed the documentation tests (specifically for `sphinx`) were not working as intended.  Since `sphinx` had an upper dependency limit placed on it, the installer could not properly resolve dependencies with `plasmapy` and the latest `sphinx`.  To resolve this issue...

1. I created the `_get_dependencies_from_pyproject_toml()` helper function (in `noxfile.py`), so I could extract the package dependencies directly from the `pyproject.toml`.
2. I then removed the target package dependency (e.g. `sphinx`), so there would be no resolution conflict.
3. I installed all the dependencies manually using `nox.Session.install`.
4. I installed `plasmapy` using `nox.Session.install` with the `--no-deps` flag so dependencies would not be overwritten.