### PR TITLE
Revert changes to the workflow that posts the welcome comment

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,7 +1,7 @@
 name: Add comment
 
 on:
-  pull_request:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened]
 
 jobs:


### PR DESCRIPTION
<!-- If this PR will fully resolve an issue, include text like "Closes #1532" so that the issue will be automatically closed when this PR is merged. Please also check out PlasmaPy's contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html. Thank you!-->

This PR reverts a change made in #2975, which appears to have broken the workflow that posts a welcome comment in PRs (e.g., #3028).
