### PR TITLE
Update internal documentation and GitHub workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -213,7 +213,7 @@ testing:
       '**/test*.py',
       '**/tests/**',
       '*codecov.y*ml',
-      '.github/workflows/ci.yml',
+      '.github/workflows/ci*.yml',
     ]
 
 tools:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -195,8 +195,6 @@ release:
     - any-glob-to-any-file: [
       '.github/workflows/ci-comprehensive.yml',
       'pyproject.toml',
-      'uv.lock',
-      'noxfile.py',
     ]
 
 'static type checking':

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,7 +23,6 @@ CI:
       '.pre-commit-config.yaml',
       '.readthedocs.yml',
       'codecov.yaml',
-      'mypy.ini',
     ]
 
 'contributor guide':
@@ -71,7 +70,6 @@ docs:
       'docs/**/*.py',
       'docs/**/make.bat',
       'docs/**/Makefile',
-      'docs/**/plasmapy_sphinx/**',
       'docs/**/robots.txt',
     ]
 
@@ -88,7 +86,6 @@ linters:
     - any-glob-to-any-file: [
       '.editorconfig',
       '.pre-commit*.yaml',
-      '.sourcery.yaml',
       '_typos.toml',
     ]
 
@@ -205,7 +202,6 @@ release:
 'static type checking':
   - changed-files:
     - any-glob-to-any-file: [
-      '**/*mypy*',
       '**/py.typed',
       '**/type_stubs/**',
     ]

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,11 +2,6 @@
 
 The [`.github/workflows`](.) directory contains [YAML] files that describe the [GitHub Actions] workflows used for during PlasmaPy development, including for continuous integration (CI) checks on pull requests (PRs).
 
-> [!NOTE]
-> Many of the workflows use the [Nox] task automation tool to run sessions defined in [`noxfile.py`](../../noxfile.py). Nox lets us run workflows locally using the same Python environment used in CI.
->
-> To see the workflows that are available, run `nox -l`. To locally execute a session named `tests-3.14(skipslow)`, run `nox -s "tests-3.14(skipslow)"`.
-
 ## Workflows
 
 ### CI
@@ -38,6 +33,8 @@ The [`.github/workflows`](.) directory contains [YAML] files that describe the [
 
 - [`comment-on-pr.yml`](./comment-on-pr.yml) — comment on PRs with information on how to contribute
 - [`labeler.yml`](./labeler.yml) — add labels to PRs
+- [`stale.yml`](./stale.yml) — close issues and PRs that have been inactive for a very long time
+- [`unlabel-pr-after-merge.yml`](./unlabel-pr-after-merge.yml) — remove certain labels from PRs after merging
 
 [github actions]: https://docs.github.com/en/actions
 [nox]: https://nox.thea.codes

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,5 +37,4 @@ The [`.github/workflows`](.) directory contains [YAML] files that describe the [
 - [`unlabel-pr-after-merge.yml`](./unlabel-pr-after-merge.yml) — remove certain labels from PRs after merging
 
 [github actions]: https://docs.github.com/en/actions
-[nox]: https://nox.thea.codes
 [yaml]: https://en.wikipedia.org/wiki/YAML

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,29 +1,43 @@
 # GitHub workflows
 
-The [`.github/workflows`](.) directory contains [YAML] files that
-describe the [GitHub Actions] workflows used when developing PlasmaPy.
-Several of the workflows invoke [Nox] sessions that are defined in the
-top-level [`noxfile.py`](../../noxfile.py).
+The [`.github/workflows`](.) directory contains [YAML] files that describe the [GitHub Actions] workflows used for during PlasmaPy development, including for continuous integration (CI) checks on pull requests (PRs).
 
-Continuous integration (CI) workflows include:
+> [!NOTE]
+> Many of the workflows use the [Nox] task automation tool to run sessions defined in [`noxfile.py`](../../noxfile.py). Nox lets us run workflows locally using the same Python environment used in CI.
+>
+> To see the workflows that are available, run `nox -l`. To locally execute a session named `tests-3.14(skipslow)`, run `nox -s "tests-3.14(skipslow)"`.
 
-- [`ci.yml`](./ci.yml) — perform CI checks during pull requests (PRs)
+## Workflows
+
+### CI
+
+- [`ci.yml`](./ci.yml) — perform standard continuous integration (CI) checks on PRs
 - [`ci-comprehensive.yml`](./ci-comprehensive.yml) — run comprehensive tests
-- [`upstream-tests.yml`](upstream-tests.yml) — test against unreleased versions of upstream dependencies
-- [`upstream-docs.yml`](upstream-docs.yml) — build documentation against unreleased versions of upstream dependencies
-- [`check-author-included.yml`](./check-author-included.yml) — verify
-  that the author of a PR is included in the top-level
-  [`CITATION.cff`](../../CITATION.cff) metadata file
+- [`upstream-tests.yml`](./upstream-tests.yml) — test against unreleased versions of upstream dependencies to find breaking changes before they make their way into a release
+- [`upstream-docs.yml`](./upstream-docs.yml) — build documentation against unreleased versions of upstream dependencies
+- [`linkcheck.yml`](./linkcheck.yml) — check the documentation for broken hyperlinks
 
-Workflows associated with the release process include:
+### Maintenance and triage
 
-- [`create-release-issue.yml`](./create-release-issue.yml) — create an
-  issue containing the release checklist (triggered manually)
-- [`mint-release.yml`](./mint-release.yml) — preparing the repository
-  for a release (triggered manually)
-- [`publish-to-pypi.yml`](./publish-to-pypi.yml) — perform the official
-  release to the Python Package Index (triggered by performing a release
-  on GitHub)
+- [`upgrade-uv-lock.yml`](./upgrade-uv-lock.yml) — update the locked Python environments used in CI
+
+### Release process
+
+- [`create-release-issue.yml`](./create-release-issue.yml) — trigger manually to create an issue containing the [release checklist](../content/release-checklist.md)
+- [`prepare-release-pr.yml`](./prepare-release-pr.yml) — trigger manually to prepare the repository for a release
+- [`publish-to-pypi.yml`](./publish-to-pypi.yml) — automatically perform the official release to the Python Package Index (PyPI) after performing a release on GitHub
+
+### Quality assurance
+
+- [`changelog.yml`](./changelog.yml) — verify that a valid changelog entry exists, unless labeled with "no changelog entry needed"
+- [`check-author-included.yml`](./check-author-included.yml) — verify that the author of a PR is included in [`CITATION.cff`](../../CITATION.cff)
+- [`installability.yml`](./installability.yml) – test package installation from official channels
+- [`pyhc-actions.yml`](./pyhc-actions.yml) – check for interoperability with the Python in Heliophysics Community (PyHC) environment
+
+### Triage
+
+- [`comment-on-pr.yml`](./comment-on-pr.yml) — comment on PRs with information on how to contribute
+- [`labeler.yml`](./labeler.yml) — add labels to PRs
 
 [github actions]: https://docs.github.com/en/actions
 [nox]: https://nox.thea.codes

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,7 +2,8 @@
 #
 # The verification is skipped if either of the `no changelog entry needed`
 # or `skip changelog checks` labels have been applied. These labels are
-# automatically applied to certain automated or minor pull requests.
+# automatically applied to certain automated or minor pull requests
+# using the configuration in .github/labeler.yml.
 
 name: Changelog
 

--- a/.github/workflows/check-author-included.yml
+++ b/.github/workflows/check-author-included.yml
@@ -1,3 +1,5 @@
+# Verify that the author of a pull request is included in CITATION.cff.
+
 name: Check metadata
 
 on:

--- a/.github/workflows/ci-comprehensive.yml
+++ b/.github/workflows/ci-comprehensive.yml
@@ -1,11 +1,11 @@
-# Define comprehensive continuous integration (CI) checks to be
-# performed periodically and on request.
+# Define thorough continuous integration checks that can be skipped for
+# most pull requests.
 
 name: comprehensive tests
 
 on:
   schedule:
-  - cron: 37 7 * * 1
+  - cron: 37 7 * * 5
   workflow_dispatch:
   pull_request:
     types: [labeled, opened, synchronize, reopened]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
-# Define continuous integration (CI) checks to be performed during
-# pull requests, such as running tests and building documentation.
+# Define continuous integration checks for all pull requests.
 #
-# The checks are defined in noxfile.py. After installing uv, the checks
-# can be run locally with
+# These checks include running tests for different versions of Python,
+# building the documentation, and performing static type checking.
+#
+# The checks are defined in `noxfile.py`. After installing uv, the
+# checks can be run locally in the top-level directory with
 #
 #    uvx nox -s '<nox_session>'
 #
@@ -22,7 +24,7 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: {}  # disables all GitHub permissions for the workflow
+permissions: {}  # disable all GitHub permissions for the workflow
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Define continuous integration checks for all pull requests.
+# Define continuous integration checks to be run for all pull requests.
 #
 # These checks include running tests for different versions of Python,
 # building the documentation, and performing static type checking.

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -8,7 +8,7 @@ jobs:
   comment:
     name: Welcome message
     # Skip posting this comment for frequent contributors
-    if: "!contains(fromJSON('[''namurphy'', ''rocco8773'', ''StanczakDominik'', ''dependabot'', ''plasmapy-requirements-bot'', ''pre-commit-ci'']'), github.event.pull_request.user.login)"
+    if: "!contains(fromJSON('[''namurphy'', ''rocco8773'', ''dependabot[bot]'', ''plasmapy-requirements-bot[bot]'', ''pre-commit-ci[bot]'']'), github.event.pull_request.user.login)"
     runs-on: ubuntu-latest
 
     steps:
@@ -26,18 +26,18 @@ jobs:
 
             [**PlasmaPy's contributor guide**](https://docs.plasmapy.org/en/latest/contributing/index.html) has pages on:
 
-             - 🌱 [Getting ready to contribute](https://docs.plasmapy.org/en/latest/contributing/getting_ready.html#getting-ready-to-contribute)
-             - 🔧 [Code contribution workflow](https://docs.plasmapy.org/en/latest/contributing/workflow.html#code-contribution-workflow)
-             - 📜 [Changelog entries](https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry)
-             - 💻 [Coding tips and guidelines](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html#coding-guide)
-             - 📚 [Documentation](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#writing-documentation)
-             - 🧪 [Tests](https://docs.plasmapy.org/en/latest/contributing/testing_guide.html#testing-guide)
+             - [Getting ready to contribute](https://docs.plasmapy.org/en/latest/contributing/getting_ready.html#getting-ready-to-contribute) 🌱
+             - [Code contribution workflow](https://docs.plasmapy.org/en/latest/contributing/workflow.html#code-contribution-workflow) 🔧
+             - [Changelog entries](https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry) 📜
+             - [Coding tips and guidelines](https://docs.plasmapy.org/en/latest/contributing/coding_guide.html#coding-guide) 💻
+             - [Documentation](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#writing-documentation) 📚
+             - [Tests](https://docs.plasmapy.org/en/latest/contributing/testing_guide.html#testing-guide) 🧪
 
             > [!TIP]
-            > 📚 For a documentation preview, click on **docs/readthedocs.org:plasmapy** below. For cryptic documentation errors, see the [documentation troubleshooting guide](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting).
+            > Click on **docs/readthedocs.org:plasmapy** below for a documentation preview. For cryptic documentation errors, see the [documentation troubleshooting guide](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting). 📚
 
             > [!TIP]
-            > 🧹 Automatically fix most **pre-commit.ci** failures by commenting \`pre-commit.ci autofix\` below. For other failures, please see the [pre-commit troubleshooting guide](https://docs.plasmapy.org/en/stable/contributing/pre-commit.html#troubleshooting-pre-commit-failures).
+            > Automatically fix most **pre-commit.ci** failures by commenting \`pre-commit.ci autofix\` below. For other failures, please see the [pre-commit troubleshooting guide](https://docs.plasmapy.org/en/stable/contributing/pre-commit.html#troubleshooting-pre-commit-failures). 🧹
 
             We thank you once again! 🌌`
           })

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,3 +1,5 @@
+# Comment on pull requests with information on how to contribute.
+
 name: Add comment
 
 on:

--- a/.github/workflows/installability.yml
+++ b/.github/workflows/installability.yml
@@ -1,3 +1,5 @@
+# Verify that PlasmaPy can be installed from official channels.
+
 name: Installability
 
 on:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,11 @@
+# Add labels to pull requests.
+#
+# Labeler rules are defined in: .github/labeler.yaml
+#
+# Documentation: https://github.com/actions/labeler#pull-request-labeler
+
 name: Pull Request Labeler
 
-# See https://github.com/actions/labeler#permissions
 on:
 - pull_request_target  # zizmor: ignore[dangerous-triggers]
 

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -1,3 +1,13 @@
+# Create a pull request that prepares the repository for a release.
+#
+# This workflow updates the package metadata, builds the changelog, and
+# deletes old changelog files. The pull request resulting from manually
+# triggering this workflow should be the last pull request merged before
+# performing the release on GitHub.
+#
+# Before running this workflow, reserve a DOI from Zenodo for the
+# forthcoming release.
+
 name: Prepare a release
 
 on:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,3 +1,8 @@
+# Publish a release made on GitHub to the Python Package Index (PyPI).
+#
+# This workflow is triggered automatically after a release is performed
+# on GitHub.
+
 name: Publish to PyPI
 
 on:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,4 @@
-# Publish a release made on GitHub to the Python Package Index (PyPI).
+# Publish a GitHub release to the Python Package Index (PyPI).
 #
 # This workflow is triggered automatically after a release is performed
 # on GitHub.

--- a/.github/workflows/pyhc-actions.yml
+++ b/.github/workflows/pyhc-actions.yml
@@ -1,3 +1,12 @@
+# Quality assurance checks for the Python in Heliophysics Community.
+#
+# Verify that PlasmaPy can be installed in PyHC's Python environment,
+# and check that requirements are consistent with the PyHC Python &
+# Upstream Package Support Policy (PHEP 3).
+#
+# Documentation: https://github.com/heliophysicsPy/pyhc-actions
+# PHEP 3: https://github.com/heliophysicsPy/standards/blob/main/pheps/phep-0003.md
+
 name: PyHC Actions
 
 on:
@@ -6,7 +15,6 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Run quarterly: Jan 1, Apr 1, Jul 1, Oct 1 at 3pm UTC (8am Mountain Time)
   - cron: 0 15 1 1,4,7,10 *
   workflow_dispatch:
 

--- a/.github/workflows/pyhc-actions.yml
+++ b/.github/workflows/pyhc-actions.yml
@@ -23,8 +23,7 @@ jobs:
 
     - name: Check PHEP 3 Compliance
       uses: heliophysicsPy/pyhc-actions/phep3-compliance@v1
-      with:
-        ignore-errors-for: xarray  # astropy.units interoperability; needed through April 2026
+      # Use `ignore-errors-for` to allow exceptions to PHEP 3 policy
 
   pyhc-env-compat:
     name: PyHC Environment Compatibility

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,9 @@
-name: Close stale issues and PRs
+# Close pull requests that have been dormant for a year and issues that
+# have been dormant for five years.
+#
+# Documentation: https://github.com/actions/stale
+
+name: Close dormant issues and PRs
 
 on:
   schedule:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,25 +6,23 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   issues: write
   pull-requests: write
 
 jobs:
-
   stale:
     runs-on: ubuntu-latest
-
     steps:
-
     - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: This issue will be closed in 90 days due to five years of inactivity unless the stale label or comment is removed.
-        close-issue-message: This issue was closed because it has had no activity for five years.
+        close-issue-message: This issue was closed because it has had no activity for five years, but may be re-opened.
         stale-pr-message: This pull request will be closed in 60 days due to a year of inactivity unless the stale label or comment is removed.
-        close-pr-message: This pull request was closed because it has had no activity for the past year.
+        close-pr-message: This pull request was closed because it has had no activity for the past year, but may be re-opened.
         days-before-issue-stale: 1826
         days-before-issue-close: 90
         days-before-pr-stale: 366
         days-before-pr-close: 60
-        exempt-issue-labels: 'bug,bug: needs more info,epic,priority: high,priority: very high,revisit in 2024,revisit in 2025,revisit in 2026,revisit in 2027'
+        exempt-issue-labels: 'bug,bug: needs more info,epic,priority: high,priority: very high,revisit in 2028,revisit in 2029,revisit in 2030,revisit in 2031,revisit in 2032,revisit in 2033,revisit in 2034,revisit in 2035,revisit in 2036'

--- a/.github/workflows/unlabel-pr-after-merge.yml
+++ b/.github/workflows/unlabel-pr-after-merge.yml
@@ -1,3 +1,5 @@
+# Remove labels from issues and pull request
+
 name: Close PR
 
 on:
@@ -22,32 +24,15 @@ jobs:
           if (!pull.data.merged) return;
 
           const labelsToRemove = [
-            'duplicate',
-            'effort: high',
-            'effort: low',
-            'effort: medium',
-            'effort: minimal',
-            'effort: very high',
             'good first issue',
             'help wanted',
             'needed for release',
             'needs changelog entry',
             'no changelog entry needed',
             'perform linkcheck in CI',
-            'priority: high',
-            'priority: low',
-            'priority: medium',
-            'priority: very high',
-            'prototype 🏗️',
+            'run comprehensive tests',
+            'run upstream tests',
             'skip changelog checks',
-            'Stale',
-            'status: assigned',
-            'status: dormant',
-            'status: in progress',
-            'status: nearing completion',
-            'status: on hold',
-            'status: ready for review',
-            'status: ready to merge'
           ];
 
           const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: number });

--- a/.github/workflows/unlabel-pr-after-merge.yml
+++ b/.github/workflows/unlabel-pr-after-merge.yml
@@ -24,12 +24,21 @@ jobs:
           if (!pull.data.merged) return;
 
           const labelsToRemove = [
+            'effort: high',
+            'effort: low',
+            'effort: medium',
+            'effort: minimal',
+            'effort: very high',
             'good first issue',
             'help wanted',
             'needed for release',
             'needs changelog entry',
             'no changelog entry needed',
             'perform linkcheck in CI',
+            'priority: high',
+            'priority: low',
+            'priority: medium',
+            'priority: very high',
             'prototype 🏗️',
             'run comprehensive tests',
             'run upstream tests',

--- a/.github/workflows/unlabel-pr-after-merge.yml
+++ b/.github/workflows/unlabel-pr-after-merge.yml
@@ -30,9 +30,22 @@ jobs:
             'needs changelog entry',
             'no changelog entry needed',
             'perform linkcheck in CI',
+            'prototype 🏗️',
             'run comprehensive tests',
             'run upstream tests',
             'skip changelog checks',
+            'Stale',
+            'status: assigned',
+            'status: dormant',
+            'status: in progress',
+            'status: nearing completion',
+            'status: needs discussion',
+            'status: not planned',
+            'status: on hold',
+            'status: ready for review',
+            'status: ready to merge',
+            'test failure is unrelated',
+            'wish list 🌠',
           ];
 
           const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: number });

--- a/.github/workflows/unlabel-pr-after-merge.yml
+++ b/.github/workflows/unlabel-pr-after-merge.yml
@@ -1,4 +1,4 @@
-# Remove labels from issues and pull request
+# Remove labels after a pull request has been merged.
 
 name: Close PR
 
@@ -53,7 +53,6 @@ jobs:
             'status: on hold',
             'status: ready for review',
             'status: ready to merge',
-            'test failure is unrelated',
             'wish list 🌠',
           ];
 

--- a/.github/workflows/upgrade-uv-lock.yml
+++ b/.github/workflows/upgrade-uv-lock.yml
@@ -1,3 +1,8 @@
+# Create a pull request to upgrade the lockfile that defines the Python
+# environments used in most continuous integration checks.
+#
+# For more details, see: .github/content/upgrade-uv-lock-pr-body.md
+
 name: Upgrade uv.lock
 
 on:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -23,14 +23,14 @@ rules:
   excessive-permissions:
     ignore:
     - create-release-issue.yml:16:3
-    - comment-on-pr.yml:8:3
-    - prepare-release-pr.yml:16:3
-    - unlabel-pr-after-merge.yml:8:3
-    - upgrade-uv-lock.yml:9:3
+    - comment-on-pr.yml:10:3
+    - prepare-release-pr.yml:26:3
+    - unlabel-pr-after-merge.yml:10:3
+    - upgrade-uv-lock.yml:14:3
   template-injection:
     ignore:
     - create-release-issue.yml:30:42
     - create-release-issue.yml:31:46
   use-trusted-publishing:
     ignore:
-    - publish-to-pypi.yml:32:7
+    - publish-to-pypi.yml:37:7

--- a/changelog/3282.internal.rst
+++ b/changelog/3282.internal.rst
@@ -1,0 +1,1 @@
+Updated comments in GitHub workflow files to describe what each workflow does.


### PR DESCRIPTION
## Updates to internal documentation

- Updated `.github/workflows/README.md` to list all workflows presenting included in that directory, so that it's easier for future maintainers to get the big picture of which workflows do what.
- Added or revised comments in GitHub workflow files, including a comment at the top of each file that describes the main purpose of the workflow. (These quasi-docstring comments are intended to make it easier for someone to navigate the files in the directory and get an idea of what the workflow defined in each file does.)

## Updates to GitHub workflows

- Removed an exemption for the PyHC workflow because the minimum allowed version of xarray had been newer than PHEP 3 recommended.
- Updated the labels to be removed after merging a PR.
- Removed some obsolete files from the labeler configuration.