### PR TITLE
Update pinned requirements on Thursdays instead of Mondays

### DIFF
--- a/.github/workflows/update-pinned-reqs.yml
+++ b/.github/workflows/update-pinned-reqs.yml
@@ -2,7 +2,7 @@ name: Update pinned requirements
 
 on:
   schedule:
-  - cron: 0 12 * * 1
+  - cron: 37 11 * * 5
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We have a weekly cron job to update `uv.lock`, which locks the dependencies used in continuous integration tests.  This PR makes it so that this job is run on Thursdays a few hours ahead of the weekly PlasmaPy community meeting.  

> This must be Thursday. I never could get the hang of Thursdays.
