### PR TITLE
Enable new rules for `ruff check`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ lint.extend-select = [
   "RUF023", # unsorted-dunder-slots
   "RUF024", # mutable-fromkeys-value
   "RUF026", # default-factory-kwarg
+  "RUF028", # invalid-formatter-suppression-comment
   "RUF030", # assert-with-print-message
   "RUF032", # decimal-from-float-literal
   "RUF033", # post-init-default
@@ -229,7 +230,11 @@ lint.extend-select = [
   "RUF041", # unnecessary-nested-literal
   "RUF046", # unnecessary-cast-to-int
   "RUF048", # map-int-version-parsing
+  "RUF049", # dataclass-enum
   "RUF051", # if-key-in-dict-del
+  "RUF053", # class-with-mixed-type-vars
+  "RUF057", # unnecessary-round
+  "RUF058", # starmap-zip
   "RUF100", # unused-noqa
   "RUF101", # redirected-noqa
   "RUF200", # invalid-pyproject-toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ lint.extend-select = [
   "FBT003", # flake8-boolean-trap
   "FIX",    # flake8-fixme
   "FLY",    # flynt
+  "FURB",   # refurb
   "G",      # flake8-logging-format
   "I",      # isort
   "ICN",    # flake8-import-conventions
@@ -198,6 +199,7 @@ lint.extend-select = [
   "PT",     # flake8-pytest-style
   "PTH",    # flake8-use-pathlib
   "PYI",    # flake8-pyi
+  "Q",      # flake8-quotes
   "RET",    # flake8-return
   "RSE",    # flake8-raise
   "RUF001", # ambiguous-unicode-character-string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,6 @@ lint.extend-select = [
   "RUF058", # starmap-zip
   "RUF100", # unused-noqa
   "RUF101", # redirected-noqa
-  "RUF102", # invalid-rule-code
   "RUF200", # invalid-pyproject-toml
   "S",      # flake8-bandit
   "SIM",    # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,7 @@ lint.extend-select = [
   "RUF058", # starmap-zip
   "RUF100", # unused-noqa
   "RUF101", # redirected-noqa
+  "RUF102", # invalid-rule-code
   "RUF200", # invalid-pyproject-toml
   "S",      # flake8-bandit
   "SIM",    # flake8-simplify


### PR DESCRIPTION
This PR enables a few new rules for the `ruff` linter, including the [`FURB`](https://docs.astral.sh/ruff/rules/#refurb-furb) and [`Q`](https://en.wikipedia.org/wiki/Q_(Star_Trek)) rule sets.  Running `ruff check` with these new rules resulted in no violations, so no changes to the code base were necessary. 🎉🎂💖🎆🪩🌌🥦