### PR TITLE
Fix changelog entry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,8 +71,7 @@ Internal Changes and Refactorings
 - Renamed and revised |Nox| sessions for updating :file:`uv.lock` and
   validating :file:`uv.lock` against the requirements defined
   in :file:`pyproject.toml`. (:pr:`3179`)
-- Adopted ``uv build`` as the build frontend and ``uv_build`` as the build
-  backend. (:pr:`3202`)
+- Adopted ``uv build`` as the build frontend. (:pr:`3202`)
 
 
 Updates to Software Testing

--- a/changelog/3239.doc.rst
+++ b/changelog/3239.doc.rst
@@ -1,0 +1,1 @@
+Corrected the changelog entry for :pr:`3202`.

--- a/docs/changelog/2026.2.0.rst
+++ b/docs/changelog/2026.2.0.rst
@@ -80,8 +80,7 @@ Internal Changes and Refactorings
 - Renamed and revised |Nox| sessions for updating :file:`uv.lock` and
   validating :file:`uv.lock` against the requirements defined
   in :file:`pyproject.toml`. (:pr:`3179`)
-- Adopted ``uv build`` as the build frontend and ``uv_build`` as the build
-  backend. (:pr:`3202`)
+- Adopted ``uv build`` as the build frontend. (:pr:`3202`)
 
 
 Updates to Software Testing


### PR DESCRIPTION
In #3202, we changed to using `uv build` as the build frontend. However, the changelog entry and PR description incorrectly stated that we switched to the `uv_build` backend.  This PR corrects that error.