### PR TITLE
Update GitHub workflow for labeling pull requests that do not need changelog entries

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,10 +24,12 @@ jobs:
 
     steps:
 
-    - name: Add no changelog label
+    - name: Add no changelog label for PR titles matching regular expressions
       uses: actions/github-script@v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+
+        # Written in JavaScript, using Node.js syntax
         script: |
           // Case-insensitive regular expressions to match PR titles
           const bumpPattern = /^Bump .* from .* to .*/i;

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -36,7 +36,6 @@ jobs:
 
         # Written in JavaScript, using Node.js syntax.
         script: |
-
           // Define regular expressions for pull requests not requiring
           // a changelog entry.
           function buildPatterns() {

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
 
     - name: Add no changelog label for PR titles matching regular expressions
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip changelog checks') }}
+      if: ${{ !(contains(github.event.pull_request.labels.*.name, 'skip changelog checks') || contains(github.event.pull_request.labels.*.name, 'needs changelog entry') ) }}
       uses: actions/github-script@v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,6 +32,7 @@ jobs:
       if: contains(github.event.pull_request.labels.*.name, 'needs changelog entry')
       run: |
         gh issue edit ${{ github.event.pull_request.number }} \
+          --repo "${{ github.repository }}" \
           --remove-label "skip changelog checks" \
           --remove-label "no changelog entry needed"
       env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CHANGELOG_INSTRUCTIONS: "⚠️ Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `trivial`, `doc`, `internal`, `bugfix`, `breaking`, or `removal`.\n\nMinor change such as typo fixes and hyperlink updates do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
+  CHANGELOG_INSTRUCTIONS: "⚠️ Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `trivial`, `doc`, `internal`, `bugfix`, `breaking`, or `removal`.\n\nMinor changes such as typo fixes and hyperlink updates do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
 
 jobs:
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -103,9 +103,6 @@ jobs:
     - name: Validate changelog entry with towncrier
       # see [tool.changelog-bot] in pyproject.toml for configuration
       uses: scientific-python/action-towncrier-changelog@v2
-      # This action fails if "no changelog entry needed" is applied, so
-      # use a conditional to make a changelog entry optional in this case.
-      if: ${{ !( contains(github.event.pull_request.labels.*.name, 'no changelog entry needed') ) }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_USERNAME: changelog-bot

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -100,8 +100,11 @@ jobs:
         persist-credentials: false
 
     - name: Validate changelog entry with towncrier
-      uses: scientific-python/action-towncrier-changelog@v2
       # see [tool.changelog-bot] in pyproject.toml for configuration
+      uses: scientific-python/action-towncrier-changelog@v2
+      # This action fails if "no changelog entry needed" is applied, so
+      # use a conditional to make a changelog entry optional in this case.
+      if: ${{ !( contains(github.event.pull_request.labels.*.name, 'no changelog entry needed') ) }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_USERNAME: changelog-bot

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,6 +31,9 @@ jobs:
 
         # Written in JavaScript, using Node.js syntax.
         script: |
+
+          // Define regular expressions for pull requests not requiring
+          // a changelog entry.
           function buildPatterns() {
             return [
               /^bump .* from .* to .*/i,
@@ -42,6 +45,13 @@ jobs:
             ];
           }
 
+          // Check whether the pull request title matches any of the provided patterns.
+          function matchesTitle(title, pullRequestTitlePatterns) {
+            const t = title || "";
+            return pullRequestTitlePatterns.some(rx => rx.test(t));
+          }
+
+          // Retrieve pull request metadata using the GitHub REST API.
           async function getPullRequest(octokit, ctx) {
             const { data } = await octokit.rest.pulls.get({
               owner: ctx.repo.owner,
@@ -51,11 +61,7 @@ jobs:
             return data;
           }
 
-          function matchesTitle(title, pullRequestTitlePatterns) {
-            const t = title || "";
-            return pullRequestTitlePatterns.some(rx => rx.test(t));
-          }
-
+          // Label a pull request.
           async function addLabel(octokit, ctx, issueNumber, label) {
             await octokit.rest.issues.addLabels({
               owner: ctx.repo.owner,

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -80,7 +80,7 @@ jobs:
           const pr = await getPullRequest(github, context);
 
           if (matchesTitle(pr.title, pullRequestTitlePatterns)) {
-            await addLabel(github, context, context.issue.number, 'no changelog entry needed');
+            await addLabel(github, context, context.issue.number, 'skip changelog checks');
           }
 
   changelog_checker:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
 
     - name: Add no changelog label for PR titles matching regular expressions
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip changelog checks') }}
       uses: actions/github-script@v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,8 +29,16 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          // Regular expression to match the PR title pattern "Bump * from * to *"
-          const bumpPattern = /^Bump .* from .* to .*/;
+          // Case-insensitive regular expressions to match PR titles
+          const bumpPattern = /^Bump .* from .* to .*/i;
+          const patterns = [
+            /autoupdate/i,
+            /Minor/i,
+            /Fix typo/i,
+            /Update changelog entries/i,
+            /Update changelog prior to/i,
+            /Update pinned requirements/i,
+          ];
 
           // Fetch the PR
           const { data: pullRequest } = await github.rest.pulls.get({
@@ -39,16 +47,12 @@ jobs:
             pull_number: context.issue.number,
           });
 
-          if (
-            pullRequest.title.includes('autoupdate') ||
-            pullRequest.title.includes('Minor') ||
-            pullRequest.title.includes('Fix typo') ||
-            pullRequest.title.includes('Update changelog entries') ||
-            pullRequest.title.includes('Update changelog prior to') ||
-            pullRequest.title.includes('Update pinned requirements') ||
-            bumpPattern.test(pullRequest.title)
-          ) {
-            // If yes, then apply the label "no changelog entry needed"
+          const title = pullRequest.title || "";
+
+          // Check if title matches any of the patterns
+          const matches = bumpPattern.test(title) || patterns.some(r => r.test(title));
+
+          if (matches) {
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,16 +29,6 @@ jobs:
 
     steps:
 
-    - name: Remove conflicting labels if needs changelog entry label is present
-      if: contains(github.event.pull_request.labels.*.name, 'needs changelog entry')
-      run: |
-          gh issue edit ${{ github.event.pull_request.number }} \
-            --repo "${{ github.repository }}" \
-            --remove-label "skip changelog checks" \
-            --remove-label "no changelog entry needed"
-      env:
-          GH_TOKEN: ${{ github.token }}
-
     - name: Add no changelog label for PR titles matching regular expressions
       if: ${{ !(contains(github.event.pull_request.labels.*.name, 'skip changelog checks') || contains(github.event.pull_request.labels.*.name, 'needs changelog entry') ) }}
       uses: actions/github-script@v8

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,26 +17,27 @@ concurrency:
 env:
   CHANGELOG_INSTRUCTIONS: "⚠️ Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `trivial`, `doc`, `internal`, `bugfix`, `breaking`, or `removal`.\n\nMinor change such as typo fixes and hyperlink updates do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
 
-
 jobs:
+
   add-no-changelog-label:
     name: Add no changelog label
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+      issues: write
 
     steps:
 
     - name: Remove conflicting labels if needs changelog entry label is present
       if: contains(github.event.pull_request.labels.*.name, 'needs changelog entry')
       run: |
-        gh issue edit ${{ github.event.pull_request.number }} \
-          --repo "${{ github.repository }}" \
-          --remove-label "skip changelog checks" \
-          --remove-label "no changelog entry needed"
+          gh issue edit ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" \
+            --remove-label "skip changelog checks" \
+            --remove-label "no changelog entry needed"
       env:
-        GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
 
     - name: Add no changelog label for PR titles matching regular expressions
       if: ${{ !(contains(github.event.pull_request.labels.*.name, 'skip changelog checks') || contains(github.event.pull_request.labels.*.name, 'needs changelog entry') ) }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
+concurrency:
+  group: changelog-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   CHANGELOG_INSTRUCTIONS: "⚠️ Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `trivial`, `doc`, `internal`, `bugfix`, `breaking`, or `removal`.\n\nMinor change such as typo fixes and hyperlink updates do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,6 +28,15 @@ jobs:
 
     steps:
 
+    - name: Remove conflicting labels if needs changelog entry label is present
+      if: contains(github.event.pull_request.labels.*.name, 'needs changelog entry')
+      run: |
+        gh issue edit ${{ github.event.pull_request.number }} \
+          --remove-label "skip changelog checks" \
+          --remove-label "no changelog entry needed"
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Add no changelog label for PR titles matching regular expressions
       if: ${{ !(contains(github.event.pull_request.labels.*.name, 'skip changelog checks') || contains(github.event.pull_request.labels.*.name, 'needs changelog entry') ) }}
       uses: actions/github-script@v8

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,15 +31,13 @@ jobs:
 
         # Written in JavaScript, using Node.js syntax
         script: |
-          // Case-insensitive regular expressions to match PR titles
-          const bumpPattern = /^Bump .* from .* to .*/i;
-          const patterns = [
+          const pullRequestTitlePatterns = [
+            /^bump .* from .* to .*/i,
             /autoupdate/i,
-            /Minor/i,
-            /Fix typo/i,
-            /Update changelog entries/i,
-            /Update changelog prior to/i,
-            /Update pinned requirements/i,
+            /fix typo/i,
+            /update changelog entries/i,
+            /update changelog prior to/i,
+            /update pinned requirements/i,
           ];
 
           // Fetch the PR
@@ -51,10 +49,7 @@ jobs:
 
           const title = pullRequest.title || "";
 
-          // Check if title matches any of the patterns
-          const matches = bumpPattern.test(title) || patterns.some(r => r.test(title));
-
-          if (matches) {
+          if (pullRequestTitlePatterns.some(r => r.test(title))) {
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,7 +25,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
 
     steps:
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,33 +29,47 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-        # Written in JavaScript, using Node.js syntax
+        # Written in JavaScript, using Node.js syntax.
         script: |
-          const pullRequestTitlePatterns = [
-            /^bump .* from .* to .*/i,
-            /autoupdate/i,
-            /fix typo/i,
-            /update changelog entries/i,
-            /update changelog prior to/i,
-            /update pinned requirements/i,
-          ];
+          function buildPatterns() {
+            return [
+              /^bump .* from .* to .*/i,
+              /autoupdate/i,
+              /fix typo/i,
+              /update changelog entries/i,
+              /update changelog prior to/i,
+              /update pinned requirements/i,
+            ];
+          }
 
-          // Fetch the PR
-          const { data: pullRequest } = await github.rest.pulls.get({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number: context.issue.number,
-          });
-
-          const title = pullRequest.title || "";
-
-          if (pullRequestTitlePatterns.some(r => r.test(title))) {
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['no changelog entry needed'],
+          async function getPullRequest(octokit, ctx) {
+            const { data } = await octokit.rest.pulls.get({
+              owner: ctx.repo.owner,
+              repo: ctx.repo.repo,
+              pull_number: ctx.issue.number,
             });
+            return data;
+          }
+
+          function matchesTitle(title, pullRequestTitlePatterns) {
+            const t = title || "";
+            return pullRequestTitlePatterns.some(rx => rx.test(t));
+          }
+
+          async function addLabel(octokit, ctx, issueNumber, label) {
+            await octokit.rest.issues.addLabels({
+              owner: ctx.repo.owner,
+              repo: ctx.repo.repo,
+              issue_number: issueNumber,
+              labels: [label],
+            });
+          }
+
+          const pullRequestTitlePatterns = buildPatterns();
+          const pr = await getPullRequest(github, context);
+
+          if (matchesTitle(pr.title, pullRequestTitlePatterns)) {
+            await addLabel(github, context, context.issue.number, 'no changelog entry needed');
           }
 
   changelog_checker:

--- a/.github/workflows/unlabel-pr-after-merge.yml
+++ b/.github/workflows/unlabel-pr-after-merge.yml
@@ -39,6 +39,7 @@ jobs:
             'priority: medium',
             'priority: very high',
             'prototype 🏗️',
+            'skip changelog checks',
             'Stale',
             'status: assigned',
             'status: dormant',

--- a/changelog/3146.internal.rst
+++ b/changelog/3146.internal.rst
@@ -1,0 +1,1 @@
+Updated the GitHub workflow for labeling pull requests that do not need changelog entries.


### PR DESCRIPTION
This PR cleans up the GitHub workflow in `.github/workflows/changelog.yml`. The changes include:

 - Splitting up the JavaScript into multiple functions. 
 - Creating an array of regular expressions rather than checking each regular expression separately.
 - Adding concurrency & cancel-in-progress steps in case of frequent pushes or labels/unlabels.
 - Skipping the labeling step if https://github.com/PlasmaPy/PlasmaPy/labels/skip%20changelog%20checks has been applied.

<!--
 - Make the https://github.com/PlasmaPy/PlasmaPy/labels/needs%20changelog%20entry label supersede the https://github.com/PlasmaPy/PlasmaPy/labels/no%20changelog%20entry%20needed and https://github.com/PlasmaPy/PlasmaPy/labels/skip%20changelog%20checks labels
-->

Because I don't know JavaScript or Node.js 😅, I got ChatGPT to help me with this. 