### PR TITLE
Plasma Frequency Added Description 

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -771,3 +771,8 @@ authors:
   affiliation: Cornell University
   orcid: https://orcid.org/0000-0003-2357-3023
   alias: vaibhavmehta1
+
+- given-names: John
+  family-names: Bonner
+  affiliation: Haverford College
+  alias: JackBonner888

--- a/src/plasmapy/formulary/frequencies.py
+++ b/src/plasmapy/formulary/frequencies.py
@@ -240,6 +240,9 @@ def plasma_frequency(
 ) -> u.Quantity[u.rad / u.s]:
     r"""Calculate the particle plasma frequency.
 
+    This frequency is the natural rate at which electrons in plasma oscillate due to 
+    electrostatic forces from ions.
+
     **Aliases:** `wp_`
 
     **Lite Version:** `~plasmapy.formulary.frequencies.plasma_frequency_lite`

--- a/src/plasmapy/formulary/frequencies.py
+++ b/src/plasmapy/formulary/frequencies.py
@@ -240,7 +240,7 @@ def plasma_frequency(
 ) -> u.Quantity[u.rad / u.s]:
     r"""Calculate the particle plasma frequency.
 
-    This frequency is the natural rate at which electrons in plasma oscillate due to 
+    This frequency is the natural rate at which electrons in plasma oscillate due to
     electrostatic forces from ions.
 
     **Aliases:** `wp_`


### PR DESCRIPTION
<This Pull Request is merely a test for my upcoming contributions to PlasmaPy. I added a one sentence description about the physical meaning of the plasma frequency with the following docstring comment: This frequency is the natural rate at which electrons in plasma oscillate due to electrostatic forces from ions. I will be emailing Nick Murphy more information in the next half hour.>
