### PR TITLE
Describe purpose of `py.typed` inside `py.typed`

### DIFF
--- a/src/plasmapy/py.typed
+++ b/src/plasmapy/py.typed
@@ -1,0 +1,1 @@
+The presence of py.typed indicates that a package supports type checking. For more details, see: https://peps.python.org/pep-0561


### PR DESCRIPTION
The presence of a `py.typed` file indicates that a package supports type checking. However, for a newcomer to Python packaging, seeing an empty file with that name probably just seems...weird. Since this file doesn't need to be empty, I added a short description in it and linked to [PEP 561](https://peps.python.org/pep-0561/).

This is part of my mission to make it easier for someone new to packaging to become a maintainer of PlasmaPy. 🎉🎂🎆🪩🌌🥦