### PR TITLE
Fix formatting in coding guide

### DIFF
--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -186,7 +186,7 @@ code is supposed to be doing.
 
 * Avoid unnecessary abbreviations, as these make code harder to read.
   Prefer clarity over brevity, except for code that is used frequently
-  and interactively (e.g., :command:`cd` or :command:`ls`).
+  and interactively (e.g., ``cd`` or ``ls``).
 
   .. tip::
 


### PR DESCRIPTION
<!-- If this PR will fully resolve an issue, include text like "Closes #1532" so that the issue will be automatically closed when this PR is merged. Please also check out PlasmaPy's contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html. Thank you!-->

This changes the coding guide to use reStructuredText literals instead of the `:command:` role since I prefer the formatting of literals.