### PR TITLE
Put office hours on an indefinite hiatus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,6 @@ which has information on:
 - [Writing and running tests](https://docs.plasmapy.org/en/latest/contributing/testing_guide.html#testing-guide)
 - [Adding a changelog entry](https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry) (needed except for minor changes)
 
-You can also find us in our
-[**chat room**](https://app.element.io/#/room/#plasmapy:openastronomy.org)
-or weekly
-[**community meetings**](https://www.plasmapy.org/meetings/weekly) &
-[**office hours**](https://www.plasmapy.org/meetings/office_hours).
+You can also find us during our [**community meetings**](https://www.plasmapy.org/meetings/weekly).
 
 We thank you once again!

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ PlasmaPy's weekly [community meetings] are a place to talk about code
 development, event planning, and other community happenings. If you have
 an idea for a new feature or would like to become involved in the
 PlasmaPy project, community meetings are a great place to start. As of
-March 2025, our community meetings are on most Thursdays at 2 pm ET.
+May 2025, our community meetings are on most Thursdays at 2 pm ET.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -107,22 +107,13 @@ an idea for a new feature or would like to become involved in the
 PlasmaPy project, community meetings are a great place to start. As of
 March 2025, our community meetings are on most Thursdays at 2 pm ET.
 
-### Office hours
-
-Our weekly informal [office hours] are an opportunity to chat with
-active members of the PlasmaPy community about topics related to Python
-and plasma physics. If you'd like to learn more about PlasmaPy, our
-office hours are one of the best places to start. As of March 2025, our
-office hours are on most Thursdays at 3 pm Eastern. Please feel free to
-come by!
-
 ## Community
 
 ## Contact information
 
 Please feel free to reach out to us at [team@plasmapy.org] or stop by
-our [office hours] with any ideas, questions, and/or puns about
-computational magnetohydrodynamics.
+one of our [community meetings] with any ideas, questions, and/or puns
+about computational magnetohydrodynamics.
 
 Please use these links to [submit a feature request] and to
 [submit a bug report] on PlasmaPy's GitHub repository.
@@ -176,7 +167,6 @@ documentation page on [authors and credits].
 [meetings]: https://www.plasmapy.org/meetings/weekly
 [nasa]: https://www.nasa.gov/
 [national science foundation]: https://nsf.gov
-[office hours]: http://www.plasmapy.org/meetings/office_hours
 [plasmapy]: https://www.plasmapy.org
 [plasmapy community on zenodo]: https://zenodo.org/communities/plasmapy
 [protections against software patents]: ./PATENT.md

--- a/changelog/3013.doc.rst
+++ b/changelog/3013.doc.rst
@@ -1,0 +1,1 @@
+Put office hours an an indefinite hiatus due to the conclusion of the NSF award supporting the development of PlasmaPy.

--- a/docs/_global_substitutions.py
+++ b/docs/_global_substitutions.py
@@ -123,7 +123,8 @@ astropy_subs: dict[str, str] = {
 links_to_become_subs: dict[str, str] = {
     "Astropy": "https://docs.astropy.org",
     "Astropy Equivalencies": "https://docs.astropy.org/en/stable/units/equivalencies.html",
-    "Citation File Format": "https://citation-file-format.github.io/",
+    "Citation File Format": "https://citation-file-format.github.io",
+    "community meetings": "https://www.plasmapy.org/meetings/weekly",
     "DOI": "https://www.doi.org",
     "editable installation": "https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs",
     "git": "https://git-scm.com",
@@ -132,7 +133,7 @@ links_to_become_subs: dict[str, str] = {
     "h5py": "https://www.h5py.org",
     "intersphinx": "https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html",
     "Jupyter": "https://jupyter.org",
-    "lmfit": "https://lmfit.github.io/lmfit-py/",
+    "lmfit": "https://lmfit.github.io/lmfit-py",
     "matplotlib": "https://matplotlib.org",
     "Matrix chat room": "https://app.element.io/#/room/#plasmapy:openastronomy.org",
     "mpmath": "https://mpmath.org/doc/current",

--- a/docs/_global_substitutions.py
+++ b/docs/_global_substitutions.py
@@ -140,7 +140,6 @@ links_to_become_subs: dict[str, str] = {
     "nbsphinx": "https://nbsphinx.readthedocs.io",
     "Nox": "https://nox.thea.codes",
     "NumPy": "https://numpy.org",
-    "office hours": "https://www.plasmapy.org/meetings/office_hours/",
     "pandas": "https://pandas.pydata.org",
     "pip": "https://pip.pypa.io",
     "Plasma Hack Week": "https://hack.plasmapy.org",

--- a/docs/contributing/getting_ready.rst
+++ b/docs/contributing/getting_ready.rst
@@ -21,8 +21,8 @@ contributors can take to get set up to contribute to PlasmaPy. After
 taking these steps, you'll be ready to go through the :ref:`code
 contribution workflow <workflow>`.
 
-If you run into any problems, please feel free to reach out to us in our
-|Matrix chat room| or during our weekly |office hours|.
+If you run into any problems, please feel free to reach out to us during
+one of our |community meetings|.
 
 Pre-requisites
 ==============

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -8,10 +8,9 @@ Thank you for your interest in contributing to PlasmaPy! |:sparkles:|
 The future of the project depends on people like you, so we deeply
 appreciate it! |:seedling:|
 
-Please feel free to reach out to us in PlasmaPy's |Matrix chat room| or
-during PlasmaPy's weekly |office hours|. The PlasmaPy community abides
-by the :ref:`Contributor Covenant Code of Conduct
-<plasmapy-code-of-conduct>`.
+Please feel free to reach out to us during one of PlasmaPy's
+|community meetings|.  The PlasmaPy community abides by the
+:ref:`Contributor Covenant Code of Conduct <plasmapy-code-of-conduct>`.
 
 If you are becoming a first-time contributor, we recommend starting with:
 

--- a/docs/contributing/workflow.rst
+++ b/docs/contributing/workflow.rst
@@ -20,8 +20,7 @@ via a `pull request`_ after having finished the steps for
 |getting ready to contribute|.
 
 If you run into any problems, please feel free to reach out to us in our
-|Matrix chat room| or during our weekly |office hours|. Thank you for
-contributing!
+|community meetings|. Thank you for contributing!
 
 .. tip::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,8 +22,8 @@ If you are new to PlasmaPy, please check out our
 
 PlasmaPy is developed openly `on GitHub`_, where you can
 `request a new feature`_ or `report a bug`_. We invite you to share
-ideas and ask questions in our |Matrix chat room| or during our weekly
-virtual |office hours|.
+ideas and ask questions in our |Matrix chat room| or during our
+virtual |community meetings|.
 
 .. important::
 


### PR DESCRIPTION
Because the NSF award supporting the development of PlasmaPy will be ending shortly, we will be putting office hours on an indefinite hiatus. Members of the broader community will continue to be able to stop by our [community meetings](https://www.plasmapy.org/meetings/weekly/) on most Thursdays at 2 pm ET.