### PR TITLE
Decorate downloader tests with `@pytest.mark.slow`

### DIFF
--- a/tests/utils/data/test_downloader.py
+++ b/tests/utils/data/test_downloader.py
@@ -67,7 +67,6 @@ test_urls = [
 ]
 
 
-
 @check_database_connection
 @pytest.mark.slow
 @pytest.mark.parametrize(("url", "expected"), test_urls)
@@ -244,6 +243,7 @@ def test_at_most_one_api_call(downloader_validated) -> None:
     limit, used1 = downloader_validated._api_usage
 
     assert used1 <= used0 + 1
+
 
 @pytest.mark.slow
 @check_database_connection


### PR DESCRIPTION
We've had a lot of intermittent test failures with the downloader functionality (see #3071).  As a tentative way to reduce the frequency that we run into these intermittent test failures, this PR marks the test as slow. As a consequence, the downloader tests will only be run on a regular pull request for the one version of Python for which coverage is being tested. This doesn't fix the problem, but rather reduces the rate at which we'll run into these false positives.  
