### PR TITLE
Fix `htmlzip` build for public RTD builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,5 +32,8 @@ build:
       html:
       - uv run --extra docs --frozen --exact nox -s docs
 
+      htmlzip:
+      - uv run nox -s docs_bundle_htmlzip
+
     post_build:
     - echo $'\n'⚠️ For help deciphering documentation build error messages, see:$'\n\n'\ \ https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -33,7 +33,7 @@ build:
       - uv run --extra docs --frozen --exact nox -s docs
 
       htmlzip:
-      - uv run nox -s docs_bundle_htmlzip
+      - uv run --extra docs --frozen --exact nox -s docs_bundle_htmlzip
 
     post_build:
     - echo $'\n'⚠️ For help deciphering documentation build error messages, see:$'\n\n'\ \ https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting

--- a/noxfile.py
+++ b/noxfile.py
@@ -384,11 +384,13 @@ def docs_bundle_htmlzip(session: nox.Session) -> None:
 
     html_build_dir = pathlib.Path(doc_build_dir)
     html_landing_page = (html_build_dir / "index.html").resolve()
+    READTHEDOCS_OUTPOUT = html_build_dir.parent
     if not html_landing_page.exists():
         session.error(
             f"No documentation build fount at: {html_landing_page}\n"
             f"It appears the documentation has not been built."
         )
+
     command = [
         "sphinx-build",
         "--show-traceback",
@@ -398,8 +400,8 @@ def docs_bundle_htmlzip(session: nox.Session) -> None:
         "singlehtml",
         "--define",
         "language=en",
-        f"./docs/",  # source directory
-        "$READTHEDOCS_OUTPUT/htmlzip",  # output directory
+        "./docs/",  # source directory
+        f"{READTHEDOCS_OUTPOUT / 'htmlzip'}",  # output directory
     ]
     session.run(*command)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -393,7 +393,7 @@ def docs_bundle_htmlzip(session: nox.Session) -> None:
         "sphinx-build",
         "--show-traceback",
         "--doctree-dir",
-        f"{html_build_dir / '.doctrees'}"
+        f"{html_build_dir / '.doctrees'}",
         "--builder",
         "singlehtml",
         "--define",

--- a/noxfile.py
+++ b/noxfile.py
@@ -370,7 +370,7 @@ def docs(session: nox.Session) -> None:
         session.error(f"Documentation preview landing page not found: {landing_page}")
 
 
-@nox.session(python=docpython)
+@nox.session(python=docpython, reuse_venv=True)
 def docs_bundle_htmlzip(session: nox.Session) -> None:
     """
     Convert html built docs to a bundle html zip file.

--- a/noxfile.py
+++ b/noxfile.py
@@ -396,7 +396,7 @@ def docs_bundle_htmlzip(session: nox.Session) -> None:
         "singlehtml",
         "--define",
         "language=en",
-        f".",  # source directory
+        f"./docs/",  # source directory
         "$READTHEDOCS_OUTPUT/htmlzip",  # output directory
     ]
     session.run(*command)

--- a/noxfile.py
+++ b/noxfile.py
@@ -371,6 +371,38 @@ def docs(session: nox.Session) -> None:
 
 
 @nox.session(python=docpython)
+def docs_bundle_htmlzip(session: nox.Session) -> None:
+    """
+    Convert html built docs to a bundle html zip file.
+    """
+
+    if not running_on_rtd:
+        session.log(
+            "Process is NOT being run on Read the Docs.  Will not html ZIP file."
+        )
+        return None
+
+    html_build_dir = pathlib.Path(doc_build_dir)
+    html_landing_page = (html_build_dir / "index.html").resolve()
+    if not html_landing_page.exists():
+        session.error(
+            f"No documentation build fount at: {html_landing_page}\n"
+            f"It appears the documentation has not been built."
+        )
+    command = [
+        "sphinx-build",
+        "--show-traceback",
+        "--builder",
+        "singlehtml",
+        "--define",
+        "language=en",
+        f"{html_build_dir}",  # source directory
+        "$READTHEDOCS_OUTPUT/htmlzip",  # output directory
+    ]
+    session.run(*command)
+
+
+@nox.session(python=docpython)
 @nox.parametrize(
     ["site", "repository"],
     [

--- a/noxfile.py
+++ b/noxfile.py
@@ -392,6 +392,8 @@ def docs_bundle_htmlzip(session: nox.Session) -> None:
     command = [
         "sphinx-build",
         "--show-traceback",
+        "--doctree-dir",
+        f"{html_build_dir / '.doctrees'}"
         "--builder",
         "singlehtml",
         "--define",

--- a/noxfile.py
+++ b/noxfile.py
@@ -396,7 +396,7 @@ def docs_bundle_htmlzip(session: nox.Session) -> None:
         "singlehtml",
         "--define",
         "language=en",
-        f"{html_build_dir}",  # source directory
+        f".",  # source directory
         "$READTHEDOCS_OUTPUT/htmlzip",  # output directory
     ]
     session.run(*command)


### PR DESCRIPTION
Since PR #2937, the RTD builds for non-hidden versions have been failing.  This has been a result of the the `htmlzip` build failing, and not the main `html` build.  We do not see this failure on PR builds, because RTD does not produce the html zip file for those builds.

Here's an example of the error...

![image](https://github.com/user-attachments/assets/e97951bf-cf6e-43e8-bd26-6b52975a5f10)

The cause of the error is `python` not being available outside the `nox` environments used to do the html build.  To remedy this I created a new `nox` runner `docs_bundle_htmlzip` and defined a htmlzip build command in the `.readthedocs.yml`.