### PR TITLE
Build the package with `uv`

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: Version
         required: true
-        default: 2025.8.0
+        default: 2026.2.0
       doi:
         description: Reserved DOI from Zenodo
         required: true
@@ -54,7 +54,7 @@ jobs:
 
     - name: Build the changelog with towncrier
       run: |
-        uvx nox -s "changelog(final)" -- $VERSION
+        uv run noxfile.py -s "changelog(final)" -- $VERSION
       env:
         VERSION: ${{ github.event.inputs.version }}
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,7 +23,7 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         python-version: 3.14
-        enable-cache: false
+        enable-cache: false  # protect against cache poisoning when publishing a package
 
     - name: Build package
       run: uv run noxfile.py -s build

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,20 +19,16 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
       with:
-        python-version: 3.13
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
+        python-version: 3.14
+        enable-cache: false
 
     - name: Build package
-      run: python -m build
+      run: uv run noxfile.py -s build
 
-    - name: Upload package to PyPI
+    - name: Upload package to Python Package Index
       uses: pypa/gh-action-pypi-publish@v1.13.0
       with:
         # TODO: set up trusted publishing https://docs.pypi.org/trusted-publishers/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -32,4 +32,4 @@ rules:
     - create-release-issue.yml:31:46
   use-trusted-publishing:
     ignore:
-    - publish-to-pypi.yml:36:7
+    - publish-to-pypi.yml:32:7

--- a/changelog/3202.internal.rst
+++ b/changelog/3202.internal.rst
@@ -1,0 +1,1 @@
+Adopted ``uv build`` as the build frontend and ``uv_build`` as the build backend.

--- a/noxfile.py
+++ b/noxfile.py
@@ -522,9 +522,24 @@ def try_import(session: nox.Session) -> None:
 
 @nox.session
 def build(session: nox.Session) -> None:
-    """Build & verify the source distribution and wheel."""
+    """
+    Build the source distribution (sdist) and wheel.
+
+    The sdist and wheel are deposited into the dist/ directory.
+    """
     session.install("uv_build")
     session.run("uv", "build", *session.posargs)
+    session.notify("check_build")
+
+
+@nox.session
+def check_build(session: nox.Session) -> None:
+    """
+    Validate the source distribution and wheel.
+
+    This session requires that `nox -s build` has already been run.
+    """
+    session.install("twine")
     session.run("twine", "check", "dist/*")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -523,11 +523,9 @@ def try_import(session: nox.Session) -> None:
 @nox.session
 def build(session: nox.Session) -> None:
     """Build & verify the source distribution and wheel."""
-    session.install("twine", "build")
-    build_command = ("python", "-m", "build")
-    session.run(*build_command, "--sdist")
-    session.run(*build_command, "--wheel")
-    session.run("twine", "check", "dist/*", *session.posargs)
+    session.install("uv_build")
+    session.run("uv", "build", *session.posargs)
+    session.run("twine", "check", "dist/*")
 
 
 AUTOTYPING_SAFE: tuple[str, ...] = (


### PR DESCRIPTION
## Description

This PR switches us to using `uv build` as the build frontend ~~and `uv_build` as the build backend~~.  These changes are made in ~~`build-backend` in `pyproject.toml`~~, the `build` session of `noxfile.py` (which is used in CI), and in the GitHub workflow that publishes the build to PyPI.

So far everything still looks compatible with `setuptools_scm`.

This PR does not switch us over to using `uv publish`.  

## Motivation

This PR is part of an ongoing effort to switch over to using [uv](https://docs.astral.sh/uv/) as a unified tool for PlasmaPy packaging needs. 

This PR is also part of an ongoing effort to speed up our CI.  I did some rough timings locally, and running `nox -s build` took ∼11 s with the old setup and ∼4.5 s with the new setup (without using the uv cache).  This includes ∼1.5 s for running `twine check` after the build step. 

I didn't do timings, but these changes should also noticeably speed up doing `pip install .` in the top-level directory of the repository.