### PR TITLE
Use a mirror repository for `typos` in `pre-commit` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,12 @@ repos:
     additional_dependencies:
     - tomli
 
-- repo: https://github.com/crate-ci/typos
+- repo: https://github.com/adhtruong/mirrors-typos
+  # Running `pre-commit autoupdate` on the crate-ci/typos repo changes
+  # the version from v1.x.y to v1, which points to the latest version of
+  # typos. Using a mirror without a v1 tag prevents spontaneous
+  # unrelated failures when a new release of typos detects new probable
+  # spelling errors.
   rev: v1.38.1
   hooks:
   - id: typos


### PR DESCRIPTION
PlasmaPy uses `typos` to check for spelling errors in code, along with `codespell`. 

Running `pre-commit autoupdate` updates the version of the `typos` hook from `v1.x.y` to `v1`, which points to the most recent `v1.x.y` release of `typos`. Setting the version as `v1` has the unfortunate side effect that new releases of `typos` can lead to spontaneous pre-commit failures in unrelated pull requests.

This PR switches the pre-commit hook from the crate-ci/typos repo to a mirror that does not have a `v1` tag.  This switch will make it so that we can use `pre-commit autoupate` without having to manually revert the version of `typos` from `v1` to `v1.x.y`.

See also: https://github.com/crate-ci/typos/issues/390