### PR TITLE
Build documentation with Python 3.13 in CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -54,7 +54,7 @@ _HERE = pathlib.Path(__file__).parent
 # the Docs. Because Read the Docs takes some time to support new
 # releases of Python, we should not link docpython to maxpython.
 
-docpython = "3.12"
+docpython = "3.13"
 
 current_python = f"{sys.version_info.major}.{sys.version_info.minor}"
 nox.options.sessions = [f"tests-{current_python}(skipslow)"]


### PR DESCRIPTION
I apparently forgot to do this in #2943. 😅 