### PR TITLE
Add `AGENTS.md` to provide instructions for AI coding assistants

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,1 +1,1 @@
-{ "context": { "fileName": "AGENTS.md" }, }
+{ "context": { "fileName": "AGENTS.md" } }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,1 @@
+{ "context": { "fileName": "AGENTS.md" }, }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot instructions
+
+- Follow the project guidelines, coding style, and rules defined in `AGENTS.md`.

--- a/.github/workflows/ci-comprehensive.yml
+++ b/.github/workflows/ci-comprehensive.yml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Run Nox session ${{ matrix.nox_session }}
       shell: bash -el {0}
-      run: uvx nox -s '${{ matrix.nox_session }}'
+      run: uvx nox --session '${{ matrix.nox_session }}'
 
     - name: Upload coverage reports to Codecov
       if: ${{ contains(matrix.nox_session, 'cov') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
     - name: Run Nox session ${{ matrix.nox_session }}
       shell: bash -el {0}
-      run: uvx nox -s '${{ matrix.nox_session }}'
+      run: uvx nox --session '${{ matrix.nox_session }}'
 
     - name: Upload coverage reports to Codecov
       if: ${{ contains(matrix.nox_session, 'cov') }}

--- a/.github/workflows/upgrade-uv-lock.yml
+++ b/.github/workflows/upgrade-uv-lock.yml
@@ -29,7 +29,7 @@ jobs:
         enable-cache: true
 
     - name: Run Nox session to upgrade uv.lock
-      run: uvx nox -s lock
+      run: uvx nox --session lock
 
     # When a pull request is created by a GitHub Action, normally the
     # checks will not be run. While the simplest workaround would have

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ requirements/*
 # Version file
 _version.py
 
+# Personal overrides for AI coding assistants
+AGENTS.override.md
+
 # basedpyright (baseline files should be cached in CI if we adopt this tool)
 .basedpyright
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AI Agent Instructions
+
+This file provides context, rules, and guidelines for AI coding assistants working on this repository.
+
+## Development environment
+
+- This project uses `uv` to manage the development environment.
+- The development environment can be created with `uv venv` and synced with `uv sync`.
+- If there is a merge conflict in `uv.lock`, first try running `uv lock`. If that doesn't work, run `uvx nox --session lock`.
+
+## Contribution guidelines
+
+- Every commit made by an AI coding assistant should indicate that it was made by an AI coding assistant, such as by starting each commit message with the name of the AI coding assistant in square brackets (e.g., `[Gemini]`, `[ChatGPT]`, or `[CoPilot]`).
+- Do not fix issues labeled with "good first issue" because they are reserved to provide human contributors with a chance to learn how to manually make a contribution.
+
+## Contributor guide
+
+- PlasmaPy's contributor guide is located in `docs/contributing/`.
+- Coding guidelines are in `docs/contributing/coding_guide.rst`.
+- Documentation guidelines are in `docs/contributing/doc_guide.rst`.
+- Testing guidelines are in `docs/contributing/testing_guide.rst`.
+- Changelog instructions are in `changelog/README.rst`.
+
+## Style
+
+- Follow the PEP 8 style guide.
+- Lint files with `pre-commit`, which uses `ruff`.
+- Follow the style conventions in `.editorconfig`.
+
+## Documentation
+
+- The documentation is written in reStructuredText, built with Sphinx, and hosted on Read the Docs.
+- The documentation can be built with `nox --session docs`.
+- Use the numpydoc style for docstrings.
+
+## Changelog
+
+- Except for trivial changes, each pull request should have a changelog entry in the `changelog/` directory using the guidelines in `changelog/README.md`.
+
+## Testing instructions
+
+- Tests are located in the `tests/` directory.
+- Find the CI plan in `.github/workflows/`, with Nox sessions defined in `noxfile.py`. The list of Nox sessions can be found by running `nox --list`.
+- The full test suite is run with `uvx nox --session 'tests-3.14(all)'` in the top-level directory, which invokes the `tests` session defined in `noxfile.py`.
+- Use pytest to run small numbers of tests when trying to fix failing tests. For example, use `pytest tests/particles/test_atomic.py::test_half_life` to run the test named `test_half_life` in `tests/particles/test_atomic.py`, or use `pytest tests/formulary/test_lengths.py` to run all tests in `tests/formulary/test_lengths.py`.
+- Fix any test errors until all tests are passing.
+
+## Static type checking
+
+- Static type checking is performed with `nox --session ty`.
+- Fix static type checking errors when possible, but use in-line ignore comments if necessary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,16 +2,19 @@
 
 This file provides context, rules, and guidelines for AI coding assistants working on this repository.
 
+## Project overview
+
+- `plasmapy` is a Python package that contains software tools for plasma science.
+- Source code is located in `src/`.
+
 ## Development environment
 
-- This project uses `uv` to manage the development environment.
-- The development environment can be created with `uv venv` and synced with `uv sync`.
-- If there is a merge conflict in `uv.lock`, first try running `uv lock`. If that doesn't work, run `uvx nox --session lock`.
+- Set up the development environment with `uv venv` followed by `uv sync`.
+- If there is a merge conflict in `uv.lock`, run `uv lock`. If that doesn't work, run `uvx nox --session lock`.
 
 ## Contribution guidelines
 
-- Every commit made by an AI coding assistant should indicate that it was made by an AI coding assistant, such as by starting each commit message with the name of the AI coding assistant in square brackets (e.g., `[Gemini]`, `[ChatGPT]`, or `[CoPilot]`).
-- Do not fix issues labeled with "good first issue" because they are reserved to provide human contributors with a chance to learn how to manually make a contribution.
+- Start every commit message with the name of the coding agent in square brackets (e.g., `[Gemini]`, `[Claude]` or `[Copilot]`).
 
 ## Contributor guide
 
@@ -23,19 +26,18 @@ This file provides context, rules, and guidelines for AI coding assistants worki
 
 ## Style
 
-- Follow the PEP 8 style guide.
-- Lint files with `pre-commit`, which uses `ruff`.
-- Follow the style conventions in `.editorconfig`.
+- Lint files with `uvx pre-commit`.
+- Use SI units.
 
 ## Documentation
 
 - The documentation is written in reStructuredText, built with Sphinx, and hosted on Read the Docs.
-- The documentation can be built with `nox --session docs`.
-- Use the numpydoc style for docstrings.
+- The documentation is built with `uvx nox --session docs`.
+- Use numpydoc style docstrings.
 
 ## Changelog
 
-- Except for trivial changes, each pull request should have a changelog entry in the `changelog/` directory using the guidelines in `changelog/README.md`.
+- When changes are not trivial, include a changelog entry in the `changelog/` directory using the guidelines in `changelog/README.md`.
 
 ## Testing instructions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude instructions
+
+- Follow the project guidelines, coding style, and rules defined in `AGENTS.md`.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,6 @@ graft src
 graft tests
 graft tools
 graft type_stubs
-graft .gemini/settings.json
 
 include *.ini *.toml *.yaml *.yml
 include *.md
@@ -17,6 +16,7 @@ include *.pyi
 include *.rst
 include *.txt
 include .editorconfig
+include .gemini/settings.json
 include .git-blame-ignore-revs
 include .jupyter/*.py
 include binder/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ graft src
 graft tests
 graft tools
 graft type_stubs
+graft .gemini/settings.json
 
 include *.ini *.toml *.yaml *.yml
 include *.md

--- a/changelog/3284.internal.rst
+++ b/changelog/3284.internal.rst
@@ -1,0 +1,1 @@
+Added :file:`AGENTS.md` to provide instructions for AI coding assistants.


### PR DESCRIPTION
This PR adds a top-level [`AGENTS.md`](https://agents.md) file to provide detailed instructions to assist AI coding assistants.

This is not intended to be the final version of `AGENTS.md`, but rather a starting point to be iterated upon. We will need to make sure that this is consistent with the outcome of #3112.

Inspired by a talk by @sapols earlier today!

Closes #3283.