### PR TITLE
[SLA] Add helper function `sort_sweep_arrays`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,7 @@ lint.per-file-ignores."docs/notebooks/plasma/grids_nonuniform.ipynb" = [ "NPY002
 
 lint.per-file-ignores."setup.py" = [ "D100" ]
 lint.per-file-ignores."src/plasmapy/analysis/fit_functions.py" = [ "D301" ]
+lint.per-file-ignores."src/plasmapy/analysis/swept_langmuir/__init__.py" = [ "E402" ]
 lint.per-file-ignores."src/plasmapy/formulary/braginskii.py" = [ "C901", "RET503", "RET504" ]
 lint.per-file-ignores."src/plasmapy/plasma/sources/*.py" = [ "D102" ]
 lint.per-file-ignores."src/plasmapy/utils/_pytest_helpers/pytest_helpers.py" = [ "BLE001", "PLR", "SLF001" ]

--- a/src/plasmapy/analysis/swept_langmuir/__init__.py
+++ b/src/plasmapy/analysis/swept_langmuir/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "check_sweep",
     "find_floating_potential",
     "find_ion_saturation_current",
+    "sort_sweep_arrays",
     "ISatExtras",
     "VFExtras",
 ]
@@ -17,7 +18,10 @@ from plasmapy.analysis.swept_langmuir.floating_potential import (
     find_floating_potential,
     find_vf_,
 )
-from plasmapy.analysis.swept_langmuir.helpers import check_sweep
+from plasmapy.analysis.swept_langmuir.helpers import (
+    check_sweep,
+    sort_sweep_arrays,
+)
 from plasmapy.analysis.swept_langmuir.ion_saturation_current import (
     ISatExtras,
     find_ion_saturation_current,

--- a/src/plasmapy/analysis/swept_langmuir/__init__.py
+++ b/src/plasmapy/analysis/swept_langmuir/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "VFExtras",
 ]
 __aliases__ = ["find_isat_", "find_vf_"]
+__all__ += __aliases__
 
 from plasmapy.analysis.swept_langmuir.floating_potential import (
     VFExtras,
@@ -27,5 +28,3 @@ from plasmapy.analysis.swept_langmuir.ion_saturation_current import (
     find_ion_saturation_current,
     find_isat_,
 )
-
-__all__ += __aliases__

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -10,28 +10,36 @@ def check_sweep(  # noqa: C901, PLR0912
     voltage: np.ndarray,
     current: np.ndarray,
     strip_units: bool = True,
+    allow_unsorted: bool = False,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
-    Function for checking that the voltage and current arrays are properly
-    formatted for analysis by `plasmapy.analysis.swept_langmuir`.
+    Function for checking that the voltage and current arrays are
+    properly formatted for analysis by
+    `plasmapy.analysis.swept_langmuir`.
 
     Parameters
     ----------
     voltage: `numpy.ndarray`
-        1D `numpy.ndarray` representing the voltage of the swept Langmuir trace.
-        Voltage should be monotonically increasing.  *No units are assumed or
-        checked, but values should be in volts.*
+        1D `numpy.ndarray` representing the voltage of the swept
+        Langmuir trace. Voltage should be monotonically increasing.
+        *No units are assumed or checked, but values should be in
+        volts.*
 
     current: `numpy.ndarray`
-        1D `numpy.ndarray` representing the current of the swept Langmuir trace.
-        Values should start from a negative ion-saturation current and increase
-        to a positive electron-saturation current.  *No units are assumed or
-        checked, but values should be in amperes.*
+        1D `numpy.ndarray` representing the current of the swept
+        Langmuir trace.  Values should start from a negative
+        ion-saturation current and increase to a positive
+        electron-saturation current.  *No units are assumed or checked,
+        but values should be in amperes.*
 
     strip_units: `bool`
-        (Default: `True`) If `True`, then the units on ``voltage`` and/or
-        ``current`` will be stripped if either are passed in as an Astropy
-        `~astropy.units.Quantity`.
+        (Default: `True`) If `True`, then the units on ``voltage``
+        and/or ``current`` will be stripped if either are passed in as
+        an Astropy `~astropy.units.Quantity`.
+
+    allow_unsorted: `bool`
+        (Default: `False`) If `True`, then the supplied ``voltage``
+        array must be monotonically increasing.
 
     Returns
     -------
@@ -93,7 +101,7 @@ def check_sweep(  # noqa: C901, PLR0912
             f"Expected 1D numpy array for voltage, but got array with "
             f"{voltage.ndim} dimensions.",
         )
-    elif not np.all(np.diff(voltage) >= 0):
+    elif not np.all(np.diff(voltage) >= 0) and not allow_unsorted:
         raise ValueError("The voltage array is not monotonically increasing.")
 
     if isinstance(voltage, u.Quantity) and strip_units:

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -141,8 +141,8 @@ def check_sweep(  # noqa: C901, PLR0912
         )
     elif current[0] > 0.0 or current[-1] < 0.0:
         raise ValueError(
-            "The current array needs to start from a negative ion-saturation current"
-            " to a positive electron-saturation current."
+            "The current array needs to start from a negative ion-saturation "
+            "current to a positive electron-saturation current."
         )
 
     if voltage.size != current.size:

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -1,9 +1,11 @@
 """Helper functions for analyzing swept Langmuir traces."""
 
-__all__ = ["check_sweep"]
+__all__ = ["check_sweep", "sort_sweep_arrays"]
 
 import astropy.units as u
 import numpy as np
+
+from typing import Literal
 
 
 def check_sweep(  # noqa: C901, PLR0912
@@ -151,5 +153,27 @@ def check_sweep(  # noqa: C901, PLR0912
 
     if isinstance(current, u.Quantity) and strip_units:
         current = current.value
+
+    return voltage, current
+
+
+def sort_sweep_arrays(
+    voltage: np.ndarray,
+    current: np.ndarray,
+    voltage_order: Literal["ascending", "descending"] = "ascending",
+) -> tuple[np.ndarray, np.ndarray]:
+    if voltage_order not in ["ascending", "descending"]:
+        raise ValueError()
+
+    voltage, current = check_sweep(
+        voltage, current, strip_units=True, allow_unsorted=True
+    )
+
+    index_sort = np.argsort(voltage)
+    if voltage_order == "descending":
+        index_sort = index_sort[::-1]
+
+    voltage = voltage[index_sort]
+    current = current[index_sort]
 
     return voltage, current


### PR DESCRIPTION
Add helper function `sort_sweep_arrays` to the `plasmapy.analysis.swept_langmuir` module.  This function will take the two time series voltage and current arrays of a swept langmuir signal and sort the arrays to ensure the voltage is either monotonically ascending or descending.