### PR TITLE
Describe how to add new module in contributor guide

### DIFF
--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -1059,6 +1059,30 @@ an angular frequency to get a length scale:
 
 .. _performing releases:
 
+Adding a new module
+===================
+
+* Create the source file at :samp:`src/plasmapy/{subpackage}/{module}.py`
+  - Add a top-level docstring
+  - Define :py:`__all__` near the top of :samp:`{module}.py`
+* Update imports in :samp:`src/plasmapy/{subpackage}/__init__.py`
+* Add tests at :samp:`tests/{subpackage}/test_{module}.py`
+* Add a documentation stub file
+* Add type hint annotations
+  - Update :file:`mypy.ini` to ignore static type checking errors that
+    are external to the new module (e.g., :issue:`2435`), if necessary
+
+.. tip::
+
+   To get a better idea of the steps necessary to add a new module,
+   check out a recent pull request that adds a new module (e.g.,
+   :pr:`3021`).
+
+.. important::
+
+   When the process for adding a new module changes, please update this
+   section accordingly.
+
 Performing releases
 ===================
 


### PR DESCRIPTION
📚 This PR adds a section to the coding guide within the contributor guide with the necessary steps to add a new module to PlasmaPy.

There are a few `formulary`-specific steps that need to be included.  I'd like to add a little more discussion about adding narrative documentation (and potentially example Jupyter notebooks) too, though this may be a bit more nebulous and possibly subpackage-specific. 🤔

This PR is inspired by the contributions by @Getahun-yw-Mahl and @josephrhsmith in #3021 to add `src/plasmapy/formulary/laser.py`). 🌱 Many thanks!


