### PR TITLE
Deprecate internal `@deprecated` decorator in favor of `@warnings.deprecated`

### DIFF
--- a/changelog/3300.removal.rst
+++ b/changelog/3300.removal.rst
@@ -1,0 +1,4 @@
+Deprecated the internal ``@plasmapy.utils.decorators.deprecation.deprecated``
+decorator in favor of `warnings.deprecated`, which was added to the standard
+library in Python 3.13. The internal ``@deprecated`` decorator will be removed
+in a future release.

--- a/src/plasmapy/utils/decorators/deprecation.py
+++ b/src/plasmapy/utils/decorators/deprecation.py
@@ -1,7 +1,7 @@
 """
 Decorators to mark objects as deprecated.
 
-.. deprecated::
+.. deprecated:: 2026.6.0
 
    This module has been deprecated in favor of ``@warnings.deprecated``,
    and will be removed in a forthcoming release of PlasmaPy.
@@ -21,7 +21,7 @@ def deprecated(*args, warning_type=PlasmaPyDeprecationWarning, **kwargs):
     A wrapper of `astropy.utils.decorators.deprecated` that by default assumes
     a warning type of `~plasmapy.utils.exceptions.PlasmaPyDeprecationWarning`.
 
-    .. deprecated::
+    .. deprecated:: 2026.6.0
 
        The decorator has been deprecated in favor of ``@warnings.decorated``,
        and will be removed in a forthcoming release of PlasmaPy.

--- a/src/plasmapy/utils/decorators/deprecation.py
+++ b/src/plasmapy/utils/decorators/deprecation.py
@@ -1,10 +1,10 @@
 """
-Decorators to mark objects that are deprecated.
+Decorators to mark objects as deprecated.
 
 .. deprecated::
 
-   This module has been deprecated and will be removed in a future
-   release of PlasmaPy.
+   This module has been deprecated in favor of `warnings.deprecated`,
+   and will be removed in a forthcoming release of PlasmaPy.
 """
 
 __all__ = ["deprecated"]
@@ -24,8 +24,7 @@ def deprecated(*args, warning_type=PlasmaPyDeprecationWarning, **kwargs):
     .. deprecated::
 
        The decorator has been deprecated in favor of `warnings.decorated`,
-       and will be removed in a future release of PlasmaPy.
-
+       and will be removed in a forthcoming release of PlasmaPy.
     """
     return astropy_deprecated(*args, warning_type=warning_type, **kwargs)
 

--- a/src/plasmapy/utils/decorators/deprecation.py
+++ b/src/plasmapy/utils/decorators/deprecation.py
@@ -1,4 +1,11 @@
-"""Decorators to mark objects that are deprecated."""
+"""
+Decorators to mark objects that are deprecated.
+
+.. deprecated::
+
+   This module has been deprecated and will be removed in a future
+   release of PlasmaPy.
+"""
 
 __all__ = ["deprecated"]
 
@@ -13,6 +20,12 @@ def deprecated(*args, warning_type=PlasmaPyDeprecationWarning, **kwargs):
     """
     A wrapper of `astropy.utils.decorators.deprecated` that by default assumes
     a warning type of `~plasmapy.utils.exceptions.PlasmaPyDeprecationWarning`.
+
+    .. deprecated::
+
+       The decorator has been deprecated in favor of `warnings.decorated`,
+       and will be removed in a future release of PlasmaPy.
+
     """
     return astropy_deprecated(*args, warning_type=warning_type, **kwargs)
 

--- a/src/plasmapy/utils/decorators/deprecation.py
+++ b/src/plasmapy/utils/decorators/deprecation.py
@@ -3,7 +3,7 @@ Decorators to mark objects as deprecated.
 
 .. deprecated::
 
-   This module has been deprecated in favor of `warnings.deprecated`,
+   This module has been deprecated in favor of ``@warnings.deprecated``,
    and will be removed in a forthcoming release of PlasmaPy.
 """
 
@@ -23,7 +23,7 @@ def deprecated(*args, warning_type=PlasmaPyDeprecationWarning, **kwargs):
 
     .. deprecated::
 
-       The decorator has been deprecated in favor of `warnings.decorated`,
+       The decorator has been deprecated in favor of ``@warnings.decorated``,
        and will be removed in a forthcoming release of PlasmaPy.
     """
     return astropy_deprecated(*args, warning_type=warning_type, **kwargs)


### PR DESCRIPTION
We have used `@plasmapy.utils.decorators.deprecation.deprecated` to decorate deprecated functions, classes, and methods. It's a thin wrapper around `@astropy.utils.decorators.deprecated`.

Since a `@warnings.deprecated` decorator was added in Python 3.13, this PR deprecates the internal `@deprecated` decorator. I'm planning to remove it once PlasmaPy drops support for Python 3.12 around October 2026.