### PR TITLE
Fix name of Nox session in Read the Docs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -38,7 +38,7 @@ build:
       - nox -s docs
 
       htmlzip:
-      - nox -s docs_bundle_htmlzip
+      - nox -s htmlzip
 
     post_build:
     - echo $'\n'⚠️ For help deciphering documentation build error messages, see:$'\n\n'\ \ https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting


### PR DESCRIPTION
Fixing an error from #3188 or #3157 where I renamed a Nox session in `noxfile.py` but didn't propagate it to `.readthedocs.yml`.