### PR TITLE
Fix Math Rendering in HarrisSheet Docs

### DIFF
--- a/src/plasmapy/plasma/equilibria1d.py
+++ b/src/plasmapy/plasma/equilibria1d.py
@@ -93,7 +93,7 @@ class HarrisSheet:
 
         .. math::
 
-          J_z(y) = - \frac{B_0}{δ μ_0) \mathrm{sech}^2 \left( \frac{y}{δ} \right)
+          J_z(y) = - \frac{B_0}{δ μ_0} \mathrm{sech}^2 \left( \frac{y}{δ} \right)
 
         Parameters
         ----------


### PR DESCRIPTION
<!-- If this PR will fully resolve an issue, include text like "Closes #1532" so that the issue will be automatically closed when this PR is merged. Please also check out PlasmaPy's contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html. Thank you!-->
The documentation for [Harris Sheet](https://docs.plasmapy.org/en/stable/api/plasmapy.plasma.equilibria1d.HarrisSheet.html#plasmapy.plasma.equilibria1d.HarrisSheet) includes an equation that does not render correctly:
<img width="463" alt="Harris_Doc" src="https://github.com/user-attachments/assets/9a418868-0301-4019-9206-75031a6508ea" />

It appears a parenthesis is used to close the right curly bracket in the denominator of the first fraction. This pull changes the parenthesis to a curly bracket. 
