### PR TITLE
Update labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -197,8 +197,6 @@ release:
   - changed-files:
     - any-glob-to-any-file: [
       '.github/workflows/*weekly*.yml',
-      'docs/conf.py',
-      'noxfile.py',
     ]
 
 'static type checking':


### PR DESCRIPTION
In #3008, we updated the pull request labeler to add the "Run weekly tests in CI" label when `pyproject.toml`, `noxfile.py`, or `.github/workflows/*weekly*.yml` were updated.  When that label is added, a PR will run the weekly tests. Since then, I've found that nearly all the time, updates to `noxfile.py` or `pyproject.toml` don't warrant running the weekly tests.  Hence, this PR removes these files from the labeler setting.