### PR TITLE
Fix `plasma_frequency` doc typo and ensure |Z| in `plasma_frequency_lite`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -759,3 +759,9 @@ authors:
   affiliation: Laboratory for Atmospheric and Space Physics
   orcid: https://orcid.org/0000-0003-0619-5745
   alias: sapols
+
+- given-names: Yaocheng
+  family-names: Chen
+  affiliation: Korea Astronomy and Space Science Institute
+  orcid: https://orcid.org/0000-0002-8967-4911
+  alias: yaochengchen

--- a/changelog/3216.bugfix.rst
+++ b/changelog/3216.bugfix.rst
@@ -1,0 +1,1 @@
+Fix typo in plasma frequency docstring formula and use absolute value of Z in plasma_frequency_lite to ensure physically consistent results.

--- a/src/plasmapy/formulary/frequencies.py
+++ b/src/plasmapy/formulary/frequencies.py
@@ -198,7 +198,7 @@ def plasma_frequency_lite(
     The particle plasma frequency is
 
     .. math::
-        ω_p = \sqrt{\frac{n |q|}{ε_0 m}}
+        ω_p = \sqrt{\frac{n q^2}{ε_0 m}}
 
     where :math:`n` is the number density, :math:`q` is the particle
     charge, and :math:`m` is the particle mass.
@@ -216,7 +216,7 @@ def plasma_frequency_lite(
     >>> plasma_frequency_lite(n=1e19, mass=mass, Z=1, to_hz=True)
     np.float64(662608904.6...)
     """
-    omega_p = Z * e_si_unitless * np.sqrt(n / (eps0_si_unitless * mass))
+    omega_p = np.abs(Z) * e_si_unitless * np.sqrt(n / (eps0_si_unitless * mass))
 
     return omega_p / (2.0 * np.pi) if to_hz else omega_p
 

--- a/src/plasmapy/formulary/frequencies.py
+++ b/src/plasmapy/formulary/frequencies.py
@@ -330,7 +330,7 @@ def plasma_frequency(
         plasma_frequency_lite(
             n=n.value,
             mass=particle.mass.value,
-            Z=np.abs(particle.charge_number),
+            Z=particle.charge_number,
         )
         * u.rad
         / u.s

--- a/tests/formulary/test_plasma_frequency.py
+++ b/tests/formulary/test_plasma_frequency.py
@@ -105,9 +105,9 @@ class TestPlasmaFrequency:
         ("args", "kwargs", "expected", "rtol"),
         [
             ((1 * u.cm**-3, "e-"), {}, 5.64e4, 1e-2),
-            ((1 * u.cm ** -3, "e+"), {}, 5.64e4, 1e-2),
+            ((1 * u.cm**-3, "e+"), {}, 5.64e4, 1e-2),
             ((1 * u.cm**-3, "N+"), {}, 3.53e2, 1e-1),
-            ((1 * u.cm ** -3, "N-"), {}, 3.53e2, 1e-1),
+            ((1 * u.cm**-3, "N-"), {}, 3.53e2, 1e-1),
             ((1e17 * u.cm**-3, "H-1"), {"Z": 0.8}, 333045427357.53955, 1e-6),
             (
                 (5e19 * u.m**-3, "p"),
@@ -155,7 +155,7 @@ class TestPlasmaFrequencyLite:
             {"n": 1e12 * u.cm**-3, "particle": "e-"},
             {"n": 1e12 * u.cm**-3, "particle": "e-", "to_hz": True},
             {"n": 1e11 * u.cm**-3, "particle": "He", "Z": 0.8},
-            {"n": 1e11 * u.cm ** -3, "particle": "He", "Z": -0.8},
+            {"n": 1e11 * u.cm**-3, "particle": "He", "Z": -0.8},
         ],
     )
     def test_normal_vs_lite_values(self, inputs) -> None:

--- a/tests/formulary/test_plasma_frequency.py
+++ b/tests/formulary/test_plasma_frequency.py
@@ -105,7 +105,9 @@ class TestPlasmaFrequency:
         ("args", "kwargs", "expected", "rtol"),
         [
             ((1 * u.cm**-3, "e-"), {}, 5.64e4, 1e-2),
+            ((1 * u.cm ** -3, "e+"), {}, 5.64e4, 1e-2),
             ((1 * u.cm**-3, "N+"), {}, 3.53e2, 1e-1),
+            ((1 * u.cm ** -3, "N-"), {}, 3.53e2, 1e-1),
             ((1e17 * u.cm**-3, "H-1"), {"Z": 0.8}, 333045427357.53955, 1e-6),
             (
                 (5e19 * u.m**-3, "p"),
@@ -153,6 +155,7 @@ class TestPlasmaFrequencyLite:
             {"n": 1e12 * u.cm**-3, "particle": "e-"},
             {"n": 1e12 * u.cm**-3, "particle": "e-", "to_hz": True},
             {"n": 1e11 * u.cm**-3, "particle": "He", "Z": 0.8},
+            {"n": 1e11 * u.cm ** -3, "particle": "He", "Z": -0.8},
         ],
     )
     def test_normal_vs_lite_values(self, inputs) -> None:
@@ -166,7 +169,7 @@ class TestPlasmaFrequencyLite:
         inputs_unitless = {
             "n": inputs["n"].to(u.m**-3).value,
             "mass": particle.mass.value,
-            "Z": np.abs(particle.charge_number),
+            "Z": particle.charge_number,
         }
 
         if "to_hz" in inputs:


### PR DESCRIPTION
<!-- If this PR will fully resolve an issue, include text like "Closes #1532" so that the issue will be automatically closed when this PR is merged. Please also check out PlasmaPy's contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html. Thank you!-->

This PR fixes a typo in the plasma frequency docstring formula by correcting the expression to use q^2 instead of |q| under the square root.

It also updates plasma_frequency_lite to use abs(Z) in the computation so that the plasma frequency is independent of charge sign and remains physically consistent.