### PR TITLE
Remove `mdformat-frontmatter` and update `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
     args: [--autofix]
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.34.1
+  rev: 0.35.0
   hooks:
   - id: check-github-workflows
 
@@ -77,14 +77,14 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 - repo: https://github.com/adhtruong/mirrors-typos
   # use mirrors-typos because `pre-commit autoupdate` drops the version
   # of the primary typos repo from v1.x.y to v1
-  rev: v1.39.0
+  rev: v1.39.2
   hooks:
   - id: typos
     name: typos (add false positives to _typos.toml)
     exclude: CITATION.cff|docs/notebooks/dispersion/stix_dispersion.ipynb
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.3
+  rev: v0.14.5
   hooks:
   - id: ruff-check
     name: ruff-check (see https://docs.astral.sh/ruff/rules)
@@ -114,13 +114,13 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
     additional_dependencies: ['validate-pyproject-schema-store[all]']
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.11.0
+  rev: v2.11.1
   hooks:
   - id: pyproject-fmt
     name: format pyproject.toml
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.7
+  rev: 0.9.10
   hooks:
     # running uv lock requires network access or a warm cache, so it
     # cannot be run via pre-commit.ci, even with the `--offline`,
@@ -130,7 +130,7 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 
 - repo: https://github.com/hukkin/mdformat
   # some plugins require mdformat<0.8, so pin mdformat at 0.7.22 for now
-  rev: 0.7.22
+  rev: 1.0.0
   hooks:
   - id: mdformat
     name: format .md files


### PR DESCRIPTION
Since `mdformat-frontmatter` has an upper limit on the version of `mdformat` it is compatible with, we won't be able to use `mdformat>=1.0.0` with `mdformat-frontmatter` enabled.  This PR drops `mdformat-frontmatter` and then does a `pre-commit autoupdate` for good measure.