### PR TITLE
Allow particle_input and validate_quantities in either order on instance methods

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -776,3 +776,7 @@ authors:
   family-names: Bonner
   affiliation: Haverford College
   alias: JackBonner888
+
+- given-names: Mohit
+  family-names: Arvind Khakharia
+  alias: Mohit-Ak

--- a/changelog/3325.bugfix.rst
+++ b/changelog/3325.bugfix.rst
@@ -1,0 +1,4 @@
+Enabled |particle_input| and |validate_quantities| to be used in
+either order when decorating an instance method. Previously,
+|particle_input| had to be the outer decorator for instance methods
+(see :issue:`2035`).

--- a/src/plasmapy/particles/decorators.py
+++ b/src/plasmapy/particles/decorators.py
@@ -144,8 +144,17 @@ def _bind_arguments(
 
     bound_arguments.apply_defaults()
 
-    bound_arguments.arguments.pop("self", None)
-    bound_arguments.arguments.pop("cls", None)
+    # When ``instance`` is provided, then wrapt has already separated
+    # ``self``/``cls`` out of ``args``/``kwargs`` and bound it above, so
+    # it must be removed before calling the wrapped callable. But when
+    # ``instance`` is `None` — as happens when |particle_input| is the
+    # *inner* decorator on an instance method and the outer decorator
+    # (e.g. |validate_quantities|) calls it directly with ``self`` among
+    # the arguments — the ``self``/``cls`` argument came from the actual
+    # call and must be preserved so it can be forwarded. See #2035.
+    if instance is not None:
+        bound_arguments.arguments.pop("self", None)
+        bound_arguments.arguments.pop("cls", None)
 
     return bound_arguments
 
@@ -742,11 +751,8 @@ def particle_input(
     .. note::
 
        When both |particle_input| and |validate_quantities| are used to
-       decorate a :term:`function`, they may be used in either order.
-       When using both |particle_input| and |validate_quantities| to
-       decorate an instance :term:`method`, |particle_input| should be
-       the outer decorator and |validate_quantities| should be the inner
-       decorator (see :issue:`2035`).
+       decorate a :term:`function` or an instance :term:`method`, they
+       may be used in either order (see :issue:`2035`).
 
        .. code-block:: python
 
@@ -863,10 +869,6 @@ def particle_input(
     - |particle_input| has limited compatibility with positional-only,
       variadic positional, and variadic keyword arguments (see
       :issue:`2150`).
-
-    - When |particle_input| and |validate_quantities| are both
-      used to decorate an instance method on a class, |particle_input|
-      must be the outside decorator (see :issue:`2035`).
 
     - Because it dynamically changes arguments, functions decorated with
       |particle_input| often do not work well with static type checkers

--- a/tests/particles/test_decorators.py
+++ b/tests/particles/test_decorators.py
@@ -478,22 +478,8 @@ def test_annotated_init() -> None:
     [
         (particle_input, validate_quantities_),
         (particle_input(), validate_quantities_),
-        pytest.param(
-            validate_quantities_,
-            particle_input,
-            marks=pytest.mark.xfail(
-                reason="For instance methods, particle_input must currently "
-                "be the outer decorator. See #2035.",
-            ),
-        ),
-        pytest.param(
-            validate_quantities_,
-            particle_input(),
-            marks=pytest.mark.xfail(
-                reason="For instance methods, particle_input must currently "
-                "be the outer decorator. See #2035.",
-            ),
-        ),
+        (validate_quantities_, particle_input),
+        (validate_quantities_, particle_input()),
     ],
 )
 def test_particle_input_with_validate_quantities(


### PR DESCRIPTION
## What was wrong

`@particle_input` and `@validate_quantities` can be stacked in either order on
plain functions, but not on instance methods. For methods, `@particle_input` had
to be the *outer* decorator — putting `@validate_quantities` on the outside broke
with:

```
TypeError: AnotherClass.method() missing 1 required positional argument: 'self'
```

Root cause: `@particle_input` is implemented with `wrapt`. When it is accessed as
an instance method (i.e. as the outer decorator), wrapt splits `self` out and
passes it as a separate `instance`, so `_bind_arguments()` correctly pops `self`
before forwarding. But when `@validate_quantities` is the outer decorator, it is
*not* wrapt-based: it binds its own signature (including `self`) and then calls the
inner `particle_input` wrapper as a plain function, with `self` sitting in the
keyword arguments and wrapt's `instance` being `None`. `_bind_arguments()` then
unconditionally popped `self`/`cls`, stripping the argument the wrapped method
still needed.

## The fix

Only pop `self`/`cls` when `instance is not None` — i.e. only when wrapt supplied
the instance separately. When `instance is None`, any `self`/`cls` present came
from the actual call and is preserved so it can be forwarded. `self` carries no
particle annotation, so `process_argument()` already passes it through untouched.

Also removed the now-obsolete "particle_input must be the outer decorator" caveats
from the `particle_input` docstring.

## How it was tested

The two decorator-order cases were already present in
`test_particle_input_with_validate_quantities` marked `xfail(... See #2035)`. With
the fix they pass, so the `xfail` markers were removed (the suite runs
`xfail_strict`, so a lingering xfail on a now-passing case would fail CI). Repro
from the issue now works in both orders.

Test results (Python 3.12, wrapt 2.2.2):

```
tests/particles/test_decorators.py .......................... 84 passed, 1 xfailed
tests/particles/                    ......................... 1883 passed, 2 xfailed
tests/utils/decorators/             ......................... 120 passed
ruff 0.15.15 check .................. All checks passed!
ruff format --check ................. 2 files already formatted
```

The remaining xfails are unrelated (#2150, variadic positional arguments).

Fixes #2035
