### PR TITLE
Update ruff rules including for annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,14 +94,14 @@ repos:
 - repo: https://github.com/adhtruong/mirrors-typos
   # use mirrors-typos because `pre-commit autoupdate` drops the version
   # of the primary typos repo from v1.x.y to v1
-  rev: v1.46.0
+  rev: v1.46.3
   hooks:
   - id: typos
     name: typos (add false positives to _typos.toml)
     exclude: CITATION.cff|docs/notebooks/dispersion/stix_dispersion.ipynb
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.12
+  rev: v0.15.14
   hooks:
   - id: ruff-check
     name: ruff-check (see https://docs.astral.sh/ruff/rules)
@@ -138,13 +138,13 @@ repos:
     - validate-pyproject[all,store]
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.21.1
+  rev: v2.21.2
   hooks:
   - id: pyproject-fmt
     name: format pyproject.toml
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.11.8
+  rev: 0.11.16
   hooks:
     # running uv lock requires network access or a warm cache, so it
     # cannot be run via pre-commit.ci, even with the `--offline`,

--- a/changelog/3292.internal.rst
+++ b/changelog/3292.internal.rst
@@ -1,0 +1,1 @@
+Enabled more |ruff| rules, including most of the ``ANN`` rule set.

--- a/docs/_author_list_from_cff.py
+++ b/docs/_author_list_from_cff.py
@@ -170,7 +170,9 @@ def generate_rst_author_list(authors: list[dict[str, str]]) -> str:
 
 
 def generate_rst_file(
-    cff_file="../CITATION.cff", rst_file="about/_authors.rst", verbose=False  # noqa: FBT002
+    cff_file="../CITATION.cff",
+    rst_file="about/_authors.rst",
+    verbose=False,  # noqa: FBT002
 ):
     """
     Parse :file:`CITATION.cff` file and generate a reStructuredText

--- a/docs/_author_list_from_cff.py
+++ b/docs/_author_list_from_cff.py
@@ -170,7 +170,7 @@ def generate_rst_author_list(authors: list[dict[str, str]]) -> str:
 
 
 def generate_rst_file(
-    cff_file="../CITATION.cff", rst_file="about/_authors.rst", verbose=False
+    cff_file="../CITATION.cff", rst_file="about/_authors.rst", verbose=False  # noqa: FBT002
 ):
     """
     Parse :file:`CITATION.cff` file and generate a reStructuredText

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ format.line-ending = "lf"
 format.docstring-code-format = true
 lint.extend-select = [
   "A",      # flake8-builtins
+  "ANN201", # missing-return-type-undocumented-public-function
   "ANN204", # missing-return-type-special-method
   "ANN205", # missing-return-type-static-method
   "ANN206", # missing-return-type-class-method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ format.line-ending = "lf"
 format.docstring-code-format = true
 lint.extend-select = [
   "A",      # flake8-builtins
+  "ANN002", # missing-type-args
   "ANN201", # missing-return-type-undocumented-public-function
   "ANN202", # missing-return-type-undocumented-public-method
   "ANN204", # missing-return-type-special-method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,7 +314,6 @@ lint.ignore = [
   "RET502",  # implicit-return-value
   "RET505",  # superfluous-else-return (enable later?)
   "RET506",  # superfluous-else-raise (enable later?)
-  "S101",    # asserts
   "SIM300",  # yoda-conditions
   "TD002",   # missing-todo-author
   "TD003",   # missing-todo-link
@@ -374,6 +373,7 @@ lint.per-file-ignores."tests/**/test_*.py" = [
   "PLC2701",
   "PLR6301",
   "RUF012",
+  "S101",
   "SLF001",
 ]
 lint.per-file-ignores."tests/formulary/collisions/test_coulomb.py" = [ "PT031" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ format.docstring-code-format = true
 lint.extend-select = [
   "A",      # flake8-builtins
   "ANN201", # missing-return-type-undocumented-public-function
+  "ANN202", # missing-return-type-undocumented-public-method
   "ANN204", # missing-return-type-special-method
   "ANN205", # missing-return-type-static-method
   "ANN206", # missing-return-type-class-method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ lint.extend-select = [
   "ANN204", # missing-return-type-special-method
   "ANN205", # missing-return-type-static-method
   "ANN206", # missing-return-type-class-method
+  "ANN401", # any-type
   "ARG",    # flake8-unused-arguments
   "ASYNC",  # flake8-async
   "B",      # flake8-bugbear

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,8 +185,8 @@ format.line-ending = "lf"
 format.docstring-code-format = true
 lint.extend-select = [
   "A",      # flake8-builtins
+  "ANN",    # flake8-annotations
   "ANN002", # missing-type-args
-  "ANN", # flake8-annotations
   "ARG",    # flake8-unused-arguments
   "ASYNC",  # flake8-async
   "B",      # flake8-bugbear
@@ -283,7 +283,7 @@ lint.extend-select = [
 # The ruff rules to include or ignore for notebooks are defined
 # separately in .pre-commit-config.yaml in the hook for nbqa-ruff
 lint.ignore = [
-  "ANN001",   # missing-type-function-argument
+  "ANN001",  # missing-type-function-argument
   "B028",    # no-explicit-stacklevel
   "D105",    # undocumented-magic-method (enable later?)
   "D200",    # fits-on-one-line (incompatible with multiline short summaries)
@@ -347,7 +347,7 @@ lint.per-file-ignores."docs/notebooks/dispersion/dispersion_function.ipynb" = [ 
 lint.per-file-ignores."docs/notebooks/dispersion/stix_dispersion.ipynb" = [ "FBT003" ]
 lint.per-file-ignores."docs/notebooks/formulary/cold_plasma_tensor_elements.ipynb" = [ "FBT003" ]
 lint.per-file-ignores."docs/notebooks/formulary/ExB_drift.ipynb" = [ "B008", "D103" ]
-lint.per-file-ignores."docs/notebooks/langmuir_samples/_generate_noisy.ipynb" = [ "NPY002", "PTH123" ]
+lint.per-file-ignores."docs/notebooks/langmuir_samples/_generate_noisy.ipynb" = [ "ANN202", "NPY002", "PTH123" ]
 lint.per-file-ignores."docs/notebooks/plasma/grids_cartesian.ipynb" = [ "NPY002", "PLW2901" ]
 lint.per-file-ignores."docs/notebooks/plasma/grids_nonuniform.ipynb" = [ "NPY002" ]
 lint.per-file-ignores."setup.py" = [ "D100" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ lint.extend-select = [
   "EM",     # flake8-errmsg
   "EXE",    # flake8-executable
   "FA102",  # flake8-required-type-annotation
+  "FBT002", # flake8-boolean-trap
   "FBT003", # flake8-boolean-trap
   "FIX",    # flake8-fixme
   "FLY",    # flynt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,8 +201,7 @@ lint.extend-select = [
   "EM",     # flake8-errmsg
   "EXE",    # flake8-executable
   "FA102",  # flake8-required-type-annotation
-  "FBT002", # flake8-boolean-trap
-  "FBT003", # flake8-boolean-trap
+  "FBT",
   "FIX",    # flake8-fixme
   "FLY",    # flynt
   "FURB",   # refurb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,13 +186,7 @@ format.docstring-code-format = true
 lint.extend-select = [
   "A",      # flake8-builtins
   "ANN002", # missing-type-args
-  "ANN003", # missing-type-kwargs
-  "ANN201", # missing-return-type-undocumented-public-function
-  "ANN202", # missing-return-type-undocumented-public-method
-  "ANN204", # missing-return-type-special-method
-  "ANN205", # missing-return-type-static-method
-  "ANN206", # missing-return-type-class-method
-  "ANN401", # any-type
+  "ANN", # flake8-annotations
   "ARG",    # flake8-unused-arguments
   "ASYNC",  # flake8-async
   "B",      # flake8-bugbear
@@ -289,6 +283,7 @@ lint.extend-select = [
 # The ruff rules to include or ignore for notebooks are defined
 # separately in .pre-commit-config.yaml in the hook for nbqa-ruff
 lint.ignore = [
+  "ANN001",   # missing-type-function-argument
   "B028",    # no-explicit-stacklevel
   "D105",    # undocumented-magic-method (enable later?)
   "D200",    # fits-on-one-line (incompatible with multiline short summaries)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ format.docstring-code-format = true
 lint.extend-select = [
   "A",      # flake8-builtins
   "ANN002", # missing-type-args
+  "ANN003", # missing-type-kwargs
   "ANN201", # missing-return-type-undocumented-public-function
   "ANN202", # missing-return-type-undocumented-public-method
   "ANN204", # missing-return-type-special-method

--- a/src/plasmapy/analysis/fit_functions.py
+++ b/src/plasmapy/analysis/fit_functions.py
@@ -67,7 +67,7 @@ class AbstractFitFunction(ABC):
         self._curve_fit_results = None
         self._rsq = None
 
-    def __call__(self, x, x_err=None, reterr: bool = False):  # noqa: ANN204
+    def __call__(self, x, x_err=None, reterr: bool = False):  # noqa: ANN204, FBT002
         """
         Direct call of the fit function :math:`f(x)`.
 
@@ -169,7 +169,7 @@ class AbstractFitFunction(ABC):
                 return err
         """,
     )
-    def func_err(self, x, x_err=None, rety: bool = False):
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
         """
         Parameters
         ----------
@@ -510,7 +510,7 @@ class Linear(AbstractFitFunction):
         return m * x + b
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -698,7 +698,7 @@ class Exponential(AbstractFitFunction):
         return a * np.exp(alpha * x)
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -862,7 +862,7 @@ class ExponentialPlusLinear(AbstractFitFunction):
         return exp_term + lin_term
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -995,7 +995,7 @@ class ExponentialPlusOffset(AbstractFitFunction):
         return self._explin.func(x, a, alpha, 0.0, b)
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.

--- a/src/plasmapy/analysis/fit_functions.py
+++ b/src/plasmapy/analysis/fit_functions.py
@@ -510,7 +510,7 @@ class Linear(AbstractFitFunction):
         return m * x + b
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: ANN201, FBT001, FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -665,7 +665,7 @@ class Exponential(AbstractFitFunction):
         """LaTeX friendly representation of the fit function."""
         return r"a \, \exp(\alpha x)"
 
-    def func(self, x: float, a: float, alpha: float):  # ty:ignore[invalid-method-override]
+    def func(self, x: float, a: float, alpha: float):  # ty:ignore[invalid-method-override]  # noqa: ANN201
         """
         The fit function, a exponential function.
 
@@ -698,7 +698,7 @@ class Exponential(AbstractFitFunction):
         return a * np.exp(alpha * x)
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: ANN201, FBT001, FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -823,7 +823,7 @@ class ExponentialPlusLinear(AbstractFitFunction):
         )
         self._linear.param_errors = (self.param_errors.m, self.param_errors.b)
 
-    def func(self, x: float, a: float, alpha: float, m: float, b: float):  # ty:ignore[invalid-method-override]
+    def func(self, x: float, a: float, alpha: float, m: float, b: float):  # ty:ignore[invalid-method-override]  # noqa: ANN201
         """
         The fit function, an exponential with a linear offset.
 
@@ -862,7 +862,7 @@ class ExponentialPlusLinear(AbstractFitFunction):
         return exp_term + lin_term
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: ANN201, FBT001, FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -961,7 +961,7 @@ class ExponentialPlusOffset(AbstractFitFunction):
             self.param_errors.b,
         )
 
-    def func(self, x: float, a: float, alpha: float, b: float):  # ty:ignore[invalid-method-override]
+    def func(self, x: float, a: float, alpha: float, b: float):  # ty:ignore[invalid-method-override]  # noqa: ANN201
         """
         The fit function, an exponential with a constant offset.
 
@@ -995,7 +995,7 @@ class ExponentialPlusOffset(AbstractFitFunction):
         return self._explin.func(x, a, alpha, 0.0, b)
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: ANN201, FBT001, FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.

--- a/src/plasmapy/analysis/fit_functions.py
+++ b/src/plasmapy/analysis/fit_functions.py
@@ -401,7 +401,7 @@ class AbstractFitFunction(ABC):
         """
         return self._rsq
 
-    def curve_fit(self, xdata, ydata, **kwargs) -> None:
+    def curve_fit(self, xdata, ydata, **kwargs) -> None:  # noqa: ANN003
         """
         Use a non-linear least squares method to fit the fit function to
         (``xdata``, ``ydata``), using `scipy.optimize.curve_fit`.  This will set
@@ -598,7 +598,7 @@ class Linear(AbstractFitFunction):
 
         return _RootResults(root, err)
 
-    def curve_fit(self, xdata, ydata, **kwargs) -> None:
+    def curve_fit(self, xdata, ydata, **kwargs) -> None:  # noqa: ANN003
         """
         Calculate a linear least-squares regression of (``xdata``, ``ydata``)
         using `scipy.stats.linregress`.  This will set the attributes

--- a/src/plasmapy/analysis/fit_functions.py
+++ b/src/plasmapy/analysis/fit_functions.py
@@ -67,7 +67,7 @@ class AbstractFitFunction(ABC):
         self._curve_fit_results = None
         self._rsq = None
 
-    def __call__(self, x, x_err=None, reterr: bool = False):  # noqa: ANN204, FBT002
+    def __call__(self, x, x_err=None, reterr: bool = False):  # noqa: ANN204, FBT001, FBT002
         """
         Direct call of the fit function :math:`f(x)`.
 
@@ -169,7 +169,7 @@ class AbstractFitFunction(ABC):
                 return err
         """,
     )
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
         """
         Parameters
         ----------
@@ -510,7 +510,7 @@ class Linear(AbstractFitFunction):
         return m * x + b
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -698,7 +698,7 @@ class Exponential(AbstractFitFunction):
         return a * np.exp(alpha * x)
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -862,7 +862,7 @@ class ExponentialPlusLinear(AbstractFitFunction):
         return exp_term + lin_term
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.
@@ -995,7 +995,7 @@ class ExponentialPlusOffset(AbstractFitFunction):
         return self._explin.func(x, a, alpha, 0.0, b)
 
     @modify_docstring(append=AbstractFitFunction.func_err.__original_doc__)
-    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT002
+    def func_err(self, x, x_err=None, rety: bool = False):  # noqa: FBT001, FBT002
         """
         Calculate dependent variable uncertainties :math:`\\delta y` for
         dependent variables :math:`y=f(x)`.

--- a/src/plasmapy/analysis/fit_functions.py
+++ b/src/plasmapy/analysis/fit_functions.py
@@ -293,7 +293,7 @@ class AbstractFitFunction(ABC):
         return x, x_err
 
     @staticmethod
-    def _check_params(*args) -> None:
+    def _check_params(*args) -> None:  # noqa: ANN002
         """
         Check fitting parameters so that they are an expected type for the
         class functionality.

--- a/src/plasmapy/analysis/nullpoint.py
+++ b/src/plasmapy/analysis/nullpoint.py
@@ -1458,7 +1458,7 @@ def _vspace_iterator(vspace, maxiter: int = 500, err: float = 1e-10):
     return nullpoints
 
 
-def null_point_find(
+def null_point_find(  # noqa: ANN201
     x_arr=None,
     y_arr=None,
     z_arr=None,
@@ -1543,7 +1543,7 @@ def null_point_find(
     return _vspace_iterator(vspace, maxiter, err)
 
 
-def uniform_null_point_find(
+def uniform_null_point_find(  # noqa: ANN201
     x_range,
     y_range,
     z_range,

--- a/src/plasmapy/analysis/nullpoint.py
+++ b/src/plasmapy/analysis/nullpoint.py
@@ -473,7 +473,7 @@ def _trilinear_jacobian(vspace, cell):
         dBzdy = cz + ez * xInput + gz * zInput + hz * xInput * yInput
         dBzdz = dz + fz * xInput + gz * yInput + hz * xInput * yInput
 
-        def get_scalar(v: float | np.ndarray):
+        def get_scalar(v: float | np.ndarray):  # noqa: ANN202
             """
             If a `float`, return the argument. If a `numpy.ndarray` with
             a single element, return that element.
@@ -1139,7 +1139,7 @@ def _trilinear_analysis(vspace, cell):  # noqa: C901, PLR0915
     if len(BxByEndpoints) != 2 or len(BxBzEndpoints) != 2 or len(ByBzEndpoints) != 2:
         return False
 
-    def endpoint_sign_check(curve_endpoints, curve_name: str):
+    def endpoint_sign_check(curve_endpoints, curve_name: str):  # noqa: ANN202
         if curve_name == "x":
             index = 0
         elif curve_name == "y":
@@ -1415,7 +1415,7 @@ def _classify_null_point(vspace, cell, loc):
     return null_point_type
 
 
-def _vspace_iterator(vspace, maxiter: int = 500, err: float = 1e-10):
+def _vspace_iterator(vspace, maxiter: int = 500, err: float = 1e-10):  # noqa: ANN202
     r"""
     Returns an array of null point objects, representing the null points
     of the given vector space.

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -15,8 +15,8 @@ from plasmapy.utils.exceptions import PlasmaPyWarning
 def check_sweep(  # noqa: C901, PLR0912
     voltage: np.ndarray,
     current: np.ndarray,
-    strip_units: bool = True,  # noqa: FBT002
-    allow_unsorted: bool = False,  # noqa: FBT002
+    strip_units: bool = True,  # noqa: FBT001, FBT002
+    allow_unsorted: bool = False,  # noqa: FBT001, FBT002
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Check that the voltage and current arrays are properly formatted
@@ -406,7 +406,7 @@ def merge_voltage_clusters(  # noqa: C901, PLR0912
     voltage: np.ndarray,
     current: np.ndarray,
     voltage_step_size: float | None = None,
-    filter_nan: bool = False,  # noqa: FBT002
+    filter_nan: bool = False,  # noqa: FBT001, FBT002
 ) -> tuple[np.ndarray, np.ndarray]:
     r"""
     Search the ``voltage`` array for closely spaced voltage clusters

--- a/src/plasmapy/analysis/swept_langmuir/helpers.py
+++ b/src/plasmapy/analysis/swept_langmuir/helpers.py
@@ -15,8 +15,8 @@ from plasmapy.utils.exceptions import PlasmaPyWarning
 def check_sweep(  # noqa: C901, PLR0912
     voltage: np.ndarray,
     current: np.ndarray,
-    strip_units: bool = True,
-    allow_unsorted: bool = False,
+    strip_units: bool = True,  # noqa: FBT002
+    allow_unsorted: bool = False,  # noqa: FBT002
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Check that the voltage and current arrays are properly formatted
@@ -406,7 +406,7 @@ def merge_voltage_clusters(  # noqa: C901, PLR0912
     voltage: np.ndarray,
     current: np.ndarray,
     voltage_step_size: float | None = None,
-    filter_nan: bool = False,
+    filter_nan: bool = False,  # noqa: FBT002
 ) -> tuple[np.ndarray, np.ndarray]:
     r"""
     Search the ``voltage`` array for closely spaced voltage clusters

--- a/src/plasmapy/analysis/time_series/excess_statistics.py
+++ b/src/plasmapy/analysis/time_series/excess_statistics.py
@@ -112,7 +112,7 @@ class ExcessStatistics:
 
             self.events_per_threshold.update({threshold: self._times_above_threshold})
 
-    def hist(self, bins: int = 32):
+    def hist(self, bins: int = 32):  # noqa: ANN201
         """
         Computes the probability density function of the time above each value
         in ``thresholds``.

--- a/src/plasmapy/analysis/time_series/running_moments.py
+++ b/src/plasmapy/analysis/time_series/running_moments.py
@@ -17,7 +17,7 @@ import numpy as np
 _run_moment_tuple = namedtuple("Running_Moment", ["run_moment", "time"])  # ty:ignore[mismatched-type-name]
 
 
-def running_mean(signal, radius: int):
+def running_mean(signal, radius: int):  # noqa: ANN201
     """
     Calculate the running mean of a sequence.
 
@@ -62,7 +62,7 @@ def running_mean(signal, radius: int):
     return run_mean[window - 1 :] / window
 
 
-def running_moment(signal, radius: int, moment: int = 1, time=None):
+def running_moment(signal, radius: int, moment: int = 1, time=None):  # noqa: ANN201
     """
     Calculate either the running mean, standard deviation, skewness or
     excess kurtosis of a sequence.

--- a/src/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
@@ -139,7 +139,10 @@ class Stack:
         return np.sum(thickness) * u.m
 
     def deposition_curves(  # noqa: ANN201
-        self, energies: u.Quantity[u.J], dx=1 * u.um, return_only_active: bool = True  # noqa: FBT001, FBT002
+        self,
+        energies: u.Quantity[u.J],
+        dx=1 * u.um,
+        return_only_active: bool = True,  # noqa: FBT001, FBT002
     ):
         """
         Calculate the deposition of an ensemble of particles over a range of

--- a/src/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
@@ -138,7 +138,7 @@ class Stack:
         thickness = np.array([layer.thickness.to(u.m).value for layer in self._layers])
         return np.sum(thickness) * u.m
 
-    def deposition_curves(
+    def deposition_curves(  # noqa: ANN201
         self, energies: u.Quantity[u.J], dx=1 * u.um, return_only_active: bool = True  # noqa: FBT001, FBT002
     ):
         """
@@ -218,7 +218,7 @@ class Stack:
 
         return deposited_energy
 
-    def energy_bands(
+    def energy_bands(  # noqa: ANN201
         self,
         energy_range: u.Quantity[u.J],
         dE: u.Quantity[u.J],

--- a/src/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
@@ -62,7 +62,7 @@ class Layer:
         energy_axis: u.Quantity[u.J],
         stopping_power: u.Quantity[u.J / u.m, u.J * u.m**2 / u.kg],
         mass_density: u.Quantity[u.kg / u.m**3] | None = None,
-        active: bool = True,
+        active: bool = True,  # noqa: FBT002
         name: str = "",
     ) -> None:
         self.thickness = thickness
@@ -139,7 +139,7 @@ class Stack:
         return np.sum(thickness) * u.m
 
     def deposition_curves(
-        self, energies: u.Quantity[u.J], dx=1 * u.um, return_only_active: bool = True
+        self, energies: u.Quantity[u.J], dx=1 * u.um, return_only_active: bool = True  # noqa: FBT002
     ):
         """
         Calculate the deposition of an ensemble of particles over a range of
@@ -223,7 +223,7 @@ class Stack:
         energy_range: u.Quantity[u.J],
         dE: u.Quantity[u.J],
         dx=1e-6 * u.m,  # noqa: ARG002
-        return_only_active: bool = True,
+        return_only_active: bool = True,  # noqa: FBT002
     ):
         """
         Calculate the energy bands in each of the active layers of a film

--- a/src/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/detector_stacks.py
@@ -62,7 +62,7 @@ class Layer:
         energy_axis: u.Quantity[u.J],
         stopping_power: u.Quantity[u.J / u.m, u.J * u.m**2 / u.kg],
         mass_density: u.Quantity[u.kg / u.m**3] | None = None,
-        active: bool = True,  # noqa: FBT002
+        active: bool = True,  # noqa: FBT001, FBT002
         name: str = "",
     ) -> None:
         self.thickness = thickness
@@ -139,7 +139,7 @@ class Stack:
         return np.sum(thickness) * u.m
 
     def deposition_curves(
-        self, energies: u.Quantity[u.J], dx=1 * u.um, return_only_active: bool = True  # noqa: FBT002
+        self, energies: u.Quantity[u.J], dx=1 * u.um, return_only_active: bool = True  # noqa: FBT001, FBT002
     ):
         """
         Calculate the deposition of an ensemble of particles over a range of
@@ -223,7 +223,7 @@ class Stack:
         energy_range: u.Quantity[u.J],
         dE: u.Quantity[u.J],
         dx=1e-6 * u.m,  # noqa: ARG002
-        return_only_active: bool = True,  # noqa: FBT002
+        return_only_active: bool = True,  # noqa: FBT001, FBT002
     ):
         """
         Calculate the energy bands in each of the active layers of a film

--- a/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -219,7 +219,7 @@ class Tracker(ParticleTracker):
         output_directory: Path | None = None,
         output_basename: str = "output",
         fraction_exited_threshold: float = 0.999,
-        verbose: bool = True,
+        verbose: bool = True,  # noqa: FBT002
     ) -> None:
         # The synthetic radiography class handles logging, so we can disable logging for the particle tracker
         # The particle tracker class ensures that the provided grid argument has the proper type and
@@ -1124,7 +1124,7 @@ class Tracker(ParticleTracker):
 # *************************************************************************
 
 
-def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):  # noqa: C901, PLR0912
+def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):  # noqa: C901, FBT002, PLR0912
     r"""
     Calculate a "synthetic radiograph" (particle count histogram in the
     image plane).

--- a/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -219,7 +219,7 @@ class Tracker(ParticleTracker):
         output_directory: Path | None = None,
         output_basename: str = "output",
         fraction_exited_threshold: float = 0.999,
-        verbose: bool = True,  # noqa: FBT002
+        verbose: bool = True,  # noqa: FBT001, FBT002
     ) -> None:
         # The synthetic radiography class handles logging, so we can disable logging for the particle tracker
         # The particle tracker class ensures that the provided grid argument has the proper type and
@@ -1124,7 +1124,7 @@ class Tracker(ParticleTracker):
 # *************************************************************************
 
 
-def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):  # noqa: C901, FBT002, PLR0912
+def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):  # noqa: C901, FBT001, FBT002, PLR0912
     r"""
     Calculate a "synthetic radiograph" (particle count histogram in the
     image plane).

--- a/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
+++ b/src/plasmapy/diagnostics/charged_particle_radiography/synthetic_radiography.py
@@ -1124,7 +1124,7 @@ class Tracker(ParticleTracker):
 # *************************************************************************
 
 
-def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):  # noqa: C901, FBT001, FBT002, PLR0912
+def synthetic_radiograph(obj, size=None, bins=None, ignore_grid: bool = False):  # noqa: ANN201, C901, FBT001, FBT002, PLR0912
     r"""
     Calculate a "synthetic radiograph" (particle count histogram in the
     image plane).

--- a/src/plasmapy/diagnostics/langmuir.py
+++ b/src/plasmapy/diagnostics/langmuir.py
@@ -125,7 +125,7 @@ class Characteristic:
         self.current = self.current[_sort]
         self.bias = self.bias[_sort]
 
-    def get_unique_bias(self, inplace: bool = False):
+    def get_unique_bias(self, inplace: bool = False):  # noqa: FBT002
         r"""Remove any duplicate bias values through averaging."""
 
         if len(self.bias) != len(self.current):
@@ -169,7 +169,7 @@ class Characteristic:
         if len(np.unique(self.bias)) != len(self.bias):
             raise ValueError("Bias array contains duplicate values.")
 
-    def get_padded_limit(self, padding, log: bool = False):
+    def get_padded_limit(self, padding, log: bool = False):  # noqa: FBT002
         r"""Return the limits of the current range for plotting, taking into
         account padding. Matplotlib lacks this functionality.
 
@@ -214,10 +214,10 @@ def swept_probe_analysis(  # noqa: PLR0915
     probe_characteristic,
     probe_area: u.Quantity[u.m**2],
     gas_argument,
-    bimaxwellian: bool = False,
-    visualize: bool = False,
-    plot_electron_fit: bool = False,
-    plot_EEDF: bool = False,
+    bimaxwellian: bool = False,  # noqa: FBT002
+    visualize: bool = False,  # noqa: FBT002
+    plot_electron_fit: bool = False,  # noqa: FBT002
+    plot_EEDF: bool = False,  # noqa: FBT002
 ):
     r"""Attempt to perform a basic swept probe analysis based on the provided
     characteristic and probe data. Suitable for single cylindrical probes in
@@ -448,7 +448,7 @@ def swept_probe_analysis(  # noqa: PLR0915
     return results
 
 
-def get_plasma_potential(probe_characteristic, return_arg: bool = False):
+def get_plasma_potential(probe_characteristic, return_arg: bool = False):  # noqa: FBT002
     r"""Implement the simplest but crudest method for obtaining an estimate of
     the plasma potential from the probe characteristic.
 
@@ -501,7 +501,7 @@ def get_plasma_potential(probe_characteristic, return_arg: bool = False):
     return probe_characteristic.bias[arg_V_P]
 
 
-def get_floating_potential(probe_characteristic, return_arg: bool = False):
+def get_floating_potential(probe_characteristic, return_arg: bool = False):  # noqa: FBT002
     r"""Implement the simplest but crudest method for obtaining an estimate of
     the floating potential from the probe characteristic.
 
@@ -846,10 +846,10 @@ def extract_ion_section(probe_characteristic):
 
 def get_electron_temperature(
     exponential_section,
-    bimaxwellian: bool = False,
-    visualize: bool = False,
-    return_fit: bool = False,
-    return_hot_fraction: bool = False,
+    bimaxwellian: bool = False,  # noqa: FBT002
+    visualize: bool = False,  # noqa: FBT002
+    return_fit: bool = False,  # noqa: FBT002
+    return_hot_fraction: bool = False,  # noqa: FBT002
 ):
     r"""Obtain the Maxwellian or bi-Maxwellian electron temperature using the
     exponential fit method.
@@ -1022,7 +1022,7 @@ def get_electron_temperature(
 
 
 def extrapolate_electron_current(
-    probe_characteristic, fit, bimaxwellian: bool = False, visualize: bool = False
+    probe_characteristic, fit, bimaxwellian: bool = False, visualize: bool = False  # noqa: FBT002
 ):
     r"""Extrapolate the electron current from the Maxwellian electron
     temperature obtained in the exponential growth region.
@@ -1155,8 +1155,8 @@ def get_ion_density_OML(
     probe_characteristic: Characteristic,
     probe_area: u.Quantity[u.m**2],
     gas,
-    visualize: bool = False,
-    return_fit: bool = False,
+    visualize: bool = False,  # noqa: FBT002
+    return_fit: bool = False,  # noqa: FBT002
 ):
     r"""Implement the Orbital Motion Limit (OML) method of obtaining an
     estimate of the ion density.
@@ -1246,7 +1246,7 @@ def get_ion_density_OML(
     return (n_i_OML.to(u.m**-3), fit) if return_fit else n_i_OML.to(u.m**-3)
 
 
-def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = False):
+def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = False):  # noqa: FBT002
     r"""Extrapolate the ion current from the ion density obtained with the
     OML method.
 
@@ -1309,7 +1309,7 @@ def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = Fal
     return ion_characteristic
 
 
-def get_EEDF(probe_characteristic, visualize: bool = False):
+def get_EEDF(probe_characteristic, visualize: bool = False):  # noqa: FBT002
     r"""Implement the Druyvesteyn method of obtaining the normalized
     Electron Energy Distribution Function (EEDF).
 

--- a/src/plasmapy/diagnostics/langmuir.py
+++ b/src/plasmapy/diagnostics/langmuir.py
@@ -1022,7 +1022,10 @@ def get_electron_temperature(  # noqa: ANN201
 
 
 def extrapolate_electron_current(  # noqa: ANN201
-    probe_characteristic, fit, bimaxwellian: bool = False, visualize: bool = False  # noqa: FBT001, FBT002
+    probe_characteristic,
+    fit,
+    bimaxwellian: bool = False,  # noqa: FBT001, FBT002
+    visualize: bool = False,  # noqa: FBT001, FBT002
 ):
     r"""Extrapolate the electron current from the Maxwellian electron
     temperature obtained in the exponential growth region.

--- a/src/plasmapy/diagnostics/langmuir.py
+++ b/src/plasmapy/diagnostics/langmuir.py
@@ -125,7 +125,7 @@ class Characteristic:
         self.current = self.current[_sort]
         self.bias = self.bias[_sort]
 
-    def get_unique_bias(self, inplace: bool = False):  # noqa: FBT002
+    def get_unique_bias(self, inplace: bool = False):  # noqa: FBT001, FBT002
         r"""Remove any duplicate bias values through averaging."""
 
         if len(self.bias) != len(self.current):
@@ -169,7 +169,7 @@ class Characteristic:
         if len(np.unique(self.bias)) != len(self.bias):
             raise ValueError("Bias array contains duplicate values.")
 
-    def get_padded_limit(self, padding, log: bool = False):  # noqa: FBT002
+    def get_padded_limit(self, padding, log: bool = False):  # noqa: FBT001, FBT002
         r"""Return the limits of the current range for plotting, taking into
         account padding. Matplotlib lacks this functionality.
 
@@ -214,10 +214,10 @@ def swept_probe_analysis(  # noqa: PLR0915
     probe_characteristic,
     probe_area: u.Quantity[u.m**2],
     gas_argument,
-    bimaxwellian: bool = False,  # noqa: FBT002
-    visualize: bool = False,  # noqa: FBT002
-    plot_electron_fit: bool = False,  # noqa: FBT002
-    plot_EEDF: bool = False,  # noqa: FBT002
+    bimaxwellian: bool = False,  # noqa: FBT001, FBT002
+    visualize: bool = False,  # noqa: FBT001, FBT002
+    plot_electron_fit: bool = False,  # noqa: FBT001, FBT002
+    plot_EEDF: bool = False,  # noqa: FBT001, FBT002
 ):
     r"""Attempt to perform a basic swept probe analysis based on the provided
     characteristic and probe data. Suitable for single cylindrical probes in
@@ -448,7 +448,7 @@ def swept_probe_analysis(  # noqa: PLR0915
     return results
 
 
-def get_plasma_potential(probe_characteristic, return_arg: bool = False):  # noqa: FBT002
+def get_plasma_potential(probe_characteristic, return_arg: bool = False):  # noqa: FBT001, FBT002
     r"""Implement the simplest but crudest method for obtaining an estimate of
     the plasma potential from the probe characteristic.
 
@@ -501,7 +501,7 @@ def get_plasma_potential(probe_characteristic, return_arg: bool = False):  # noq
     return probe_characteristic.bias[arg_V_P]
 
 
-def get_floating_potential(probe_characteristic, return_arg: bool = False):  # noqa: FBT002
+def get_floating_potential(probe_characteristic, return_arg: bool = False):  # noqa: FBT001, FBT002
     r"""Implement the simplest but crudest method for obtaining an estimate of
     the floating potential from the probe characteristic.
 
@@ -846,10 +846,10 @@ def extract_ion_section(probe_characteristic):
 
 def get_electron_temperature(
     exponential_section,
-    bimaxwellian: bool = False,  # noqa: FBT002
-    visualize: bool = False,  # noqa: FBT002
-    return_fit: bool = False,  # noqa: FBT002
-    return_hot_fraction: bool = False,  # noqa: FBT002
+    bimaxwellian: bool = False,  # noqa: FBT001, FBT002
+    visualize: bool = False,  # noqa: FBT001, FBT002
+    return_fit: bool = False,  # noqa: FBT001, FBT002
+    return_hot_fraction: bool = False,  # noqa: FBT001, FBT002
 ):
     r"""Obtain the Maxwellian or bi-Maxwellian electron temperature using the
     exponential fit method.
@@ -1022,7 +1022,7 @@ def get_electron_temperature(
 
 
 def extrapolate_electron_current(
-    probe_characteristic, fit, bimaxwellian: bool = False, visualize: bool = False  # noqa: FBT002
+    probe_characteristic, fit, bimaxwellian: bool = False, visualize: bool = False  # noqa: FBT001, FBT002
 ):
     r"""Extrapolate the electron current from the Maxwellian electron
     temperature obtained in the exponential growth region.
@@ -1155,8 +1155,8 @@ def get_ion_density_OML(
     probe_characteristic: Characteristic,
     probe_area: u.Quantity[u.m**2],
     gas,
-    visualize: bool = False,  # noqa: FBT002
-    return_fit: bool = False,  # noqa: FBT002
+    visualize: bool = False,  # noqa: FBT001, FBT002
+    return_fit: bool = False,  # noqa: FBT001, FBT002
 ):
     r"""Implement the Orbital Motion Limit (OML) method of obtaining an
     estimate of the ion density.
@@ -1246,7 +1246,7 @@ def get_ion_density_OML(
     return (n_i_OML.to(u.m**-3), fit) if return_fit else n_i_OML.to(u.m**-3)
 
 
-def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = False):  # noqa: FBT002
+def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = False):  # noqa: FBT001, FBT002
     r"""Extrapolate the ion current from the ion density obtained with the
     OML method.
 
@@ -1309,7 +1309,7 @@ def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = Fal
     return ion_characteristic
 
 
-def get_EEDF(probe_characteristic, visualize: bool = False):  # noqa: FBT002
+def get_EEDF(probe_characteristic, visualize: bool = False):  # noqa: FBT001, FBT002
     r"""Implement the Druyvesteyn method of obtaining the normalized
     Electron Energy Distribution Function (EEDF).
 

--- a/src/plasmapy/diagnostics/langmuir.py
+++ b/src/plasmapy/diagnostics/langmuir.py
@@ -125,7 +125,7 @@ class Characteristic:
         self.current = self.current[_sort]
         self.bias = self.bias[_sort]
 
-    def get_unique_bias(self, inplace: bool = False):  # noqa: FBT001, FBT002
+    def get_unique_bias(self, inplace: bool = False):  # noqa: ANN201, FBT001, FBT002
         r"""Remove any duplicate bias values through averaging."""
 
         if len(self.bias) != len(self.current):
@@ -169,7 +169,7 @@ class Characteristic:
         if len(np.unique(self.bias)) != len(self.bias):
             raise ValueError("Bias array contains duplicate values.")
 
-    def get_padded_limit(self, padding, log: bool = False):  # noqa: FBT001, FBT002
+    def get_padded_limit(self, padding, log: bool = False):  # noqa: ANN201, FBT001, FBT002
         r"""Return the limits of the current range for plotting, taking into
         account padding. Matplotlib lacks this functionality.
 
@@ -210,7 +210,7 @@ class Characteristic:
 @validate_quantities(
     probe_area={"can_be_negative": False, "can_be_inf": False, "can_be_nan": False}
 )
-def swept_probe_analysis(  # noqa: PLR0915
+def swept_probe_analysis(  # noqa: ANN201, PLR0915
     probe_characteristic,
     probe_area: u.Quantity[u.m**2],
     gas_argument,
@@ -448,7 +448,7 @@ def swept_probe_analysis(  # noqa: PLR0915
     return results
 
 
-def get_plasma_potential(probe_characteristic, return_arg: bool = False):  # noqa: FBT001, FBT002
+def get_plasma_potential(probe_characteristic, return_arg: bool = False):  # noqa: ANN201, FBT001, FBT002
     r"""Implement the simplest but crudest method for obtaining an estimate of
     the plasma potential from the probe characteristic.
 
@@ -501,7 +501,7 @@ def get_plasma_potential(probe_characteristic, return_arg: bool = False):  # noq
     return probe_characteristic.bias[arg_V_P]
 
 
-def get_floating_potential(probe_characteristic, return_arg: bool = False):  # noqa: FBT001, FBT002
+def get_floating_potential(probe_characteristic, return_arg: bool = False):  # noqa: ANN201, FBT001, FBT002
     r"""Implement the simplest but crudest method for obtaining an estimate of
     the floating potential from the probe characteristic.
 
@@ -844,7 +844,7 @@ def extract_ion_section(probe_characteristic):
     return probe_characteristic[probe_characteristic.bias < V_F]
 
 
-def get_electron_temperature(
+def get_electron_temperature(  # noqa: ANN201
     exponential_section,
     bimaxwellian: bool = False,  # noqa: FBT001, FBT002
     visualize: bool = False,  # noqa: FBT001, FBT002
@@ -1021,7 +1021,7 @@ def get_electron_temperature(
     return k
 
 
-def extrapolate_electron_current(
+def extrapolate_electron_current(  # noqa: ANN201
     probe_characteristic, fit, bimaxwellian: bool = False, visualize: bool = False  # noqa: FBT001, FBT002
 ):
     r"""Extrapolate the electron current from the Maxwellian electron
@@ -1151,7 +1151,7 @@ def reduce_bimaxwellian_temperature(
 @validate_quantities(
     probe_area={"can_be_negative": False, "can_be_inf": False, "can_be_nan": False}
 )
-def get_ion_density_OML(
+def get_ion_density_OML(  # noqa: ANN201
     probe_characteristic: Characteristic,
     probe_area: u.Quantity[u.m**2],
     gas,
@@ -1246,7 +1246,7 @@ def get_ion_density_OML(
     return (n_i_OML.to(u.m**-3), fit) if return_fit else n_i_OML.to(u.m**-3)
 
 
-def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = False):  # noqa: FBT001, FBT002
+def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = False):  # noqa: ANN201, FBT001, FBT002
     r"""Extrapolate the ion current from the ion density obtained with the
     OML method.
 
@@ -1309,7 +1309,7 @@ def extrapolate_ion_current_OML(probe_characteristic, fit, visualize: bool = Fal
     return ion_characteristic
 
 
-def get_EEDF(probe_characteristic, visualize: bool = False):  # noqa: FBT001, FBT002
+def get_EEDF(probe_characteristic, visualize: bool = False):  # noqa: ANN201, FBT001, FBT002
     r"""Implement the Druyvesteyn method of obtaining the normalized
     Electron Energy Distribution Function (EEDF).
 

--- a/src/plasmapy/diagnostics/thomson.py
+++ b/src/plasmapy/diagnostics/thomson.py
@@ -638,7 +638,7 @@ def _count_populations_in_params(params: dict[str, Any], prefix: str) -> int:
 
 
 def _params_to_array(
-    params: dict[str, Any], prefix: str, vector: bool = False
+    params: dict[str, Any], prefix: str, vector: bool = False  # noqa: FBT002
 ) -> np.ndarray:
     """
     Constructs an array from the values contained in the dictionary

--- a/src/plasmapy/diagnostics/thomson.py
+++ b/src/plasmapy/diagnostics/thomson.py
@@ -638,7 +638,7 @@ def _count_populations_in_params(params: dict[str, Any], prefix: str) -> int:
 
 
 def _params_to_array(
-    params: dict[str, Any], prefix: str, vector: bool = False  # noqa: FBT002
+    params: dict[str, Any], prefix: str, vector: bool = False  # noqa: FBT001, FBT002
 ) -> np.ndarray:
     """
     Constructs an array from the values contained in the dictionary

--- a/src/plasmapy/diagnostics/thomson.py
+++ b/src/plasmapy/diagnostics/thomson.py
@@ -638,7 +638,9 @@ def _count_populations_in_params(params: dict[str, Any], prefix: str) -> int:
 
 
 def _params_to_array(
-    params: dict[str, Any], prefix: str, vector: bool = False  # noqa: FBT001, FBT002
+    params: dict[str, Any],
+    prefix: str,
+    vector: bool = False,  # noqa: FBT001, FBT002
 ) -> np.ndarray:
     """
     Constructs an array from the values contained in the dictionary

--- a/src/plasmapy/dispersion/analytical/mhd_waves_.py
+++ b/src/plasmapy/dispersion/analytical/mhd_waves_.py
@@ -390,7 +390,7 @@ class AlfvenWave(AbstractMHDWave):
     <Quantity 218060.97295233 m / s>
     """
 
-    def angular_frequency(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):
+    def angular_frequency(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):  # noqa: ANN201
         r"""
         Calculate the angular frequency of magnetohydrodynamic
         Alfvén waves.
@@ -462,7 +462,7 @@ class AlfvenWave(AbstractMHDWave):
         omega = k * self._Alfven_speed * np.abs(np.cos(theta))
         return super()._validate_angular_frequency(omega)
 
-    def group_velocity(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):
+    def group_velocity(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):  # noqa: ANN201
         r"""
         Calculate the group velocities of magnetohydrodynamic Alfvén
         waves.
@@ -613,7 +613,7 @@ class FastMagnetosonicWave(AbstractMHDWave):
     <Quantity 218060.97295233 m / s>
     """
 
-    def angular_frequency(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):
+    def angular_frequency(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):  # noqa: ANN201
         r"""
         Calculate the angular frequency of a fast magnetosonic waves.
 
@@ -704,7 +704,7 @@ class FastMagnetosonicWave(AbstractMHDWave):
         )
         return super()._validate_angular_frequency(omega)
 
-    def group_velocity(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):
+    def group_velocity(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):  # noqa: ANN201
         r"""
         Calculate the group velocities of fast magnetosonic waves.
 
@@ -859,7 +859,7 @@ class SlowMagnetosonicWave(AbstractMHDWave):
     <Quantity 185454.39417735 m / s>
     """
 
-    def angular_frequency(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):
+    def angular_frequency(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):  # noqa: ANN201
         r"""
         Calculate the angular frequency of slow magnetosonic waves.
 
@@ -947,7 +947,7 @@ class SlowMagnetosonicWave(AbstractMHDWave):
         )
         return super()._validate_angular_frequency(omega)
 
-    def group_velocity(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):
+    def group_velocity(self, k: u.Quantity[u.rad / u.m], theta: u.Quantity[u.rad]):  # noqa: ANN201
         r"""
         Calculate the group velocities of slow magnetosonic waves.
 

--- a/src/plasmapy/dispersion/analytical/mhd_waves_.py
+++ b/src/plasmapy/dispersion/analytical/mhd_waves_.py
@@ -137,7 +137,7 @@ class AbstractMHDWave(ABC):
         return np.meshgrid(theta, k)
 
     @validate_quantities
-    def _validate_angular_frequency(self, omega: u.Quantity[u.rad / u.s]):
+    def _validate_angular_frequency(self, omega: u.Quantity[u.rad / u.s]):  # noqa: ANN202
         """Validate and return angular frequency."""
         omega_gyrofrequency_max = np.max(omega / self._gyrofrequency)
         omega_plasma_frequency_max = np.max(omega / self._plasma_frequency)

--- a/src/plasmapy/dispersion/analytical/stix_.py
+++ b/src/plasmapy/dispersion/analytical/stix_.py
@@ -21,7 +21,7 @@ c_si_unitless = c.value
     n_i={"can_be_negative": False},
     w={"can_be_negative": False, "can_be_zero": False},
 )
-def stix(  # noqa: C901, PLR0912, PLR0915
+def stix(  # noqa: ANN201, C901, PLR0912, PLR0915
     B: u.Quantity[u.T],
     w: u.Quantity[u.rad / u.s],
     ions: Particle,

--- a/src/plasmapy/dispersion/analytical/two_fluid_.py
+++ b/src/plasmapy/dispersion/analytical/two_fluid_.py
@@ -26,7 +26,7 @@ from plasmapy.utils.exceptions import PhysicsWarning
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def two_fluid(
+def two_fluid(  # noqa: ANN201
     B: u.Quantity[u.T],
     ion: ParticleLike,
     k: u.Quantity[u.rad / u.m],

--- a/src/plasmapy/dispersion/numerical/hollweg_.py
+++ b/src/plasmapy/dispersion/numerical/hollweg_.py
@@ -28,7 +28,7 @@ c_si_unitless = c.value
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
 @particle_input
-def hollweg(  # noqa: C901, PLR0912, PLR0915
+def hollweg(  # noqa: ANN201, C901, PLR0912, PLR0915
     B: u.Quantity[u.T],
     ion: ParticleLike,
     k: u.Quantity[u.rad / u.m],

--- a/src/plasmapy/dispersion/numerical/kinetic_alfven_.py
+++ b/src/plasmapy/dispersion/numerical/kinetic_alfven_.py
@@ -28,7 +28,7 @@ c_si_unitless = c.value
     T_e={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_i={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def kinetic_alfven(  # noqa: C901, PLR0912
+def kinetic_alfven(  # noqa: ANN201, C901, PLR0912
     B: u.Quantity[u.T],
     ion: ParticleLike,
     k: u.Quantity[u.rad / u.m],

--- a/src/plasmapy/formulary/braginskii.py
+++ b/src/plasmapy/formulary/braginskii.py
@@ -1154,7 +1154,7 @@ def electron_viscosity(
     return ct.electron_viscosity
 
 
-def _nondim_thermal_conductivity(
+def _nondim_thermal_conductivity(  # noqa: ANN202
     hall, Z, particle, model, field_orientation, mu=None, theta: float | None = None
 ):
     """
@@ -1191,7 +1191,7 @@ def _nondim_thermal_conductivity(
     return kappa_hat
 
 
-def _nondim_viscosity(
+def _nondim_viscosity(  # noqa: ANN202
     hall,
     Z,
     particle,
@@ -2062,7 +2062,7 @@ def _nondim_visc_e_ji_held(hall, Z):
     return np.array((eta_0, eta_1, eta_2, eta_3, eta_4))
 
 
-def _nondim_tc_i_ji_held(hall, Z, mu, theta: float, field_orientation, K: int = 3):
+def _nondim_tc_i_ji_held(hall, Z, mu, theta: float, field_orientation, K: int = 3):  # noqa: ANN202
     """
     Dimensionless ion thermal conductivity — Ji-Held.
 
@@ -2143,7 +2143,7 @@ def _nondim_tc_i_ji_held(hall, Z, mu, theta: float, field_orientation, K: int = 
         )
 
 
-def _nondim_visc_i_ji_held(hall, Z, mu, theta: float, K: int = 3):
+def _nondim_visc_i_ji_held(hall, Z, mu, theta: float, K: int = 3):  # noqa: ANN202
     """
     Dimensionless ion viscosity — Ji-Held.
 

--- a/src/plasmapy/formulary/braginskii.py
+++ b/src/plasmapy/formulary/braginskii.py
@@ -849,7 +849,7 @@ def resistivity(
 
 
 @validate_quantities
-def thermoelectric_conductivity(
+def thermoelectric_conductivity(  # noqa: ANN201
     T_e,
     n_e,
     T_i,

--- a/src/plasmapy/formulary/collisions/coulomb.py
+++ b/src/plasmapy/formulary/collisions/coulomb.py
@@ -35,7 +35,7 @@ from plasmapy.utils.exceptions import CouplingWarning
     V={"none_shall_pass": True},
 )
 @particles.particle_input
-def Coulomb_logarithm(
+def Coulomb_logarithm(  # noqa: ANN201
     T: u.Quantity[u.K],
     n_e: u.Quantity[u.m**-3],
     species: (particles.Particle, particles.Particle),

--- a/src/plasmapy/formulary/collisions/frequencies.py
+++ b/src/plasmapy/formulary/collisions/frequencies.py
@@ -283,7 +283,7 @@ class SingleParticleCollisionFrequencies:
         """
         return np.sqrt(t) * np.exp(-t)
 
-    def _phi_explicit(self, x: float):
+    def _phi_explicit(self, x: float):  # noqa: ANN202
         """The non-vectorized method for evaluating the integral for phi."""
         integral, _ = scipy.integrate.quad(self._phi_integrand, 0, x)
         return integral

--- a/src/plasmapy/formulary/collisions/helio/collisional_analysis.py
+++ b/src/plasmapy/formulary/collisions/helio/collisional_analysis.py
@@ -16,7 +16,7 @@ from plasmapy.utils.decorators import validate_quantities
     T_1={"can_be_negative": False, "equivalencies": u.temperature_energy()},
     T_2={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
-def temp_ratio(  # noqa: C901
+def temp_ratio(  # noqa: ANN201, C901
     *,
     r_0: u.Quantity[u.au],
     r_n: u.Quantity[u.au],

--- a/src/plasmapy/formulary/collisions/helio/collisional_analysis.py
+++ b/src/plasmapy/formulary/collisions/helio/collisional_analysis.py
@@ -233,7 +233,7 @@ def temp_ratio(  # noqa: ANN201, C901
             )
 
     # Define differential equation function
-    def df_eq(
+    def df_eq(  # noqa: ANN202
         r_0,
         r_n,
         n_1_0,
@@ -262,7 +262,7 @@ def temp_ratio(  # noqa: ANN201, C901
         B = 1 / (u.cm * u.K) ** 1.5
 
         # Define Coulomb log for mixed ion collisions, see docstring
-        def lambda_ba(
+        def lambda_ba(  # noqa: ANN202
             theta: float,
             T_1,
             n_1,

--- a/src/plasmapy/formulary/collisions/lengths.py
+++ b/src/plasmapy/formulary/collisions/lengths.py
@@ -106,7 +106,7 @@ def impact_parameter_perp(
     n_e={"can_be_negative": False},
     V={"none_shall_pass": True},
 )
-def impact_parameter(  # noqa: C901
+def impact_parameter(  # noqa: ANN201, C901
     T: u.Quantity[u.K],
     n_e: u.Quantity[u.m**-3],
     species,

--- a/src/plasmapy/formulary/collisions/misc.py
+++ b/src/plasmapy/formulary/collisions/misc.py
@@ -33,7 +33,7 @@ _m_e = const.m_e
 
 @validate_quantities(T={"equivalencies": u.temperature_energy()})
 @particle_input
-def _process_inputs(T: u.Quantity[u.K], species: (Particle, Particle), V):
+def _process_inputs(T: u.Quantity[u.K], species: (Particle, Particle), V):  # noqa: ANN202
     """
     Helper function for processing inputs to functionality contained
     in `plasmapy.formulary.collisions`.

--- a/src/plasmapy/formulary/dimensionless.py
+++ b/src/plasmapy/formulary/dimensionless.py
@@ -113,7 +113,7 @@ nD_ = Debye_number
     T={"can_be_negative": False, "equivalencies": u.temperature_energy()},
 )
 @particle_input
-def Hall_parameter(
+def Hall_parameter(  # noqa: ANN201
     n: u.Quantity[u.m**-3],
     T: u.Quantity[u.K],
     B: u.Quantity[u.T],

--- a/src/plasmapy/formulary/distribution.py
+++ b/src/plasmapy/formulary/distribution.py
@@ -33,7 +33,7 @@ def _v_drift_conversion(v_drift: float | u.Quantity[u.m / u.s]):
 
 
 @particle_input
-def Maxwellian_1D(
+def Maxwellian_1D(  # noqa: ANN201
     v,
     T,
     particle: ParticleLike = "e-",
@@ -159,7 +159,7 @@ def Maxwellian_1D(
 
 
 @particle_input
-def Maxwellian_velocity_2D(
+def Maxwellian_velocity_2D(  # noqa: ANN201
     vx,
     vy,
     T,
@@ -309,7 +309,7 @@ def Maxwellian_velocity_2D(
 
 
 @particle_input
-def Maxwellian_velocity_3D(
+def Maxwellian_velocity_3D(  # noqa: ANN201
     vx,
     vy,
     vz,
@@ -475,7 +475,7 @@ def Maxwellian_velocity_3D(
 
 
 @particle_input
-def Maxwellian_speed_1D(
+def Maxwellian_speed_1D(  # noqa: ANN201
     v,
     T,
     particle: ParticleLike = "e-",
@@ -601,7 +601,7 @@ def Maxwellian_speed_1D(
 
 
 @particle_input
-def Maxwellian_speed_2D(
+def Maxwellian_speed_2D(  # noqa: ANN201
     v,
     T,
     particle: ParticleLike = "e-",
@@ -735,7 +735,7 @@ def Maxwellian_speed_2D(
 
 
 @particle_input
-def Maxwellian_speed_3D(
+def Maxwellian_speed_3D(  # noqa: ANN201
     v,
     T,
     particle: ParticleLike = "e-",
@@ -869,7 +869,7 @@ def Maxwellian_speed_3D(
 
 
 @particle_input
-def kappa_velocity_1D(
+def kappa_velocity_1D(  # noqa: ANN201
     v,
     T,
     kappa,
@@ -1024,7 +1024,7 @@ def kappa_velocity_1D(
 
 
 @particle_input
-def kappa_velocity_3D(
+def kappa_velocity_3D(  # noqa: ANN201
     vx,
     vy,
     vz,

--- a/src/plasmapy/formulary/distribution.py
+++ b/src/plasmapy/formulary/distribution.py
@@ -25,7 +25,7 @@ from plasmapy.utils._units_definitions import (
 )
 
 
-def _v_drift_conversion(v_drift: float | u.Quantity[u.m / u.s]):
+def _v_drift_conversion(v_drift: float | u.Quantity[u.m / u.s]):  # noqa: ANN202
     # Helper method to assign equivalent value in SPEED_UNITS and/or remove units
     if isinstance(v_drift, u.Quantity):
         v_drift = v_drift.to_value(SPEED_UNITS)

--- a/src/plasmapy/formulary/frequencies.py
+++ b/src/plasmapy/formulary/frequencies.py
@@ -43,7 +43,7 @@ eps0_si_unitless = eps0.value
 def gyrofrequency(
     B: u.Quantity[u.T],
     particle: ParticleLike,
-    signed: bool = False,  # noqa: FBT002
+    signed: bool = False,  # noqa: FBT001, FBT002
     Z: float | None = None,
     mass_numb: int | None = None,
 ) -> u.Quantity[u.rad / u.s]:
@@ -159,7 +159,7 @@ def plasma_frequency_lite(
     n: float,
     mass: float,
     Z: float,
-    to_hz: bool = False,  # noqa: FBT002
+    to_hz: bool = False,  # noqa: FBT001, FBT002
 ) -> float:
     r"""
     The :term:`lite-function` for

--- a/src/plasmapy/formulary/frequencies.py
+++ b/src/plasmapy/formulary/frequencies.py
@@ -43,7 +43,7 @@ eps0_si_unitless = eps0.value
 def gyrofrequency(
     B: u.Quantity[u.T],
     particle: ParticleLike,
-    signed: bool = False,
+    signed: bool = False,  # noqa: FBT002
     Z: float | None = None,
     mass_numb: int | None = None,
 ) -> u.Quantity[u.rad / u.s]:
@@ -159,7 +159,7 @@ def plasma_frequency_lite(
     n: float,
     mass: float,
     Z: float,
-    to_hz: bool = False,
+    to_hz: bool = False,  # noqa: FBT002
 ) -> float:
     r"""
     The :term:`lite-function` for

--- a/src/plasmapy/formulary/misc.py
+++ b/src/plasmapy/formulary/misc.py
@@ -18,7 +18,7 @@ from plasmapy.utils.decorators import validate_quantities
 __all__ += __aliases__
 
 
-def _grab_charge(ion: ParticleLike, z_mean=None):
+def _grab_charge(ion: ParticleLike, z_mean=None):  # noqa: ANN202
     """
     Merge two possible inputs for particle charge.
 

--- a/src/plasmapy/formulary/relativity.py
+++ b/src/plasmapy/formulary/relativity.py
@@ -17,7 +17,7 @@ from plasmapy.utils.exceptions import RelativityError
 
 
 @validate_quantities(V={"can_be_negative": True})
-def Lorentz_factor(V: u.Quantity[u.m / u.s]):
+def Lorentz_factor(V: u.Quantity[u.m / u.s]):  # noqa: ANN201
     r"""
     Return the Lorentz factor.
 

--- a/src/plasmapy/particles/_parsing.py
+++ b/src/plasmapy/particles/_parsing.py
@@ -127,7 +127,7 @@ def dealias_particle_aliases(alias: str | int) -> str:
     return alias  # ty:ignore[invalid-return-type]
 
 
-def invalid_particle_errmsg(
+def invalid_particle_errmsg(  # noqa: ANN202
     argument,
     mass_numb: int | None = None,
     Z: int | None = None,
@@ -149,7 +149,7 @@ def invalid_particle_errmsg(
     return errmsg
 
 
-def extract_charge(arg: str):  # noqa: C901
+def extract_charge(arg: str):  # noqa: ANN202, C901
     """
     Receive a `str` representing an element, isotope, or ion.
     Return a `tuple` containing a `str` that should represent an
@@ -223,7 +223,7 @@ def extract_charge(arg: str):  # noqa: C901
     return isotope_info, Z_from_arg
 
 
-def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
+def parse_and_check_atomic_input(  # noqa: ANN202, C901, PLR0912, PLR0915
     argument: str | int,
     mass_numb: int | None = None,
     Z: int | None = None,
@@ -272,7 +272,7 @@ def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
         correct type.
     """
 
-    def atomic_number_to_symbol(atomic_numb: int):
+    def atomic_number_to_symbol(atomic_numb: int):  # noqa: ANN202
         """
         Return the atomic symbol associated with an integer representing
         an atomic number, or raises an
@@ -284,7 +284,7 @@ def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
         else:
             raise InvalidParticleError(f"{atomic_numb} is not a valid atomic number.")
 
-    def extract_mass_number(isotope_info: str):
+    def extract_mass_number(isotope_info: str):  # noqa: ANN202
         """
         Receives a string representing an element or isotope. Return a
         tuple containing a string that should represent an element, and
@@ -358,7 +358,7 @@ def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
 
         return isotope
 
-    def reconstruct_ion_symbol(
+    def reconstruct_ion_symbol(  # noqa: ANN202
         element: str, isotope: int | None = None, Z: int | None = None
     ):
         """
@@ -476,7 +476,7 @@ def parse_and_check_atomic_input(  # noqa: C901, PLR0912, PLR0915
     }
 
 
-def parse_and_check_molecule_input(argument: str, Z: int | None = None):
+def parse_and_check_molecule_input(argument: str, Z: int | None = None):  # noqa: ANN202
     """
     Separate the constitutive elements and charge of a molecule symbol.
 

--- a/src/plasmapy/particles/atomic.py
+++ b/src/plasmapy/particles/atomic.py
@@ -1118,7 +1118,7 @@ def ionic_levels(
     )
 
 
-def _is_electron(arg: Any) -> bool:
+def _is_electron(arg: Any) -> bool:  # noqa: ANN401
     """
     Return `True` if the argument corresponds to an electron, and
     `False` otherwise.

--- a/src/plasmapy/particles/atomic.py
+++ b/src/plasmapy/particles/atomic.py
@@ -591,7 +591,7 @@ def known_isotopes(argument: ParticleLike | None = None) -> ParticleList:
 
 
 def common_isotopes(
-    argument: ParticleLike | None = None, most_common_only: bool = False  # noqa: FBT002
+    argument: ParticleLike | None = None, most_common_only: bool = False  # noqa: FBT001, FBT002
 ) -> ParticleList:
     """
     Return a list of isotopes of an element with an isotopic abundances
@@ -662,7 +662,7 @@ def common_isotopes(
     # TODO: Allow Particle objects representing elements to be inputs
 
     def common_isotopes_for_element(
-        argument: ParticleLike, most_common_only: bool | None
+        argument: ParticleLike, most_common_only: bool | None  # noqa: FBT001
     ) -> list[Particle]:
         isotopes = known_isotopes(argument)
 
@@ -712,7 +712,7 @@ def common_isotopes(
 
 
 def stable_isotopes(
-    argument: ParticleLike | None = None, unstable: bool = False  # noqa: FBT002
+    argument: ParticleLike | None = None, unstable: bool = False  # noqa: FBT001, FBT002
 ) -> ParticleList:
     """
     Return a list of all stable isotopes of an element, or if no input is
@@ -782,7 +782,7 @@ def stable_isotopes(
     # TODO: Allow Particle objects representing elements to be inputs
 
     def stable_isotopes_for_element(
-        argument: str | int, stable_only: bool | None
+        argument: str | int, stable_only: bool | None  # noqa: FBT001
     ) -> list[Particle]:
         KnownIsotopes = known_isotopes(argument)
         return [
@@ -1138,7 +1138,7 @@ def stopping_power(
     incident_particle: ParticleLike,
     material: str,
     energies: u.Quantity[u.MeV] | None = None,
-    return_interpolator: bool = False,  # noqa: FBT002
+    return_interpolator: bool = False,  # noqa: FBT001, FBT002
     component: Literal["total", "electronic", "nuclear"] = "total",
 ) -> (
     tuple[u.Quantity, u.Quantity]

--- a/src/plasmapy/particles/atomic.py
+++ b/src/plasmapy/particles/atomic.py
@@ -591,7 +591,7 @@ def known_isotopes(argument: ParticleLike | None = None) -> ParticleList:
 
 
 def common_isotopes(
-    argument: ParticleLike | None = None, most_common_only: bool = False
+    argument: ParticleLike | None = None, most_common_only: bool = False  # noqa: FBT002
 ) -> ParticleList:
     """
     Return a list of isotopes of an element with an isotopic abundances
@@ -712,7 +712,7 @@ def common_isotopes(
 
 
 def stable_isotopes(
-    argument: ParticleLike | None = None, unstable: bool = False
+    argument: ParticleLike | None = None, unstable: bool = False  # noqa: FBT002
 ) -> ParticleList:
     """
     Return a list of all stable isotopes of an element, or if no input is
@@ -1138,7 +1138,7 @@ def stopping_power(
     incident_particle: ParticleLike,
     material: str,
     energies: u.Quantity[u.MeV] | None = None,
-    return_interpolator: bool = False,
+    return_interpolator: bool = False,  # noqa: FBT002
     component: Literal["total", "electronic", "nuclear"] = "total",
 ) -> (
     tuple[u.Quantity, u.Quantity]

--- a/src/plasmapy/particles/atomic.py
+++ b/src/plasmapy/particles/atomic.py
@@ -591,7 +591,8 @@ def known_isotopes(argument: ParticleLike | None = None) -> ParticleList:
 
 
 def common_isotopes(
-    argument: ParticleLike | None = None, most_common_only: bool = False  # noqa: FBT001, FBT002
+    argument: ParticleLike | None = None,
+    most_common_only: bool = False,  # noqa: FBT001, FBT002
 ) -> ParticleList:
     """
     Return a list of isotopes of an element with an isotopic abundances
@@ -662,7 +663,8 @@ def common_isotopes(
     # TODO: Allow Particle objects representing elements to be inputs
 
     def common_isotopes_for_element(
-        argument: ParticleLike, most_common_only: bool | None  # noqa: FBT001
+        argument: ParticleLike,
+        most_common_only: bool | None,  # noqa: FBT001
     ) -> list[Particle]:
         isotopes = known_isotopes(argument)
 
@@ -712,7 +714,8 @@ def common_isotopes(
 
 
 def stable_isotopes(
-    argument: ParticleLike | None = None, unstable: bool = False  # noqa: FBT001, FBT002
+    argument: ParticleLike | None = None,
+    unstable: bool = False,  # noqa: FBT001, FBT002
 ) -> ParticleList:
     """
     Return a list of all stable isotopes of an element, or if no input is
@@ -782,7 +785,8 @@ def stable_isotopes(
     # TODO: Allow Particle objects representing elements to be inputs
 
     def stable_isotopes_for_element(
-        argument: str | int, stable_only: bool | None  # noqa: FBT001
+        argument: str | int,
+        stable_only: bool | None,  # noqa: FBT001
     ) -> list[Particle]:
         KnownIsotopes = known_isotopes(argument)
         return [

--- a/src/plasmapy/particles/decorators.py
+++ b/src/plasmapy/particles/decorators.py
@@ -59,7 +59,7 @@ _particle_input_annotations = (
 )
 
 
-def _make_into_set_or_none(obj: Any) -> Iterable[str] | None:
+def _make_into_set_or_none(obj: Any) -> Iterable[str] | None:  # noqa: ANN401
     """
     Return `None` if ``obj`` is `None`, and otherwise convert ``obj``
     into a `set`.
@@ -77,7 +77,7 @@ def _bind_arguments(
     callable_: Callable[..., Any],
     args: Iterable[Any],
     kwargs: MutableMapping[str, Any],
-    instance: Any = None,
+    instance: Any = None,  # noqa: ANN401
 ) -> inspect.BoundArguments:
     """
     Bind the arguments provided by ``args`` and ``kwargs`` to
@@ -527,10 +527,10 @@ class _ParticleInput:
     def process_argument(
         self,
         parameter: str,
-        argument: Any,
+        argument: Any,  # noqa: ANN401
         Z: float | None,
         mass_numb: int | None,
-    ) -> Any:
+    ) -> Any:  # noqa: ANN401
         """
         Process an argument that has an appropriate annotation.
 
@@ -645,7 +645,7 @@ class _ParticleInput:
         self,
         args: Iterable[Any],
         kwargs: MutableMapping[str, Any],
-        instance: Any = None,
+        instance: Any = None,  # noqa: ANN401
     ) -> BoundArguments:
         """
         Process the arguments passed to the callable_ callable.
@@ -992,7 +992,7 @@ def particle_input(
     @wrapt.decorator
     def wrapper(
         callable__: Callable[..., Any],
-        instance: Any,
+        instance: Any,  # noqa: ANN401
         args: Iterable[Any],
         kwargs: MutableMapping[str, Any],
     ) -> Callable[..., Any]:

--- a/src/plasmapy/particles/ionization_state_collection.py
+++ b/src/plasmapy/particles/ionization_state_collection.py
@@ -25,7 +25,7 @@ from plasmapy.particles.symbols import particle_symbol
 from plasmapy.utils.decorators import validate_quantities
 
 
-def _atomic_number_and_mass_number(p: ParticleLike):
+def _atomic_number_and_mass_number(p: ParticleLike):  # noqa: ANN202
     return p.atomic_number, p.mass_number if p.isotope else 0
 
 

--- a/src/plasmapy/particles/ionization_state_collection.py
+++ b/src/plasmapy/particles/ionization_state_collection.py
@@ -190,7 +190,7 @@ class IonizationStateCollection:  # noqa: PLW1641
     def __repr__(self) -> str:
         return self.__str__()
 
-    def __getitem__(self, *values) -> IonizationState | IonicLevel:
+    def __getitem__(self, *values) -> IonizationState | IonicLevel:  # noqa: ANN002
         errmsg = f"Invalid indexing for IonizationStateCollection instance: {values[0]}"
 
         one_input = not isinstance(values[0], tuple)

--- a/src/plasmapy/particles/nuclear.py
+++ b/src/plasmapy/particles/nuclear.py
@@ -107,7 +107,7 @@ def mass_energy(particle: Particle, mass_numb: int | None = None) -> u.Quantity[
     return particle.mass_energy
 
 
-def nuclear_reaction_energy(*args, **kwargs) -> u.Quantity[u.J]:  # noqa: ANN002, C901, PLR0915
+def nuclear_reaction_energy(*args, **kwargs) -> u.Quantity[u.J]:  # noqa: ANN002, ANN003, C901, PLR0915
     """
     Return the released energy from a nuclear reaction.
 

--- a/src/plasmapy/particles/nuclear.py
+++ b/src/plasmapy/particles/nuclear.py
@@ -107,7 +107,7 @@ def mass_energy(particle: Particle, mass_numb: int | None = None) -> u.Quantity[
     return particle.mass_energy
 
 
-def nuclear_reaction_energy(*args, **kwargs) -> u.Quantity[u.J]:  # noqa: C901, PLR0915
+def nuclear_reaction_energy(*args, **kwargs) -> u.Quantity[u.J]:  # noqa: ANN002, C901, PLR0915
     """
     Return the released energy from a nuclear reaction.
 

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -2112,7 +2112,7 @@ class DimensionlessParticle(AbstractParticle):
         return f"DimensionlessParticle(mass={self.mass}, charge={self.charge})"
 
     @staticmethod
-    def _validate_parameter(obj: Any, can_be_negative: bool = True) -> np.float64:  # noqa: FBT001, FBT002
+    def _validate_parameter(obj: Any, can_be_negative: bool = True) -> np.float64:  # noqa: ANN401, FBT001, FBT002
         """Verify that the argument corresponds to a valid real number."""
 
         # TODO: Replace with validator? Use an equivalency between

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -1782,7 +1782,9 @@ class Particle(AbstractPhysicalParticle):
         return self.is_category("ion")
 
     def ionize(
-        self, n: int | Literal[np.inf] = 1, inplace: bool = False  # noqa: FBT001, FBT002
+        self,
+        n: int | Literal[np.inf] = 1,
+        inplace: bool = False,  # noqa: FBT001, FBT002
     ) -> Self | None:
         """
         Create a new |Particle| instance corresponding to the current

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -236,7 +236,7 @@ class AbstractPhysicalParticle(AbstractParticle):
 
     def is_category(
         self,
-        *category_tuple,
+        *category_tuple,  # noqa: ANN002
         require: str | Iterable[str] | None = None,
         any_of: str | Iterable[str] | None = None,
         exclude: str | Iterable[str] | None = None,
@@ -2322,7 +2322,7 @@ class CustomParticle(AbstractPhysicalParticle):
     @classmethod
     def _from_quantities(
         cls,
-        *quantities,
+        *quantities,  # noqa: ANN002
         symbol: str | None = None,
         Z: float | None = None,
     ) -> Self:

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -1782,7 +1782,7 @@ class Particle(AbstractPhysicalParticle):
         return self.is_category("ion")
 
     def ionize(
-        self, n: int | Literal[np.inf] = 1, inplace: bool = False
+        self, n: int | Literal[np.inf] = 1, inplace: bool = False  # noqa: FBT002
     ) -> Self | None:
         """
         Create a new |Particle| instance corresponding to the current
@@ -1874,7 +1874,7 @@ class Particle(AbstractPhysicalParticle):
         else:
             return Particle(base_particle, Z=new_charge_number)  # ty:ignore[invalid-return-type]
 
-    def recombine(self, n: int = 1, inplace: bool = False) -> Self | None:
+    def recombine(self, n: int = 1, inplace: bool = False) -> Self | None:  # noqa: FBT002
         """
         Create a new |Particle| instance corresponding to the current
         |Particle| after undergoing recombination ``n`` times.
@@ -2112,7 +2112,7 @@ class DimensionlessParticle(AbstractParticle):
         return f"DimensionlessParticle(mass={self.mass}, charge={self.charge})"
 
     @staticmethod
-    def _validate_parameter(obj: Any, can_be_negative: bool = True) -> np.float64:
+    def _validate_parameter(obj: Any, can_be_negative: bool = True) -> np.float64:  # noqa: FBT002
         """Verify that the argument corresponds to a valid real number."""
 
         # TODO: Replace with validator? Use an equivalency between

--- a/src/plasmapy/particles/particle_class.py
+++ b/src/plasmapy/particles/particle_class.py
@@ -1782,7 +1782,7 @@ class Particle(AbstractPhysicalParticle):
         return self.is_category("ion")
 
     def ionize(
-        self, n: int | Literal[np.inf] = 1, inplace: bool = False  # noqa: FBT002
+        self, n: int | Literal[np.inf] = 1, inplace: bool = False  # noqa: FBT001, FBT002
     ) -> Self | None:
         """
         Create a new |Particle| instance corresponding to the current
@@ -1874,7 +1874,7 @@ class Particle(AbstractPhysicalParticle):
         else:
             return Particle(base_particle, Z=new_charge_number)  # ty:ignore[invalid-return-type]
 
-    def recombine(self, n: int = 1, inplace: bool = False) -> Self | None:  # noqa: FBT002
+    def recombine(self, n: int = 1, inplace: bool = False) -> Self | None:  # noqa: FBT001, FBT002
         """
         Create a new |Particle| instance corresponding to the current
         |Particle| after undergoing recombination ``n`` times.
@@ -2112,7 +2112,7 @@ class DimensionlessParticle(AbstractParticle):
         return f"DimensionlessParticle(mass={self.mass}, charge={self.charge})"
 
     @staticmethod
-    def _validate_parameter(obj: Any, can_be_negative: bool = True) -> np.float64:  # noqa: FBT002
+    def _validate_parameter(obj: Any, can_be_negative: bool = True) -> np.float64:  # noqa: FBT001, FBT002
         """Verify that the argument corresponds to a valid real number."""
 
         # TODO: Replace with validator? Use an equivalency between

--- a/src/plasmapy/particles/particle_collections.py
+++ b/src/plasmapy/particles/particle_collections.py
@@ -438,7 +438,7 @@ class ParticleList(collections.UserList):
             default=np.nan * u.J,
         )
 
-    def sort(self, key: Callable | None = None, reverse: bool = False):  # noqa: FBT002
+    def sort(self, key: Callable | None = None, reverse: bool = False):  # noqa: FBT001, FBT002
         """
         Sort the |ParticleList| in-place.
 

--- a/src/plasmapy/particles/particle_collections.py
+++ b/src/plasmapy/particles/particle_collections.py
@@ -317,7 +317,7 @@ class ParticleList(collections.UserList):
     @overload
     def is_category(
         self,
-        *category_tuple,
+        *category_tuple,  # noqa: ANN002
         require: str | Iterable[str] | None = None,
         any_of: str | Iterable[str] | None = None,
         exclude: str | Iterable[str] | None = None,
@@ -327,7 +327,7 @@ class ParticleList(collections.UserList):
     @overload
     def is_category(
         self,
-        *category_tuple,
+        *category_tuple,  # noqa: ANN002
         require: str | Iterable[str] | None = None,
         any_of: str | Iterable[str] | None = None,
         exclude: str | Iterable[str] | None = None,

--- a/src/plasmapy/particles/particle_collections.py
+++ b/src/plasmapy/particles/particle_collections.py
@@ -438,7 +438,7 @@ class ParticleList(collections.UserList):
             default=np.nan * u.J,
         )
 
-    def sort(self, key: Callable | None = None, reverse: bool = False):
+    def sort(self, key: Callable | None = None, reverse: bool = False):  # noqa: FBT002
         """
         Sort the |ParticleList| in-place.
 

--- a/src/plasmapy/particles/serialization.py
+++ b/src/plasmapy/particles/serialization.py
@@ -35,7 +35,7 @@ class ParticleJSONDecoder(json.JSONDecoder):
         Any keyword accepted by `~json.JSONDecoder`.
     """
 
-    def __init__(self, *, object_hook=None, **kwargs) -> None:
+    def __init__(self, *, object_hook=None, **kwargs) -> None:  # noqa: ANN003
         if object_hook is None:
             object_hook = self.particle_hook
         json.JSONDecoder.__init__(self, object_hook=object_hook, **kwargs)

--- a/src/plasmapy/plasma/grids.py
+++ b/src/plasmapy/plasma/grids.py
@@ -28,7 +28,7 @@ from scipy.special import erf
 from plasmapy.utils.decorators.helpers import modify_docstring
 
 
-def _detect_is_uniform_grid(pts0, pts1, pts2, tol: float = 1e-6):
+def _detect_is_uniform_grid(pts0, pts1, pts2, tol: float = 1e-6):  # noqa: ANN202
     r"""
     Determine whether a grid is uniform (uniformly spaced) by computing the
     variance of the grid gradients.
@@ -399,7 +399,7 @@ class AbstractGrid(ABC):
         """
         return self._si_factors
 
-    def _get_ax(self, *, axis: int, si: bool = False):
+    def _get_ax(self, *, axis: int, si: bool = False):  # noqa: ANN202
         """
         Helper function for retrieving axis values.
 
@@ -433,7 +433,7 @@ class AbstractGrid(ABC):
         vals = self.ds.coords[ax_name].to_numpy()
         return vals * self.si_scale_factors[axis] if si else vals * self.units[axis]
 
-    def _get_dax(self, *, axis: int, si: bool = False):
+    def _get_dax(self, *, axis: int, si: bool = False):  # noqa: ANN202
         """
         Helper function for calculating grid spacing.
 
@@ -819,7 +819,7 @@ class AbstractGrid(ABC):
             pts2 * units[2],
         )
 
-    def _make_mesh(self, start, stop, num: int, **kwargs):
+    def _make_mesh(self, start, stop, num: int, **kwargs):  # noqa: ANN202
         r"""
         Creates mesh as part of _make_grid(). Separated into its own function
         so it can be re-implemented to make non-uniformly spaced meshes.
@@ -1434,7 +1434,7 @@ class NonUniformCartesianGrid(AbstractGrid):
 
         return Tmin < Tmax
 
-    def _make_mesh(self, start, stop, num: int, **kwargs):
+    def _make_mesh(self, start, stop, num: int, **kwargs):  # noqa: ANN202
         r"""
         Creates mesh as part of ``_make_grid()``. Separated into its own
         function so it can be re-implemented to make non-uniform grids.

--- a/src/plasmapy/plasma/grids.py
+++ b/src/plasmapy/plasma/grids.py
@@ -926,7 +926,10 @@ class AbstractGrid(ABC):
 
     @abstractmethod
     def nearest_neighbor_interpolator(
-        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False  # noqa: ANN002
+        self,
+        pos: np.ndarray | u.Quantity,
+        *args,  # noqa: ANN002
+        persistent: bool = False,  # noqa: ANN002, RUF100
     ):
         r"""
         Interpolate values on the grid using a nearest-neighbor scheme with
@@ -1168,7 +1171,10 @@ class CartesianGrid(AbstractGrid):
 
     @modify_docstring(prepend=AbstractGrid.nearest_neighbor_interpolator.__doc__)
     def nearest_neighbor_interpolator(  # noqa: ANN201
-        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False  # noqa: ANN002
+        self,
+        pos: np.ndarray | u.Quantity,
+        *args,  # noqa: ANN002
+        persistent: bool = False,  # noqa: ANN002, RUF100
     ):
         r""" """  # noqa: D419
 
@@ -1207,7 +1213,10 @@ class CartesianGrid(AbstractGrid):
         return output[0] if len(output) == 1 else tuple(output)
 
     def volume_averaged_interpolator(  # noqa: ANN201
-        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False  # noqa: ANN002
+        self,
+        pos: np.ndarray | u.Quantity,
+        *args,  # noqa: ANN002
+        persistent: bool = False,  # noqa: ANN002, RUF100
     ):
         r"""
         Interpolate values on the grid using a volume-averaged scheme with
@@ -1471,7 +1480,10 @@ class NonUniformCartesianGrid(AbstractGrid):
 
     @modify_docstring(prepend=AbstractGrid.nearest_neighbor_interpolator.__doc__)
     def nearest_neighbor_interpolator(  # noqa: ANN201
-        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False  # noqa: ANN002
+        self,
+        pos: np.ndarray | u.Quantity,
+        *args,  # noqa: ANN002
+        persistent: bool = False,  # noqa: ANN002, RUF100
     ):
         r""" """  # noqa: D419
         # Shared setup

--- a/src/plasmapy/plasma/grids.py
+++ b/src/plasmapy/plasma/grids.py
@@ -151,8 +151,8 @@ class AbstractGrid(ABC):
     def require_quantities(
         self,
         req_quantities: Iterable[str],
-        replace_with_zeros: bool = False,
-        warn_on_replace_with_zeros: bool = True,
+        replace_with_zeros: bool = False,  # noqa: FBT002
+        warn_on_replace_with_zeros: bool = True,  # noqa: FBT002
     ):
         r"""
         Check to make sure that a list of required quantities are present.

--- a/src/plasmapy/plasma/grids.py
+++ b/src/plasmapy/plasma/grids.py
@@ -926,7 +926,7 @@ class AbstractGrid(ABC):
 
     @abstractmethod
     def nearest_neighbor_interpolator(
-        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
+        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False  # noqa: ANN002
     ):
         r"""
         Interpolate values on the grid using a nearest-neighbor scheme with
@@ -1168,7 +1168,7 @@ class CartesianGrid(AbstractGrid):
 
     @modify_docstring(prepend=AbstractGrid.nearest_neighbor_interpolator.__doc__)
     def nearest_neighbor_interpolator(  # noqa: ANN201
-        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
+        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False  # noqa: ANN002
     ):
         r""" """  # noqa: D419
 
@@ -1207,7 +1207,7 @@ class CartesianGrid(AbstractGrid):
         return output[0] if len(output) == 1 else tuple(output)
 
     def volume_averaged_interpolator(  # noqa: ANN201
-        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
+        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False  # noqa: ANN002
     ):
         r"""
         Interpolate values on the grid using a volume-averaged scheme with
@@ -1471,7 +1471,7 @@ class NonUniformCartesianGrid(AbstractGrid):
 
     @modify_docstring(prepend=AbstractGrid.nearest_neighbor_interpolator.__doc__)
     def nearest_neighbor_interpolator(  # noqa: ANN201
-        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
+        self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False  # noqa: ANN002
     ):
         r""" """  # noqa: D419
         # Shared setup

--- a/src/plasmapy/plasma/grids.py
+++ b/src/plasmapy/plasma/grids.py
@@ -1167,7 +1167,7 @@ class CartesianGrid(AbstractGrid):
             self.ds[quantity].data = self.ds[quantity].data * mask * edge_mask
 
     @modify_docstring(prepend=AbstractGrid.nearest_neighbor_interpolator.__doc__)
-    def nearest_neighbor_interpolator(
+    def nearest_neighbor_interpolator(  # noqa: ANN201
         self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
     ):
         r""" """  # noqa: D419
@@ -1206,7 +1206,7 @@ class CartesianGrid(AbstractGrid):
         ]
         return output[0] if len(output) == 1 else tuple(output)
 
-    def volume_averaged_interpolator(
+    def volume_averaged_interpolator(  # noqa: ANN201
         self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
     ):
         r"""
@@ -1470,7 +1470,7 @@ class NonUniformCartesianGrid(AbstractGrid):
         )
 
     @modify_docstring(prepend=AbstractGrid.nearest_neighbor_interpolator.__doc__)
-    def nearest_neighbor_interpolator(
+    def nearest_neighbor_interpolator(  # noqa: ANN201
         self, pos: np.ndarray | u.Quantity, *args, persistent: bool = False
     ):
         r""" """  # noqa: D419

--- a/src/plasmapy/plasma/grids.py
+++ b/src/plasmapy/plasma/grids.py
@@ -79,7 +79,7 @@ class AbstractGrid(ABC):
 
     """
 
-    def __init__(self, *seeds: Sequence[u.Quantity], num: int = 100, **kwargs) -> None:
+    def __init__(self, *seeds: Sequence[u.Quantity], num: int = 100, **kwargs) -> None:  # noqa: ANN003
         # Initialize some variables
         self._interpolator = None
         self._is_uniform = None
@@ -693,7 +693,7 @@ class AbstractGrid(ABC):
         stop: float | u.Quantity,
         num: int = 100,
         units=None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         r"""
         Creates a grid based on ``start``, ``stop``, and ``num`` values
@@ -819,7 +819,7 @@ class AbstractGrid(ABC):
             pts2 * units[2],
         )
 
-    def _make_mesh(self, start, stop, num: int, **kwargs):  # noqa: ANN202
+    def _make_mesh(self, start, stop, num: int, **kwargs):  # noqa: ANN003, ANN202
         r"""
         Creates mesh as part of _make_grid(). Separated into its own function
         so it can be re-implemented to make non-uniformly spaced meshes.
@@ -1434,7 +1434,7 @@ class NonUniformCartesianGrid(AbstractGrid):
 
         return Tmin < Tmax
 
-    def _make_mesh(self, start, stop, num: int, **kwargs):  # noqa: ANN202
+    def _make_mesh(self, start, stop, num: int, **kwargs):  # noqa: ANN003, ANN202
         r"""
         Creates mesh as part of ``_make_grid()``. Separated into its own
         function so it can be re-implemented to make non-uniform grids.

--- a/src/plasmapy/plasma/grids.py
+++ b/src/plasmapy/plasma/grids.py
@@ -151,8 +151,8 @@ class AbstractGrid(ABC):
     def require_quantities(
         self,
         req_quantities: Iterable[str],
-        replace_with_zeros: bool = False,  # noqa: FBT002
-        warn_on_replace_with_zeros: bool = True,  # noqa: FBT002
+        replace_with_zeros: bool = False,  # noqa: FBT001, FBT002
+        warn_on_replace_with_zeros: bool = True,  # noqa: FBT001, FBT002
     ):
         r"""
         Check to make sure that a list of required quantities are present.

--- a/src/plasmapy/plasma/plasma_base.py
+++ b/src/plasmapy/plasma/plasma_base.py
@@ -31,7 +31,7 @@ class BasePlasma(ABC):
     # GenericPlasma subclass registry
     _registry: ClassVar[dict[type, Callable]] = {}
 
-    def __init_subclass__(cls, **kwargs) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:  # noqa: ANN003
         super().__init_subclass__(**kwargs)
         if hasattr(cls, "is_datasource_for"):
             cls._registry[cls] = cls.is_datasource_for  # ty:ignore[invalid-assignment]
@@ -78,7 +78,7 @@ class GenericPlasma(BasePlasma):
     methods declared in the `~plasmapy.plasma.plasma_base.BasePlasma`.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
         pass
 
     # The definitions for the abstract methods declared in `BasePlasma`

--- a/src/plasmapy/plasma/sources/openpmd_hdf5.py
+++ b/src/plasmapy/plasma/sources/openpmd_hdf5.py
@@ -55,7 +55,7 @@ class HDF5Reader(GenericPlasma):
         Any keyword accepted by `~plasmapy.plasma.plasma_base.GenericPlasma`.
     """
 
-    def __init__(self, hdf5, **kwargs) -> None:
+    def __init__(self, hdf5, **kwargs) -> None:  # noqa: ANN003
         super().__init__(**kwargs)
 
         if not Path(hdf5).is_file():

--- a/src/plasmapy/plasma/sources/plasma3d.py
+++ b/src/plasmapy/plasma/sources/plasma3d.py
@@ -39,7 +39,7 @@ class Plasma3D(GenericPlasma):
     """
 
     @validate_quantities(domain_x=u.m, domain_y=u.m, domain_z=u.m)
-    def __init__(self, domain_x, domain_y, domain_z, **kwargs) -> None:
+    def __init__(self, domain_x, domain_y, domain_z, **kwargs) -> None:  # noqa: ANN003
         super().__init__(**kwargs)
 
         # Define domain sizes

--- a/src/plasmapy/plasma/sources/plasmablob.py
+++ b/src/plasmapy/plasma/sources/plasmablob.py
@@ -146,5 +146,5 @@ class PlasmaBlob(GenericPlasma):
         return quantum_theta(self.T_e, self.n_e)
 
     @classmethod
-    def is_datasource_for(cls, **kwargs) -> bool:
+    def is_datasource_for(cls, **kwargs) -> bool:  # noqa: ANN003
         return "T_e" in kwargs and "n_e" in kwargs

--- a/src/plasmapy/simulation/particle_tracker/particle_tracker.py
+++ b/src/plasmapy/simulation/particle_tracker/particle_tracker.py
@@ -175,7 +175,7 @@ class ParticleTracker:
         dt=None,
         dt_range=None,
         field_weighting: str = "volume averaged",
-        verbose: bool = True,
+        verbose: bool = True,  # noqa: FBT002
     ) -> None:
         # Verbose flag controls whether or not output is printed to stdout
         self.verbose = verbose

--- a/src/plasmapy/simulation/particle_tracker/particle_tracker.py
+++ b/src/plasmapy/simulation/particle_tracker/particle_tracker.py
@@ -175,7 +175,7 @@ class ParticleTracker:
         dt=None,
         dt_range=None,
         field_weighting: str = "volume averaged",
-        verbose: bool = True,  # noqa: FBT002
+        verbose: bool = True,  # noqa: FBT001, FBT002
     ) -> None:
         # Verbose flag controls whether or not output is printed to stdout
         self.verbose = verbose

--- a/src/plasmapy/simulation/particle_tracker/save_routines.py
+++ b/src/plasmapy/simulation/particle_tracker/save_routines.py
@@ -199,7 +199,7 @@ class SaveOnceOnCompletion(AbstractSaveRoutine):
 class IntervalSaveRoutine(AbstractSaveRoutine):
     """Abstract class describing a save routine that saves every given interval."""
 
-    def __init__(self, interval: u.Quantity, **kwargs) -> None:
+    def __init__(self, interval: u.Quantity, **kwargs) -> None:  # noqa: ANN003
         super().__init__(**kwargs)
 
         self._quantities = {

--- a/src/plasmapy/tests/_helpers/tests/sample_functions.py
+++ b/src/plasmapy/tests/_helpers/tests/sample_functions.py
@@ -90,7 +90,7 @@ def return_none() -> None:
 class SampleClass1:
     """A sample class to be used for testing purposes."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002
         pass
 
     @classmethod

--- a/src/plasmapy/tests/_helpers/tests/sample_functions.py
+++ b/src/plasmapy/tests/_helpers/tests/sample_functions.py
@@ -90,7 +90,7 @@ def return_none() -> None:
 class SampleClass1:
     """A sample class to be used for testing purposes."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         pass
 
     @classmethod

--- a/src/plasmapy/utils/_pytest_helpers/pytest_helpers.py
+++ b/src/plasmapy/utils/_pytest_helpers/pytest_helpers.py
@@ -418,7 +418,7 @@ def run_test(  # noqa: C901
 
 
 def run_test_equivalent_calls(  # noqa: C901
-    *test_inputs,
+    *test_inputs,  # noqa: ANN002
     require_same_type: bool = True,
 ):
     """

--- a/src/plasmapy/utils/_pytest_helpers/pytest_helpers.py
+++ b/src/plasmapy/utils/_pytest_helpers/pytest_helpers.py
@@ -68,9 +68,9 @@ def _process_input(wrapped_function: Callable):  # noqa: ANN202
 @_process_input
 def run_test(  # noqa: C901
     func,
-    args: Any = (),
+    args: Any = (),  # noqa: ANN401
     kwargs: dict | None = None,
-    expected_outcome: Any = None,
+    expected_outcome: Any = None,  # noqa: ANN401
     rtol: float = 0.0,
     atol: float = 0.0,
 ):

--- a/src/plasmapy/utils/_pytest_helpers/pytest_helpers.py
+++ b/src/plasmapy/utils/_pytest_helpers/pytest_helpers.py
@@ -32,7 +32,7 @@ from plasmapy.utils.code_repr import _name_with_article, _object_name, call_stri
 from plasmapy.utils.exceptions import PlasmaPyWarning
 
 
-def _process_input(wrapped_function: Callable):
+def _process_input(wrapped_function: Callable):  # noqa: ANN202
     """
     Allow `run_test` to take a single positional argument that is a
     `list` or `tuple` in lieu of using multiple positional/keyword
@@ -41,7 +41,7 @@ def _process_input(wrapped_function: Callable):
     result/outcome is the last item.
     """
 
-    def decorator(wrapped_function: Callable):
+    def decorator(wrapped_function: Callable):  # noqa: ANN202
         wrapped_signature = inspect.signature(wrapped_function)
 
         @functools.wraps(wrapped_function)
@@ -689,7 +689,7 @@ def assert_can_handle_nparray(  # noqa: C901
     if kwargs is None:
         kwargs = {}
 
-    def _prepare_input(  # noqa: C901
+    def _prepare_input(  # noqa: ANN202, C901
         param_name: str, param_default, insert_some_nans, insert_all_nans, kwargs
     ):
         """

--- a/src/plasmapy/utils/code_repr.py
+++ b/src/plasmapy/utils/code_repr.py
@@ -29,7 +29,7 @@ def _code_repr_of_ndarray(array: np.ndarray, max_items=np.inf) -> str:
         s = s.replace("inf", "np.inf")
         return s.replace("nan", "np.nan")
 
-    def replace_excess_items_with_ellipsis(s: str, max_items: int):
+    def replace_excess_items_with_ellipsis(s: str, max_items: int):  # noqa: ANN202
         substrings_between_commas = s.split(",")
         to_comma_before_ellipsis = ",".join(substrings_between_commas[:max_items])
         closing_brackets = "]" * substrings_between_commas[-1].count("]")
@@ -147,7 +147,7 @@ def _object_name(obj: Any, showmodule: bool = False) -> str:  # noqa: FBT001, FB
     in `astropy.units`.
     """
 
-    def substitute_module_shortcuts(module_name: str):
+    def substitute_module_shortcuts(module_name: str):  # noqa: ANN202
         """Substitute common import shortcuts within module names."""
         replacements = {
             "numpy": "np",
@@ -170,7 +170,7 @@ def _object_name(obj: Any, showmodule: bool = False) -> str:  # noqa: FBT001, FB
     return obj_name
 
 
-def _string_together_warnings_for_printing(
+def _string_together_warnings_for_printing(  # noqa: ANN202
     warning_types: list[Warning], warning_messages: list[str]
 ):
     """

--- a/src/plasmapy/utils/code_repr.py
+++ b/src/plasmapy/utils/code_repr.py
@@ -89,7 +89,9 @@ def _code_repr_of_arg(arg, max_items=np.inf) -> str:
 
 
 def _code_repr_of_args_and_kwargs(
-    args: Any = None, kwargs: dict | None = None, max_items=np.inf  # noqa: ANN401
+    args: Any = None,  # noqa: ANN401
+    kwargs: dict | None = None,
+    max_items=np.inf,  # noqa: ANN401, RUF100
 ) -> str:
     """
     Take positional and keyword arguments, and format them into a

--- a/src/plasmapy/utils/code_repr.py
+++ b/src/plasmapy/utils/code_repr.py
@@ -137,7 +137,7 @@ def _name_with_article(ex: Exception) -> str:
     return f"{indefinite_article} {name}"
 
 
-def _object_name(obj: Any, showmodule: bool = False) -> str:  # noqa: FBT002
+def _object_name(obj: Any, showmodule: bool = False) -> str:  # noqa: FBT001, FBT002
     """
     Return the name of an `object`.
 

--- a/src/plasmapy/utils/code_repr.py
+++ b/src/plasmapy/utils/code_repr.py
@@ -137,7 +137,7 @@ def _name_with_article(ex: Exception) -> str:
     return f"{indefinite_article} {name}"
 
 
-def _object_name(obj: Any, showmodule: bool = False) -> str:
+def _object_name(obj: Any, showmodule: bool = False) -> str:  # noqa: FBT002
     """
     Return the name of an `object`.
 

--- a/src/plasmapy/utils/code_repr.py
+++ b/src/plasmapy/utils/code_repr.py
@@ -89,7 +89,7 @@ def _code_repr_of_arg(arg, max_items=np.inf) -> str:
 
 
 def _code_repr_of_args_and_kwargs(
-    args: Any = None, kwargs: dict | None = None, max_items=np.inf
+    args: Any = None, kwargs: dict | None = None, max_items=np.inf  # noqa: ANN401
 ) -> str:
     """
     Take positional and keyword arguments, and format them into a
@@ -137,7 +137,7 @@ def _name_with_article(ex: Exception) -> str:
     return f"{indefinite_article} {name}"
 
 
-def _object_name(obj: Any, showmodule: bool = False) -> str:  # noqa: FBT001, FBT002
+def _object_name(obj: Any, showmodule: bool = False) -> str:  # noqa: ANN401, FBT001, FBT002
     """
     Return the name of an `object`.
 
@@ -188,7 +188,7 @@ def _string_together_warnings_for_printing(  # noqa: ANN202
 
 def call_string(
     f: Callable,
-    args: Any = None,
+    args: Any = None,  # noqa: ANN401
     kwargs: dict[str, Any] | None = None,
     max_items: int = 12,
 ) -> str:
@@ -250,7 +250,7 @@ def call_string(
 def attribute_call_string(
     cls,
     attr: str,
-    args_to_cls: tuple | Any | None = None,
+    args_to_cls: tuple | Any | None = None,  # noqa: ANN401
     kwargs_to_cls: dict[str, Any] | None = None,
     max_items: int = 12,
 ) -> str:
@@ -325,9 +325,9 @@ def method_call_string(
     cls,
     method: str,
     *,
-    args_to_cls: Any | None = None,
+    args_to_cls: Any | None = None,  # noqa: ANN401
     kwargs_to_cls: dict[str, Any] | None = None,
-    args_to_method: Any | None = None,
+    args_to_method: Any | None = None,  # noqa: ANN401
     kwargs_to_method: dict[str, Any] | None = None,
     max_items: int = 12,
 ) -> str:

--- a/src/plasmapy/utils/data/downloader.py
+++ b/src/plasmapy/utils/data/downloader.py
@@ -75,7 +75,7 @@ class Downloader:
     def __init__(
         self,
         directory: Path | None = None,
-        validate: bool = True,
+        validate: bool = True,  # noqa: FBT002
         api_token: str | None = None,
     ) -> None:
         if directory is None:

--- a/src/plasmapy/utils/data/downloader.py
+++ b/src/plasmapy/utils/data/downloader.py
@@ -75,7 +75,7 @@ class Downloader:
     def __init__(
         self,
         directory: Path | None = None,
-        validate: bool = True,  # noqa: FBT002
+        validate: bool = True,  # noqa: FBT001, FBT002
         api_token: str | None = None,
     ) -> None:
         if directory is None:

--- a/src/plasmapy/utils/datatype_factory_base.py
+++ b/src/plasmapy/utils/datatype_factory_base.py
@@ -137,7 +137,7 @@ class BasicRegistrationFactory:
 
         return WidgetType(*args, **kwargs)
 
-    def register(self, WidgetType, validation_function=None, is_default: bool = False):
+    def register(self, WidgetType, validation_function=None, is_default: bool = False):  # noqa: FBT002
         """Register a widget with the factory.
 
         If ``validation_function`` is not specified, tests ``WidgetType`` for

--- a/src/plasmapy/utils/datatype_factory_base.py
+++ b/src/plasmapy/utils/datatype_factory_base.py
@@ -137,7 +137,7 @@ class BasicRegistrationFactory:
 
         return WidgetType(*args, **kwargs)
 
-    def register(self, WidgetType, validation_function=None, is_default: bool = False):  # noqa: FBT002
+    def register(self, WidgetType, validation_function=None, is_default: bool = False):  # noqa: FBT001, FBT002
         """Register a widget with the factory.
 
         If ``validation_function`` is not specified, tests ``WidgetType`` for

--- a/src/plasmapy/utils/decorators/checks.py
+++ b/src/plasmapy/utils/decorators/checks.py
@@ -900,7 +900,7 @@ class CheckUnits(CheckBase):
     @staticmethod
     def _condition_target_units(
         targets: list[str | u.Unit | u.Quantity],
-        from_annotations: bool = False,  # noqa: FBT002
+        from_annotations: bool = False,  # noqa: FBT001, FBT002
     ) -> list:
         """
         From a `list` of target objects that have or represent units,

--- a/src/plasmapy/utils/decorators/checks.py
+++ b/src/plasmapy/utils/decorators/checks.py
@@ -1052,7 +1052,7 @@ class CheckUnits(CheckBase):
         return new_list
 
 
-def check_units(
+def check_units(  # noqa: ANN201
     func=None,
     checks_on_return: dict[str, Any] | None = None,
     **checks: dict[str, Any],
@@ -1177,7 +1177,7 @@ def check_units(
     return CheckUnits(**checks)(func) if func is not None else CheckUnits(**checks)
 
 
-def check_values(
+def check_values(  # noqa: ANN201
     func=None,
     checks_on_return: dict[str, bool] | None = None,
     **checks: dict[str, bool],
@@ -1257,7 +1257,7 @@ def check_values(
     return CheckValues(**checks) if func is None else CheckValues(**checks)(func)
 
 
-def check_relativistic(func=None, betafrac: float = 0.05):
+def check_relativistic(func=None, betafrac: float = 0.05):  # noqa: ANN201
     """
     Warns or raises an exception when the output of the decorated
     function is greater than ``betafrac`` times the speed of light.

--- a/src/plasmapy/utils/decorators/checks.py
+++ b/src/plasmapy/utils/decorators/checks.py
@@ -44,7 +44,7 @@ class CheckBase:
         specified checks on the input arguments of the wrapped function
     """
 
-    def __init__(self, checks_on_return=None, **checks) -> None:
+    def __init__(self, checks_on_return=None, **checks) -> None:  # noqa: ANN003
         self._checks = checks
         if checks_on_return is not None:
             self._checks["checks_on_return"] = checks_on_return

--- a/src/plasmapy/utils/decorators/checks.py
+++ b/src/plasmapy/utils/decorators/checks.py
@@ -900,7 +900,7 @@ class CheckUnits(CheckBase):
     @staticmethod
     def _condition_target_units(
         targets: list[str | u.Unit | u.Quantity],
-        from_annotations: bool = False,
+        from_annotations: bool = False,  # noqa: FBT002
     ) -> list:
         """
         From a `list` of target objects that have or represent units,

--- a/src/plasmapy/utils/decorators/helpers.py
+++ b/src/plasmapy/utils/decorators/helpers.py
@@ -8,7 +8,7 @@ import functools
 import inspect
 
 
-def modify_docstring(func=None, prepend: str | None = None, append: str | None = None):
+def modify_docstring(func=None, prepend: str | None = None, append: str | None = None):  # noqa: ANN201
     r"""
     A decorator which programmatically prepends and/or appends the docstring
     of the decorated method/function.  The unmodified/original docstring is

--- a/src/plasmapy/utils/decorators/lite_func.py
+++ b/src/plasmapy/utils/decorators/lite_func.py
@@ -22,7 +22,7 @@ class _LiteFuncDict(dict):
     # This is only to give __bound_lite_func__ a docstring.
 
 
-def bind_lite_func(lite_func, attrs: dict[str, Callable] | None = None):
+def bind_lite_func(lite_func, attrs: dict[str, Callable] | None = None):  # noqa: ANN201
     """
     Decorator to bind a lightweight "lite" version of a formulary
     function to the full formulary function, as well as any supporting

--- a/src/plasmapy/utils/decorators/validators.py
+++ b/src/plasmapy/utils/decorators/validators.py
@@ -584,7 +584,7 @@ def get_attributes_not_provided(
     return attributes_not_provided
 
 
-def validate_class_attributes(
+def validate_class_attributes(  # noqa: ANN201
     expected_attributes: list[str] | None = None,
     both_or_either_attributes: list[Iterable[str]] | None = None,
     mutually_exclusive_attributes: list[Iterable[str]] | None = None,

--- a/src/plasmapy/utils/decorators/validators.py
+++ b/src/plasmapy/utils/decorators/validators.py
@@ -285,7 +285,7 @@ class ValidateQuantities(CheckUnits, CheckValues):
 
         return validations
 
-    def _validate_quantity(  # noqa: C901
+    def _validate_quantity(  # noqa: ANN202, C901
         self,
         arg,
         arg_name: str,
@@ -542,7 +542,7 @@ def validate_quantities(func=None, validations_on_return=None, **validations):
     return ValidateQuantities(**validations)
 
 
-def get_attributes_not_provided(
+def get_attributes_not_provided(  # noqa: ANN202
     self,
     expected_attributes: list[str] | None = None,
     both_or_either_attributes: list[Iterable[str]] | None = None,

--- a/tests/analysis/test_fit_functions.py
+++ b/tests/analysis/test_fit_functions.py
@@ -45,7 +45,7 @@ class TestAbstractFitFunction:
             ("root_solve", False),
         ],
     )
-    def test_methods(self, name: str, isproperty: bool) -> None:
+    def test_methods(self, name: str, isproperty: bool) -> None:  # noqa: FBT001
         """Test for required methods and properties."""
         assert hasattr(self.ff_class, name)
 
@@ -122,7 +122,7 @@ class BaseFFTests(ABC):
             ("root_solve", False),
         ],
     )
-    def test_methods(self, name: str, isproperty: bool) -> None:
+    def test_methods(self, name: str, isproperty: bool) -> None:  # noqa: FBT001
         """Test attribute/method/property existence."""
         assert hasattr(self.ff_class, name)
 

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -168,7 +168,7 @@ def test_multiple_grids() -> None:
     _hax, _vax, _values = cpr.synthetic_radiograph(sim, size=size, bins=bins)
 
 
-def run_1D_example(name: str):
+def run_1D_example(name: str):  # noqa: ANN201
     """
     Run a simulation through an example with parameters optimized to
     sum up to a lineout along x. The goal is to run a relatively fast

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -553,7 +553,7 @@ def test_run_options() -> None:
     assert 0 < sim.max_deflection.to(u.rad).value < np.pi / 2
 
 
-def create_tracker_obj(**kwargs) -> cpr.Tracker:
+def create_tracker_obj(**kwargs) -> cpr.Tracker:  # noqa: ANN003
     # CREATE A RADIOGRAPH OBJECT
     grid = _test_grid("electrostatic_gaussian_sphere", num=50)
     source = (0 * u.mm, -10 * u.mm, 0 * u.mm)

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -19,7 +19,7 @@ from plasmapy.plasma.grids import CartesianGrid
 rng = np.random.default_rng()
 
 
-def _test_grid(  # noqa: C901, PLR0912
+def _test_grid(  # noqa: ANN202, C901, PLR0912
     name: str,
     L: u.Quantity[u.m] = 1 * u.mm,
     num: int = 100,

--- a/tests/diagnostics/test_thomson.py
+++ b/tests/diagnostics/test_thomson.py
@@ -752,7 +752,7 @@ def run_fit(  # noqa: C901
     max_iter=None,
     require_redchi: float = 1.0,
     # If false, don't perform the actual fit but instead just create the Model
-    run_fit: bool = True,  # noqa: FBT002
+    run_fit: bool = True,  # noqa: FBT001, FBT002
 ) -> None:
     """
     Take a Parameters object, generate some synthetic data near it,

--- a/tests/diagnostics/test_thomson.py
+++ b/tests/diagnostics/test_thomson.py
@@ -752,7 +752,7 @@ def run_fit(  # noqa: C901
     max_iter=None,
     require_redchi: float = 1.0,
     # If false, don't perform the actual fit but instead just create the Model
-    run_fit: bool = True,
+    run_fit: bool = True,  # noqa: FBT002
 ) -> None:
     """
     Take a Parameters object, generate some synthetic data near it,

--- a/tests/particles/test_decorators.py
+++ b/tests/particles/test_decorators.py
@@ -27,9 +27,9 @@ from plasmapy.utils.exceptions import PlasmaPyDeprecationWarning
 
 @particle_input
 def function_decorated_with_particle_input(
-    a: Any,
+    a: Any,  # noqa: ANN401
     particle: ParticleLike,
-    b: Any = None,
+    b: Any = None,  # noqa: ANN401
     Z: float | None = None,
     mass_numb: int | None = None,
 ) -> Particle | CustomParticle | ParticleList:
@@ -51,9 +51,9 @@ def function_decorated_with_particle_input(
 
 @particle_input()
 def function_decorated_with_call_of_particle_input(
-    a: Any,
+    a: Any,  # noqa: ANN401
     particle: ParticleLike,
-    b: Any = None,
+    b: Any = None,  # noqa: ANN401
     Z: float | None = None,
     mass_numb: int | None = None,
 ) -> Particle | CustomParticle | ParticleList:
@@ -416,7 +416,7 @@ def test_self_stacked_decorator(
 
     @outer_decorator
     @inner_decorator
-    def f(x: Any, particle: ParticleLike) -> Particle | CustomParticle | ParticleList:
+    def f(x: Any, particle: ParticleLike) -> Particle | CustomParticle | ParticleList:  # noqa: ANN401
         return particle  # ty:ignore[invalid-return-type]
 
     result = f(1, "p+")
@@ -455,7 +455,7 @@ def test_annotated_init() -> None:
 
     class HasAnnotatedInit:
         @particle_input(require="element")
-        def __init__(self, particle: ParticleLike, ionic_fractions: Any = None) -> None:
+        def __init__(self, particle: ParticleLike, ionic_fractions: Any = None) -> None:  # noqa: ANN401
             self.particle = particle
 
     x = HasAnnotatedInit("H-1", ionic_fractions=32)
@@ -524,7 +524,7 @@ kwargs_to_decorator_and_args = [
     ("kwargs_to_particle_input", "arg"), kwargs_to_decorator_and_args
 )
 def test_particle_input_verification(
-    kwargs_to_particle_input: dict[str, Any], arg: Any
+    kwargs_to_particle_input: dict[str, Any], arg: Any  # noqa: ANN401
 ) -> None:
     """Test the allow_custom_particles keyword argument to particle_input."""
 
@@ -750,7 +750,7 @@ def test_particle_input_with_pos_and_var_positional_arguments() -> None:
 
     @particle_input
     def function_with_pos_and_var_positional_arguments(
-        a: Any,
+        a: Any,  # noqa: ANN401
         *args: Any,
         particle: ParticleLike = None,  # ty:ignore[invalid-parameter-default]
     ) -> tuple[tuple[Any, ...], Particle]:

--- a/tests/particles/test_decorators.py
+++ b/tests/particles/test_decorators.py
@@ -524,7 +524,8 @@ kwargs_to_decorator_and_args = [
     ("kwargs_to_particle_input", "arg"), kwargs_to_decorator_and_args
 )
 def test_particle_input_verification(
-    kwargs_to_particle_input: dict[str, Any], arg: Any  # noqa: ANN401
+    kwargs_to_particle_input: dict[str, Any],
+    arg: Any,  # noqa: ANN401
 ) -> None:
     """Test the allow_custom_particles keyword argument to particle_input."""
 

--- a/tests/particles/test_particle_class.py
+++ b/tests/particles/test_particle_class.py
@@ -790,7 +790,7 @@ def test_particle_half_life_string() -> None:
 @pytest.mark.parametrize(
     ("p", "is_one"), [(Particle("e-"), True), (Particle("p+"), False)]
 )
-def test_particle_is_electron(p, is_one: bool) -> None:
+def test_particle_is_electron(p, is_one: bool) -> None:  # noqa: FBT001
     assert p.is_electron == is_one
 
 

--- a/tests/plasma/test_grids.py
+++ b/tests/plasma/test_grids.py
@@ -383,7 +383,7 @@ req_q = [
     ("required", "replace_with_zeros", "error", "warning", "match"), req_q
 )
 def test_AbstractGrid_require_quantities(
-    abstract_grid_uniform, required: bool, replace_with_zeros, error, warning, match
+    abstract_grid_uniform, required: bool, replace_with_zeros, error, warning, match  # noqa: FBT001
 ) -> None:
     """
     Tests the AbstractGrid require_quantities method

--- a/tests/plasma/test_grids.py
+++ b/tests/plasma/test_grids.py
@@ -383,7 +383,12 @@ req_q = [
     ("required", "replace_with_zeros", "error", "warning", "match"), req_q
 )
 def test_AbstractGrid_require_quantities(
-    abstract_grid_uniform, required: bool, replace_with_zeros, error, warning, match  # noqa: FBT001
+    abstract_grid_uniform,
+    required: bool,  # noqa: FBT001
+    replace_with_zeros,
+    error,
+    warning,
+    match,  # noqa: FBT001, RUF100
 ) -> None:
     """
     Tests the AbstractGrid require_quantities method

--- a/tests/plasma/test_plasma_base.py
+++ b/tests/plasma/test_plasma_base.py
@@ -10,13 +10,13 @@ class NoDataSource(BasePlasma):
 
 class IsDataSource(BasePlasma):
     @classmethod
-    def is_datasource_for(cls, **kwargs) -> bool:
+    def is_datasource_for(cls, **kwargs) -> bool:  # noqa: ANN003
         return True
 
 
 class IsNotDataSource(BasePlasma):
     @classmethod
-    def is_datasource_for(cls, **kwargs) -> bool:
+    def is_datasource_for(cls, **kwargs) -> bool:  # noqa: ANN003
         return False
 
 

--- a/tests/simulation/test_particle_tracker.py
+++ b/tests/simulation/test_particle_tracker.py
@@ -684,7 +684,7 @@ class TestParticleTrajectory:
         B,
         q=const.e.si,
         m=const.m_p.si,
-        is_relativistic: bool = True,  # noqa: FBT002
+        is_relativistic: bool = True,  # noqa: FBT001, FBT002
     ):
         """
         Calculates the relativistically-correct ExB drift trajectory for a

--- a/tests/simulation/test_particle_tracker.py
+++ b/tests/simulation/test_particle_tracker.py
@@ -684,7 +684,7 @@ class TestParticleTrajectory:
         B,
         q=const.e.si,
         m=const.m_p.si,
-        is_relativistic: bool = True,
+        is_relativistic: bool = True,  # noqa: FBT002
     ):
         """
         Calculates the relativistically-correct ExB drift trajectory for a

--- a/tests/utils/_pytest_helpers/test_pytest_helpers.py
+++ b/tests/utils/_pytest_helpers/test_pytest_helpers.py
@@ -39,7 +39,7 @@ def adams_number(*args, **kwargs) -> int:
     return 42
 
 
-def return_quantity(*args, should_warn: bool = False):
+def return_quantity(*args, should_warn: bool = False):  # noqa: ANN202
     if should_warn:
         warnings.warn("", UserWarning)
     return 5 * u.m / u.s
@@ -177,7 +177,7 @@ def test_run_test_atol_failure() -> None:
         pytest.fail("No exception raised for atol test.")
 
 
-def func(x, raise_exception: bool = False, issue_warning: bool = False):  # noqa: FBT001, FBT002
+def func(x, raise_exception: bool = False, issue_warning: bool = False):  # noqa: ANN202, FBT001, FBT002
     if raise_exception:
         raise ValueError("")
     elif issue_warning:

--- a/tests/utils/_pytest_helpers/test_pytest_helpers.py
+++ b/tests/utils/_pytest_helpers/test_pytest_helpers.py
@@ -45,7 +45,7 @@ def return_quantity(*args, should_warn: bool = False):
     return 5 * u.m / u.s
 
 
-def return_arg(arg: Any, should_warn: bool = False) -> Any:  # noqa: FBT002
+def return_arg(arg: Any, should_warn: bool = False) -> Any:  # noqa: FBT001, FBT002
     if should_warn:
         warnings.warn("", UserWarning)
     return arg
@@ -177,7 +177,7 @@ def test_run_test_atol_failure() -> None:
         pytest.fail("No exception raised for atol test.")
 
 
-def func(x, raise_exception: bool = False, issue_warning: bool = False):  # noqa: FBT002
+def func(x, raise_exception: bool = False, issue_warning: bool = False):  # noqa: FBT001, FBT002
     if raise_exception:
         raise ValueError("")
     elif issue_warning:

--- a/tests/utils/_pytest_helpers/test_pytest_helpers.py
+++ b/tests/utils/_pytest_helpers/test_pytest_helpers.py
@@ -30,16 +30,16 @@ def raise_exception(*args, **kwargs):
     )
 
 
-def issue_warning(*args, **kwargs) -> int:
+def issue_warning(*args, **kwargs) -> int:  # noqa: ANN002
     warnings.warn(f"\n{args}\n{kwargs}", PlasmaPyWarning)
     return 42
 
 
-def adams_number(*args, **kwargs) -> int:
+def adams_number(*args, **kwargs) -> int:  # noqa: ANN002
     return 42
 
 
-def return_quantity(*args, should_warn: bool = False):  # noqa: ANN202
+def return_quantity(*args, should_warn: bool = False):  # noqa: ANN002, ANN202
     if should_warn:
         warnings.warn("", UserWarning)
     return 5 * u.m / u.s

--- a/tests/utils/_pytest_helpers/test_pytest_helpers.py
+++ b/tests/utils/_pytest_helpers/test_pytest_helpers.py
@@ -45,7 +45,7 @@ def return_quantity(*args, should_warn: bool = False):  # noqa: ANN002, ANN202
     return 5 * u.m / u.s
 
 
-def return_arg(arg: Any, should_warn: bool = False) -> Any:  # noqa: FBT001, FBT002
+def return_arg(arg: Any, should_warn: bool = False) -> Any:  # noqa: ANN401, FBT001, FBT002
     if should_warn:
         warnings.warn("", UserWarning)
     return arg

--- a/tests/utils/_pytest_helpers/test_pytest_helpers.py
+++ b/tests/utils/_pytest_helpers/test_pytest_helpers.py
@@ -45,7 +45,7 @@ def return_quantity(*args, should_warn: bool = False):
     return 5 * u.m / u.s
 
 
-def return_arg(arg: Any, should_warn: bool = False) -> Any:
+def return_arg(arg: Any, should_warn: bool = False) -> Any:  # noqa: FBT002
     if should_warn:
         warnings.warn("", UserWarning)
     return arg
@@ -177,7 +177,7 @@ def test_run_test_atol_failure() -> None:
         pytest.fail("No exception raised for atol test.")
 
 
-def func(x, raise_exception: bool = False, issue_warning: bool = False):
+def func(x, raise_exception: bool = False, issue_warning: bool = False):  # noqa: FBT002
     if raise_exception:
         raise ValueError("")
     elif issue_warning:

--- a/tests/utils/_pytest_helpers/test_pytest_helpers.py
+++ b/tests/utils/_pytest_helpers/test_pytest_helpers.py
@@ -30,12 +30,12 @@ def raise_exception(*args, **kwargs):
     )
 
 
-def issue_warning(*args, **kwargs) -> int:  # noqa: ANN002
+def issue_warning(*args, **kwargs) -> int:  # noqa: ANN002, ANN003
     warnings.warn(f"\n{args}\n{kwargs}", PlasmaPyWarning)
     return 42
 
 
-def adams_number(*args, **kwargs) -> int:  # noqa: ANN002
+def adams_number(*args, **kwargs) -> int:  # noqa: ANN002, ANN003
     return 42
 
 

--- a/tests/utils/decorators/test_checks.py
+++ b/tests/utils/decorators/test_checks.py
@@ -791,7 +791,7 @@ class TestCheckValues:
         return x + y
 
     @staticmethod
-    def foo_stars(x, *args, y: Any = 3, **kwargs) -> Any:  # noqa: ANN002, ANN003
+    def foo_stars(x, *args, y: Any = 3, **kwargs) -> Any:  # noqa: ANN002, ANN003, ANN401
         return x + y
 
     def test_inheritance(self) -> None:

--- a/tests/utils/decorators/test_checks.py
+++ b/tests/utils/decorators/test_checks.py
@@ -78,7 +78,7 @@ class TestCheckUnits:
         return x.value + y.value
 
     @staticmethod
-    def foo_stars(x: u.Quantity, *args, y=3 * u.cm, **kwargs):  # noqa: ANN002, ANN205
+    def foo_stars(x: u.Quantity, *args, y=3 * u.cm, **kwargs):  # noqa: ANN002, ANN003, ANN205
         return x.value + y.value
 
     @staticmethod
@@ -791,7 +791,7 @@ class TestCheckValues:
         return x + y
 
     @staticmethod
-    def foo_stars(x, *args, y: Any = 3, **kwargs) -> Any:  # noqa: ANN002
+    def foo_stars(x, *args, y: Any = 3, **kwargs) -> Any:  # noqa: ANN002, ANN003
         return x + y
 
     def test_inheritance(self) -> None:

--- a/tests/utils/decorators/test_checks.py
+++ b/tests/utils/decorators/test_checks.py
@@ -78,7 +78,7 @@ class TestCheckUnits:
         return x.value + y.value
 
     @staticmethod
-    def foo_stars(x: u.Quantity, *args, y=3 * u.cm, **kwargs):  # noqa: ANN205
+    def foo_stars(x: u.Quantity, *args, y=3 * u.cm, **kwargs):  # noqa: ANN002, ANN205
         return x.value + y.value
 
     @staticmethod
@@ -791,7 +791,7 @@ class TestCheckValues:
         return x + y
 
     @staticmethod
-    def foo_stars(x, *args, y: Any = 3, **kwargs) -> Any:
+    def foo_stars(x, *args, y: Any = 3, **kwargs) -> Any:  # noqa: ANN002
         return x + y
 
     def test_inheritance(self) -> None:

--- a/tests/utils/decorators/test_converters.py
+++ b/tests/utils/decorators/test_converters.py
@@ -35,7 +35,7 @@ def test_to_hz_complicated_signature() -> None:
     """
 
     @angular_freq_to_hz
-    def func2(a, /, b, *args, c, d: int = 2, **kwargs):  # noqa: ANN202
+    def func2(a, /, b, *args, c, d: int = 2, **kwargs):  # noqa: ANN002, ANN202
         return 2 * np.pi * u.rad / u.s
 
     result_rad_per_s = func2(1, 2, 3, 4, c=5, d=6, e=7)
@@ -75,7 +75,7 @@ def test_angular_freq_to_hz_preserves_signature() -> None:
 
     @angular_freq_to_hz
     def test_func(  # noqa: ANN202
-        pos_only, /, arg, *args, required_kwarg, optional_kwarg: int = 2, **kwargs
+        pos_only, /, arg, *args, required_kwarg, optional_kwarg: int = 2, **kwargs  # noqa: ANN002
     ):
         return 2 * u.rad / u.s
 
@@ -83,7 +83,7 @@ def test_angular_freq_to_hz_preserves_signature() -> None:
         pos_only,
         /,
         arg,
-        *args,
+        *args,  # noqa: ANN002
         required_kwarg,
         optional_kwarg: int = 2,
         to_hz: bool = False,

--- a/tests/utils/decorators/test_converters.py
+++ b/tests/utils/decorators/test_converters.py
@@ -35,7 +35,7 @@ def test_to_hz_complicated_signature() -> None:
     """
 
     @angular_freq_to_hz
-    def func2(a, /, b, *args, c, d: int = 2, **kwargs):  # noqa: ANN002, ANN202
+    def func2(a, /, b, *args, c, d: int = 2, **kwargs):  # noqa: ANN002, ANN003, ANN202
         return 2 * np.pi * u.rad / u.s
 
     result_rad_per_s = func2(1, 2, 3, 4, c=5, d=6, e=7)
@@ -75,7 +75,7 @@ def test_angular_freq_to_hz_preserves_signature() -> None:
 
     @angular_freq_to_hz
     def test_func(  # noqa: ANN202
-        pos_only, /, arg, *args, required_kwarg, optional_kwarg: int = 2, **kwargs  # noqa: ANN002
+        pos_only, /, arg, *args, required_kwarg, optional_kwarg: int = 2, **kwargs  # noqa: ANN002, ANN003
     ):
         return 2 * u.rad / u.s
 
@@ -87,7 +87,7 @@ def test_angular_freq_to_hz_preserves_signature() -> None:
         required_kwarg,
         optional_kwarg: int = 2,
         to_hz: bool = False,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         return 2 * u.rad / u.s
 

--- a/tests/utils/decorators/test_converters.py
+++ b/tests/utils/decorators/test_converters.py
@@ -35,7 +35,7 @@ def test_to_hz_complicated_signature() -> None:
     """
 
     @angular_freq_to_hz
-    def func2(a, /, b, *args, c, d: int = 2, **kwargs):
+    def func2(a, /, b, *args, c, d: int = 2, **kwargs):  # noqa: ANN202
         return 2 * np.pi * u.rad / u.s
 
     result_rad_per_s = func2(1, 2, 3, 4, c=5, d=6, e=7)
@@ -60,7 +60,7 @@ def test_to_hz_stacked_decorators() -> None:
     @particle_input
     @validate_quantities
     @angular_freq_to_hz
-    def func(particle: ParticleLike | None = None):
+    def func(particle: ParticleLike | None = None):  # noqa: ANN202
         return 2 * np.pi * u.rad / u.s
 
     assert u.isclose(func(), 2 * np.pi * u.rad / u.s)
@@ -74,12 +74,12 @@ def test_angular_freq_to_hz_preserves_signature() -> None:
     """
 
     @angular_freq_to_hz
-    def test_func(
+    def test_func(  # noqa: ANN202
         pos_only, /, arg, *args, required_kwarg, optional_kwarg: int = 2, **kwargs
     ):
         return 2 * u.rad / u.s
 
-    def func_with_expected_signature(
+    def func_with_expected_signature(  # noqa: ANN202
         pos_only,
         /,
         arg,

--- a/tests/utils/decorators/test_converters.py
+++ b/tests/utils/decorators/test_converters.py
@@ -75,7 +75,13 @@ def test_angular_freq_to_hz_preserves_signature() -> None:
 
     @angular_freq_to_hz
     def test_func(  # noqa: ANN202
-        pos_only, /, arg, *args, required_kwarg, optional_kwarg: int = 2, **kwargs  # noqa: ANN002, ANN003
+        pos_only,
+        /,
+        arg,
+        *args,  # noqa: ANN002
+        required_kwarg,
+        optional_kwarg: int = 2,
+        **kwargs,  # noqa: ANN002, ANN003, RUF100
     ):
         return 2 * u.rad / u.s
 

--- a/tests/utils/decorators/test_validators.py
+++ b/tests/utils/decorators/test_validators.py
@@ -641,7 +641,7 @@ def test_validate_quantities_argument_type_annotation() -> None:
     """
 
     @validate_quantities
-    def f(x: u.Quantity[u.m]):
+    def f(x: u.Quantity[u.m]):  # noqa: ANN202
         return x
 
     argument = 100 * u.cm

--- a/tests/utils/test_code_repr.py
+++ b/tests/utils/test_code_repr.py
@@ -138,7 +138,7 @@ def test_call_string(func, args, kwargs, expected) -> None:
 
 
 class SampleClass:
-    def method(self, *args, **kwargs) -> None:  # noqa: ANN002
+    def method(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         pass
 
     @property

--- a/tests/utils/test_code_repr.py
+++ b/tests/utils/test_code_repr.py
@@ -138,7 +138,7 @@ def test_call_string(func, args, kwargs, expected) -> None:
 
 
 class SampleClass:
-    def method(self, *args, **kwargs) -> None:
+    def method(self, *args, **kwargs) -> None:  # noqa: ANN002
         pass
 
     @property

--- a/tests/utils/test_datatype_factory_base.py
+++ b/tests/utils/test_datatype_factory_base.py
@@ -41,7 +41,7 @@ from plasmapy.utils.datatype_factory_base import (
 
 
 class BaseWidget:
-    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         pass
 
 

--- a/tests/utils/test_datatype_factory_base.py
+++ b/tests/utils/test_datatype_factory_base.py
@@ -41,7 +41,7 @@ from plasmapy.utils.datatype_factory_base import (
 
 
 class BaseWidget:
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002
         pass
 
 

--- a/tests/utils/test_roman.py
+++ b/tests/utils/test_roman.py
@@ -188,5 +188,5 @@ test_is_roman_numeral_table: list[tuple[str, bool]] = [
 
 
 @pytest.mark.parametrize(("argument", "expected"), test_is_roman_numeral_table)
-def test_is_roman_numeral(argument: str, expected: bool) -> None:
+def test_is_roman_numeral(argument: str, expected: bool) -> None:  # noqa: FBT001
     run_test(func=roman.is_roman_numeral, args=argument, expected_outcome=expected)

--- a/type_stubs/wrapt.pyi
+++ b/type_stubs/wrapt.pyi
@@ -7,7 +7,7 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 
 def decorator(  # noqa: UP047
     wrapper: _F,
-    enabled: Any = None,
-    adapter: Any = None,
-    proxy: Any = None,
+    enabled: Any = None,  # noqa: ANN401
+    adapter: Any = None,  # noqa: ANN401
+    proxy: Any = None,  # noqa: ANN401
 ) -> _F: ...


### PR DESCRIPTION
This PR enables a few more ruff rules, and adds a bunch of comments to ignore ruff checks on particular lines.

This PR enables the reset of the `ANN` rule set, except for `ANN001`.  This is partially for consistency with ty.  

Given the number of `noqa` comments, it would be worthwhile to add this PR to the list of ones ignored by `git blame` (which I think should be renamed as `git credit`).