### PR TITLE
Rename changelog category and update workflow to validate changelog entries

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  CHANGELOG_INSTRUCTIONS: "::error title=Changelog entry needed::Please add one or more changelog entries at `changelog/${{ github.event.pull_request.number }}.TYPE.rst`, where `TYPE` is one of `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`.\n\nTrivial changes like typo fixes do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
+  CHANGELOG_INSTRUCTIONS: "::error title=Changelog entry needed::Please add a changelog entry of the form `changelog/${{ github.event.pull_request.number }}.TYPE.rst`, where `TYPE` can be `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`.\n\nTrivial changes like typo fixes do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
 
 
 jobs:
@@ -117,10 +117,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_USERNAME: changelog-bot
 
-    - name: List changelog entries
+    - name: List all changelog entries
+      if: always()
       run: ls changelog --ignore=README.rst
 
-    - name: ⚠️ Troubleshooting information
+    - name: Troubleshooting information ⚠️
       if: ${{ failure() }}
       run: |
         echo -e $CHANGELOG_INSTRUCTIONS

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CHANGELOG_INSTRUCTIONS: "⚠️ Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `trivial`, `doc`, `internal`, `bugfix`, `breaking`, or `removal`.\n\nMinor changes such as typo fixes and hyperlink updates do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
+  CHANGELOG_INSTRUCTIONS: "::error title=⚠️ Changelog entry needed::Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`. Trivial changes such as typo fixes do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
 
 jobs:
 
@@ -36,16 +36,22 @@ jobs:
 
         # Written in JavaScript, using Node.js syntax.
         script: |
-          // Define regular expressions for pull requests not requiring
-          // a changelog entry.
+          // Define regular expressions for pull requests not requiring a changelog entry.
           function buildPatterns() {
             return [
               /^bump .* from .* to .*/i,
-              /autoupdate/i,
+              /fix a typo/i,
               /fix typo/i,
+              /fix typos/i,
+              /fixed a typo/i,
+              /fixed typo/i,
+              /fixed typos/i,
+              /pre-commit autoupdate/i
+              /typo fix/i,
               /update changelog entries/i,
               /update changelog prior to/i,
-              /update lockfile/i,
+              /upgrade uv.lock/i,
+
             ];
           }
 
@@ -111,3 +117,9 @@ jobs:
       run: |
         echo -e $CHANGELOG_INSTRUCTIONS
         exit 1
+
+    - name: List invalid changelog entries
+      if: ${{ failure() }}
+      run: |
+        ls
+

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -117,10 +117,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_USERNAME: changelog-bot
 
-    - name: Changelog entry needed
+    - name: List changelog entries
+      run: ls changelog --ignore=README.rst
+
+    - name: Troubleshooting information
       if: ${{ failure() }}
       run: echo -e $CHANGELOG_INSTRUCTIONS
-
-    - name: List changelog entries
-      if: ${{ failure() }}
-      run: ls changelog --ignore=README.rst

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,8 +14,13 @@ concurrency:
   group: changelog-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 env:
-  CHANGELOG_INSTRUCTIONS: "::error title=Changelog entry needed::Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`. Trivial changes such as typo fixes do not need a changelog entry. For details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
+  CHANGELOG_INSTRUCTIONS: "::error title=Changelog entry needed::Please add one or more changelog entries at `changelog/${{ github.event.pull_request.number }}.TYPE.rst`, where `TYPE` is one of `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`. Trivial changes like typo fixes do not need a changelog entry. For details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
+
 
 jobs:
 
@@ -112,9 +117,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_USERNAME: changelog-bot
 
-    - name: Print troubleshooting information
+    - name: Changelog entry needed
       if: ${{ failure() }}
-      run: |
-        echo -e $CHANGELOG_INSTRUCTIONS
-        ls changelog
+      run: echo -e $CHANGELOG_INSTRUCTIONS
 
+    - name: List changelog entries
+      if: ${{ failure() }}
+      run: ls changelog --ignore=README.rst

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -56,7 +56,6 @@ jobs:
               /update changelog entries/i,
               /update changelog prior to/i,
               /upgrade uv.lock/i,
-
             ];
           }
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -46,7 +46,7 @@ jobs:
               /fixed a typo/i,
               /fixed typo/i,
               /fixed typos/i,
-              /pre-commit autoupdate/i
+              /pre-commit autoupdate/i,
               /typo fix/i,
               /update changelog entries/i,
               /update changelog prior to/i,

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CHANGELOG_INSTRUCTIONS: "::error title=⚠️ Changelog entry needed::Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`. Trivial changes such as typo fixes do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
+  CHANGELOG_INSTRUCTIONS: "::error title=Changelog entry needed::Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`. Trivial changes such as typo fixes do not need a changelog entry. For details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
 
 jobs:
 
@@ -116,10 +116,5 @@ jobs:
       if: ${{ failure() }}
       run: |
         echo -e $CHANGELOG_INSTRUCTIONS
-        exit 1
-
-    - name: List invalid changelog entries
-      if: ${{ failure() }}
-      run: |
-        ls
+        ls changelog
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  CHANGELOG_INSTRUCTIONS: "::error title=Changelog entry needed::Please add one or more changelog entries at `changelog/${{ github.event.pull_request.number }}.TYPE.rst`, where `TYPE` is one of `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`. Trivial changes like typo fixes do not need a changelog entry. For details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
+  CHANGELOG_INSTRUCTIONS: "::error title=Changelog entry needed::Please add one or more changelog entries at `changelog/${{ github.event.pull_request.number }}.TYPE.rst`, where `TYPE` is one of `feature`, `doc`, `test`, `internal`, `bugfix`, `breaking`, `removal`, or `misc`.\n\nTrivial changes like typo fixes do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
 
 
 jobs:
@@ -120,6 +120,8 @@ jobs:
     - name: List changelog entries
       run: ls changelog --ignore=README.rst
 
-    - name: Troubleshooting information
+    - name: ⚠️ Troubleshooting information
       if: ${{ failure() }}
-      run: echo -e $CHANGELOG_INSTRUCTIONS
+      run: |
+        echo -e $CHANGELOG_INSTRUCTIONS
+        exit 1

--- a/changelog/3241.doc.rst
+++ b/changelog/3241.doc.rst
@@ -1,0 +1,1 @@
+Renamed the ``trivial`` changelog category to ``misc`` to represent miscellaneous changes.

--- a/changelog/3241.test.rst
+++ b/changelog/3241.test.rst
@@ -1,0 +1,1 @@
+Updated the GitHub workflow that validates changelog entries to provide more diagnostic information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,6 +574,7 @@ title_format = "{name} v{version} ({project_date})"
 # Despite the name mismatch, we use `issue_format` for linking to PRs
 issue_format = ":pr:`{issue}`"
 wrap = true
+# Changes to changelog tags need to be propagated into .github/workflows/changelog.yml
 type = [
   { directory = "feature", name = "New Features", showcontent = true },
   { directory = "doc", name = "Documentation Improvements", showcontent = true },
@@ -582,7 +583,7 @@ type = [
   { directory = "bugfix", name = "Bug Fixes", showcontent = true },
   { directory = "internal", name = "Internal Changes and Refactorings", showcontent = true },
   { directory = "test", name = "Updates to Software Testing", showcontent = true },
-  { directory = "trivial", name = "Additional Changes", showcontent = true },
+  { directory = "misc", name = "Miscellaneous Changes", showcontent = true },
 ]
 
 [tool.build_docs]


### PR DESCRIPTION
 - Renamed the `trivial` category to `misc` for "Miscellaneous Changes", because the stated policy is to avoid creating changelog entries for trivial changes.
 - Updated the workflow to validate changelog entries by using the `::error::` syntax (to get the error message to show up more obviously when there is a problem).
 - Updated the error message to include the current pull request number in the suggested filename.
 - Added a new step to the workflow to list files in the `changelog/` directory since the extra information can help clarify what the problem is.

> [!NOTE]
> The workflow to for adding the no changelog label is failing in this PR with an `HttpError`, but that's probably because it's running from a fork and doesn't have permissions.