### PR TITLE
[SLA] Add helper function `merge_voltage_clusters`

### DIFF
--- a/changelog/3034.feature.rst
+++ b/changelog/3034.feature.rst
@@ -1,4 +1,4 @@
 .. currentmodule:: plasmapy.analysis.swept_langmuir
 
-Added helper function `~helper.sort_sweep_arrays` to the
-`~plasmapy.analysis.swept_analysis` module.
+Added helper function `~helpers.sort_sweep_arrays` to the
+`~plasmapy.analysis.swept_langmuir` module.

--- a/changelog/3034.feature.rst
+++ b/changelog/3034.feature.rst
@@ -1,0 +1,4 @@
+.. currentmodule:: plasmapy.analysis.swept_langmuir
+
+Added helper function `~helper.sort_sweep_arrays` to the
+`~plasmapy.analysis.swept_analysis` module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,7 @@ lint.per-file-ignores."docs/notebooks/plasma/grids_nonuniform.ipynb" = [ "NPY002
 
 lint.per-file-ignores."setup.py" = [ "D100" ]
 lint.per-file-ignores."src/plasmapy/analysis/fit_functions.py" = [ "D301" ]
+lint.per-file-ignores."src/plasmapy/analysis/swept_langmuir/__init__.py" = [ "E402" ]
 lint.per-file-ignores."src/plasmapy/formulary/braginskii.py" = [ "C901", "RET503", "RET504" ]
 lint.per-file-ignores."src/plasmapy/plasma/sources/*.py" = [ "D102" ]
 lint.per-file-ignores."src/plasmapy/utils/_pytest_helpers/pytest_helpers.py" = [ "BLE001", "PLR", "SLF001" ]

--- a/src/plasmapy/analysis/swept_langmuir/__init__.py
+++ b/src/plasmapy/analysis/swept_langmuir/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "check_sweep",
     "find_floating_potential",
     "find_ion_saturation_current",
+    "sort_sweep_arrays",
     "ISatExtras",
     "VFExtras",
 ]
@@ -17,7 +18,10 @@ from plasmapy.analysis.swept_langmuir.floating_potential import (
     find_floating_potential,
     find_vf_,
 )
-from plasmapy.analysis.swept_langmuir.helpers import check_sweep
+from plasmapy.analysis.swept_langmuir.helpers import (
+    check_sweep,
+    sort_sweep_arrays,
+)
 from plasmapy.analysis.swept_langmuir.ion_saturation_current import (
     ISatExtras,
     find_ion_saturation_current,

--- a/src/plasmapy/analysis/swept_langmuir/__init__.py
+++ b/src/plasmapy/analysis/swept_langmuir/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "check_sweep",
     "find_floating_potential",
     "find_ion_saturation_current",
+    "merge_voltage_clusters",
     "sort_sweep_arrays",
     "ISatExtras",
     "VFExtras",
@@ -21,6 +22,7 @@ from plasmapy.analysis.swept_langmuir.floating_potential import (
 )
 from plasmapy.analysis.swept_langmuir.helpers import (
     check_sweep,
+    merge_voltage_clusters,
     sort_sweep_arrays,
 )
 from plasmapy.analysis.swept_langmuir.ion_saturation_current import (

--- a/src/plasmapy/analysis/swept_langmuir/__init__.py
+++ b/src/plasmapy/analysis/swept_langmuir/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "VFExtras",
 ]
 __aliases__ = ["find_isat_", "find_vf_"]
+__all__ += __aliases__
 
 from plasmapy.analysis.swept_langmuir.floating_potential import (
     VFExtras,
@@ -27,5 +28,3 @@ from plasmapy.analysis.swept_langmuir.ion_saturation_current import (
     find_ion_saturation_current,
     find_isat_,
 )
-
-__all__ += __aliases__

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -162,8 +162,16 @@ def sort_sweep_arrays(
     current: np.ndarray,
     voltage_order: Literal["ascending", "descending"] = "ascending",
 ) -> tuple[np.ndarray, np.ndarray]:
-    if voltage_order not in ["ascending", "descending"]:
-        raise ValueError()
+    if not isinstance(voltage_order, str):
+        raise TypeError(
+            "Expected 'voltage_order' to be a string equal to 'ascending' "
+            f"or 'descending', but got type {type(voltage_order)}."
+        )
+    elif voltage_order not in ["ascending", "descending"]:
+        raise ValueError(
+            "Expected 'voltage_order' to be a string equal to 'ascending' "
+            f"or 'descending', but got '{voltage_order}'."
+        )
 
     voltage, current = check_sweep(
         voltage, current, strip_units=True, allow_unsorted=True

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -236,61 +236,164 @@ def sort_sweep_arrays(
     return voltage, current
 
 
+def _nan_stuff_regular_grid(
+    voltage: np.ndarray,
+    current: np.ndarray,
+    voltage_step_size: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    size = int(np.round((voltage[-1] - voltage[0]) / voltage_step_size)) + 1
+    reg_voltage = np.linspace(voltage[0], voltage[-1], num=size, dtype=voltage.dtype)
+
+    _, reg_indices, new_indices = np.intersect1d(
+        np.round(reg_voltage, decimals=5),
+        np.round(voltage, decimals=5),
+        return_indices=True,
+    )
+    mask = np.ones_like(reg_voltage, dtype=bool)
+    mask[reg_indices] = False
+    reg_voltage[mask] = np.nan
+
+    reg_current = np.full(size, np.nan, dtype=current.dtype)
+    reg_current[np.logical_not(mask)] = current[...]
+
+    return reg_voltage, reg_current
+
+
 def merge_voltage_clusters(
     voltage: np.ndarray,
     current: np.ndarray,
     voltage_step_size: float = None,
-    force_regular_grid: bool = False,
-):
-    # step_size = 0 (only merge identical voltages)
-    # None : calculate steps size as average of array step sizes
-
-    voltage, current = check_sweep(voltage, current)
-
-    if not isinstance(force_regular_grid, bool):
+    force_regular_spacing: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    # condition force_regular_grid
+    if not isinstance(force_regular_spacing, bool):
         raise TypeError(
-            "Expected 'force_regular_grid' to be a bool, but got type "
-            f"{type(force_regular_grid)}."
+            "Expected 'force_regular_spacing' to be a bool, but got type "
+            f"{type(force_regular_spacing)}."
         )
 
-    if voltage_step_size is None:
-        voltage_step_size = np.abs(np.average(np.diff(voltage)))
-    elif voltage_step_size == 0:
-        voltage_step_size = 0.0
-    elif not isinstance(voltage_step_size, float):
+    # condition voltage_step_size
+    if (
+        voltage_step_size is not None
+        and not isinstance(voltage_step_size, (float, np.floating, int, np.integer))
+    ):
         raise TypeError(
             "Expected 'voltage_step_size' to be a float or None, got type "
             f"{type(voltage_step_size)}."
         )
+    elif isinstance(voltage_step_size, (int, np.integer)):
+        voltage_step_size = float(voltage_step_size)
+
+    voltage, current = check_sweep(voltage, current)
+
+    # check if grid is regularly spaced
+    voltage_diff = np.diff(voltage)
+    mask_zero_diff = np.isclose(voltage_diff, 0.0)
+    if np.count_nonzero(mask_zero_diff) > 0:
+        is_regular_grid = False
+    elif np.allclose(voltage_diff, voltage_diff[0]):
+        # grid is already regularly spaced
+        is_regular_grid = True
+    elif np.allclose(
+        np.rint(voltage_diff / np.min(voltage_diff))
+        - voltage_diff / np.min(voltage_diff),
+        0,
+    ):
+        # grid has a common dV, but at times jumps N * dV times
+        if force_regular_spacing and (voltage_step_size is None or voltage_step_size == 0):
+            # need to stuff with NaN values
+            voltage, current = _nan_stuff_regular_grid(
+                voltage=voltage,
+                current=current,
+                voltage_step_size=np.min(voltage_diff),
+            )
+        is_regular_grid = True
+    else:
+        is_regular_grid = False
+
+    # return if voltage is already regularly spaced and no voltage merging is
+    # requested
+    if is_regular_grid and (voltage_step_size is None or voltage_step_size == 0):
+        return voltage.copy(), current.copy()
+
+    # condition voltage_step_size ... Round 2
+    if voltage_step_size is None:
+        voltage_step_size = np.abs(
+            np.average(voltage_diff[np.logical_not(mask_zero_diff)])
+        )
+    elif voltage_step_size == 0:
+        voltage_step_size = 0.0
     elif voltage_step_size < 0:
         voltage_step_size = -voltage_step_size
 
-    voltage_ascending = bool(np.all(np.diff(voltage) >= 0))
+    # ensure voltage is ascending for calculation
+    voltage_ascending = bool(np.all(voltage_diff >= 0))
     if not voltage_ascending:
         voltage, current = sort_sweep_arrays(voltage, current, voltage_order="ascending")
 
     # now merge clusters
-    new_voltage = np.unique(voltage)
-    if voltage_step_size == 0 and new_voltage.size == voltage.size:
+    voltage_diff = np.diff(voltage)
+    if voltage_step_size != 0 and np.all(voltage_diff >= voltage_step_size):
+        new_voltage = voltage.copy()
         new_current = current.copy()
-    elif voltage_step_size == 0:
-        new_current = np.empty_like(new_voltage, dtype=current.dtype)
 
-        for ii in range(new_voltage.size):
-            mask = voltage == new_voltage[ii]
-            if np.count_nonzero(mask) == 1:
-                new_current[ii] = current[mask]
-            else:
-                new_current[ii] = np.average(current[mask])
+        if force_regular_spacing:
+            size = int(
+                np.round((new_voltage[-1] - new_voltage[0]) / voltage_step_size)
+            ) + 1
+            reg_voltage = np.linspace(
+                new_voltage[0], new_voltage[-1], num=size, dtype=new_voltage.dtype
+            )
+            reg_current = np.interp(reg_voltage, new_voltage, new_current)
+
+            new_voltage = reg_voltage
+            new_current = reg_current
+    elif voltage_step_size == 0:
+        voltage_diff = np.diff(voltage)
+        mask_zero_diff = np.isclose(voltage_diff, 0.0)
+        mask_zero_diff = np.append(mask_zero_diff, [mask_zero_diff[-1]])
+
+        new_voltage = np.full(voltage.shape, np.nan, dtype=voltage.dtype)
+        new_current = np.full(current.shape, np.nan, dtype=current.dtype)
+
+        mask = np.logical_not(mask_zero_diff)
+        new_voltage[mask] = voltage[mask]
+        new_current[mask] = current[mask]
+
+        while np.any(mask_zero_diff):
+            volt = voltage[mask_zero_diff][0]
+            index = np.where(new_voltage == volt)[0]
+            if len(index) == 0:
+                index = np.where(mask_zero_diff)[0]
+
+            index = index[0]
+            volt_mask = np.isclose(voltage, volt)
+
+            new_voltage[index] = volt
+            new_current[index] = np.average(current[volt_mask])
+
+            mask_zero_diff[volt_mask] = False
+
+        # remove nan entries
+        mask = np.logical_not(np.isnan(new_voltage))
+        new_voltage = new_voltage[mask]
+        new_current = new_current[mask]
+
+        if force_regular_spacing:
+            new_voltage, new_current = merge_voltage_clusters(
+                voltage=new_voltage,
+                current=new_current,
+                voltage_step_size=voltage_step_size,
+            )
+
     else:
-        new_voltage = np.empty_like(voltage, dtype=voltage.dtype)
-        new_voltage[...] = np.nan
-        new_current = np.empty_like(current, dtype=current.dtype)
-        new_current[...] = np.nan
+        new_voltage = np.full(voltage.shape, np.nan, dtype=voltage.dtype)
+        new_current = np.full(current.shape, np.nan, dtype=current.dtype)
 
         start_voltage = voltage[0]
         stop_voltage = start_voltage + voltage_step_size
 
+        # populate
         ii = 0
         while start_voltage <= voltage[-1]:
             mask1 = voltage >= start_voltage
@@ -299,7 +402,7 @@ def merge_voltage_clusters(
 
             if np.count_nonzero(mask) > 0:
                 new_voltage[ii] = (
-                    start_voltage + 0.5 * voltage_step_size if force_regular_grid
+                    start_voltage + 0.5 * voltage_step_size if force_regular_spacing
                     else np.average(voltage[mask])
                 )
                 new_current[ii] = np.average(current[mask])
@@ -307,25 +410,24 @@ def merge_voltage_clusters(
                 ii += 1
 
             start_voltage = stop_voltage
-            stop_voltage = start_voltage + voltage_step_size
+            stop_voltage += voltage_step_size
 
-        # filter out NaN values
+        # crop new arrays
         new_voltage = new_voltage[:ii]
         new_current = new_current[:ii]
 
-        # force regular spacing
-        if force_regular_grid:
+        if force_regular_spacing:
             # Need to fill array with NaN values to force the regular spacing
-            ...
+            new_voltage, new_current = _nan_stuff_regular_grid(
+                voltage=new_voltage,
+                current=new_current,
+                voltage_step_size=voltage_step_size,
+            )
 
     if not voltage_ascending:
-        voltage, current = sort_sweep_arrays(voltage, current, voltage_order="descending")
-        new_voltage, new_current = sort_sweep_arrays(
-            new_voltage, new_current, voltage_order="descending"
-        )
-    else:
-        new_voltage, new_current = sort_sweep_arrays(
-            new_voltage, new_current, voltage_order="ascending"
-        )
+        voltage = voltage[::-1]
+        current = current[::-1]
+        new_voltage = new_voltage[::-1]
+        new_current = new_current[::-1]
 
     return new_voltage, new_current

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -10,28 +10,36 @@ def check_sweep(  # noqa: C901, PLR0912
     voltage: np.ndarray,
     current: np.ndarray,
     strip_units: bool = True,
+    allow_unsorted: bool = False,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
-    Function for checking that the voltage and current arrays are properly
-    formatted for analysis by `plasmapy.analysis.swept_langmuir`.
+    Function for checking that the voltage and current arrays are
+    properly formatted for analysis by
+    `plasmapy.analysis.swept_langmuir`.
 
     Parameters
     ----------
     voltage: `numpy.ndarray`
-        1D `numpy.ndarray` representing the voltage of the swept Langmuir trace.
-        Voltage should be monotonically increasing.  *No units are assumed or
-        checked, but values should be in volts.*
+        1D `numpy.ndarray` representing the voltage of the swept
+        Langmuir trace. Voltage should be monotonically increasing.
+        *No units are assumed or checked, but values should be in
+        volts.*
 
     current: `numpy.ndarray`
-        1D `numpy.ndarray` representing the current of the swept Langmuir trace.
-        Values should start from a negative ion-saturation current and increase
-        to a positive electron-saturation current.  *No units are assumed or
-        checked, but values should be in amperes.*
+        1D `numpy.ndarray` representing the current of the swept
+        Langmuir trace.  Values should start from a negative
+        ion-saturation current and increase to a positive
+        electron-saturation current.  *No units are assumed or checked,
+        but values should be in amperes.*
 
     strip_units: `bool`
-        (Default: `True`) If `True`, then the units on ``voltage`` and/or
-        ``current`` will be stripped if either are passed in as an Astropy
-        `~astropy.units.Quantity`.
+        (Default: `True`) If `True`, then the units on ``voltage``
+        and/or ``current`` will be stripped if either are passed in as
+        an Astropy `~astropy.units.Quantity`.
+
+    allow_unsorted: `bool`
+        (Default: `False`) If `True`, then the supplied ``voltage``
+        array must be monotonically increasing.
 
     Returns
     -------
@@ -93,7 +101,7 @@ def check_sweep(  # noqa: C901, PLR0912
             f"Expected 1D numpy array for voltage, but got array with "
             f"{voltage.ndim} dimensions.",
         )
-    elif not np.all(np.diff(voltage) >= 0):
+    elif not np.all(np.diff(voltage) >= 0) and not allow_unsorted:
         raise ValueError("The voltage array is not monotonically increasing.")
 
     if isinstance(voltage, u.Quantity) and strip_units:

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -141,8 +141,8 @@ def check_sweep(  # noqa: C901, PLR0912
         )
     elif current[0] > 0.0 or current[-1] < 0.0:
         raise ValueError(
-            "The current array needs to start from a negative ion-saturation current"
-            " to a positive electron-saturation current."
+            "The current array needs to start from a negative ion-saturation "
+            "current to a positive electron-saturation current."
         )
 
     if voltage.size != current.size:

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -2,10 +2,10 @@
 
 __all__ = ["check_sweep", "sort_sweep_arrays"]
 
+from typing import Literal
+
 import astropy.units as u
 import numpy as np
-
-from typing import Literal
 
 
 def check_sweep(  # noqa: C901, PLR0912

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -162,6 +162,37 @@ def sort_sweep_arrays(
     current: np.ndarray,
     voltage_order: Literal["ascending", "descending"] = "ascending",
 ) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Sort the swept langmuir ``voltage`` and ``current`` traces to
+    ensure the ``voltage`` array is either monotonically increasing or
+    decreasing.
+
+    Parameters
+    ----------
+    voltage: `numpy.ndarray`
+        1D `numpy.ndarray` representing the voltage of the swept
+        Langmuir trace.  *No units are assumed or checked, but values
+        should be in volts.*
+
+    current: `numpy.ndarray`
+        1D `numpy.ndarray` representing the current of the swept
+        Langmuir trace.  Values should start from a negative
+        ion-saturation current and increase to a positive
+        electron-saturation current.  *No units are assumed or checked,
+        but values should be in amperes.*
+
+    voltage_order: `str`
+        Either 'ascending' or 'descending' to indicate how the
+        ``voltage`` array should be sorted.  (DEFAULT: ``'ascending'``)
+
+    Returns
+    -------
+    voltage : `numpy.ndarray`
+        Sorted ``voltage`` array.
+
+    current : `numpy.ndarray`
+        Matched ``current`` array to the sorted ``voltage`` array.
+    """
     if not isinstance(voltage_order, str):
         raise TypeError(
             "Expected 'voltage_order' to be a string equal to 'ascending' "

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -1,9 +1,11 @@
 """Helper functions for analyzing swept Langmuir traces."""
 
-__all__ = ["check_sweep"]
+__all__ = ["check_sweep", "sort_sweep_arrays"]
 
 import astropy.units as u
 import numpy as np
+
+from typing import Literal
 
 
 def check_sweep(  # noqa: C901, PLR0912
@@ -151,5 +153,27 @@ def check_sweep(  # noqa: C901, PLR0912
 
     if isinstance(current, u.Quantity) and strip_units:
         current = current.value
+
+    return voltage, current
+
+
+def sort_sweep_arrays(
+    voltage: np.ndarray,
+    current: np.ndarray,
+    voltage_order: Literal["ascending", "descending"] = "ascending",
+) -> tuple[np.ndarray, np.ndarray]:
+    if voltage_order not in ["ascending", "descending"]:
+        raise ValueError()
+
+    voltage, current = check_sweep(
+        voltage, current, strip_units=True, allow_unsorted=True
+    )
+
+    index_sort = np.argsort(voltage)
+    if voltage_order == "descending":
+        index_sort = index_sort[::-1]
+
+    voltage = voltage[index_sort]
+    current = current[index_sort]
 
     return voltage, current

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -208,11 +208,29 @@ def sort_sweep_arrays(
         voltage, current, strip_units=True, allow_unsorted=True
     )
 
-    index_sort = np.argsort(voltage)
-    if voltage_order == "descending":
-        index_sort = index_sort[::-1]
+    # determine order
+    voltage_diff = np.diff(voltage)
+    if np.all(voltage_diff >= 0):
+        _order = "ascending"
+    elif np.all(voltage_diff <= 0):
+        _order = "descending"
+    else:
+        _order = None
 
-    voltage = voltage[index_sort]
-    current = current[index_sort]
+    if _order == voltage_order:
+        # already ordered
+        return voltage, current
+
+    # perform sorting
+    if _order is None:
+        index_sort = np.argsort(voltage)
+        if voltage_order == "descending":
+            index_sort = index_sort[::-1]
+
+        voltage = voltage[index_sort]
+        current = current[index_sort]
+    else:
+        voltage = voltage[::-1]
+        current = current[::-1]
 
     return voltage, current

--- a/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
+++ b/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
@@ -166,7 +166,7 @@ from plasmapy.analysis.swept_langmuir.helpers import check_sweep, sort_sweep_arr
         ),
         # -- allow_unsorted == True --
         (
-            30.0 * np.random.rand(100) - 20.0,
+            30.0 * np.random.default_rng().random(100) - 20.0,
             np.linspace(-10.0, 30, 100),
             {"allow_unsorted": True},
             does_not_raise(),

--- a/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
+++ b/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
@@ -1,12 +1,13 @@
 """Tests for `plasmapy.analysis.swept_langmuir.helpers`."""
 
 from contextlib import nullcontext as does_not_raise
+from unittest import mock
 
 import astropy.units as u
 import numpy as np
 import pytest
 
-from plasmapy.analysis.swept_langmuir.helpers import check_sweep
+from plasmapy.analysis.swept_langmuir.helpers import check_sweep, sort_sweep_arrays
 
 
 @pytest.mark.parametrize(
@@ -188,3 +189,92 @@ def test_check_sweep(voltage, current, kwargs, with_context, expected) -> None:
         else:
             assert np.allclose(rtn_voltage, expected[0])
             assert np.allclose(rtn_current, expected[1])
+
+
+@pytest.mark.parametrize(
+    ("voltage", "current", "kwargs", "with_context", "expected"),
+    [
+        # raises
+        (
+            np.linspace(-40.0, 40, 100),
+            np.linspace(-10.0, 30, 100),
+            {"voltage_order": 5.0},  # not a string
+            pytest.raises(TypeError),
+            None,
+        ),
+        (
+            np.linspace(-40.0, 40, 100),
+            np.linspace(-10.0, 30, 100),
+            {"voltage_order": "wrong string"},
+            pytest.raises(ValueError),
+            None,
+        ),
+        # values
+        (
+            np.linspace(-40.0, 40, 100),
+            np.linspace(-10.0, 30, 100),
+            {"voltage_order": "ascending"},
+            does_not_raise(),
+            None,
+        ),
+        (
+            np.linspace(-40.0, 40, 100),
+            np.linspace(-10.0, 30, 100),
+            {"voltage_order": "descending"},
+            does_not_raise(),
+            (np.linspace(40.0, -40, 100), np.linspace(30.0, -10, 100)),
+        ),
+        (
+            np.linspace(40.0, -40, 100),
+            np.linspace(-10.0, 30, 100),
+            {"voltage_order": "descending"},
+            does_not_raise(),
+            None,
+        ),
+        (
+            np.linspace(40.0, -40, 100),
+            np.linspace(-10.0, 30, 100),
+            {"voltage_order": "ascending"},
+            does_not_raise(),
+            (np.linspace(-40.0, 40, 100), np.linspace(30.0, -10, 100)),
+        ),
+        (
+            np.array([-40.0, 20.0, -22.0, 40.0]),
+            np.array([-10.0, 10.0, -5.0, 30.0]),
+            {"voltage_order": "ascending"},
+            does_not_raise(),
+            (np.array([-40.0, -22.0, 20.0, 40.0]), np.array([-10.0, -5.0, 10.0, 30.0])),
+        ),
+        (
+            np.array([-40.0, 20.0, -22.0, 40.0]),
+            np.array([-10.0, 10.0, -5.0, 30.0]),
+            {"voltage_order": "descending"},
+            does_not_raise(),
+            (np.array([40.0, 20.0, -22.0, -40.0]), np.array([30.0, 10.0, -5.0, -10.0])),
+        ),
+    ],
+)
+def test_sort_sweep_arrays(voltage, current, kwargs, with_context, expected) -> None:
+    with with_context, mock.patch(
+        "plasmapy.analysis.swept_langmuir.helpers.check_sweep",
+        wraps=check_sweep,
+    ) as mock_check_sweep:
+        rtn_voltage, rtn_current = sort_sweep_arrays(
+            voltage=voltage,
+            current=current,
+            **kwargs,
+        )
+
+        if expected is not None:
+            assert np.allclose(rtn_voltage, expected[0])
+            assert np.allclose(rtn_current, expected[1])
+        elif kwargs["voltage_order"] in ("ascending", "descending"):
+            ...
+        elif kwargs["voltage_order"] == "descending":
+            ...
+        else:
+            assert np.allclose(rtn_voltage, voltage)
+            assert np.allclose(rtn_current, current)
+
+        mock_check_sweep.assert_called_once()
+        mock_check_sweep.reset_mock()

--- a/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
+++ b/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
@@ -268,10 +268,6 @@ def test_sort_sweep_arrays(voltage, current, kwargs, with_context, expected) -> 
         if expected is not None:
             assert np.allclose(rtn_voltage, expected[0])
             assert np.allclose(rtn_current, expected[1])
-        elif kwargs["voltage_order"] in ("ascending", "descending"):
-            ...
-        elif kwargs["voltage_order"] == "descending":
-            ...
         else:
             assert np.allclose(rtn_voltage, voltage)
             assert np.allclose(rtn_current, current)

--- a/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
+++ b/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
@@ -255,10 +255,13 @@ def test_check_sweep(voltage, current, kwargs, with_context, expected) -> None:
     ],
 )
 def test_sort_sweep_arrays(voltage, current, kwargs, with_context, expected) -> None:
-    with with_context, mock.patch(
-        "plasmapy.analysis.swept_langmuir.helpers.check_sweep",
-        wraps=check_sweep,
-    ) as mock_check_sweep:
+    with (
+        with_context,
+        mock.patch(
+            "plasmapy.analysis.swept_langmuir.helpers.check_sweep",
+            wraps=check_sweep,
+        ) as mock_check_sweep,
+    ):
         rtn_voltage, rtn_current = sort_sweep_arrays(
             voltage=voltage,
             current=current,

--- a/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
+++ b/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
@@ -163,6 +163,14 @@ from plasmapy.analysis.swept_langmuir.helpers import check_sweep
             does_not_raise(),
             (np.linspace(-40.0, 40, 100), np.linspace(-10.0, 30, 100)),
         ),
+        # -- allow_unsorted == True --
+        (
+            30.0 * np.random.rand(100) - 20.0,
+            np.linspace(-10.0, 30, 100),
+            {"allow_unsorted": True},
+            does_not_raise(),
+            "expected same as inputs",
+        ),
     ],
 )
 def test_check_sweep(voltage, current, kwargs, with_context, expected) -> None:


### PR DESCRIPTION
Add helper function `merge_voltage_clusters` to the `plasmapy.analysis.swept_langmuir` module.  This function takes the two time series voltage and current arrays of a swept langmuir signal and merges clusters/islands of closely spaced voltage values.  Since several langmuir analysis techniques requires differentiation, the often irregularly spaced voltage signals can cause erratic behavior during differentiation.  Merging clusters can help "smooth out" the signal for differentiation.