### PR TITLE
Skip plasmapy-sphinx from dependency cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ no-build-package = [ "astropy", "h5py", "matplotlib", "numpy", "pandas", "scipy"
 # Use a dependency cooldown so that security vulnerabilities in upstream
 # packages can be identified and yanked before we start using them.
 exclude-newer = "3 days"
-exclude-newer-package = { plasmapy_sphinx = false }
+exclude-newer-package = { plasmapy-sphinx = false }
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ no-build-package = [ "astropy", "h5py", "matplotlib", "numpy", "pandas", "scipy"
 # Use a dependency cooldown so that security vulnerabilities in upstream
 # packages can be identified and yanked before we start using them.
 exclude-newer = "3 days"
+exclude-newer-package = { plasmapy_sphinx = false }
 
 [tool.ruff]
 target-version = "py312"

--- a/uv.lock
+++ b/uv.lock
@@ -17,8 +17,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-10T19:31:17.966449829Z"
+exclude-newer = "2026-05-10T20:24:43.879788175Z"
 exclude-newer-span = "P3D"
+
+[options.exclude-newer-package]
+plasmapy-sphinx = false
 
 [[package]]
 name = "alabaster"


### PR DESCRIPTION
We recently added a dependency cooldown when creating uv.lock for security. However, when we do a new release of plasmapy-sphinx, we generally want to start using it immediately to make sure that it's working okay.  This PR excludes plasmapy-sphinx from the dependency cooldown.
