### PR TITLE
Reduce CPR test time

### DIFF
--- a/changelog/3039.internal.rst
+++ b/changelog/3039.internal.rst
@@ -1,0 +1,1 @@
+Refactored tests for the `~plasmapy.diagnostics.charged_particle_radiography` module to reduce test runtime.

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -809,11 +809,11 @@ def test_gaussian_sphere_analytical_comparison() -> None:
     "kwargs",
     [
         # Test a circular mesh
-        {"extent": 1 * u.mm},
+        ({"extent": 1 * u.mm}),
         # Test providing hdir
-        {"mesh_hdir": np.array([0.5, 0, 0.5])},
+        ({"mesh_hdir": np.array([0.5, 0, 0.5])}),
         # Test providing hdir and vdir
-        {"mesh_hdir": np.array([0.5, 0, 0.5]), "mesh_vdir": np.array([0, 0.1, 1])},
+        ({"mesh_hdir": np.array([0.5, 0, 0.5]), "mesh_vdir": np.array([0, 0.1, 1])}),
     ],
 )
 @pytest.mark.slow
@@ -822,7 +822,7 @@ def test_add_wire_mesh_inputs(kwargs) -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs,exception",
+    ("kwargs", "exception"),
     [
         # Test invalid extent (too many elements)
         ({"extent": (1 * u.mm, 2 * u.mm, 3 * u.mm)}, ValueError),

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -805,38 +805,45 @@ def test_gaussian_sphere_analytical_comparison() -> None:
     assert np.isclose(max_deflection, sim.max_deflection.to(u.rad).value, atol=1e-3)
 
 
-@pytest.mark.parametrize('kwargs', [
-    # Test a circular mesh
-    {'extent':1*u.mm},
-    # Test providing hdir
-    {'mesh_hdir':np.array([0.5, 0, 0.5])},
-    # Test providing hdir and vdir
-    {'mesh_hdir':np.array([0.5, 0, 0.5]), 'mesh_vdir':np.array([0, 0.1, 1])},
-                         ])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # Test a circular mesh
+        {"extent": 1 * u.mm},
+        # Test providing hdir
+        {"mesh_hdir": np.array([0.5, 0, 0.5])},
+        # Test providing hdir and vdir
+        {"mesh_hdir": np.array([0.5, 0, 0.5]), "mesh_vdir": np.array([0, 0.1, 1])},
+    ],
+)
 @pytest.mark.slow
-def test_add_wire_mesh_inputs(kwargs)->None:
+def test_add_wire_mesh_inputs(kwargs) -> None:
     run_mesh_example(**kwargs)
-    
-@pytest.mark.parametrize('kwargs,exception', [
-    # Test invalid extent (too many elements)
-    ({'extent':(1 * u.mm, 2 * u.mm, 3 * u.mm)}, ValueError ),
-    # Test wire mesh completely blocks all particles (in this case because
-    # the wire diameter is absurdly large)
-    ({'wire_diameter':5 * u.mm}, ValueError),
-    # Test if wire mesh is not between the source and object
-    ({'location':np.array([0, 3, 0]) * u.mm}, ValueError),
-                         ])
+
+
+@pytest.mark.parametrize(
+    "kwargs,exception",
+    [
+        # Test invalid extent (too many elements)
+        ({"extent": (1 * u.mm, 2 * u.mm, 3 * u.mm)}, ValueError),
+        # Test wire mesh completely blocks all particles (in this case because
+        # the wire diameter is absurdly large)
+        ({"wire_diameter": 5 * u.mm}, ValueError),
+        # Test if wire mesh is not between the source and object
+        ({"location": np.array([0, 3, 0]) * u.mm}, ValueError),
+    ],
+)
 @pytest.mark.slow
-def test_add_wire_mesh_invalid_inputs(kwargs,exception) -> None:
+def test_add_wire_mesh_invalid_inputs(kwargs, exception) -> None:
     with pytest.raises(exception):
         run_mesh_example(**kwargs)
-    
+
 
 @pytest.mark.slow
 def test_add_wire_mesh_accuracy() -> None:
     """
     Test that a mesh is imaged correctly in the detector plane.
-    
+
     Test that mesh is the right size in the detector plane, and that
     the wire spacing images correctly.
     This is actually a good overall test of the whole proton radiography
@@ -846,7 +853,7 @@ def test_add_wire_mesh_accuracy() -> None:
     extent = (1 * u.mm, 1 * u.mm)
     wire_diameter = 30 * u.um
     nwires = 9
-    
+
     # A large number of particles is needed to get a good image
     # of the mesh, so this is a slow test
     sim = run_mesh_example(

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -148,8 +148,8 @@ def test_multiple_grids() -> None:
     solution??
     """
 
-    grid1 = _test_grid("constant_bz", L=3 * u.cm, num=50, B0=0.7 * u.T)
-    grid2 = _test_grid("electrostatic_gaussian_sphere", L=1 * u.mm, num=50)
+    grid1 = _test_grid("constant_bz", L=3 * u.cm, num=20, B0=0.7 * u.T)
+    grid2 = _test_grid("electrostatic_gaussian_sphere", L=1 * u.mm, num=20)
     grids = [grid1, grid2]
 
     source = (0 * u.mm, -10 * u.mm, 0 * u.mm)
@@ -159,20 +159,13 @@ def test_multiple_grids() -> None:
         grids, source, detector, field_weighting="nearest neighbor", verbose=True
     )
 
-    sim.create_particles(1e5, 15 * u.MeV, max_theta=8 * u.deg, random_seed=42)
+    sim.create_particles(1e2, 15 * u.MeV, max_theta=8 * u.deg, random_seed=42)
 
     sim.run()
 
     size = np.array([[-1, 1], [-1, 1]]) * 5 * u.cm
     bins = [100, 100]
     hax, vax, values = cpr.synthetic_radiograph(sim, size=size, bins=bins)
-
-    """
-    import matplotlib.pyplot as plt
-    fig, ax = plt.subplots()
-    ax.set_aspect('equal')
-    ax.pcolormesh(hax.to(u.cm).value, vax.to(u.cm).value, values.T)
-    """
 
 
 def run_1D_example(name: str):
@@ -922,42 +915,6 @@ def test_add_wire_mesh() -> None:
 
     # Verify that the spacing is correct by checking the FFT
     assert np.isclose(measured_spacing, true_spacing, 0.5)
-
-
-@pytest.mark.slow
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_multiple_grids2() -> None:
-    """
-    Test that a case with two grids runs.
-    TODO: automate test by including two fields with some obvious analytical
-    solution??
-    """
-
-    grid1 = _test_grid("constant_bz", L=3 * u.cm, num=50, B0=0.7 * u.T)
-    grid2 = _test_grid("electrostatic_gaussian_sphere", L=1 * u.mm, num=50)
-    grids = [grid1, grid2]
-
-    source = (0 * u.mm, -10 * u.mm, 0 * u.mm)
-    detector = (0 * u.mm, 200 * u.mm, 0 * u.mm)
-
-    sim = cpr.Tracker(
-        grids, source, detector, field_weighting="nearest neighbor", verbose=True
-    )
-
-    sim.create_particles(1e5, 15 * u.MeV, max_theta=8 * u.deg, random_seed=42)
-
-    sim.run()
-
-    size = np.array([[-1, 1], [-1, 1]]) * 5 * u.cm
-    bins = [100, 100]
-    hax, vax, values = cpr.synthetic_radiograph(sim, size=size, bins=bins)
-
-    """
-    import matplotlib.pyplot as plt
-    fig, ax = plt.subplots()
-    ax.set_aspect('equal')
-    ax.pcolormesh(hax.to(u.cm).value, vax.to(u.cm).value, values.T)
-    """
 
 
 def test_radiography_disk_save_routine(tmp_path) -> None:


### PR DESCRIPTION
Closes #3026 

This PR should go a long way to reducing the CPR module test execution time. The following changes are made: 

1) test_multiple_grids and test_multiple_grids2 were literally just duplicate tests - I have deleted the second one. 
2) test_multiple_grids is just a "does it run" test: no actual validation, so it definitely didn't need 1E5 particles. I've dropped it down to just 100 particles, so that should run much faster. 
3) test_add_wire_mesh was a badly structured test that was actually running a BUNCH of simulations to test a variety of things. I've broken the input validation tests into two other parametrized tests. 
4) The remaining `test_add_wire_mesh_accuracy` is actually a pretty important test for the CPR module: it checks that a radiograph of a grid returns the expected image, which is probably the best integrated test of the whole module. So, I left it alone but found I could reduce the particle number some and it still passed. So, I've done that. 
