### PR TITLE
test: replace bare assert np.isclose/allclose with np.testing.assert_allclose

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -780,3 +780,7 @@ authors:
 - given-names: Mohit
   family-names: Arvind Khakharia
   alias: Mohit-Ak
+
+- given-names: Mike
+  family-names: German
+  alias: steps-re

--- a/changelog/3327.test.rst
+++ b/changelog/3327.test.rst
@@ -1,0 +1,4 @@
+Replaced bare ``assert np.isclose(...)`` and ``assert np.allclose(...)``
+calls across 41 test files with ``np.testing.assert_allclose(...)``, which
+produces informative failure messages showing actual vs. desired values and
+the tolerance used instead of a bare `AssertionError`.

--- a/tests/analysis/swept_langmuir/test_floating_potential.py
+++ b/tests/analysis/swept_langmuir/test_floating_potential.py
@@ -228,7 +228,7 @@ class TestFindFloatingPotential:
                 if np.isnan(val):
                     assert np.isnan(rtn_val)
                 else:
-                    np.testing.assert_allclose(rtn_val, val, rtol=1e-5, atol=1e-8)
+                    np.testing.assert_allclose(rtn_val, val, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
             else:
                 assert rtn_val == val
 
@@ -363,7 +363,7 @@ class TestFindFloatingPotential:
                 if np.isnan(val):
                     assert np.isnan(rtn_val)
                 else:
-                    np.testing.assert_allclose(rtn_val, val, atol=1e-7, rtol=1e-5)
+                    np.testing.assert_allclose(rtn_val, val, atol=1e-7, rtol=1e-5)  # ty:ignore[no-matching-overload]
             else:
                 assert rtn_val == val
 
@@ -385,8 +385,12 @@ class TestFindFloatingPotential:
         np.testing.assert_allclose(extras.vf_err, 0.0, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
         np.testing.assert_allclose(extras.rsq, 1.0, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
         assert isinstance(extras.fitted_func, ffuncs.Linear)
-        np.testing.assert_allclose(extras.fitted_func.params, (m, b), rtol=1e-5, atol=1e-8)  # ty:ignore[invalid-argument-type]
-        np.testing.assert_allclose(extras.fitted_func.param_errors, (0.0, 0.0), atol=2e-8, rtol=1e-5)  # ty:ignore[invalid-argument-type]
+        np.testing.assert_allclose(
+            extras.fitted_func.params, (m, b), rtol=1e-5, atol=1e-8
+        )  # ty:ignore[no-matching-overload]
+        np.testing.assert_allclose(
+            extras.fitted_func.param_errors, (0.0, 0.0), atol=2e-8, rtol=1e-5
+        )  # ty:ignore[no-matching-overload]
 
     @pytest.mark.parametrize(
         ("a", "alpha", "b"),
@@ -409,5 +413,9 @@ class TestFindFloatingPotential:
         np.testing.assert_allclose(extras.vf_err, 0.0, 1e-7, atol=1e-8)  # ty:ignore[no-matching-overload]
         np.testing.assert_allclose(extras.rsq, 1.0, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
         assert isinstance(extras.fitted_func, ffuncs.ExponentialPlusOffset)
-        np.testing.assert_allclose(extras.fitted_func.params, (a, alpha, b), rtol=1e-5, atol=1e-8)  # ty:ignore[invalid-argument-type]
-        np.testing.assert_allclose(extras.fitted_func.param_errors, (0.0, 0.0, 0.0), atol=2e-8, rtol=1e-5)  # ty:ignore[invalid-argument-type]
+        np.testing.assert_allclose(
+            extras.fitted_func.params, (a, alpha, b), rtol=1e-5, atol=1e-8
+        )  # ty:ignore[no-matching-overload]
+        np.testing.assert_allclose(
+            extras.fitted_func.param_errors, (0.0, 0.0, 0.0), atol=2e-8, rtol=1e-5
+        )  # ty:ignore[no-matching-overload]

--- a/tests/analysis/swept_langmuir/test_floating_potential.py
+++ b/tests/analysis/swept_langmuir/test_floating_potential.py
@@ -228,7 +228,7 @@ class TestFindFloatingPotential:
                 if np.isnan(val):
                     assert np.isnan(rtn_val)
                 else:
-                    assert np.isclose(rtn_val, val)
+                    np.testing.assert_allclose(rtn_val, val, rtol=1e-5, atol=1e-8)
             else:
                 assert rtn_val == val
 
@@ -363,7 +363,7 @@ class TestFindFloatingPotential:
                 if np.isnan(val):
                     assert np.isnan(rtn_val)
                 else:
-                    assert np.isclose(rtn_val, val, atol=1e-7)
+                    np.testing.assert_allclose(rtn_val, val, atol=1e-7, rtol=1e-5)
             else:
                 assert rtn_val == val
 
@@ -381,12 +381,12 @@ class TestFindFloatingPotential:
         )
 
         assert isinstance(extras, VFExtras)
-        assert np.isclose(vf, -b / m)
-        assert np.isclose(extras.vf_err, 0.0)  # ty:ignore[no-matching-overload]
-        assert np.isclose(extras.rsq, 1.0)  # ty:ignore[no-matching-overload]
+        np.testing.assert_allclose(vf, -b / m, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(extras.vf_err, 0.0, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
+        np.testing.assert_allclose(extras.rsq, 1.0, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
         assert isinstance(extras.fitted_func, ffuncs.Linear)
-        assert np.allclose(extras.fitted_func.params, (m, b))  # ty:ignore[invalid-argument-type]
-        assert np.allclose(extras.fitted_func.param_errors, (0.0, 0.0), atol=2e-8)  # ty:ignore[invalid-argument-type]
+        np.testing.assert_allclose(extras.fitted_func.params, (m, b), rtol=1e-5, atol=1e-8)  # ty:ignore[invalid-argument-type]
+        np.testing.assert_allclose(extras.fitted_func.param_errors, (0.0, 0.0), atol=2e-8, rtol=1e-5)  # ty:ignore[invalid-argument-type]
 
     @pytest.mark.parametrize(
         ("a", "alpha", "b"),
@@ -405,9 +405,9 @@ class TestFindFloatingPotential:
         )
 
         assert isinstance(extras, VFExtras)
-        assert np.isclose(vf, np.log(-b / a) / alpha)
-        assert np.isclose(extras.vf_err, 0.0, 1e-7)  # ty:ignore[no-matching-overload]
-        assert np.isclose(extras.rsq, 1.0)  # ty:ignore[no-matching-overload]
+        np.testing.assert_allclose(vf, np.log(-b / a) / alpha, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(extras.vf_err, 0.0, 1e-7, atol=1e-8)  # ty:ignore[no-matching-overload]
+        np.testing.assert_allclose(extras.rsq, 1.0, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
         assert isinstance(extras.fitted_func, ffuncs.ExponentialPlusOffset)
-        assert np.allclose(extras.fitted_func.params, (a, alpha, b))  # ty:ignore[invalid-argument-type]
-        assert np.allclose(extras.fitted_func.param_errors, (0.0, 0.0, 0.0), atol=2e-8)  # ty:ignore[invalid-argument-type]
+        np.testing.assert_allclose(extras.fitted_func.params, (a, alpha, b), rtol=1e-5, atol=1e-8)  # ty:ignore[invalid-argument-type]
+        np.testing.assert_allclose(extras.fitted_func.param_errors, (0.0, 0.0, 0.0), atol=2e-8, rtol=1e-5)  # ty:ignore[invalid-argument-type]

--- a/tests/analysis/swept_langmuir/test_helpers__merge_voltage_clusters.py
+++ b/tests/analysis/swept_langmuir/test_helpers__merge_voltage_clusters.py
@@ -189,11 +189,11 @@ def test_merge_voltage_clusters(
         )
 
         if expected is not None:
-            assert np.allclose(rtn_voltage, expected[0])
-            assert np.allclose(rtn_current, expected[1])
+            np.testing.assert_allclose(rtn_voltage, expected[0], rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(rtn_current, expected[1], rtol=1e-5, atol=1e-8)
         else:
-            assert np.allclose(rtn_voltage, voltage)
-            assert np.allclose(rtn_current, current)
+            np.testing.assert_allclose(rtn_voltage, voltage, rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(rtn_current, current, rtol=1e-5, atol=1e-8)
 
         # ensure check_sweep() is called...then we do not have to
         # explicitly add test cases covered by check_sweep()

--- a/tests/analysis/swept_langmuir/test_ion_saturation_current.py
+++ b/tests/analysis/swept_langmuir/test_ion_saturation_current.py
@@ -264,12 +264,19 @@ class TestFindIonSaturationCurrent:
 
         # assertions on isat
         assert isinstance(isat, type(expected[0]))
-        np.testing.assert_allclose(isat.params, expected[0].params, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            isat.params, expected[0].params, rtol=1e-5, atol=1e-8
+        )
 
         # assertions on extras
         assert isinstance(extras, ISatExtras)
         assert isinstance(extras.fitted_func, type(expected[1].fitted_func))
-        np.testing.assert_allclose(extras.fitted_func.params, expected[1].fitted_func.params, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            extras.fitted_func.params,
+            expected[1].fitted_func.params,
+            rtol=1e-5,
+            atol=1e-8,
+        )
         np.testing.assert_allclose(extras.rsq, 1.0, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
         assert extras.fitted_indices == expected[1].fitted_indices
 
@@ -297,4 +304,6 @@ class TestFindIonSaturationCurrent:
         np.testing.assert_allclose(isat.params.m, 3.81079e-6, rtol=1e-3, atol=0)
         np.testing.assert_allclose(isat.params.b, 0.000110422, rtol=2e-3, atol=0)
         np.testing.assert_allclose(extras.rsq, 0.982, rtol=0, atol=0.002)  # ty:ignore[no-matching-overload]
-        np.testing.assert_allclose(np.min(isat(voltage)), -0.00014275, rtol=2e-3, atol=0)
+        np.testing.assert_allclose(
+            np.min(isat(voltage)), -0.00014275, rtol=2e-3, atol=0
+        )

--- a/tests/analysis/swept_langmuir/test_ion_saturation_current.py
+++ b/tests/analysis/swept_langmuir/test_ion_saturation_current.py
@@ -264,13 +264,13 @@ class TestFindIonSaturationCurrent:
 
         # assertions on isat
         assert isinstance(isat, type(expected[0]))
-        assert np.allclose(isat.params, expected[0].params)
+        np.testing.assert_allclose(isat.params, expected[0].params, rtol=1e-5, atol=1e-8)
 
         # assertions on extras
         assert isinstance(extras, ISatExtras)
         assert isinstance(extras.fitted_func, type(expected[1].fitted_func))
-        assert np.allclose(extras.fitted_func.params, expected[1].fitted_func.params)
-        assert np.isclose(extras.rsq, 1.0)  # ty:ignore[no-matching-overload]
+        np.testing.assert_allclose(extras.fitted_func.params, expected[1].fitted_func.params, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(extras.rsq, 1.0, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
         assert extras.fitted_indices == expected[1].fitted_indices
 
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
@@ -294,7 +294,7 @@ class TestFindIonSaturationCurrent:
             current_bound=3.6,
         )
 
-        assert np.isclose(isat.params.m, 3.81079e-6, rtol=1e-3, atol=0)
-        assert np.isclose(isat.params.b, 0.000110422, rtol=2e-3, atol=0)
-        assert np.isclose(extras.rsq, 0.982, rtol=0, atol=0.002)  # ty:ignore[no-matching-overload]
-        assert np.isclose(np.min(isat(voltage)), -0.00014275, rtol=2e-3, atol=0)
+        np.testing.assert_allclose(isat.params.m, 3.81079e-6, rtol=1e-3, atol=0)
+        np.testing.assert_allclose(isat.params.b, 0.000110422, rtol=2e-3, atol=0)
+        np.testing.assert_allclose(extras.rsq, 0.982, rtol=0, atol=0.002)  # ty:ignore[no-matching-overload]
+        np.testing.assert_allclose(np.min(isat(voltage)), -0.00014275, rtol=2e-3, atol=0)

--- a/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
+++ b/tests/analysis/swept_langmuir/test_swept_langmuir_helpers.py
@@ -184,11 +184,11 @@ def test_check_sweep(voltage, current, kwargs, with_context, expected) -> None:
         )
 
         if expected == "expected same as inputs":
-            assert np.allclose(rtn_voltage, voltage)
-            assert np.allclose(rtn_current, current)
+            np.testing.assert_allclose(rtn_voltage, voltage, rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(rtn_current, current, rtol=1e-5, atol=1e-8)
         else:
-            assert np.allclose(rtn_voltage, expected[0])
-            assert np.allclose(rtn_current, expected[1])
+            np.testing.assert_allclose(rtn_voltage, expected[0], rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(rtn_current, expected[1], rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize(
@@ -269,11 +269,11 @@ def test_sort_sweep_arrays(voltage, current, kwargs, with_context, expected) -> 
         )
 
         if expected is not None:
-            assert np.allclose(rtn_voltage, expected[0])
-            assert np.allclose(rtn_current, expected[1])
+            np.testing.assert_allclose(rtn_voltage, expected[0], rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(rtn_current, expected[1], rtol=1e-5, atol=1e-8)
         else:
-            assert np.allclose(rtn_voltage, voltage)
-            assert np.allclose(rtn_current, current)
+            np.testing.assert_allclose(rtn_voltage, voltage, rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(rtn_current, current, rtol=1e-5, atol=1e-8)
 
         mock_check_sweep.assert_called_once()
         mock_check_sweep.reset_mock()

--- a/tests/analysis/test_fit_functions.py
+++ b/tests/analysis/test_fit_functions.py
@@ -295,7 +295,7 @@ class BaseFFTests(ABC):
                 x = np.array(x)
             y_expected = self.func(x, *params)  # ty:ignore[not-iterable]
 
-            assert np.allclose(y, y_expected)
+            np.testing.assert_allclose(y, y_expected, rtol=1e-5, atol=1e-8)
 
     @pytest.mark.parametrize(
         ("x", "kwargs", "with_condition"),
@@ -328,10 +328,10 @@ class BaseFFTests(ABC):
                 x = np.array(x)
             y_err_expected = self.func_err(x, params, param_errors, x_err=x_err)
 
-            assert np.allclose(y_err, y_err_expected)
+            np.testing.assert_allclose(y_err, y_err_expected, rtol=1e-5, atol=1e-8)
 
             if y is not None:
-                assert np.allclose(y, self.func(x, *params))  # ty:ignore[not-iterable]
+                np.testing.assert_allclose(y, self.func(x, *params), rtol=1e-5, atol=1e-8)  # ty:ignore[not-iterable]
 
     @pytest.mark.parametrize(
         ("x", "kwargs", "with_condition"),
@@ -367,11 +367,11 @@ class BaseFFTests(ABC):
                 x = np.array(x)
             y_expected = self.func(x, *params)  # ty:ignore[not-iterable]
 
-            assert np.allclose(y, y_expected)
+            np.testing.assert_allclose(y, y_expected, rtol=1e-5, atol=1e-8)
 
             if reterr:
                 y_err_expected = self.func_err(x, params, param_errors, x_err=x_err)
-                assert np.allclose(y_err, y_err_expected)
+                np.testing.assert_allclose(y_err, y_err_expected, rtol=1e-5, atol=1e-8)
 
     @abstractmethod
     def test_root_solve(self): ...
@@ -391,13 +391,9 @@ class BaseFFTests(ABC):
         ff_obj.curve_fit(xdata, ydata)
 
         assert ff_obj.curve_fit_results is not None
-        assert np.isclose(ff_obj.rsq, 1.0)
-        assert np.allclose(
-            ff_obj.param_errors,
-            tuple([0] * len(ff_obj.param_names)),
-            atol=1.5e-8,
-        )
-        assert np.allclose(ff_obj.params, self._test_params)
+        np.testing.assert_allclose(ff_obj.rsq, 1.0, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(ff_obj.param_errors, tuple([0] * len(ff_obj.param_names)), atol=1.5e-8, rtol=1e-5)
+        np.testing.assert_allclose(ff_obj.params, self._test_params, rtol=1e-5, atol=1e-8)
 
 
 class TestFFExponential(BaseFFTests):
@@ -481,7 +477,7 @@ class TestFFExponentialPlusLinear(BaseFFTests):
     def test_root_solve(self) -> None:
         ff_obj = self.ff_class(params=(5.0, 0.5, 1.0, 5.0), param_errors=(0, 0, 0, 0))
         root, err = ff_obj.root_solve(-5)
-        assert np.isclose(root, -5.345338)
+        np.testing.assert_allclose(root, -5.345338, rtol=1e-5, atol=1e-8)
         assert np.isnan(err)
 
 
@@ -593,9 +589,9 @@ class TestFFLinear(BaseFFTests):
                 assert np.all(np.isnan(results))
             elif np.isnan(root):
                 assert np.isnan(results[0])
-                assert np.isclose(results[1], root_err)
+                np.testing.assert_allclose(results[1], root_err, rtol=1e-5, atol=1e-8)
             elif np.isnan(root_err):
-                assert np.isclose(results[0], root)
+                np.testing.assert_allclose(results[0], root, rtol=1e-5, atol=1e-8)
                 assert np.isnan(results[1])
             else:
-                assert np.allclose(results, [root, root_err])
+                np.testing.assert_allclose(results, [root, root_err], rtol=1e-5, atol=1e-8)

--- a/tests/analysis/test_fit_functions.py
+++ b/tests/analysis/test_fit_functions.py
@@ -332,7 +332,10 @@ class BaseFFTests(ABC):
 
             if y is not None:
                 np.testing.assert_allclose(
-                    y, self.func(x, *params), rtol=1e-5, atol=1e-8  # ty:ignore[not-iterable]
+                    y,
+                    self.func(x, *params),
+                    rtol=1e-5,
+                    atol=1e-8,  # ty:ignore[not-iterable]
                 )
 
     @pytest.mark.parametrize(

--- a/tests/analysis/test_fit_functions.py
+++ b/tests/analysis/test_fit_functions.py
@@ -331,7 +331,9 @@ class BaseFFTests(ABC):
             np.testing.assert_allclose(y_err, y_err_expected, rtol=1e-5, atol=1e-8)
 
             if y is not None:
-                np.testing.assert_allclose(y, self.func(x, *params), rtol=1e-5, atol=1e-8)  # ty:ignore[not-iterable]
+                np.testing.assert_allclose(
+                    y, self.func(x, *params), rtol=1e-5, atol=1e-8
+                )  # ty:ignore[not-iterable]
 
     @pytest.mark.parametrize(
         ("x", "kwargs", "with_condition"),
@@ -392,8 +394,15 @@ class BaseFFTests(ABC):
 
         assert ff_obj.curve_fit_results is not None
         np.testing.assert_allclose(ff_obj.rsq, 1.0, rtol=1e-5, atol=1e-8)
-        np.testing.assert_allclose(ff_obj.param_errors, tuple([0] * len(ff_obj.param_names)), atol=1.5e-8, rtol=1e-5)
-        np.testing.assert_allclose(ff_obj.params, self._test_params, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            ff_obj.param_errors,
+            tuple([0] * len(ff_obj.param_names)),
+            atol=1.5e-8,
+            rtol=1e-5,
+        )
+        np.testing.assert_allclose(
+            ff_obj.params, self._test_params, rtol=1e-5, atol=1e-8
+        )
 
 
 class TestFFExponential(BaseFFTests):
@@ -594,4 +603,6 @@ class TestFFLinear(BaseFFTests):
                 np.testing.assert_allclose(results[0], root, rtol=1e-5, atol=1e-8)
                 assert np.isnan(results[1])
             else:
-                np.testing.assert_allclose(results, [root, root_err], rtol=1e-5, atol=1e-8)
+                np.testing.assert_allclose(
+                    results, [root, root_err], rtol=1e-5, atol=1e-8
+                )

--- a/tests/analysis/test_fit_functions.py
+++ b/tests/analysis/test_fit_functions.py
@@ -332,8 +332,8 @@ class BaseFFTests(ABC):
 
             if y is not None:
                 np.testing.assert_allclose(
-                    y, self.func(x, *params), rtol=1e-5, atol=1e-8
-                )  # ty:ignore[not-iterable]
+                    y, self.func(x, *params), rtol=1e-5, atol=1e-8  # ty:ignore[not-iterable]
+                )
 
     @pytest.mark.parametrize(
         ("x", "kwargs", "with_condition"),

--- a/tests/analysis/test_fit_functions.py
+++ b/tests/analysis/test_fit_functions.py
@@ -333,9 +333,9 @@ class BaseFFTests(ABC):
             if y is not None:
                 np.testing.assert_allclose(
                     y,
-                    self.func(x, *params),
+                    self.func(x, *params),  # ty:ignore[not-iterable]
                     rtol=1e-5,
-                    atol=1e-8,  # ty:ignore[not-iterable]
+                    atol=1e-8,
                 )
 
     @pytest.mark.parametrize(

--- a/tests/analysis/test_nullpoint.py
+++ b/tests/analysis/test_nullpoint.py
@@ -95,7 +95,7 @@ def test_trilinear_jacobian() -> None:
     jcb = _trilinear_jacobian(vspace, [0, 0, 0])
     mtrx = jcb(0.5, 0.5, 0.5)
     exact_mtrx = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
-    assert np.allclose(mtrx, exact_mtrx, atol=_EQUALITY_ATOL)
+    np.testing.assert_allclose(mtrx, exact_mtrx, atol=_EQUALITY_ATOL, rtol=1e-5)
 
 
 def test_trilinear_approx() -> None:
@@ -127,16 +127,12 @@ def test_trilinear_approx() -> None:
     for p in corners:
         approx = tlApprox(p[0], p[1], p[2])
         exact = vspace_func_2(p[0], p[1], p[2])
-        approx = approx.reshape(1, 3)
-        assert np.allclose(approx, exact, atol=_EQUALITY_ATOL)
+        approx = approx.flatten()
+        np.testing.assert_allclose(approx, exact, atol=_EQUALITY_ATOL, rtol=1e-5)
     # Testing Trilinear Approx function on a midpoint
     approx = tlApprox(mid[0], mid[1], mid[2])
-    approx = approx.reshape(1, 3)
-    assert np.allclose(
-        approx,
-        [-5.39130435, -21.5652174, 23.68667299],
-        atol=_EQUALITY_ATOL,
-    )
+    approx = approx.flatten()
+    np.testing.assert_allclose(approx, [-5.39130435, -21.5652174, 23.68667299], atol=_EQUALITY_ATOL, rtol=1e-5)
 
 
 class Test_reduction:
@@ -207,10 +203,10 @@ class Test_bilinear_root:
         r"""Test expected values."""
         x1, y1 = _bilinear_root(**kwargs)[0]
         x2, y2 = _bilinear_root(**kwargs)[1]
-        assert np.isclose(x1, expected[0], atol=_EQUALITY_ATOL)
-        assert np.isclose(y1, expected[1], atol=_EQUALITY_ATOL)
-        assert np.isclose(x2, expected[2], atol=_EQUALITY_ATOL)
-        assert np.isclose(y2, expected[3], atol=_EQUALITY_ATOL)
+        np.testing.assert_allclose(x1, expected[0], atol=_EQUALITY_ATOL, rtol=1e-5)
+        np.testing.assert_allclose(y1, expected[1], atol=_EQUALITY_ATOL, rtol=1e-5)
+        np.testing.assert_allclose(x2, expected[2], atol=_EQUALITY_ATOL, rtol=1e-5)
+        np.testing.assert_allclose(y2, expected[3], atol=_EQUALITY_ATOL, rtol=1e-5)
 
 
 class Test_locate_null_point:
@@ -235,11 +231,7 @@ class Test_locate_null_point:
     @pytest.mark.parametrize(("kwargs", "expected"), test_locate_null_point_values)
     def test_locate_null_point_vals(self, kwargs, expected) -> None:
         r"""Test expected values."""
-        assert np.isclose(
-            _locate_null_point(**kwargs).reshape(1, 3),
-            expected,
-            atol=_EQUALITY_ATOL,
-        ).all()
+        np.testing.assert_allclose(_locate_null_point(**kwargs).flatten(), expected, atol=_EQUALITY_ATOL, rtol=1e-5)
 
 
 @pytest.mark.slow
@@ -254,9 +246,9 @@ def test_null_point_find1() -> None:
         "func": vspace_func_1,
     }
     npoints = uniform_null_point_find(**nullpoint_args)  # ty:ignore[invalid-argument-type]
-    loc = npoints[0].loc.reshape(1, 3)
+    loc = npoints[0].loc.flatten()
     assert len(npoints) == 1
-    assert np.isclose(loc, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
+    np.testing.assert_allclose(loc, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5)
 
 
 @pytest.mark.slow
@@ -271,9 +263,9 @@ def test_null_point_find2() -> None:
     }
     vspace = _vector_space(**vspace_args)
     npoints2 = _vspace_iterator(vspace)
-    loc2 = npoints2[0].loc.reshape(1, 3)
+    loc2 = npoints2[0].loc.flatten()
     assert len(npoints2) == 1
-    assert np.isclose(loc2, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
+    np.testing.assert_allclose(loc2, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5)
 
 
 def test_null_point_find3() -> None:
@@ -288,9 +280,9 @@ def test_null_point_find3() -> None:
         "w_arr": np.array([[[-0.5, -0.5], [-0.5, -0.5]], [[0.5, 0.5], [0.5, 0.5]]]),
     }
     npoints3 = null_point_find(**nullpoint3_args)  # ty:ignore[invalid-argument-type]
-    loc3 = npoints3[0].loc.reshape(1, 3)
+    loc3 = npoints3[0].loc.flatten()
     assert len(npoints3) == 1
-    assert np.isclose(loc3, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
+    np.testing.assert_allclose(loc3, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5)
 
 
 @pytest.mark.slow
@@ -305,11 +297,11 @@ def test_null_point_find4() -> None:
         "func": vspace_func_3,
     }
     npoints4 = uniform_null_point_find(**nullpoint4_args)  # ty:ignore[invalid-argument-type]
-    first_loc4 = npoints4[0].loc.reshape(1, 3)
-    second_loc4 = npoints4[1].loc.reshape(1, 3)
+    first_loc4 = npoints4[0].loc.flatten()
+    second_loc4 = npoints4[1].loc.flatten()
     assert len(npoints4) == 2
-    assert np.isclose(first_loc4, [5.5, 5.3, 5.5], atol=_EQUALITY_ATOL).all()
-    assert np.isclose(second_loc4, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL).all()
+    np.testing.assert_allclose(first_loc4, [5.5, 5.3, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5)
+    np.testing.assert_allclose(second_loc4, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5)
 
 
 @pytest.mark.slow
@@ -392,10 +384,10 @@ def test_null_point_find8() -> None:
     }
     npoints8 = uniform_null_point_find(**nullpoint8_args)  # ty:ignore[invalid-argument-type]
     assert len(npoints8) == 2
-    loc1 = npoints8[0].loc.reshape(1, 3)
-    loc2 = npoints8[1].loc.reshape(1, 3)
-    assert np.allclose(loc1, [5.5, -5.5, 5.5], atol=_TESTING_ATOL)
-    assert np.allclose(loc2, [5.5, 5.5, 5.5], atol=_TESTING_ATOL)
+    loc1 = npoints8[0].loc.flatten()
+    loc2 = npoints8[1].loc.flatten()
+    np.testing.assert_allclose(loc1, [5.5, -5.5, 5.5], atol=_TESTING_ATOL, rtol=1e-5)
+    np.testing.assert_allclose(loc2, [5.5, 5.5, 5.5], atol=_TESTING_ATOL, rtol=1e-5)
 
 
 @pytest.mark.slow

--- a/tests/analysis/test_nullpoint.py
+++ b/tests/analysis/test_nullpoint.py
@@ -132,7 +132,9 @@ def test_trilinear_approx() -> None:
     # Testing Trilinear Approx function on a midpoint
     approx = tlApprox(mid[0], mid[1], mid[2])
     approx = approx.flatten()
-    np.testing.assert_allclose(approx, [-5.39130435, -21.5652174, 23.68667299], atol=_EQUALITY_ATOL, rtol=1e-5)
+    np.testing.assert_allclose(
+        approx, [-5.39130435, -21.5652174, 23.68667299], atol=_EQUALITY_ATOL, rtol=1e-5
+    )
 
 
 class Test_reduction:
@@ -231,7 +233,12 @@ class Test_locate_null_point:
     @pytest.mark.parametrize(("kwargs", "expected"), test_locate_null_point_values)
     def test_locate_null_point_vals(self, kwargs, expected) -> None:
         r"""Test expected values."""
-        np.testing.assert_allclose(_locate_null_point(**kwargs).flatten(), expected, atol=_EQUALITY_ATOL, rtol=1e-5)
+        np.testing.assert_allclose(
+            _locate_null_point(**kwargs).flatten(),
+            expected,
+            atol=_EQUALITY_ATOL,
+            rtol=1e-5,
+        )
 
 
 @pytest.mark.slow
@@ -300,8 +307,12 @@ def test_null_point_find4() -> None:
     first_loc4 = npoints4[0].loc.flatten()
     second_loc4 = npoints4[1].loc.flatten()
     assert len(npoints4) == 2
-    np.testing.assert_allclose(first_loc4, [5.5, 5.3, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5)
-    np.testing.assert_allclose(second_loc4, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5)
+    np.testing.assert_allclose(
+        first_loc4, [5.5, 5.3, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5
+    )
+    np.testing.assert_allclose(
+        second_loc4, [5.5, 5.5, 5.5], atol=_EQUALITY_ATOL, rtol=1e-5
+    )
 
 
 @pytest.mark.slow

--- a/tests/analysis/time_series/test_excess_statistics.py
+++ b/tests/analysis/time_series/test_excess_statistics.py
@@ -92,8 +92,8 @@ def test_ExcessStatistics(signal, thresholds, time_step, pdf, bins, expected) ->
     assert excess_stats.rms_times == expected[3]
     if pdf:
         hist, bin_centers = excess_stats.hist(bins)
-        assert np.allclose(hist, expected[4])
-        assert np.allclose(bin_centers, expected[5])
+        np.testing.assert_allclose(hist, expected[4], rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(bin_centers, expected[5], rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize(

--- a/tests/analysis/time_series/test_running_moments.py
+++ b/tests/analysis/time_series/test_running_moments.py
@@ -19,7 +19,7 @@ from plasmapy.analysis.time_series.running_moments import running_mean, running_
 def test_running_mean(signal, radius: int, expected) -> None:
     """Test running_mean function"""
     result = running_mean(signal=signal, radius=radius)
-    assert np.allclose(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize(("signal", "radius"), [([1, 2], 1), ([1, 2, 3, 4], 1.2)])
@@ -49,7 +49,7 @@ def test_running_mean_exception(signal, radius: int) -> None:
 def test_running_moment(signal, radius: int, moment, time, expected) -> None:
     """Test running_moment_function"""
     result = running_moment(signal, radius, moment, time)
-    assert np.allclose(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize(

--- a/tests/diagnostics/charged_particle_radiography/test_detector_stacks.py
+++ b/tests/diagnostics/charged_particle_radiography/test_detector_stacks.py
@@ -119,7 +119,9 @@ def test_film_stack_num_active(hdv2_stack) -> None:
 @check_database_connection
 def test_film_stack_thickness(hdv2_stack) -> None:
     # Test thickness property
-    np.testing.assert_allclose(hdv2_stack.thickness.to(u.mm).value, 1.19, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        hdv2_stack.thickness.to(u.mm).value, 1.19, rtol=1e-5, atol=1e-8
+    )
 
 
 @check_database_connection
@@ -141,7 +143,9 @@ def test_film_stack_energy_bands_active(hdv2_stack) -> None:
     # Expected energy bands, in MeV (only in active layers)
     expected = np.array([[3.5, 3.8], [4.6, 4.9], [5.6, 5.7], [6.4, 6.5], [7.1, 7.2]])
 
-    np.testing.assert_allclose(ebands.to(u.MeV).value[:5, :], expected, atol=0.15, rtol=1e-5)
+    np.testing.assert_allclose(
+        ebands.to(u.MeV).value[:5, :], expected, atol=0.15, rtol=1e-5
+    )
 
 
 @check_database_connection
@@ -155,4 +159,6 @@ def test_film_stack_energy_bands_inum_active(hdv2_stack) -> None:
     )
     # Expected first 5 energy bands
     expected = np.array([[0.1, 4.2], [3.5, 3.8], [3.9, 5.1], [4.6, 4.9], [4.9, 6]])
-    np.testing.assert_allclose(ebands.to(u.MeV).value[0:5, :], expected, atol=0.15, rtol=1e-5)
+    np.testing.assert_allclose(
+        ebands.to(u.MeV).value[0:5, :], expected, atol=0.15, rtol=1e-5
+    )

--- a/tests/diagnostics/charged_particle_radiography/test_detector_stacks.py
+++ b/tests/diagnostics/charged_particle_radiography/test_detector_stacks.py
@@ -119,7 +119,7 @@ def test_film_stack_num_active(hdv2_stack) -> None:
 @check_database_connection
 def test_film_stack_thickness(hdv2_stack) -> None:
     # Test thickness property
-    assert np.isclose(hdv2_stack.thickness.to(u.mm).value, 1.19)
+    np.testing.assert_allclose(hdv2_stack.thickness.to(u.mm).value, 1.19, rtol=1e-5, atol=1e-8)
 
 
 @check_database_connection
@@ -141,7 +141,7 @@ def test_film_stack_energy_bands_active(hdv2_stack) -> None:
     # Expected energy bands, in MeV (only in active layers)
     expected = np.array([[3.5, 3.8], [4.6, 4.9], [5.6, 5.7], [6.4, 6.5], [7.1, 7.2]])
 
-    assert np.allclose(ebands.to(u.MeV).value[:5, :], expected, atol=0.15)
+    np.testing.assert_allclose(ebands.to(u.MeV).value[:5, :], expected, atol=0.15, rtol=1e-5)
 
 
 @check_database_connection
@@ -155,4 +155,4 @@ def test_film_stack_energy_bands_inum_active(hdv2_stack) -> None:
     )
     # Expected first 5 energy bands
     expected = np.array([[0.1, 4.2], [3.5, 3.8], [3.9, 5.1], [4.6, 4.9], [4.9, 6]])
-    assert np.allclose(ebands.to(u.MeV).value[0:5, :], expected, atol=0.15)
+    np.testing.assert_allclose(ebands.to(u.MeV).value[0:5, :], expected, atol=0.15, rtol=1e-5)

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -256,12 +256,12 @@ def test_1D_deflections() -> None:
     # Check B-deflection
     hax, lineout = run_1D_example("constant_bz")
     loc = hax[np.argmax(lineout)]
-    assert np.isclose(loc.si.value, 0.0165, 0.005)
+    np.testing.assert_allclose(loc.si.value, 0.0165, 0.005, atol=1e-8)
 
     # Check E-deflection
     hax, lineout = run_1D_example("constant_ex")
     loc = hax[np.argmax(lineout)]
-    assert np.isclose(loc.si.value, 0.0335, 0.005)
+    np.testing.assert_allclose(loc.si.value, 0.0335, 0.005, atol=1e-8)
 
 
 @pytest.mark.slow
@@ -287,10 +287,10 @@ def test_coordinate_systems() -> None:
     detector = (0.1 * u.m, 90 * u.deg, 45 * u.deg)
     sim3 = cpr.Tracker(grid, source, detector, verbose=False)
 
-    assert np.allclose(sim1.source, sim2.source, atol=1e-2)
-    assert np.allclose(sim2.source, sim3.source, atol=1e-2)
-    assert np.allclose(sim1.detector, sim2.detector, atol=1e-2)
-    assert np.allclose(sim2.detector, sim3.detector, atol=1e-2)
+    np.testing.assert_allclose(sim1.source, sim2.source, atol=1e-2, rtol=1e-5)
+    np.testing.assert_allclose(sim2.source, sim3.source, atol=1e-2, rtol=1e-5)
+    np.testing.assert_allclose(sim1.detector, sim2.detector, atol=1e-2, rtol=1e-5)
+    np.testing.assert_allclose(sim2.detector, sim3.detector, atol=1e-2, rtol=1e-5)
 
 
 @pytest.mark.slow
@@ -464,7 +464,7 @@ def test_create_particles() -> None:
     # Assert particle velocities are actually in that direction
     vdir = np.mean(sim.v, axis=0)
     vdir /= np.linalg.norm(vdir)
-    assert np.allclose(vdir, src_vdir, atol=0.05)
+    np.testing.assert_allclose(vdir, src_vdir, atol=0.05, rtol=1e-5)
 
 
 @pytest.mark.slow
@@ -699,15 +699,15 @@ class TestSyntheticRadiograph:
         assert isinstance(x, u.Quantity)
         assert x.unit == u.m
         assert x.shape == (expected["bins"][0],)
-        assert np.isclose(np.min(x), expected["xrange"][0], rtol=1e4)
-        assert np.isclose(np.max(x), expected["xrange"][1], rtol=1e4)
+        np.testing.assert_allclose(np.min(x), expected["xrange"][0], rtol=1e4, atol=1e-8)
+        np.testing.assert_allclose(np.max(x), expected["xrange"][1], rtol=1e4, atol=1e-8)
 
         y = results[1]
         assert isinstance(y, u.Quantity)
         assert y.unit == u.m
         assert y.shape == (expected["bins"][1],)
-        assert np.isclose(np.min(y), expected["yrange"][0], rtol=1e4)
-        assert np.isclose(np.max(y), expected["yrange"][1], rtol=1e4)
+        np.testing.assert_allclose(np.min(y), expected["yrange"][0], rtol=1e4, atol=1e-8)
+        np.testing.assert_allclose(np.max(y), expected["yrange"][1], rtol=1e4, atol=1e-8)
 
         histogram = results[2]
         assert isinstance(histogram, np.ndarray)
@@ -843,7 +843,7 @@ def test_gaussian_sphere_analytical_comparison() -> None:
     ax.plot(h, theory_deflect)
     """
 
-    assert np.isclose(max_deflection, sim.max_deflection.to(u.rad).value, atol=1e-3)
+    np.testing.assert_allclose(max_deflection, sim.max_deflection.to(u.rad).value, atol=1e-3, rtol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -961,10 +961,10 @@ def test_add_wire_mesh_accuracy() -> None:
     """
 
     # Verify that the edges of the mesh are imaged correctly
-    assert np.isclose(measured_width, true_width, 1)
+    np.testing.assert_allclose(measured_width, true_width, 1, atol=1e-8)
 
     # Verify that the spacing is correct by checking the FFT
-    assert np.isclose(measured_spacing, true_spacing, 0.5)
+    np.testing.assert_allclose(measured_spacing, true_spacing, 0.5, atol=1e-8)
 
 
 def test_radiography_disk_save_routine(tmp_path) -> None:
@@ -996,7 +996,7 @@ def test_radiography_disk_save_routine(tmp_path) -> None:
     _h, _v, i2 = cpr.synthetic_radiograph(path)
 
     # The two synthetic radiographs should be identical
-    assert np.allclose(i1, i2)
+    np.testing.assert_allclose(i1, i2, rtol=1e-5, atol=1e-8)
 
 
 def test_radiography_memory_save_routine() -> None:
@@ -1120,4 +1120,4 @@ def test_NIST_particle_stopping(
         np.reshape(sim.x[:, 1], (energies.shape[0], PARTICLES_PER_CONFIGURATION)) * u.m
     )
 
-    assert np.isclose(np.median(x_final, axis=-1), projected_ranges, rtol=0.05).all()
+    np.testing.assert_allclose(np.median(x_final, axis=-1), projected_ranges, rtol=0.05, atol=1e-8)

--- a/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
+++ b/tests/diagnostics/charged_particle_radiography/test_synthetic_radiography.py
@@ -699,15 +699,23 @@ class TestSyntheticRadiograph:
         assert isinstance(x, u.Quantity)
         assert x.unit == u.m
         assert x.shape == (expected["bins"][0],)
-        np.testing.assert_allclose(np.min(x), expected["xrange"][0], rtol=1e4, atol=1e-8)
-        np.testing.assert_allclose(np.max(x), expected["xrange"][1], rtol=1e4, atol=1e-8)
+        np.testing.assert_allclose(
+            np.min(x), expected["xrange"][0], rtol=1e4, atol=1e-8
+        )
+        np.testing.assert_allclose(
+            np.max(x), expected["xrange"][1], rtol=1e4, atol=1e-8
+        )
 
         y = results[1]
         assert isinstance(y, u.Quantity)
         assert y.unit == u.m
         assert y.shape == (expected["bins"][1],)
-        np.testing.assert_allclose(np.min(y), expected["yrange"][0], rtol=1e4, atol=1e-8)
-        np.testing.assert_allclose(np.max(y), expected["yrange"][1], rtol=1e4, atol=1e-8)
+        np.testing.assert_allclose(
+            np.min(y), expected["yrange"][0], rtol=1e4, atol=1e-8
+        )
+        np.testing.assert_allclose(
+            np.max(y), expected["yrange"][1], rtol=1e4, atol=1e-8
+        )
 
         histogram = results[2]
         assert isinstance(histogram, np.ndarray)
@@ -843,7 +851,9 @@ def test_gaussian_sphere_analytical_comparison() -> None:
     ax.plot(h, theory_deflect)
     """
 
-    np.testing.assert_allclose(max_deflection, sim.max_deflection.to(u.rad).value, atol=1e-3, rtol=1e-5)
+    np.testing.assert_allclose(
+        max_deflection, sim.max_deflection.to(u.rad).value, atol=1e-3, rtol=1e-5
+    )
 
 
 @pytest.mark.parametrize(
@@ -1120,4 +1130,6 @@ def test_NIST_particle_stopping(
         np.reshape(sim.x[:, 1], (energies.shape[0], PARTICLES_PER_CONFIGURATION)) * u.m
     )
 
-    np.testing.assert_allclose(np.median(x_final, axis=-1), projected_ranges, rtol=0.05, atol=1e-8)
+    np.testing.assert_allclose(
+        np.median(x_final, axis=-1), projected_ranges, rtol=0.05, atol=1e-8
+    )

--- a/tests/diagnostics/test_langmuir.py
+++ b/tests/diagnostics/test_langmuir.py
@@ -244,8 +244,18 @@ class Test__Characteristic_inherited_methods:
         char = characteristic
         limits = char.get_padded_limit(0.1)
         log_limits = char.get_padded_limit(0.1, log=True)
-        np.testing.assert_allclose(limits.to(u.A).value, np.array((-0.07434804, 1.06484239)), rtol=1e-5, atol=1e-8)
-        np.testing.assert_allclose(log_limits.to(u.A).value, np.array((0.014003, 1.42577333)), rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            limits.to(u.A).value,
+            np.array((-0.07434804, 1.06484239)),
+            rtol=1e-5,
+            atol=1e-8,
+        )
+        np.testing.assert_allclose(
+            log_limits.to(u.A).value,
+            np.array((0.014003, 1.42577333)),
+            rtol=1e-5,
+            atol=1e-8,
+        )
 
 
 @pytest.mark.slow
@@ -302,7 +312,9 @@ def test_get_floating_potential_with_return_arg(characteristic) -> None:
             characteristic,
             return_arg=True,
         )
-    np.testing.assert_allclose((potential.to(u.V).value, arg), (0.12203823, 5), rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        (potential.to(u.V).value, arg), (0.12203823, 5), rtol=1e-5, atol=1e-8
+    )
 
 
 def test_get_ion_density_OML_without_return_fit(characteristic) -> None:
@@ -327,5 +339,9 @@ def test_get_EEDF() -> None:
     expect_energy = (0.14118696, 0.05293109, 0.00709731)
     expect_probability = (8.64838751, 8.05295503, 3.42348436)
 
-    np.testing.assert_allclose(energy.to(u.eV).value, np.array(expect_energy), rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(probability, np.array(expect_probability), rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        energy.to(u.eV).value, np.array(expect_energy), rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        probability, np.array(expect_probability), rtol=1e-5, atol=1e-8
+    )

--- a/tests/diagnostics/test_langmuir.py
+++ b/tests/diagnostics/test_langmuir.py
@@ -244,8 +244,8 @@ class Test__Characteristic_inherited_methods:
         char = characteristic
         limits = char.get_padded_limit(0.1)
         log_limits = char.get_padded_limit(0.1, log=True)
-        assert np.allclose(limits.to(u.A).value, np.array((-0.07434804, 1.06484239)))
-        assert np.allclose(log_limits.to(u.A).value, np.array((0.014003, 1.42577333)))
+        np.testing.assert_allclose(limits.to(u.A).value, np.array((-0.07434804, 1.06484239)), rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(log_limits.to(u.A).value, np.array((0.014003, 1.42577333)), rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.slow
@@ -302,7 +302,7 @@ def test_get_floating_potential_with_return_arg(characteristic) -> None:
             characteristic,
             return_arg=True,
         )
-    assert np.allclose((potential.to(u.V).value, arg), (0.12203823, 5))
+    np.testing.assert_allclose((potential.to(u.V).value, arg), (0.12203823, 5), rtol=1e-5, atol=1e-8)
 
 
 def test_get_ion_density_OML_without_return_fit(characteristic) -> None:
@@ -314,7 +314,7 @@ def test_get_ion_density_OML_without_return_fit(characteristic) -> None:
             "p+",
             return_fit=False,
         )
-    assert np.isclose(density.value, 385344135.12064785)
+    np.testing.assert_allclose(density.value, 385344135.12064785, rtol=1e-5, atol=1e-8)
 
 
 def test_get_EEDF() -> None:
@@ -327,5 +327,5 @@ def test_get_EEDF() -> None:
     expect_energy = (0.14118696, 0.05293109, 0.00709731)
     expect_probability = (8.64838751, 8.05295503, 3.42348436)
 
-    assert np.allclose(energy.to(u.eV).value, np.array(expect_energy))
-    assert np.allclose(probability, np.array(expect_probability))
+    np.testing.assert_allclose(energy.to(u.eV).value, np.array(expect_energy), rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(probability, np.array(expect_probability), rtol=1e-5, atol=1e-8)

--- a/tests/diagnostics/test_thomson.py
+++ b/tests/diagnostics/test_thomson.py
@@ -240,18 +240,18 @@ def test_notched_spectrum(notch, notch_num, single_species_collective_args) -> N
     alpha_notched, Skw_notched = thomson.spectral_density(*args, **kwargs)
 
     # Check that notch does not affect alpha
-    assert np.isclose(alpha_notched, alpha_unnotched)
+    np.testing.assert_allclose(alpha_notched, alpha_unnotched, rtol=1e-5, atol=1e-8)
 
     if notch_num == 1:
         # Record wavelength array indices corresponding to notch
         x0 = np.argwhere(wavelengths > notch[0])[0][0]
         x1 = np.argwhere(wavelengths > notch[1])[0][0]
         # Check that regions outside the notch are the same for both Skws
-        assert np.allclose(Skw_notched[:x0], Skw_unnotched[:x0])
-        assert np.allclose(Skw_notched[x1:], Skw_unnotched[x1:])
+        np.testing.assert_allclose(Skw_notched[:x0], Skw_unnotched[:x0], rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(Skw_notched[x1:], Skw_unnotched[x1:], rtol=1e-5, atol=1e-8)
 
         # Check that region inside the notch is 0 for notched Skw
-        assert np.allclose(Skw_notched[x0:x1], np.zeros(x1 - x0))
+        np.testing.assert_allclose(Skw_notched[x0:x1], np.zeros(x1 - x0), rtol=1e-5, atol=1e-8)
     elif notch_num == 2:
         x0 = np.argwhere(wavelengths > notch[0, 0])[0][0]
         x1 = np.argwhere(wavelengths > notch[0, 1])[0][0]
@@ -259,13 +259,13 @@ def test_notched_spectrum(notch, notch_num, single_species_collective_args) -> N
         x3 = np.argwhere(wavelengths > notch[1, 1])[0][0]
 
         # Check that regions outside the notches are the same for both Skws
-        assert np.allclose(Skw_notched[:x0], Skw_unnotched[:x0])
-        assert np.allclose(Skw_notched[x1:x2], Skw_unnotched[x1:x2])
-        assert np.allclose(Skw_notched[x3:], Skw_unnotched[x3:])
+        np.testing.assert_allclose(Skw_notched[:x0], Skw_unnotched[:x0], rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(Skw_notched[x1:x2], Skw_unnotched[x1:x2], rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(Skw_notched[x3:], Skw_unnotched[x3:], rtol=1e-5, atol=1e-8)
 
         # Check that region inside the notches is 0 for notched Skw
-        assert np.allclose(Skw_notched[x0:x1], np.zeros(x1 - x0))
-        assert np.allclose(Skw_notched[x2:x3], np.zeros(x3 - x2))
+        np.testing.assert_allclose(Skw_notched[x0:x1], np.zeros(x1 - x0), rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(Skw_notched[x2:x3], np.zeros(x3 - x2), rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize(
@@ -323,9 +323,9 @@ def test_single_species_collective_lite(single_species_collective_args) -> None:
     args, kwargs = spectral_density_args_kwargs(lite_kwargs)
     alpha2, Skw2 = thomson.spectral_density.lite(*args, **kwargs)
 
-    assert np.isclose(alpha1, alpha2)
+    np.testing.assert_allclose(alpha1, alpha2, rtol=1e-5, atol=1e-8)
 
-    assert np.allclose(Skw1.to(u.s / u.rad).value, Skw2)
+    np.testing.assert_allclose(Skw1.to(u.s / u.rad).value, Skw2, rtol=1e-5, atol=1e-8)
 
 
 def test_spectral_density_lite_minimal_arguments(

--- a/tests/diagnostics/test_thomson.py
+++ b/tests/diagnostics/test_thomson.py
@@ -247,11 +247,17 @@ def test_notched_spectrum(notch, notch_num, single_species_collective_args) -> N
         x0 = np.argwhere(wavelengths > notch[0])[0][0]
         x1 = np.argwhere(wavelengths > notch[1])[0][0]
         # Check that regions outside the notch are the same for both Skws
-        np.testing.assert_allclose(Skw_notched[:x0], Skw_unnotched[:x0], rtol=1e-5, atol=1e-8)
-        np.testing.assert_allclose(Skw_notched[x1:], Skw_unnotched[x1:], rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            Skw_notched[:x0], Skw_unnotched[:x0], rtol=1e-5, atol=1e-8
+        )
+        np.testing.assert_allclose(
+            Skw_notched[x1:], Skw_unnotched[x1:], rtol=1e-5, atol=1e-8
+        )
 
         # Check that region inside the notch is 0 for notched Skw
-        np.testing.assert_allclose(Skw_notched[x0:x1], np.zeros(x1 - x0), rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            Skw_notched[x0:x1], np.zeros(x1 - x0), rtol=1e-5, atol=1e-8
+        )
     elif notch_num == 2:
         x0 = np.argwhere(wavelengths > notch[0, 0])[0][0]
         x1 = np.argwhere(wavelengths > notch[0, 1])[0][0]
@@ -259,13 +265,23 @@ def test_notched_spectrum(notch, notch_num, single_species_collective_args) -> N
         x3 = np.argwhere(wavelengths > notch[1, 1])[0][0]
 
         # Check that regions outside the notches are the same for both Skws
-        np.testing.assert_allclose(Skw_notched[:x0], Skw_unnotched[:x0], rtol=1e-5, atol=1e-8)
-        np.testing.assert_allclose(Skw_notched[x1:x2], Skw_unnotched[x1:x2], rtol=1e-5, atol=1e-8)
-        np.testing.assert_allclose(Skw_notched[x3:], Skw_unnotched[x3:], rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            Skw_notched[:x0], Skw_unnotched[:x0], rtol=1e-5, atol=1e-8
+        )
+        np.testing.assert_allclose(
+            Skw_notched[x1:x2], Skw_unnotched[x1:x2], rtol=1e-5, atol=1e-8
+        )
+        np.testing.assert_allclose(
+            Skw_notched[x3:], Skw_unnotched[x3:], rtol=1e-5, atol=1e-8
+        )
 
         # Check that region inside the notches is 0 for notched Skw
-        np.testing.assert_allclose(Skw_notched[x0:x1], np.zeros(x1 - x0), rtol=1e-5, atol=1e-8)
-        np.testing.assert_allclose(Skw_notched[x2:x3], np.zeros(x3 - x2), rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            Skw_notched[x0:x1], np.zeros(x1 - x0), rtol=1e-5, atol=1e-8
+        )
+        np.testing.assert_allclose(
+            Skw_notched[x2:x3], np.zeros(x3 - x2), rtol=1e-5, atol=1e-8
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/dispersion/analytical/test_mhd_wave_class.py
+++ b/tests/dispersion/analytical/test_mhd_wave_class.py
@@ -99,8 +99,8 @@ class TestMHDWave:
         for mode in range(3):
             omega = waves[mode].angular_frequency(**kwargs_wave_limits)
             v_ph = waves[mode].phase_velocity(**kwargs_wave_limits)
-            assert np.allclose(omega / kwargs_wave_limits["k"], expected[mode])
-            assert np.allclose(omega / kwargs_wave_limits["k"], v_ph)
+            np.testing.assert_allclose(omega / kwargs_wave_limits["k"], u.Quantity(expected[mode]), rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(omega / kwargs_wave_limits["k"], v_ph, rtol=1e-5, atol=1e-8)
 
     @pytest.mark.parametrize(
         ("kwargs", "expected"),
@@ -150,5 +150,5 @@ class TestMHDWave:
             # symmetric difference quotient
             dv_dtheta = (phase_velocity_p - phase_velocity_m) / (2 * dt / u.rad)
 
-            assert np.allclose(group_velocity_k, phase_velocity)
-            assert np.allclose(group_velocity_theta, dv_dtheta)
+            np.testing.assert_allclose(group_velocity_k, phase_velocity, rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(group_velocity_theta.flatten(), dv_dtheta.flatten(), rtol=1e-5, atol=1e-8)

--- a/tests/dispersion/analytical/test_mhd_wave_class.py
+++ b/tests/dispersion/analytical/test_mhd_wave_class.py
@@ -99,8 +99,15 @@ class TestMHDWave:
         for mode in range(3):
             omega = waves[mode].angular_frequency(**kwargs_wave_limits)
             v_ph = waves[mode].phase_velocity(**kwargs_wave_limits)
-            np.testing.assert_allclose(omega / kwargs_wave_limits["k"], u.Quantity(expected[mode]), rtol=1e-5, atol=1e-8)
-            np.testing.assert_allclose(omega / kwargs_wave_limits["k"], v_ph, rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(
+                omega / kwargs_wave_limits["k"],
+                u.Quantity(expected[mode]),
+                rtol=1e-5,
+                atol=1e-8,
+            )
+            np.testing.assert_allclose(
+                omega / kwargs_wave_limits["k"], v_ph, rtol=1e-5, atol=1e-8
+            )
 
     @pytest.mark.parametrize(
         ("kwargs", "expected"),
@@ -150,5 +157,12 @@ class TestMHDWave:
             # symmetric difference quotient
             dv_dtheta = (phase_velocity_p - phase_velocity_m) / (2 * dt / u.rad)
 
-            np.testing.assert_allclose(group_velocity_k, phase_velocity, rtol=1e-5, atol=1e-8)
-            np.testing.assert_allclose(group_velocity_theta.flatten(), dv_dtheta.flatten(), rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(
+                group_velocity_k, phase_velocity, rtol=1e-5, atol=1e-8
+            )
+            np.testing.assert_allclose(
+                group_velocity_theta.flatten(),
+                dv_dtheta.flatten(),
+                rtol=1e-5,
+                atol=1e-8,
+            )

--- a/tests/dispersion/analytical/test_stix_.py
+++ b/tests/dispersion/analytical/test_stix_.py
@@ -264,7 +264,7 @@ class TestStix:
         ks = stix(**kwargs)
         ns = ks.value * c_si_unitless / kwargs["w"].value
 
-        assert np.allclose(ns, expected["ns"])
+        np.testing.assert_allclose(ns, expected["ns"], rtol=1e-5, atol=1e-8)
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -314,10 +314,10 @@ class TestStix:
         n_soln1 = np.emath.sqrt(0.5 * (R + L - np.abs(R - L)))  # n^2 = L
         n_soln2 = np.emath.sqrt(0.5 * (R + L + np.abs(R - L)))  # n^2 = R
 
-        assert np.allclose(ns[..., 0], n_soln1)
-        assert np.allclose(ns[..., 1], -n_soln1)
-        assert np.allclose(ns[..., 2], n_soln2)
-        assert np.allclose(ns[..., 3], -n_soln2)
+        np.testing.assert_allclose(ns[..., 0], n_soln1, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(ns[..., 1], -n_soln1, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(ns[..., 2], n_soln2, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(ns[..., 3], -n_soln2, rtol=1e-5, atol=1e-8)
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -371,7 +371,7 @@ class TestStix:
             (R * L + P * S - np.abs(R * L - P * S)) / (2 * S),
         )  # n^2 = P
 
-        assert np.allclose(ns[..., 0], n_soln1)
-        assert np.allclose(ns[..., 1], -n_soln1)
-        assert np.allclose(ns[..., 2], n_soln2)
-        assert np.allclose(ns[..., 3], -n_soln2)
+        np.testing.assert_allclose(ns[..., 0], n_soln1, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(ns[..., 1], -n_soln1, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(ns[..., 2], n_soln2, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(ns[..., 3], -n_soln2, rtol=1e-5, atol=1e-8)

--- a/tests/dispersion/analytical/test_two_fluid_.py
+++ b/tests/dispersion/analytical/test_two_fluid_.py
@@ -130,7 +130,7 @@ class TestTwoFluid:
         ws = two_fluid(**kwargs)
         for mode, val in ws.items():
             norm = (np.absolute(val) / (kwargs["k"] * va)).value ** 2
-            assert np.isclose(norm, expected[mode])
+            np.testing.assert_allclose(norm, expected[mode], rtol=1e-5, atol=1e-8)
 
     @pytest.mark.parametrize(
         ("kwargs", "expected"),

--- a/tests/dispersion/numerical/test_hollweg_.py
+++ b/tests/dispersion/numerical/test_hollweg_.py
@@ -327,7 +327,9 @@ class TestHollweg:
         ws_expected = hollweg(**expected)
 
         for mode in ws:
-            np.testing.assert_allclose(ws[mode], ws_expected[mode], atol=1e-5, rtol=1.7e-4)
+            np.testing.assert_allclose(
+                ws[mode], ws_expected[mode], atol=1e-5, rtol=1.7e-4
+            )
 
     @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
     @pytest.mark.parametrize(

--- a/tests/dispersion/numerical/test_hollweg_.py
+++ b/tests/dispersion/numerical/test_hollweg_.py
@@ -187,7 +187,7 @@ class TestHollweg:
         """Test scenarios involving k and theta arrays."""
         ws = hollweg(**kwargs)
         for mode, val in ws.items():
-            assert np.allclose(val.value, expected[mode])
+            np.testing.assert_allclose(val.value, expected[mode], rtol=1e-5, atol=1e-8)
 
     @pytest.mark.parametrize(
         ("kwargs", "expected", "desired_beta"),
@@ -290,7 +290,7 @@ class TestHollweg:
         w_alfven = (hollweg(**kwargs)["alfven_mode"]).value
         big_omega = np.abs(w_alfven / (kz * va))
 
-        assert np.allclose(big_omega, expected, atol=1e-2)
+        np.testing.assert_allclose(big_omega, expected, atol=1e-2, rtol=1e-5)
 
     @pytest.mark.xfail(
         reason=(
@@ -327,7 +327,7 @@ class TestHollweg:
         ws_expected = hollweg(**expected)
 
         for mode in ws:
-            assert np.isclose(ws[mode], ws_expected[mode], atol=1e-5, rtol=1.7e-4)
+            np.testing.assert_allclose(ws[mode], ws_expected[mode], atol=1e-5, rtol=1.7e-4)
 
     @pytest.mark.filterwarnings("ignore::plasmapy.utils.exceptions.PhysicsWarning")
     @pytest.mark.parametrize(

--- a/tests/formulary/collisions/test_collisions_frequencies.py
+++ b/tests/formulary/collisions/test_collisions_frequencies.py
@@ -421,12 +421,7 @@ class TestSingleParticleCollisionFrequencies:
                     coulomb_density_constant * charge_constant
                 )
 
-            assert np.allclose(
-                calculated_limit_value,
-                expected_limit_value,
-                rtol=0.05,
-                atol=0,
-            )
+            np.testing.assert_allclose(calculated_limit_value, expected_limit_value, rtol=0.05, atol=0)
 
     @pytest.mark.parametrize(
         ("expected_error", "constructor_arguments", "constructor_keyword_arguments"),
@@ -670,7 +665,7 @@ class TestMaxwellianCollisionFrequencies:
             constructor_keyword_arguments["Coulomb_log"],
         )
 
-        assert np.allclose(calculated_value, expected_value, rtol=5e-3, atol=0)
+        np.testing.assert_allclose(calculated_value, expected_value, rtol=5e-3, atol=0)
 
     @pytest.mark.parametrize(
         ("frequency_to_test", "constructor_keyword_arguments", "expected_value"),
@@ -718,7 +713,7 @@ class TestMaxwellianCollisionFrequencies:
 
         calculated_value = getattr(value_test_case, frequency_to_test)
 
-        assert np.allclose(calculated_value, expected_value, rtol=5e-3, atol=0)
+        np.testing.assert_allclose(calculated_value, expected_value, rtol=5e-3, atol=0)
 
 
 class Test_collision_frequency:

--- a/tests/formulary/collisions/test_collisions_frequencies.py
+++ b/tests/formulary/collisions/test_collisions_frequencies.py
@@ -421,7 +421,9 @@ class TestSingleParticleCollisionFrequencies:
                     coulomb_density_constant * charge_constant
                 )
 
-            np.testing.assert_allclose(calculated_limit_value, expected_limit_value, rtol=0.05, atol=0)
+            np.testing.assert_allclose(
+                calculated_limit_value, expected_limit_value, rtol=0.05, atol=0
+            )
 
     @pytest.mark.parametrize(
         ("expected_error", "constructor_arguments", "constructor_keyword_arguments"),

--- a/tests/formulary/collisions/test_collisions_lengths.py
+++ b/tests/formulary/collisions/test_collisions_lengths.py
@@ -67,10 +67,7 @@ class Test_impact_parameter_perp:
             {},
         )
 
-    assert np.isclose(
-        coulomb.Coulomb_logarithm(1 * u.eV, 5 * u.m**-3, ("e", "e")),
-        coulomb.Coulomb_logarithm(11604.5220 * u.K, 5 * u.m**-3, ("e", "e")),
-    )
+    np.testing.assert_allclose(coulomb.Coulomb_logarithm(1 * u.eV, 5 * u.m**-3, ("e", "e")), coulomb.Coulomb_logarithm(11604.5220 * u.K, 5 * u.m**-3, ("e", "e")), rtol=1e-5, atol=1e-8)
 
 
 class Test_impact_parameter:

--- a/tests/formulary/collisions/test_collisions_lengths.py
+++ b/tests/formulary/collisions/test_collisions_lengths.py
@@ -67,7 +67,12 @@ class Test_impact_parameter_perp:
             {},
         )
 
-    np.testing.assert_allclose(coulomb.Coulomb_logarithm(1 * u.eV, 5 * u.m**-3, ("e", "e")), coulomb.Coulomb_logarithm(11604.5220 * u.K, 5 * u.m**-3, ("e", "e")), rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        coulomb.Coulomb_logarithm(1 * u.eV, 5 * u.m**-3, ("e", "e")),
+        coulomb.Coulomb_logarithm(11604.5220 * u.K, 5 * u.m**-3, ("e", "e")),
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
 
 class Test_impact_parameter:

--- a/tests/formulary/collisions/test_collisions_misc.py
+++ b/tests/formulary/collisions/test_collisions_misc.py
@@ -58,7 +58,7 @@ def test_Bethe_stopping(material, rho, I, n_e, T2) -> None:  # noqa: E741
     )
     NIST_stopping_space = NIST_stopping_space_density * rho
 
-    assert np.isclose(Bethe_stopping_space, NIST_stopping_space).all()
+    np.testing.assert_allclose(Bethe_stopping_space, NIST_stopping_space, rtol=1e-5, atol=1e-8)
 
 
 class Test_Spitzer_resistivity:

--- a/tests/formulary/collisions/test_collisions_misc.py
+++ b/tests/formulary/collisions/test_collisions_misc.py
@@ -58,7 +58,9 @@ def test_Bethe_stopping(material, rho, I, n_e, T2) -> None:  # noqa: E741
     )
     NIST_stopping_space = NIST_stopping_space_density * rho
 
-    np.testing.assert_allclose(Bethe_stopping_space, NIST_stopping_space, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        Bethe_stopping_space, NIST_stopping_space, rtol=1e-5, atol=1e-8
+    )
 
 
 class Test_Spitzer_resistivity:

--- a/tests/formulary/test_densities.py
+++ b/tests/formulary/test_densities.py
@@ -33,7 +33,7 @@ class TestCriticalDensity:
         defined as the value at which the electron plasma frequency equals
         the frequency of the radiation.
         """
-        assert np.isclose(n_c.value, self.n_i.value)
+        np.testing.assert_allclose(n_c.value, self.n_i.value, rtol=1e-5, atol=1e-8)
 
 
 class Test_mass_density:
@@ -82,7 +82,7 @@ class Test_mass_density:
         ],
     )
     def test_values(self, args, kwargs, expected) -> None:
-        assert np.isclose(mass_density(*args, **kwargs), expected)
+        np.testing.assert_allclose(mass_density(*args, **kwargs), expected, rtol=1e-5, atol=1e-8)
 
     def test_handle_nparrays(self) -> None:
         """Test for ability to handle numpy array quantities"""

--- a/tests/formulary/test_densities.py
+++ b/tests/formulary/test_densities.py
@@ -82,7 +82,9 @@ class Test_mass_density:
         ],
     )
     def test_values(self, args, kwargs, expected) -> None:
-        np.testing.assert_allclose(mass_density(*args, **kwargs), expected, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            mass_density(*args, **kwargs), expected, rtol=1e-5, atol=1e-8
+        )
 
     def test_handle_nparrays(self) -> None:
         """Test for ability to handle numpy array quantities"""

--- a/tests/formulary/test_dielectric.py
+++ b/tests/formulary/test_dielectric.py
@@ -59,9 +59,9 @@ class Test_ColdPlasmaPermittivity:
         assert tuple_result.plasma is P
         assert isinstance(tuple_result, StixTensorElements)
 
-        assert np.isclose(S, S_analytical)
-        assert np.isclose(D, D_analytical)
-        assert np.isclose(P, P_analytical)
+        np.testing.assert_allclose(S, S_analytical, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(D, D_analytical, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(P, P_analytical, rtol=1e-5, atol=1e-8)
 
         L, R, P = rotating_tuple_result = cold_plasma_permittivity_LRP(
             B,
@@ -80,9 +80,9 @@ class Test_ColdPlasmaPermittivity:
         """
         n_3 = np.array([1, 1, 5 / 100]) * 1e19 / u.m**3
         S, D, P = cold_plasma_permittivity_SDP(B, three_species, n_3, omega)
-        assert np.isclose(S, -11753.3)
-        assert np.isclose(D, 13408.99181054283)
-        assert np.isclose(P, -10524167.9)
+        np.testing.assert_allclose(S, -11753.3, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(D, 13408.99181054283, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(P, -10524167.9, rtol=1e-5, atol=1e-8)
 
     def test_SD_to_LR_relationships(self) -> None:
         """
@@ -96,10 +96,10 @@ class Test_ColdPlasmaPermittivity:
         S, D, _ = cold_plasma_permittivity_SDP(B, single_species, n, omega)
         L, R, _ = cold_plasma_permittivity_LRP(B, single_species, n, omega)
 
-        assert np.isclose(R, S + D)
-        assert np.isclose(L, S - D)
-        assert np.isclose(S, (R + L) / 2)
-        assert np.isclose(D, (R - L) / 2)
+        np.testing.assert_allclose(R, S + D, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(L, S - D, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(S, (R + L) / 2, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(D, (R - L) / 2, rtol=1e-5, atol=1e-8)
 
     def test_numpy_array_workflow(self) -> None:
         """

--- a/tests/formulary/test_dimensionless.py
+++ b/tests/formulary/test_dimensionless.py
@@ -102,9 +102,19 @@ def test_Debye_number() -> None:
     assert Debye_number(T_e, n_e).unit.is_equivalent(u.dimensionless_unscaled)
 
     T_e_eV = T_e.to(u.eV, equivalencies=u.temperature_energy())
-    np.testing.assert_allclose(Debye_number(T_e, n_e).value, Debye_number(T_e_eV, n_e).value, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        Debye_number(T_e, n_e).value,
+        Debye_number(T_e_eV, n_e).value,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
-    np.testing.assert_allclose(Debye_number(1 * u.eV, 1 * u.cm**-3).value, 1720862385.43342, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        Debye_number(1 * u.eV, 1 * u.cm**-3).value,
+        1720862385.43342,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
     with pytest.warns(u.UnitsWarning):
         Debye_number(T_e, 4)
@@ -149,7 +159,12 @@ def test_Hall_parameter() -> None:
         u.dimensionless_unscaled,
     )
 
-    np.testing.assert_allclose(Hall_parameter(n, T, B, ion, particle).value, 70461.38821149625, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        Hall_parameter(n, T, B, ion, particle).value,
+        70461.38821149625,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
     with pytest.warns(u.UnitsWarning):
         Hall_parameter(n, T, 1.0, ion, particle)

--- a/tests/formulary/test_dimensionless.py
+++ b/tests/formulary/test_dimensionless.py
@@ -102,9 +102,9 @@ def test_Debye_number() -> None:
     assert Debye_number(T_e, n_e).unit.is_equivalent(u.dimensionless_unscaled)
 
     T_e_eV = T_e.to(u.eV, equivalencies=u.temperature_energy())
-    assert np.isclose(Debye_number(T_e, n_e).value, Debye_number(T_e_eV, n_e).value)
+    np.testing.assert_allclose(Debye_number(T_e, n_e).value, Debye_number(T_e_eV, n_e).value, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(Debye_number(1 * u.eV, 1 * u.cm**-3).value, 1720862385.43342)
+    np.testing.assert_allclose(Debye_number(1 * u.eV, 1 * u.cm**-3).value, 1720862385.43342, rtol=1e-5, atol=1e-8)
 
     with pytest.warns(u.UnitsWarning):
         Debye_number(T_e, 4)
@@ -149,7 +149,7 @@ def test_Hall_parameter() -> None:
         u.dimensionless_unscaled,
     )
 
-    assert np.isclose(Hall_parameter(n, T, B, ion, particle).value, 70461.38821149625)
+    np.testing.assert_allclose(Hall_parameter(n, T, B, ion, particle).value, 70461.38821149625, rtol=1e-5, atol=1e-8)
 
     with pytest.warns(u.UnitsWarning):
         Hall_parameter(n, T, 1.0, ion, particle)

--- a/tests/formulary/test_distribution.py
+++ b/tests/formulary/test_distribution.py
@@ -47,7 +47,7 @@ class Test_Maxwellian_1D:
             particle=self.particle,
             v_drift=0 * u.m / u.s,
         ).argmax()
-        assert np.isclose(self.v_vect[max_index].value, 0.0)
+        np.testing.assert_allclose(self.v_vect[max_index].value, 0.0, rtol=1e-5, atol=1e-8)
 
     def test_max_drift(self) -> None:
         """
@@ -60,7 +60,7 @@ class Test_Maxwellian_1D:
             particle=self.particle,
             v_drift=self.v_drift,
         ).argmax()
-        assert np.isclose(self.v_vect[max_index].value, self.v_drift.value)
+        np.testing.assert_allclose(self.v_vect[max_index].value, self.v_drift.value, rtol=1e-5, atol=1e-8)
 
     def test_norm(self) -> None:
         """
@@ -96,7 +96,7 @@ class Test_Maxwellian_1D:
         ).sum()
         std = np.sqrt(std)
         T_distri = (std**2 / k_B * m_e).to(u.K)
-        assert np.isclose(T_distri.value, self.T_e.value)
+        np.testing.assert_allclose(T_distri.value, self.T_e.value, rtol=1e-5, atol=1e-8)
 
     def test_units_no_vTh(self) -> None:
         """
@@ -1063,7 +1063,7 @@ class Test_kappa_velocity_1D:
             particle=self.particle,
             v_drift=0 * u.m / u.s,
         ).argmax()
-        assert np.isclose(self.v_vect[max_index].value, 0.0)
+        np.testing.assert_allclose(self.v_vect[max_index].value, 0.0, rtol=1e-5, atol=1e-8)
 
     def test_max_drift(self) -> None:
         """
@@ -1077,7 +1077,7 @@ class Test_kappa_velocity_1D:
             particle=self.particle,
             v_drift=self.v_drift,
         ).argmax()
-        assert np.isclose(self.v_vect[max_index].value, self.v_drift.value)
+        np.testing.assert_allclose(self.v_vect[max_index].value, self.v_drift.value, rtol=1e-5, atol=1e-8)
 
     # TODO: Need to add a test to see if the kappa distribution goes to a  # noqa: FIX002
     # Maxwellian in the limit of large κ
@@ -1121,7 +1121,7 @@ class Test_kappa_velocity_1D:
         ).sum()
         std = np.sqrt(std)
         T_distri = (std**2 / k_B * m_e).to(u.K)
-        assert np.isclose(T_distri.value, self.T_e.value)
+        np.testing.assert_allclose(T_distri.value, self.T_e.value, rtol=1e-5, atol=1e-8)
 
     def test_units_no_vTh(self) -> None:
         """

--- a/tests/formulary/test_distribution.py
+++ b/tests/formulary/test_distribution.py
@@ -47,7 +47,9 @@ class Test_Maxwellian_1D:
             particle=self.particle,
             v_drift=0 * u.m / u.s,
         ).argmax()
-        np.testing.assert_allclose(self.v_vect[max_index].value, 0.0, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            self.v_vect[max_index].value, 0.0, rtol=1e-5, atol=1e-8
+        )
 
     def test_max_drift(self) -> None:
         """
@@ -60,7 +62,9 @@ class Test_Maxwellian_1D:
             particle=self.particle,
             v_drift=self.v_drift,
         ).argmax()
-        np.testing.assert_allclose(self.v_vect[max_index].value, self.v_drift.value, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            self.v_vect[max_index].value, self.v_drift.value, rtol=1e-5, atol=1e-8
+        )
 
     def test_norm(self) -> None:
         """
@@ -1063,7 +1067,9 @@ class Test_kappa_velocity_1D:
             particle=self.particle,
             v_drift=0 * u.m / u.s,
         ).argmax()
-        np.testing.assert_allclose(self.v_vect[max_index].value, 0.0, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            self.v_vect[max_index].value, 0.0, rtol=1e-5, atol=1e-8
+        )
 
     def test_max_drift(self) -> None:
         """
@@ -1077,7 +1083,9 @@ class Test_kappa_velocity_1D:
             particle=self.particle,
             v_drift=self.v_drift,
         ).argmax()
-        np.testing.assert_allclose(self.v_vect[max_index].value, self.v_drift.value, rtol=1e-5, atol=1e-8)
+        np.testing.assert_allclose(
+            self.v_vect[max_index].value, self.v_drift.value, rtol=1e-5, atol=1e-8
+        )
 
     # TODO: Need to add a test to see if the kappa distribution goes to a  # noqa: FIX002
     # Maxwellian in the limit of large κ

--- a/tests/formulary/test_frequencies.py
+++ b/tests/formulary/test_frequencies.py
@@ -48,15 +48,31 @@ def test_gyrofrequency() -> None:
 
     assert gyrofrequency(B, "e-", to_hz=True).unit.is_equivalent(u.Hz)
 
-    np.testing.assert_allclose(gyrofrequency(1 * u.T, "e-").value, 175882008784.72018, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        gyrofrequency(1 * u.T, "e-").value, 175882008784.72018, rtol=1e-5, atol=1e-8
+    )
 
-    np.testing.assert_allclose(gyrofrequency(2.4 * u.T, "e-").value, 422116821083.3284, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        gyrofrequency(2.4 * u.T, "e-").value, 422116821083.3284, rtol=1e-5, atol=1e-8
+    )
 
-    np.testing.assert_allclose(gyrofrequency(1 * u.T, "e-", to_hz=True).value, 27992490076.528206, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        gyrofrequency(1 * u.T, "e-", to_hz=True).value,
+        27992490076.528206,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
-    np.testing.assert_allclose(gyrofrequency(2.4 * u.T, "e-", signed=True).value, -422116821083.3284, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        gyrofrequency(2.4 * u.T, "e-", signed=True).value,
+        -422116821083.3284,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
-    np.testing.assert_allclose(gyrofrequency(1 * u.G, "e-").cgs.value, 1.76e7, rtol=1e-3, atol=1e-8)
+    np.testing.assert_allclose(
+        gyrofrequency(1 * u.G, "e-").cgs.value, 1.76e7, rtol=1e-3, atol=1e-8
+    )
 
     with pytest.raises(TypeError), pytest.warns(u.UnitsWarning):
         gyrofrequency(u.m, "e-")
@@ -78,11 +94,23 @@ def test_gyrofrequency() -> None:
 
     assert gyrofrequency(B, particle=ion).unit.is_equivalent(u.rad / u.s)
 
-    np.testing.assert_allclose(gyrofrequency(1 * u.T, particle="p+").value, 95788335.834874, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        gyrofrequency(1 * u.T, particle="p+").value,
+        95788335.834874,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
-    np.testing.assert_allclose(gyrofrequency(2.4 * u.T, particle="p+").value, 229892006.00369796, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        gyrofrequency(2.4 * u.T, particle="p+").value,
+        229892006.00369796,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
-    np.testing.assert_allclose(gyrofrequency(1 * u.G, particle="p+").cgs.value, 9.58e3, rtol=2e-3, atol=1e-8)
+    np.testing.assert_allclose(
+        gyrofrequency(1 * u.G, particle="p+").cgs.value, 9.58e3, rtol=2e-3, atol=1e-8
+    )
 
     assert gyrofrequency(-5 * u.T, "p") == gyrofrequency(5 * u.T, "p")
 
@@ -130,9 +158,13 @@ def test_lower_hybrid_frequency() -> None:
     assert omega_lh.unit.is_equivalent(u.rad / u.s)
     left_hand_side = omega_lh**-2
     right_hand_side = 1 / (omega_ci**2 + omega_pi**2) + omega_ci**-1 * omega_ce**-1
-    np.testing.assert_allclose(left_hand_side.value, right_hand_side.value, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        left_hand_side.value, right_hand_side.value, rtol=1e-5, atol=1e-8
+    )
 
-    np.testing.assert_allclose(omega_lh_hz.value, 299878691.3223296, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        omega_lh_hz.value, 299878691.3223296, rtol=1e-5, atol=1e-8
+    )
 
     with pytest.raises(ValueError):
         lower_hybrid_frequency(0.2 * u.T, n_i=5e19 * u.m**-3, ion="asdfasd")
@@ -164,9 +196,13 @@ def test_upper_hybrid_frequency() -> None:
     assert omega_uh_hz.unit.is_equivalent(u.Hz)
     left_hand_side = omega_uh**2
     right_hand_side = omega_ce**2 + omega_pe**2
-    np.testing.assert_allclose(left_hand_side.value, right_hand_side.value, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        left_hand_side.value, right_hand_side.value, rtol=1e-5, atol=1e-8
+    )
 
-    np.testing.assert_allclose(omega_uh_hz.value, 69385868857.90918, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        omega_uh_hz.value, 69385868857.90918, rtol=1e-5, atol=1e-8
+    )
 
     with pytest.raises(ValueError):
         upper_hybrid_frequency(5 * u.T, n_e=-1 * u.m**-3)
@@ -206,10 +242,15 @@ def test_Buchsbaum_frequency() -> None:
             "venezuelan beaver cheese",
         )
 
-    np.testing.assert_allclose(Buchsbaum_frequency(
+    np.testing.assert_allclose(
+        Buchsbaum_frequency(
             B=0.1 * u.T,
             n1=1e18 * u.m**-3,
             n2=1e18 * u.m**-3,
             ion1="proton",
             ion2="He-4 +1",
-        ).value, 4805575.93140432, rtol=1e-5, atol=1e-8)
+        ).value,
+        4805575.93140432,
+        rtol=1e-5,
+        atol=1e-8,
+    )

--- a/tests/formulary/test_frequencies.py
+++ b/tests/formulary/test_frequencies.py
@@ -48,21 +48,15 @@ def test_gyrofrequency() -> None:
 
     assert gyrofrequency(B, "e-", to_hz=True).unit.is_equivalent(u.Hz)
 
-    assert np.isclose(gyrofrequency(1 * u.T, "e-").value, 175882008784.72018)
+    np.testing.assert_allclose(gyrofrequency(1 * u.T, "e-").value, 175882008784.72018, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(gyrofrequency(2.4 * u.T, "e-").value, 422116821083.3284)
+    np.testing.assert_allclose(gyrofrequency(2.4 * u.T, "e-").value, 422116821083.3284, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(
-        gyrofrequency(1 * u.T, "e-", to_hz=True).value,
-        27992490076.528206,
-    )
+    np.testing.assert_allclose(gyrofrequency(1 * u.T, "e-", to_hz=True).value, 27992490076.528206, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(
-        gyrofrequency(2.4 * u.T, "e-", signed=True).value,
-        -422116821083.3284,
-    )
+    np.testing.assert_allclose(gyrofrequency(2.4 * u.T, "e-", signed=True).value, -422116821083.3284, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(gyrofrequency(1 * u.G, "e-").cgs.value, 1.76e7, rtol=1e-3)
+    np.testing.assert_allclose(gyrofrequency(1 * u.G, "e-").cgs.value, 1.76e7, rtol=1e-3, atol=1e-8)
 
     with pytest.raises(TypeError), pytest.warns(u.UnitsWarning):
         gyrofrequency(u.m, "e-")
@@ -77,22 +71,18 @@ def test_gyrofrequency() -> None:
     omega_ce = gyrofrequency(2.2 * u.T, "e-")
     f_ce = (omega_ce / (2 * np.pi)) / u.rad
     f_ce_use_equiv = omega_ce.to(u.Hz, equivalencies=[(u.cy / u.s, u.Hz)])
-    assert np.isclose(f_ce.value, f_ce_use_equiv.value)
+    np.testing.assert_allclose(f_ce.value, f_ce_use_equiv.value, rtol=1e-5, atol=1e-8)
 
     with pytest.warns(u.UnitsWarning):
         assert gyrofrequency(5.0, "e-") == gyrofrequency(5.0 * u.T, "e-")
 
     assert gyrofrequency(B, particle=ion).unit.is_equivalent(u.rad / u.s)
 
-    assert np.isclose(gyrofrequency(1 * u.T, particle="p+").value, 95788335.834874)
+    np.testing.assert_allclose(gyrofrequency(1 * u.T, particle="p+").value, 95788335.834874, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(gyrofrequency(2.4 * u.T, particle="p+").value, 229892006.00369796)
+    np.testing.assert_allclose(gyrofrequency(2.4 * u.T, particle="p+").value, 229892006.00369796, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(
-        gyrofrequency(1 * u.G, particle="p+").cgs.value,
-        9.58e3,
-        rtol=2e-3,
-    )
+    np.testing.assert_allclose(gyrofrequency(1 * u.G, particle="p+").cgs.value, 9.58e3, rtol=2e-3, atol=1e-8)
 
     assert gyrofrequency(-5 * u.T, "p") == gyrofrequency(5 * u.T, "p")
 
@@ -140,9 +130,9 @@ def test_lower_hybrid_frequency() -> None:
     assert omega_lh.unit.is_equivalent(u.rad / u.s)
     left_hand_side = omega_lh**-2
     right_hand_side = 1 / (omega_ci**2 + omega_pi**2) + omega_ci**-1 * omega_ce**-1
-    assert np.isclose(left_hand_side.value, right_hand_side.value)
+    np.testing.assert_allclose(left_hand_side.value, right_hand_side.value, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(omega_lh_hz.value, 299878691.3223296)
+    np.testing.assert_allclose(omega_lh_hz.value, 299878691.3223296, rtol=1e-5, atol=1e-8)
 
     with pytest.raises(ValueError):
         lower_hybrid_frequency(0.2 * u.T, n_i=5e19 * u.m**-3, ion="asdfasd")
@@ -174,9 +164,9 @@ def test_upper_hybrid_frequency() -> None:
     assert omega_uh_hz.unit.is_equivalent(u.Hz)
     left_hand_side = omega_uh**2
     right_hand_side = omega_ce**2 + omega_pe**2
-    assert np.isclose(left_hand_side.value, right_hand_side.value)
+    np.testing.assert_allclose(left_hand_side.value, right_hand_side.value, rtol=1e-5, atol=1e-8)
 
-    assert np.isclose(omega_uh_hz.value, 69385868857.90918)
+    np.testing.assert_allclose(omega_uh_hz.value, 69385868857.90918, rtol=1e-5, atol=1e-8)
 
     with pytest.raises(ValueError):
         upper_hybrid_frequency(5 * u.T, n_e=-1 * u.m**-3)
@@ -216,13 +206,10 @@ def test_Buchsbaum_frequency() -> None:
             "venezuelan beaver cheese",
         )
 
-    assert np.isclose(
-        Buchsbaum_frequency(
+    np.testing.assert_allclose(Buchsbaum_frequency(
             B=0.1 * u.T,
             n1=1e18 * u.m**-3,
             n2=1e18 * u.m**-3,
             ion1="proton",
             ion2="He-4 +1",
-        ).value,
-        4805575.93140432,
-    )
+        ).value, 4805575.93140432, rtol=1e-5, atol=1e-8)

--- a/tests/formulary/test_ionization.py
+++ b/tests/formulary/test_ionization.py
@@ -11,7 +11,7 @@ def test_ionization_balance() -> None:
 
     val = ionization_balance(n, T_e)
     assert val.unit == u.dimensionless_unscaled
-    assert np.isclose(val.value, 0.27478417234035346)
+    np.testing.assert_allclose(val.value, 0.27478417234035346, rtol=1e-5, atol=1e-8)
 
     # aliases must be the same function
     assert Z_bal_ is ionization_balance
@@ -32,7 +32,7 @@ def test_Saha() -> None:
 
     val = Saha(g_j, g_k, n_e, E_jk, T_e)
     assert val.unit == u.dimensionless_unscaled
-    assert np.isclose(val.value, 2.4775608756800435e-129)
+    np.testing.assert_allclose(val.value, 2.4775608756800435e-129, rtol=1e-5, atol=1e-8)
 
     with pytest.warns(u.UnitsWarning):
         Saha(g_j, g_k, 1e19, E_jk, T_e)

--- a/tests/formulary/test_lengths.py
+++ b/tests/formulary/test_lengths.py
@@ -366,7 +366,12 @@ def test_inertial_length() -> None:
     r"""Test the inertial_length function in lengths.py."""
     assert inertial_length(n_i, particle="p+").unit.is_equivalent(u.m)
 
-    np.testing.assert_allclose(inertial_length(mu * u.cm**-3, particle="p+").cgs.value, 2.28e7, rtol=0.01, atol=1e-8)
+    np.testing.assert_allclose(
+        inertial_length(mu * u.cm**-3, particle="p+").cgs.value,
+        2.28e7,
+        rtol=0.01,
+        atol=1e-8,
+    )
 
     inertial_length_electron_plus = inertial_length(5.351 * u.m**-3, particle="e+")
     assert inertial_length_electron_plus == inertial_length(
@@ -394,7 +399,9 @@ def test_inertial_length() -> None:
 
     assert inertial_length(n_e, "e-").unit.is_equivalent(u.m)
 
-    np.testing.assert_allclose(inertial_length(1 * u.cm**-3, "e-").cgs.value, 5.31e5, rtol=1e-3, atol=1e-8)
+    np.testing.assert_allclose(
+        inertial_length(1 * u.cm**-3, "e-").cgs.value, 5.31e5, rtol=1e-3, atol=1e-8
+    )
 
     with pytest.warns(u.UnitsWarning):
         inertial_length(5, "e-")

--- a/tests/formulary/test_lengths.py
+++ b/tests/formulary/test_lengths.py
@@ -310,7 +310,7 @@ class TestGyroradius:
             atol = 1e-8
 
         rc = gyroradius(*args, **kwargs)
-        assert np.allclose(rc, expected, atol=atol)
+        np.testing.assert_allclose(rc, expected, atol=atol, rtol=1e-5)
         assert rc.unit == u.m
 
     @pytest.mark.parametrize(
@@ -333,7 +333,7 @@ class TestGyroradius:
         with pytest.warns(_warns):
             rc = gyroradius(*args, **kwargs)
         if expected is not None:
-            assert np.allclose(rc, expected)
+            np.testing.assert_allclose(rc, expected, rtol=1e-5, atol=1e-8)
 
     def test_keeps_arguments_unchanged(self) -> None:
         Vperp1 = u.Quantity([np.nan, 1], unit=u.m / u.s)
@@ -366,11 +366,7 @@ def test_inertial_length() -> None:
     r"""Test the inertial_length function in lengths.py."""
     assert inertial_length(n_i, particle="p+").unit.is_equivalent(u.m)
 
-    assert np.isclose(
-        inertial_length(mu * u.cm**-3, particle="p+").cgs.value,
-        2.28e7,
-        rtol=0.01,
-    )
+    np.testing.assert_allclose(inertial_length(mu * u.cm**-3, particle="p+").cgs.value, 2.28e7, rtol=0.01, atol=1e-8)
 
     inertial_length_electron_plus = inertial_length(5.351 * u.m**-3, particle="e+")
     assert inertial_length_electron_plus == inertial_length(
@@ -398,7 +394,7 @@ def test_inertial_length() -> None:
 
     assert inertial_length(n_e, "e-").unit.is_equivalent(u.m)
 
-    assert np.isclose(inertial_length(1 * u.cm**-3, "e-").cgs.value, 5.31e5, rtol=1e-3)
+    np.testing.assert_allclose(inertial_length(1 * u.cm**-3, "e-").cgs.value, 5.31e5, rtol=1e-3, atol=1e-8)
 
     with pytest.warns(u.UnitsWarning):
         inertial_length(5, "e-")

--- a/tests/formulary/test_misc.py
+++ b/tests/formulary/test_misc.py
@@ -59,7 +59,9 @@ def test_magnetic_pressure() -> None:
 
     assert magnetic_pressure(B) == magnetic_energy_density(B.to(u.G))
 
-    np.testing.assert_allclose(magnetic_pressure(B).value, 397887.35772973835, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        magnetic_pressure(B).value, 397887.35772973835, rtol=1e-5, atol=1e-8
+    )
 
     with pytest.warns(u.UnitsWarning):
         magnetic_pressure(5)

--- a/tests/formulary/test_misc.py
+++ b/tests/formulary/test_misc.py
@@ -59,7 +59,7 @@ def test_magnetic_pressure() -> None:
 
     assert magnetic_pressure(B) == magnetic_energy_density(B.to(u.G))
 
-    assert np.isclose(magnetic_pressure(B).value, 397887.35772973835)
+    np.testing.assert_allclose(magnetic_pressure(B).value, 397887.35772973835, rtol=1e-5, atol=1e-8)
 
     with pytest.warns(u.UnitsWarning):
         magnetic_pressure(5)

--- a/tests/formulary/test_plasma_frequency.py
+++ b/tests/formulary/test_plasma_frequency.py
@@ -99,7 +99,7 @@ class TestPlasmaFrequency:
         assert wp.unit == u.rad / u.s
 
         if expected is not None:
-            assert np.allclose(wp, expected)
+            np.testing.assert_allclose(wp, expected, rtol=1e-5, atol=1e-8)
 
     @pytest.mark.parametrize(
         ("args", "kwargs", "expected", "rtol"),
@@ -124,7 +124,7 @@ class TestPlasmaFrequency:
 
         assert isinstance(wp, u.Quantity)
         assert wp.unit == u.rad / u.s
-        assert np.allclose(wp.value, expected, rtol=rtol)
+        np.testing.assert_allclose(wp.value, expected, rtol=rtol, atol=1e-8)
 
     @pytest.mark.parametrize(
         ("args", "kwargs"),
@@ -178,4 +178,4 @@ class TestPlasmaFrequencyLite:
         lite = plasma_frequency_lite(**inputs_unitless)
 
         normal = plasma_frequency(**inputs)
-        assert np.allclose(normal.value, lite)
+        np.testing.assert_allclose(normal.value, lite, rtol=1e-5, atol=1e-8)

--- a/tests/formulary/test_quantum.py
+++ b/tests/formulary/test_quantum.py
@@ -22,7 +22,9 @@ from plasmapy.utils.exceptions import RelativityError
 
 def test_deBroglie_wavelength() -> None:
     dbwavelength1 = deBroglie_wavelength(2e7 * u.cm / u.s, "e")
-    np.testing.assert_allclose(dbwavelength1.value, 3.628845222852886e-11, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        dbwavelength1.value, 3.628845222852886e-11, rtol=1e-5, atol=1e-8
+    )
     assert dbwavelength1.unit == u.m
 
     dbwavelength2 = deBroglie_wavelength(0 * u.m / u.s, "e")
@@ -31,15 +33,21 @@ def test_deBroglie_wavelength() -> None:
     V_array = np.array([2e5, 0]) * u.m / u.s
     dbwavelength_arr = deBroglie_wavelength(V_array, "e")
 
-    np.testing.assert_allclose(dbwavelength_arr.value[0], 3.628845222852886e-11, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        dbwavelength_arr.value[0], 3.628845222852886e-11, rtol=1e-5, atol=1e-8
+    )
     assert dbwavelength_arr.value[1] == np.inf
     assert dbwavelength_arr.unit == u.m
 
     V_array = np.array([2e5, 2e5]) * u.m / u.s
     dbwavelength_arr = deBroglie_wavelength(V_array, "e")
 
-    np.testing.assert_allclose(dbwavelength_arr.value[0], 3.628845222852886e-11, rtol=1e-5, atol=1e-8)
-    np.testing.assert_allclose(dbwavelength_arr.value[1], 3.628845222852886e-11, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        dbwavelength_arr.value[0], 3.628845222852886e-11, rtol=1e-5, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        dbwavelength_arr.value[1], 3.628845222852886e-11, rtol=1e-5, atol=1e-8
+    )
     assert dbwavelength_arr.unit == u.m
 
     assert deBroglie_wavelength(-5e5 * u.m / u.s, "p") == deBroglie_wavelength(

--- a/tests/formulary/test_quantum.py
+++ b/tests/formulary/test_quantum.py
@@ -22,7 +22,7 @@ from plasmapy.utils.exceptions import RelativityError
 
 def test_deBroglie_wavelength() -> None:
     dbwavelength1 = deBroglie_wavelength(2e7 * u.cm / u.s, "e")
-    assert np.isclose(dbwavelength1.value, 3.628845222852886e-11)
+    np.testing.assert_allclose(dbwavelength1.value, 3.628845222852886e-11, rtol=1e-5, atol=1e-8)
     assert dbwavelength1.unit == u.m
 
     dbwavelength2 = deBroglie_wavelength(0 * u.m / u.s, "e")
@@ -31,15 +31,15 @@ def test_deBroglie_wavelength() -> None:
     V_array = np.array([2e5, 0]) * u.m / u.s
     dbwavelength_arr = deBroglie_wavelength(V_array, "e")
 
-    assert np.isclose(dbwavelength_arr.value[0], 3.628845222852886e-11)
+    np.testing.assert_allclose(dbwavelength_arr.value[0], 3.628845222852886e-11, rtol=1e-5, atol=1e-8)
     assert dbwavelength_arr.value[1] == np.inf
     assert dbwavelength_arr.unit == u.m
 
     V_array = np.array([2e5, 2e5]) * u.m / u.s
     dbwavelength_arr = deBroglie_wavelength(V_array, "e")
 
-    assert np.isclose(dbwavelength_arr.value[0], 3.628845222852886e-11)
-    assert np.isclose(dbwavelength_arr.value[1], 3.628845222852886e-11)
+    np.testing.assert_allclose(dbwavelength_arr.value[0], 3.628845222852886e-11, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(dbwavelength_arr.value[1], 3.628845222852886e-11, rtol=1e-5, atol=1e-8)
     assert dbwavelength_arr.unit == u.m
 
     assert deBroglie_wavelength(-5e5 * u.m / u.s, "p") == deBroglie_wavelength(
@@ -262,4 +262,4 @@ class TestQuantumTheta:
         """Compare the calculated theta with the expected value."""
         theta = quantum_theta(T, n_e)
 
-        assert np.isclose(theta.value, expected_theta)
+        np.testing.assert_allclose(theta.value, expected_theta, rtol=1e-5, atol=1e-8)

--- a/tests/formulary/test_speeds.py
+++ b/tests/formulary/test_speeds.py
@@ -114,7 +114,9 @@ class TestAlfvenSpeed:
             val = Alfven_speed(*args, **kwargs)
             assert isinstance(val, u.Quantity)
             assert val.unit == u.m / u.s
-            np.testing.assert_allclose(val.value, expected, **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw})
+            np.testing.assert_allclose(
+                val.value, expected, **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw}
+            )  # ty:ignore[no-matching-overload]
 
     @pytest.mark.parametrize(
         ("args", "kwargs", "expected", "isclose_kw"),
@@ -183,7 +185,11 @@ class TestAlfvenSpeed:
     )
     def test_values(self, args, kwargs, expected, isclose_kw) -> None:
         """Test expected values."""
-        np.testing.assert_allclose(Alfven_speed(*args, **kwargs), expected, **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw})
+        np.testing.assert_allclose(
+            Alfven_speed(*args, **kwargs),
+            expected,
+            **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw},
+        )  # ty:ignore[no-matching-overload]
 
     @pytest.mark.parametrize(
         ("args", "kwargs", "nan_mask"),
@@ -308,7 +314,11 @@ class Test_Ion_Sound_Speed:
         ],
     )
     def test_values(self, args, kwargs, expected, isclose_kw) -> None:
-        np.testing.assert_allclose(ion_sound_speed(*args, **kwargs), expected, **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw})
+        np.testing.assert_allclose(
+            ion_sound_speed(*args, **kwargs),
+            expected,
+            **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw},
+        )  # ty:ignore[no-matching-overload]
 
     # case when Z=1 is assumed
     # assert ion_sound_speed(T_i=T_i, T_e=T_e, ion='p+') == ion_sound_speed(T_i=T_i, T_e=T_e,

--- a/tests/formulary/test_speeds.py
+++ b/tests/formulary/test_speeds.py
@@ -114,7 +114,7 @@ class TestAlfvenSpeed:
             val = Alfven_speed(*args, **kwargs)
             assert isinstance(val, u.Quantity)
             assert val.unit == u.m / u.s
-            assert np.isclose(val.value, expected, **isclose_kw)
+            np.testing.assert_allclose(val.value, expected, **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw})
 
     @pytest.mark.parametrize(
         ("args", "kwargs", "expected", "isclose_kw"),
@@ -183,7 +183,7 @@ class TestAlfvenSpeed:
     )
     def test_values(self, args, kwargs, expected, isclose_kw) -> None:
         """Test expected values."""
-        assert np.allclose(Alfven_speed(*args, **kwargs), expected, **isclose_kw)
+        np.testing.assert_allclose(Alfven_speed(*args, **kwargs), expected, **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw})
 
     @pytest.mark.parametrize(
         ("args", "kwargs", "nan_mask"),
@@ -308,7 +308,7 @@ class Test_Ion_Sound_Speed:
         ],
     )
     def test_values(self, args, kwargs, expected, isclose_kw) -> None:
-        assert np.isclose(ion_sound_speed(*args, **kwargs), expected, **isclose_kw)
+        np.testing.assert_allclose(ion_sound_speed(*args, **kwargs), expected, **{"rtol": 1e-5, "atol": 1e-8, **isclose_kw})
 
     # case when Z=1 is assumed
     # assert ion_sound_speed(T_i=T_i, T_e=T_e, ion='p+') == ion_sound_speed(T_i=T_i, T_e=T_e,

--- a/tests/formulary/test_thermal_speed.py
+++ b/tests/formulary/test_thermal_speed.py
@@ -78,7 +78,7 @@ class TestThermalSpeedCoefficients:
     def test_values(self, ndim, method, expected) -> None:
         """Test that the correct values are returned."""
         val = thermal_speed_coefficients(ndim=ndim, method=method)
-        assert np.isclose(val, expected)
+        np.testing.assert_allclose(val, expected, rtol=1e-5, atol=1e-8)
 
 
 class TestThermalSpeed:
@@ -234,7 +234,7 @@ class TestThermalSpeed:
     def test_values(self, args, kwargs, expected) -> None:
         """Test scenarios with known calculated values."""
         vth = thermal_speed(*args, **kwargs)
-        assert np.allclose(vth.value, expected)
+        np.testing.assert_allclose(vth.value, expected, rtol=1e-5, atol=1e-8)
         assert vth.unit == u.m / u.s
 
     @pytest.mark.parametrize(
@@ -324,7 +324,7 @@ class TestThermalSpeedLite:
         lite = thermal_speed_lite(T=T_unitless, mass=m_unitless, coeff=coeff)
 
         normal = thermal_speed(**inputs)
-        assert np.isclose(normal.value, lite)
+        np.testing.assert_allclose(normal.value, lite, rtol=1e-5, atol=1e-8)
 
 
 # test class for kappa_thermal_speed() function:

--- a/tests/formulary/test_transport.py
+++ b/tests/formulary/test_transport.py
@@ -807,7 +807,7 @@ class Test__nondim_tc_e_braginskii:
     def test_known_values_par(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         kappa_e_hat = _nondim_tc_e_braginskii(self.big_hall, Z, field_orientation)
-        assert np.isclose(kappa_e_hat, expected, atol=1e-1)
+        np.testing.assert_allclose(kappa_e_hat, expected, atol=1e-1, rtol=1e-5)
 
     # values from Braginskii '65
     @pytest.mark.parametrize(
@@ -823,14 +823,14 @@ class Test__nondim_tc_e_braginskii:
     def test_known_values_perp(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         kappa_e_hat = _nondim_tc_e_braginskii(self.big_hall, Z, field_orientation)
-        assert np.isclose(kappa_e_hat * self.big_hall**2, expected, atol=1e-1)
+        np.testing.assert_allclose(kappa_e_hat * self.big_hall**2, expected, atol=1e-1, rtol=1e-5)
 
     @pytest.mark.parametrize("Z", [1, 2, 3, 4, np.inf])
     def test_unmagnetized(self, Z) -> None:
         """Confirm perp -> par as B -> 0"""
         kappa_e_hat_par = _nondim_tc_e_braginskii(self.small_hall, Z, "par")
         kappa_e_hat_perp = _nondim_tc_e_braginskii(self.small_hall, Z, "perp")
-        assert np.isclose(kappa_e_hat_par, kappa_e_hat_perp, rtol=1e-3)
+        np.testing.assert_allclose(kappa_e_hat_par, kappa_e_hat_perp, rtol=1e-3, atol=1e-8)
 
     @pytest.mark.parametrize("Z", [1, 4])
     def test_cross_vs_ji_held(self, Z) -> None:
@@ -857,25 +857,25 @@ class Test__nondim_tc_i_braginskii:
         """Check some known values"""
         kappa_i_hat = _nondim_tc_i_braginskii(self.big_hall, field_orientation="par")
         expected = 3.9  # Braginskii '65 eq (2.15)
-        assert np.isclose(kappa_i_hat, expected, atol=1e-1)
+        np.testing.assert_allclose(kappa_i_hat, expected, atol=1e-1, rtol=1e-5)
 
     def test_known_values_perp(self) -> None:
         """Check some known values"""
         kappa_i_hat = _nondim_tc_i_braginskii(self.big_hall, field_orientation="perp")
         expected = 2.0  # Braginskii '65 eq (2.16)
-        assert np.isclose(kappa_i_hat * self.big_hall**2, expected, atol=1e-1)
+        np.testing.assert_allclose(kappa_i_hat * self.big_hall**2, expected, atol=1e-1, rtol=1e-5)
 
     def test_unmagnetized(self) -> None:
         """Confirm perp -> par as B -> 0"""
         kappa_i_hat_par = _nondim_tc_i_braginskii(self.small_hall, "par")
         kappa_i_hat_perp = _nondim_tc_i_braginskii(self.small_hall, "perp")
-        assert np.isclose(kappa_i_hat_par, kappa_i_hat_perp, rtol=1e-3)
+        np.testing.assert_allclose(kappa_i_hat_par, kappa_i_hat_perp, rtol=1e-3, atol=1e-8)
 
     def test_cross_vs_ji_held_K2(self) -> None:
         """Confirm cross agrees with ji-held model when K=2"""
         kappa_i_hat_brag = _nondim_tc_i_braginskii(self.big_hall, "cross")
         kappa_i_hat_jh = _nondim_tc_i_ji_held(self.big_hall, 1, 0, 100, "cross", K=2)
-        assert np.isclose(kappa_i_hat_brag, kappa_i_hat_jh, rtol=2e-2)
+        np.testing.assert_allclose(kappa_i_hat_brag, kappa_i_hat_jh, rtol=2e-2, atol=1e-8)
 
 
 # test class for _nondim_tec_braginskii function:
@@ -900,21 +900,21 @@ class Test__nondim_tec_braginskii:
     def test_known_values_par(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         beta_hat = _nondim_tec_braginskii(self.big_hall, Z, field_orientation)
-        assert np.isclose(beta_hat, expected, atol=1e-1)
+        np.testing.assert_allclose(beta_hat, expected, atol=1e-1, rtol=1e-5)
 
     @pytest.mark.parametrize("Z", [1, 2, 3, 4, np.inf])
     def test_unmagnetized(self, Z) -> None:
         """Confirm perp -> par as B -> 0"""
         beta_hat_par = _nondim_tec_braginskii(self.small_hall, Z, "par")
         beta_hat_perp = _nondim_tec_braginskii(self.small_hall, Z, "perp")
-        assert np.isclose(beta_hat_par, beta_hat_perp, rtol=1e-3)
+        np.testing.assert_allclose(beta_hat_par, beta_hat_perp, rtol=1e-3, atol=1e-8)
 
     @pytest.mark.parametrize("Z", [1, 4])
     def test_cross_vs_ji_held(self, Z) -> None:
         """Cross should roughly agree with ji-held"""
         beta_hat_cross_brag = _nondim_tec_braginskii(self.big_hall, Z, "cross")
         beta_hat_cross_jh = _nondim_tec_ji_held(self.big_hall, Z, "cross")
-        assert np.isclose(beta_hat_cross_brag, beta_hat_cross_jh, rtol=3e-2)
+        np.testing.assert_allclose(beta_hat_cross_brag, beta_hat_cross_jh, rtol=3e-2, atol=1e-8)
 
 
 # test class for _nondim_resist_braginskii function:
@@ -939,21 +939,21 @@ class Test__nondim_resist_braginskii:
     def test_known_values_par(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         beta_hat = _nondim_resist_braginskii(self.big_hall, Z, field_orientation)
-        assert np.isclose(beta_hat, expected, atol=1e-2)
+        np.testing.assert_allclose(beta_hat, expected, atol=1e-2, rtol=1e-5)
 
     @pytest.mark.parametrize("Z", [1, 2, 3, 4, np.inf])
     def test_unmagnetized(self, Z) -> None:
         """Confirm perp -> par as B -> 0"""
         alpha_hat_par = _nondim_resist_braginskii(self.small_hall, Z, "par")
         alpha_hat_perp = _nondim_resist_braginskii(self.small_hall, Z, "perp")
-        assert np.isclose(alpha_hat_par, alpha_hat_perp, rtol=1e-3)
+        np.testing.assert_allclose(alpha_hat_par, alpha_hat_perp, rtol=1e-3, atol=1e-8)
 
     @pytest.mark.parametrize("Z", [1, 4])
     def test_cross_vs_ji_held(self, Z) -> None:
         """Cross should roughly agree with ji-held at hall 0.1"""
         alpha_hat_cross_brag = _nondim_resist_braginskii(0.1, Z, "cross")
         alpha_hat_cross_jh = _nondim_resist_ji_held(0.1, Z, "cross")
-        assert np.isclose(alpha_hat_cross_brag, alpha_hat_cross_jh, rtol=5e-2)
+        np.testing.assert_allclose(alpha_hat_cross_brag, alpha_hat_cross_jh, rtol=5e-2, atol=1e-8)
 
 
 # test class for _nondim_visc_i_braginskii function:
@@ -973,14 +973,14 @@ class Test__nondim_visc_i_braginskii:
         """Check some known values"""
         eta_i_hat = _nondim_visc_i_braginskii(self.big_hall)
         eta_i_hat_with_powers = eta_i_hat * self.big_hall**power
-        assert np.allclose(eta_i_hat_with_powers, expected, atol=1e-2)
+        np.testing.assert_allclose(eta_i_hat_with_powers, expected, atol=1e-2, rtol=1e-5)
 
     def test_vs_ji_held_K2(self) -> None:
         """Confirm agreement with ji-held model when K=2"""
         eta_i_hat_brag = _nondim_visc_i_braginskii(self.big_hall)
         eta_i_hat_jh = _nondim_visc_i_ji_held(self.big_hall, 1, 0, 100, K=2)
         for idx in (0, 1, 2, 3, 4):
-            assert np.isclose(eta_i_hat_brag[idx], eta_i_hat_jh[idx], rtol=2e-2)
+            np.testing.assert_allclose(eta_i_hat_brag[idx], eta_i_hat_jh[idx], rtol=2e-2, atol=1e-8)
 
 
 # test class for _nondim_visc_e_braginskii function:
@@ -1006,11 +1006,11 @@ class Test__nondim_visc_e_braginskii:
         """Check some known values"""
         beta_hat = _nondim_visc_e_braginskii(self.big_hall, Z)
         if idx == 0:
-            assert np.isclose(beta_hat[idx], expected, atol=1e-2)
+            np.testing.assert_allclose(beta_hat[idx], expected, atol=1e-2, rtol=1e-5)
         elif idx in {1, 2}:
-            assert np.isclose(beta_hat[idx] * self.big_hall**2, expected, atol=1e-2)
+            np.testing.assert_allclose(beta_hat[idx] * self.big_hall**2, expected, atol=1e-2, rtol=1e-5)
         elif idx in {3, 4}:
-            assert np.isclose(beta_hat[idx] * self.big_hall, expected, atol=1e-1)
+            np.testing.assert_allclose(beta_hat[idx] * self.big_hall, expected, atol=1e-1, rtol=1e-5)
 
 
 def test_fail__check_Z_nan() -> None:
@@ -1034,7 +1034,7 @@ def test__nondim_tc_e_spitzer(Z) -> None:
     elif np.inf == Z:
         kappa_check = _nondim_tc_e_ji_held(0, 1e6, "par")
         rtol = 2e-2
-    assert np.isclose(kappa, kappa_check, rtol=rtol)
+    np.testing.assert_allclose(kappa, kappa_check, rtol=rtol, atol=1e-8)
 
 
 @pytest.mark.parametrize("Z", [1, 2, 4, 16, np.inf])
@@ -1050,7 +1050,7 @@ def test__nondim_resist_spitzer(Z) -> None:
     elif Z == 16:
         alpha_check = _nondim_resist_ji_held(0, Z, "par")
         rtol = 2e-2
-    assert np.isclose(alpha, alpha_check, rtol=rtol)
+    np.testing.assert_allclose(alpha, alpha_check, rtol=rtol, atol=1e-8)
 
 
 @pytest.mark.parametrize("Z", [1, 2, 4, 16, np.inf])
@@ -1066,7 +1066,7 @@ def test__nondim_tec_spitzer(Z) -> None:
     elif Z == 16:
         beta_check = _nondim_tec_ji_held(0, Z, "par")
         rtol = 2e-2
-    assert np.isclose(beta, beta_check, rtol=rtol)
+    np.testing.assert_allclose(beta, beta_check, rtol=rtol, atol=1e-8)
 
 
 # approximated from Ji-Held '13 figures 1 and 2 (black circles)
@@ -1171,7 +1171,7 @@ def test__nondim_tec_ji_held(hall, Z, field_orientation, expected) -> None:
     """Test _nondim_tec_ji_held function"""
     beta_hat = _nondim_tec_ji_held(hall, Z, field_orientation)
     beta_check = expected
-    assert np.isclose(beta_hat, beta_check, rtol=2e-2)
+    np.testing.assert_allclose(beta_hat, beta_check, rtol=2e-2, atol=1e-8)
 
 
 # approximated from Ji-Held '13 figures 1 and 2 (black circles)
@@ -1222,7 +1222,7 @@ def test__nondim_resist_ji_held(hall, Z, field_orientation, expected) -> None:
     """Test _nondim_resist_ji_held function"""
     alpha_hat = _nondim_resist_ji_held(hall, Z, field_orientation)
     alpha_check = expected
-    assert np.isclose(alpha_hat, alpha_check, rtol=2e-2)
+    np.testing.assert_allclose(alpha_hat, alpha_check, rtol=2e-2, atol=1e-8)
 
 
 # approximated from Ji-Held '13 figure 3 (K = 80)
@@ -1253,7 +1253,7 @@ def test__nondim_visc_e_ji_held(hall, Z, index, expected) -> None:
     """Test _nondim_visc_e_ji_held function"""
     alpha_hat = _nondim_visc_e_ji_held(hall, Z)
     alpha_check = expected
-    assert np.isclose(alpha_hat[index], alpha_check, rtol=2e-2)
+    np.testing.assert_allclose(alpha_hat[index], alpha_check, rtol=2e-2, atol=1e-8)
 
 
 # approximated from Ji-Held '13 figure 7
@@ -1292,7 +1292,7 @@ def test__nondim_tc_i_ji_held(
     """Test _nondim_tc_i_ji_held function"""
     kappa_hat = _nondim_tc_i_ji_held(hall, Z, mu, theta, field_orientation)
     kappa_check = expected
-    assert np.isclose(kappa_hat, kappa_check, rtol=2e-2)
+    np.testing.assert_allclose(kappa_hat, kappa_check, rtol=2e-2, atol=1e-8)
 
 
 # approximated from Ji-Held '13 figure 7
@@ -1320,4 +1320,4 @@ def test__nondim_visc_i_ji_held(hall, Z, mu, theta: float, index, expected) -> N
     """Test _nondim_visc_i_ji_held function"""
     kappa_hat = _nondim_visc_i_ji_held(hall, Z, mu, theta)
     kappa_check = expected
-    assert np.isclose(kappa_hat[index], kappa_check, rtol=2e-2)
+    np.testing.assert_allclose(kappa_hat[index], kappa_check, rtol=2e-2, atol=1e-8)

--- a/tests/formulary/test_transport.py
+++ b/tests/formulary/test_transport.py
@@ -823,14 +823,18 @@ class Test__nondim_tc_e_braginskii:
     def test_known_values_perp(self, Z, field_orientation, expected) -> None:
         """Check some known values"""
         kappa_e_hat = _nondim_tc_e_braginskii(self.big_hall, Z, field_orientation)
-        np.testing.assert_allclose(kappa_e_hat * self.big_hall**2, expected, atol=1e-1, rtol=1e-5)
+        np.testing.assert_allclose(
+            kappa_e_hat * self.big_hall**2, expected, atol=1e-1, rtol=1e-5
+        )
 
     @pytest.mark.parametrize("Z", [1, 2, 3, 4, np.inf])
     def test_unmagnetized(self, Z) -> None:
         """Confirm perp -> par as B -> 0"""
         kappa_e_hat_par = _nondim_tc_e_braginskii(self.small_hall, Z, "par")
         kappa_e_hat_perp = _nondim_tc_e_braginskii(self.small_hall, Z, "perp")
-        np.testing.assert_allclose(kappa_e_hat_par, kappa_e_hat_perp, rtol=1e-3, atol=1e-8)
+        np.testing.assert_allclose(
+            kappa_e_hat_par, kappa_e_hat_perp, rtol=1e-3, atol=1e-8
+        )
 
     @pytest.mark.parametrize("Z", [1, 4])
     def test_cross_vs_ji_held(self, Z) -> None:
@@ -863,19 +867,25 @@ class Test__nondim_tc_i_braginskii:
         """Check some known values"""
         kappa_i_hat = _nondim_tc_i_braginskii(self.big_hall, field_orientation="perp")
         expected = 2.0  # Braginskii '65 eq (2.16)
-        np.testing.assert_allclose(kappa_i_hat * self.big_hall**2, expected, atol=1e-1, rtol=1e-5)
+        np.testing.assert_allclose(
+            kappa_i_hat * self.big_hall**2, expected, atol=1e-1, rtol=1e-5
+        )
 
     def test_unmagnetized(self) -> None:
         """Confirm perp -> par as B -> 0"""
         kappa_i_hat_par = _nondim_tc_i_braginskii(self.small_hall, "par")
         kappa_i_hat_perp = _nondim_tc_i_braginskii(self.small_hall, "perp")
-        np.testing.assert_allclose(kappa_i_hat_par, kappa_i_hat_perp, rtol=1e-3, atol=1e-8)
+        np.testing.assert_allclose(
+            kappa_i_hat_par, kappa_i_hat_perp, rtol=1e-3, atol=1e-8
+        )
 
     def test_cross_vs_ji_held_K2(self) -> None:
         """Confirm cross agrees with ji-held model when K=2"""
         kappa_i_hat_brag = _nondim_tc_i_braginskii(self.big_hall, "cross")
         kappa_i_hat_jh = _nondim_tc_i_ji_held(self.big_hall, 1, 0, 100, "cross", K=2)
-        np.testing.assert_allclose(kappa_i_hat_brag, kappa_i_hat_jh, rtol=2e-2, atol=1e-8)
+        np.testing.assert_allclose(
+            kappa_i_hat_brag, kappa_i_hat_jh, rtol=2e-2, atol=1e-8
+        )
 
 
 # test class for _nondim_tec_braginskii function:
@@ -914,7 +924,9 @@ class Test__nondim_tec_braginskii:
         """Cross should roughly agree with ji-held"""
         beta_hat_cross_brag = _nondim_tec_braginskii(self.big_hall, Z, "cross")
         beta_hat_cross_jh = _nondim_tec_ji_held(self.big_hall, Z, "cross")
-        np.testing.assert_allclose(beta_hat_cross_brag, beta_hat_cross_jh, rtol=3e-2, atol=1e-8)
+        np.testing.assert_allclose(
+            beta_hat_cross_brag, beta_hat_cross_jh, rtol=3e-2, atol=1e-8
+        )
 
 
 # test class for _nondim_resist_braginskii function:
@@ -953,7 +965,9 @@ class Test__nondim_resist_braginskii:
         """Cross should roughly agree with ji-held at hall 0.1"""
         alpha_hat_cross_brag = _nondim_resist_braginskii(0.1, Z, "cross")
         alpha_hat_cross_jh = _nondim_resist_ji_held(0.1, Z, "cross")
-        np.testing.assert_allclose(alpha_hat_cross_brag, alpha_hat_cross_jh, rtol=5e-2, atol=1e-8)
+        np.testing.assert_allclose(
+            alpha_hat_cross_brag, alpha_hat_cross_jh, rtol=5e-2, atol=1e-8
+        )
 
 
 # test class for _nondim_visc_i_braginskii function:
@@ -973,14 +987,18 @@ class Test__nondim_visc_i_braginskii:
         """Check some known values"""
         eta_i_hat = _nondim_visc_i_braginskii(self.big_hall)
         eta_i_hat_with_powers = eta_i_hat * self.big_hall**power
-        np.testing.assert_allclose(eta_i_hat_with_powers, expected, atol=1e-2, rtol=1e-5)
+        np.testing.assert_allclose(
+            eta_i_hat_with_powers, expected, atol=1e-2, rtol=1e-5
+        )
 
     def test_vs_ji_held_K2(self) -> None:
         """Confirm agreement with ji-held model when K=2"""
         eta_i_hat_brag = _nondim_visc_i_braginskii(self.big_hall)
         eta_i_hat_jh = _nondim_visc_i_ji_held(self.big_hall, 1, 0, 100, K=2)
         for idx in (0, 1, 2, 3, 4):
-            np.testing.assert_allclose(eta_i_hat_brag[idx], eta_i_hat_jh[idx], rtol=2e-2, atol=1e-8)
+            np.testing.assert_allclose(
+                eta_i_hat_brag[idx], eta_i_hat_jh[idx], rtol=2e-2, atol=1e-8
+            )
 
 
 # test class for _nondim_visc_e_braginskii function:
@@ -1008,9 +1026,13 @@ class Test__nondim_visc_e_braginskii:
         if idx == 0:
             np.testing.assert_allclose(beta_hat[idx], expected, atol=1e-2, rtol=1e-5)
         elif idx in {1, 2}:
-            np.testing.assert_allclose(beta_hat[idx] * self.big_hall**2, expected, atol=1e-2, rtol=1e-5)
+            np.testing.assert_allclose(
+                beta_hat[idx] * self.big_hall**2, expected, atol=1e-2, rtol=1e-5
+            )
         elif idx in {3, 4}:
-            np.testing.assert_allclose(beta_hat[idx] * self.big_hall, expected, atol=1e-1, rtol=1e-5)
+            np.testing.assert_allclose(
+                beta_hat[idx] * self.big_hall, expected, atol=1e-1, rtol=1e-5
+            )
 
 
 def test_fail__check_Z_nan() -> None:

--- a/tests/particles/test_atomic.py
+++ b/tests/particles/test_atomic.py
@@ -469,7 +469,7 @@ def test_isotopic_abundance() -> None:
     """Test that `isotopic_abundance` returns the appropriate values or
     raises appropriate errors for various isotopes."""
     assert isotopic_abundance("H", 1) == isotopic_abundance("protium")
-    assert np.isclose(isotopic_abundance("D"), 0.000115)
+    np.testing.assert_allclose(isotopic_abundance("D"), 0.000115, rtol=1e-5, atol=1e-8)
     assert isotopic_abundance("Be-8") == 0.0, "Be-8"
     assert isotopic_abundance("Li-8") == 0.0, "Li-8"
 
@@ -713,7 +713,7 @@ def test_stopping_power_interpolation(
     )
 
     # NIST data is given to four significant figures: use a tolerance of 1 part in 1000
-    assert np.isclose(actual_stopping_power, expected_stopping_power, rtol=0.001).all()
+    np.testing.assert_allclose(actual_stopping_power, expected_stopping_power, rtol=0.001, atol=1e-8)
 
 
 def test_stopping_power_no_interpolation() -> None:

--- a/tests/particles/test_atomic.py
+++ b/tests/particles/test_atomic.py
@@ -713,7 +713,9 @@ def test_stopping_power_interpolation(
     )
 
     # NIST data is given to four significant figures: use a tolerance of 1 part in 1000
-    np.testing.assert_allclose(actual_stopping_power, expected_stopping_power, rtol=0.001, atol=1e-8)
+    np.testing.assert_allclose(
+        actual_stopping_power, expected_stopping_power, rtol=0.001, atol=1e-8
+    )
 
 
 def test_stopping_power_no_interpolation() -> None:

--- a/tests/particles/test_ionization_state.py
+++ b/tests/particles/test_ionization_state.py
@@ -151,7 +151,7 @@ def test_charge_numbers(test_ionization_state) -> None:
     numbers.
     """
     expected_charge_numbers = np.arange(test_ionization_state.atomic_number + 1)
-    assert np.allclose(test_ionization_state.charge_numbers, expected_charge_numbers)
+    np.testing.assert_allclose(test_ionization_state.charge_numbers, expected_charge_numbers, rtol=1e-5, atol=1e-8)
 
 
 def test_equal_to_itself(He_ionization_state) -> None:
@@ -464,7 +464,7 @@ def test_IonizationState_attributes(instance, key) -> None:
         try:
             assert expected == actual
         except ValueError:
-            assert np.allclose(expected, actual)
+            np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8)
 
 
 def test_IonizationState_methods(instance) -> None:
@@ -560,7 +560,7 @@ def test_setting_ionic_fractions() -> None:
     instance = IonizationState("He")
     new_ionic_fractions = [0.2, 0.5, 0.3]
     instance.ionic_fractions = new_ionic_fractions
-    assert np.allclose(instance.ionic_fractions, new_ionic_fractions)
+    np.testing.assert_allclose(instance.ionic_fractions, new_ionic_fractions, rtol=1e-5, atol=1e-8)
 
 
 class Test_IonizationStateNumberDensitiesSetter:

--- a/tests/particles/test_ionization_state.py
+++ b/tests/particles/test_ionization_state.py
@@ -151,7 +151,12 @@ def test_charge_numbers(test_ionization_state) -> None:
     numbers.
     """
     expected_charge_numbers = np.arange(test_ionization_state.atomic_number + 1)
-    np.testing.assert_allclose(test_ionization_state.charge_numbers, expected_charge_numbers, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        test_ionization_state.charge_numbers,
+        expected_charge_numbers,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
 
 def test_equal_to_itself(He_ionization_state) -> None:
@@ -464,7 +469,7 @@ def test_IonizationState_attributes(instance, key) -> None:
         try:
             assert expected == actual
         except ValueError:
-            np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8)  # ty:ignore[no-matching-overload]
 
 
 def test_IonizationState_methods(instance) -> None:
@@ -560,7 +565,9 @@ def test_setting_ionic_fractions() -> None:
     instance = IonizationState("He")
     new_ionic_fractions = [0.2, 0.5, 0.3]
     instance.ionic_fractions = new_ionic_fractions
-    np.testing.assert_allclose(instance.ionic_fractions, new_ionic_fractions, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        instance.ionic_fractions, new_ionic_fractions, rtol=1e-5, atol=1e-8
+    )
 
 
 class Test_IonizationStateNumberDensitiesSetter:

--- a/tests/particles/test_nuclear.py
+++ b/tests/particles/test_nuclear.py
@@ -24,7 +24,7 @@ def test_nuclear_binding_energy_D_T() -> None:
     before = nuclear_binding_energy("D") + nuclear_binding_energy("T")
     after = nuclear_binding_energy("alpha")
     E_in_MeV = (after - before).to(u.MeV).value  # D + T --> alpha + n + E
-    assert np.isclose(E_in_MeV, 17.58, rtol=0.01)
+    np.testing.assert_allclose(E_in_MeV, 17.58, rtol=0.01, atol=1e-8)
 
 
 def test_nuclear_reaction_energy() -> None:
@@ -32,7 +32,7 @@ def test_nuclear_reaction_energy() -> None:
     reaction2 = "T + D -> n + alpha"
     released_energy1 = nuclear_reaction_energy(reaction1)
     released_energy2 = nuclear_reaction_energy(reaction2)
-    assert np.isclose((released_energy1.to(u.MeV)).value, 17.58, rtol=0.01)
+    np.testing.assert_allclose((released_energy1.to(u.MeV)).value, 17.58, rtol=0.01, atol=1e-8)
     assert released_energy1 == released_energy2
     assert nuclear_reaction_energy(
         "n + p+ --> n + p+ + p- + p+",
@@ -45,31 +45,31 @@ def test_nuclear_reaction_energy_triple_alpha() -> None:
     triple_alpha2 = "Be-8 + alpha --> carbon-12"
     energy_triplealpha1 = nuclear_reaction_energy(triple_alpha1)
     energy_triplealpha2 = nuclear_reaction_energy(triple_alpha2)
-    assert np.isclose(energy_triplealpha1.to(u.keV).value, -91.8, atol=0.1)
-    assert np.isclose(energy_triplealpha2.to(u.MeV).value, 7.367, atol=0.1)
+    np.testing.assert_allclose(energy_triplealpha1.to(u.keV).value, -91.8, atol=0.1, rtol=1e-5)
+    np.testing.assert_allclose(energy_triplealpha2.to(u.MeV).value, 7.367, atol=0.1, rtol=1e-5)
     reactants = ["He-4", "alpha"]
     products = ["Be-8"]
     energy = nuclear_reaction_energy(reactants=reactants, products=products)
-    assert np.isclose(energy.to(u.keV).value, -91.8, atol=0.1)
+    np.testing.assert_allclose(energy.to(u.keV).value, -91.8, atol=0.1, rtol=1e-5)
 
 
 def test_nuclear_reaction_energy_alpha_decay() -> None:
     alpha_decay_example = "U-238 --> Th-234 + alpha"
     energy_alpha_decay = nuclear_reaction_energy(alpha_decay_example)
-    assert np.isclose(energy_alpha_decay.to(u.MeV).value, 4.26975, atol=1e-5)
+    np.testing.assert_allclose(energy_alpha_decay.to(u.MeV).value, 4.26975, atol=1e-5, rtol=1e-5)
 
 
 def test_nuclear_reaction_energy_triple_alpha_r() -> None:
     triple_alpha1_r = "4*He-4 --> 2*Be-8"
     energy_triplealpha1_r = nuclear_reaction_energy(triple_alpha1_r)
-    assert np.isclose(energy_triplealpha1_r.to(u.keV).value, -91.8 * 2, atol=0.1)
+    np.testing.assert_allclose(energy_triplealpha1_r.to(u.keV).value, -91.8 * 2, atol=0.1, rtol=1e-5)
 
 
 def test_nuclear_reaction_energy_beta() -> None:
     energy1 = nuclear_reaction_energy(reactants=["n"], products=["p", "e-"])
-    assert np.isclose(energy1.to(u.MeV).value, 0.78, atol=0.01)
+    np.testing.assert_allclose(energy1.to(u.MeV).value, 0.78, atol=0.01, rtol=1e-5)
     energy2 = nuclear_reaction_energy(reactants=["Mg-23"], products=["Na-23", "e+"])
-    assert np.isclose(energy2.to(u.MeV).value, 3.034591, atol=1e-5)
+    np.testing.assert_allclose(energy2.to(u.MeV).value, 3.034591, atol=1e-5, rtol=1e-5)
 
 
 # (reactants, products, expectedMeV, tol)
@@ -98,7 +98,7 @@ def test_nuclear_reaction_energy_kwargs(
 ) -> None:
     energy = nuclear_reaction_energy(reactants=reactants, products=products).si
     expected = (expectedMeV * u.MeV).si
-    assert np.isclose(expected.value, energy.value, atol=tol)
+    np.testing.assert_allclose(expected.value, energy.value, atol=tol, rtol=1e-5)
 
 
 def test_nuclear_reaction_energy2() -> None:

--- a/tests/particles/test_nuclear.py
+++ b/tests/particles/test_nuclear.py
@@ -32,7 +32,9 @@ def test_nuclear_reaction_energy() -> None:
     reaction2 = "T + D -> n + alpha"
     released_energy1 = nuclear_reaction_energy(reaction1)
     released_energy2 = nuclear_reaction_energy(reaction2)
-    np.testing.assert_allclose((released_energy1.to(u.MeV)).value, 17.58, rtol=0.01, atol=1e-8)
+    np.testing.assert_allclose(
+        (released_energy1.to(u.MeV)).value, 17.58, rtol=0.01, atol=1e-8
+    )
     assert released_energy1 == released_energy2
     assert nuclear_reaction_energy(
         "n + p+ --> n + p+ + p- + p+",
@@ -45,8 +47,12 @@ def test_nuclear_reaction_energy_triple_alpha() -> None:
     triple_alpha2 = "Be-8 + alpha --> carbon-12"
     energy_triplealpha1 = nuclear_reaction_energy(triple_alpha1)
     energy_triplealpha2 = nuclear_reaction_energy(triple_alpha2)
-    np.testing.assert_allclose(energy_triplealpha1.to(u.keV).value, -91.8, atol=0.1, rtol=1e-5)
-    np.testing.assert_allclose(energy_triplealpha2.to(u.MeV).value, 7.367, atol=0.1, rtol=1e-5)
+    np.testing.assert_allclose(
+        energy_triplealpha1.to(u.keV).value, -91.8, atol=0.1, rtol=1e-5
+    )
+    np.testing.assert_allclose(
+        energy_triplealpha2.to(u.MeV).value, 7.367, atol=0.1, rtol=1e-5
+    )
     reactants = ["He-4", "alpha"]
     products = ["Be-8"]
     energy = nuclear_reaction_energy(reactants=reactants, products=products)
@@ -56,13 +62,17 @@ def test_nuclear_reaction_energy_triple_alpha() -> None:
 def test_nuclear_reaction_energy_alpha_decay() -> None:
     alpha_decay_example = "U-238 --> Th-234 + alpha"
     energy_alpha_decay = nuclear_reaction_energy(alpha_decay_example)
-    np.testing.assert_allclose(energy_alpha_decay.to(u.MeV).value, 4.26975, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(
+        energy_alpha_decay.to(u.MeV).value, 4.26975, atol=1e-5, rtol=1e-5
+    )
 
 
 def test_nuclear_reaction_energy_triple_alpha_r() -> None:
     triple_alpha1_r = "4*He-4 --> 2*Be-8"
     energy_triplealpha1_r = nuclear_reaction_energy(triple_alpha1_r)
-    np.testing.assert_allclose(energy_triplealpha1_r.to(u.keV).value, -91.8 * 2, atol=0.1, rtol=1e-5)
+    np.testing.assert_allclose(
+        energy_triplealpha1_r.to(u.keV).value, -91.8 * 2, atol=0.1, rtol=1e-5
+    )
 
 
 def test_nuclear_reaction_energy_beta() -> None:

--- a/tests/plasma/sources/test_plasma3d.py
+++ b/tests/plasma/sources/test_plasma3d.py
@@ -90,7 +90,9 @@ def test_Plasma3D_derived_vars() -> None:
         == test_plasma.magnetic_field.shape[1:]
     )
     assert test_plasma.magnetic_field_strength.si.unit == u.T
-    np.testing.assert_allclose(test_plasma.magnetic_field_strength.value, 0.017320508, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        test_plasma.magnetic_field_strength.value, 0.017320508, rtol=1e-5, atol=1e-8
+    )
 
     assert (
         test_plasma.electric_field_strength.shape
@@ -100,4 +102,6 @@ def test_Plasma3D_derived_vars() -> None:
 
     assert test_plasma.alfven_speed.shape == test_plasma.density.shape
     assert test_plasma.alfven_speed.unit.si == u.m / u.s
-    np.testing.assert_allclose(test_plasma.alfven_speed.value, 10.92548431, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        test_plasma.alfven_speed.value, 10.92548431, rtol=1e-5, atol=1e-8
+    )

--- a/tests/plasma/sources/test_plasma3d.py
+++ b/tests/plasma/sources/test_plasma3d.py
@@ -90,7 +90,7 @@ def test_Plasma3D_derived_vars() -> None:
         == test_plasma.magnetic_field.shape[1:]
     )
     assert test_plasma.magnetic_field_strength.si.unit == u.T
-    assert np.allclose(test_plasma.magnetic_field_strength.value, 0.017320508)
+    np.testing.assert_allclose(test_plasma.magnetic_field_strength.value, 0.017320508, rtol=1e-5, atol=1e-8)
 
     assert (
         test_plasma.electric_field_strength.shape
@@ -100,4 +100,4 @@ def test_Plasma3D_derived_vars() -> None:
 
     assert test_plasma.alfven_speed.shape == test_plasma.density.shape
     assert test_plasma.alfven_speed.unit.si == u.m / u.s
-    assert np.allclose(test_plasma.alfven_speed.value, 10.92548431)
+    np.testing.assert_allclose(test_plasma.alfven_speed.value, 10.92548431, rtol=1e-5, atol=1e-8)

--- a/tests/plasma/sources/test_plasmablob.py
+++ b/tests/plasma/sources/test_plasmablob.py
@@ -93,7 +93,9 @@ def test_Plasma3D_derived_vars() -> None:
         == test_plasma.magnetic_field.shape[1:]
     )
     assert test_plasma.magnetic_field_strength.si.unit == u.T
-    np.testing.assert_allclose(test_plasma.magnetic_field_strength.value, 0.017320508, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        test_plasma.magnetic_field_strength.value, 0.017320508, rtol=1e-5, atol=1e-8
+    )
 
     assert (
         test_plasma.electric_field_strength.shape
@@ -103,7 +105,9 @@ def test_Plasma3D_derived_vars() -> None:
 
     assert test_plasma.alfven_speed.shape == test_plasma.density.shape
     assert test_plasma.alfven_speed.unit.si == u.m / u.s
-    np.testing.assert_allclose(test_plasma.alfven_speed.value, 10.92548431, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        test_plasma.alfven_speed.value, 10.92548431, rtol=1e-5, atol=1e-8
+    )
 
 
 @pytest.mark.slow

--- a/tests/plasma/sources/test_plasmablob.py
+++ b/tests/plasma/sources/test_plasmablob.py
@@ -93,7 +93,7 @@ def test_Plasma3D_derived_vars() -> None:
         == test_plasma.magnetic_field.shape[1:]
     )
     assert test_plasma.magnetic_field_strength.si.unit == u.T
-    assert np.allclose(test_plasma.magnetic_field_strength.value, 0.017320508)
+    np.testing.assert_allclose(test_plasma.magnetic_field_strength.value, 0.017320508, rtol=1e-5, atol=1e-8)
 
     assert (
         test_plasma.electric_field_strength.shape
@@ -103,7 +103,7 @@ def test_Plasma3D_derived_vars() -> None:
 
     assert test_plasma.alfven_speed.shape == test_plasma.density.shape
     assert test_plasma.alfven_speed.unit.si == u.m / u.s
-    assert np.allclose(test_plasma.alfven_speed.value, 10.92548431)
+    np.testing.assert_allclose(test_plasma.alfven_speed.value, 10.92548431, rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.slow

--- a/tests/plasma/test_grids.py
+++ b/tests/plasma/test_grids.py
@@ -797,7 +797,7 @@ def test_nonuniform_cartesian_NN_interp(
     np.testing.assert_allclose(
         np.asarray(pout),
         np.asarray(expected),
-        atol=np.asarray(dx_max),
+        atol=float(np.asarray(dx_max)),
         equal_nan=True,
         rtol=1e-5,
     )

--- a/tests/plasma/test_grids.py
+++ b/tests/plasma/test_grids.py
@@ -259,9 +259,9 @@ def test_AbstractGrid_uniform_attributes(
     # If an expected value is given, verify the attribute matches
     if value is not None:
         if isinstance(value, np.ndarray):
-            assert np.allclose(attr, value, rtol=0.1)
+            np.testing.assert_allclose(attr, value, rtol=0.1, atol=1e-8)
         elif isinstance(value, float | int):
-            assert np.isclose(attr, value, rtol=0.1)
+            np.testing.assert_allclose(attr, value, rtol=0.1, atol=1e-8)
         else:
             assert attr == value
 
@@ -299,9 +299,9 @@ def test_AbstractGrid_nonuniform_attributes(
     # If an expected value is given, verify the attribute matches
     if value is not None:
         if isinstance(value, np.ndarray):
-            assert np.allclose(attr, value, rtol=0.1)
+            np.testing.assert_allclose(attr, value, rtol=0.1, atol=1e-8)
         elif isinstance(value, float | int):
-            assert np.isclose(attr, value, rtol=0.1)
+            np.testing.assert_allclose(attr, value, rtol=0.1, atol=1e-8)
         else:
             assert attr == value
 
@@ -555,7 +555,7 @@ def test_soften_edges(uniform_cartesian_grid, width) -> None:
     assert_quantity_allclose(grid["rho"][:, :, -1], 0 * u.kg / u.m**3)
 
     # Assert center value is nearly unchanged
-    assert np.isclose(grid["rho"][xi, yi, zi], center_value)
+    np.testing.assert_allclose(grid["rho"][xi, yi, zi], center_value, rtol=1e-5, atol=1e-8)
 
 
 create_args_uniform_cartesian = [
@@ -614,12 +614,7 @@ def test_uniform_cartesian_NN_interp(
     pout = uniform_cartesian_grid.nearest_neighbor_interpolator(pos, *quantities)
 
     # Should be correct to within dx/2, so 0.6 leaves some room
-    assert np.allclose(
-        pout,
-        expected,
-        atol=0.6 * uniform_cartesian_grid.dax0,
-        equal_nan=True,
-    )
+    np.testing.assert_allclose(np.asarray(pout), np.asarray(expected), atol=(0.6 * uniform_cartesian_grid.dax0).value, equal_nan=True, rtol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -662,7 +657,7 @@ def test_uniform_cartesian_NN_interp_persistence(uniform_cartesian_grid) -> None
 
     # Transpose of pos is required because pout is ordered first by quantity
     # (axis in this case) while pos is [N,3]
-    assert np.allclose(pout, pos[:, [0, 1]].T, atol=0.6 * uniform_cartesian_grid.dax0)
+    np.testing.assert_allclose(np.asarray(pout), np.asarray(pos[:, [0, 1]].T), atol=(0.6 * uniform_cartesian_grid.dax0).value, rtol=1e-5)
 
     # Change quantities with persistent still True
     # Code should detect this and automatically run as
@@ -675,7 +670,7 @@ def test_uniform_cartesian_NN_interp_persistence(uniform_cartesian_grid) -> None
         persistent=True,
     )
 
-    assert np.allclose(pout, pos[:, [0, 2]].T, atol=0.6 * uniform_cartesian_grid.dax0)
+    np.testing.assert_allclose(np.asarray(pout), np.asarray(pos[:, [0, 2]].T), atol=(0.6 * uniform_cartesian_grid.dax0).value, rtol=1e-5)
 
 
 # **********************************************************************
@@ -785,7 +780,7 @@ def test_nonuniform_cartesian_NN_interp(
     # for this test
     dx_max = np.max(np.gradient(nonuniform_cartesian_grid.grid[:, 0]))
 
-    assert np.allclose(pout, expected, atol=dx_max, equal_nan=True)
+    np.testing.assert_allclose(np.asarray(pout), np.asarray(expected), atol=np.asarray(dx_max), equal_nan=True, rtol=1e-5)
 
 
 @pytest.mark.filterwarnings(
@@ -806,7 +801,7 @@ def test_nonuniform_cartesian_nearest_neighbor_interpolator() -> None:
     # One position
     pos = np.array([0.1, -0.3, 0]) * u.cm
     pout = grid.nearest_neighbor_interpolator(pos, "x", persistent=True)
-    assert np.allclose(pos[0], pout, atol=0.5)
+    np.testing.assert_allclose(pos[0], pout, atol=0.5, rtol=1e-5)
 
     # Test out of bounds
     pos = np.array([-2, -0.3, 0]) * u.cm
@@ -817,7 +812,7 @@ def test_nonuniform_cartesian_nearest_neighbor_interpolator() -> None:
     pos = np.array([[0.1, -0.3, 0], [0.1, -0.3, 0]]) * u.cm
     pout1 = grid.nearest_neighbor_interpolator(pos, "x", "y", persistent=False)
     pout2 = grid.nearest_neighbor_interpolator(pos, "x", "y", persistent=True)
-    assert np.allclose(pout1, pout2)
+    np.testing.assert_allclose(pout1, pout2, rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize(
@@ -864,12 +859,12 @@ def test_volume_averaged_interpolator_at_several_positions(
 ) -> None:
     pout = uniform_cartesian_grid.volume_averaged_interpolator(pos, *what)
     if len(what) == 1:
-        assert np.allclose(pout, expected)
+        np.testing.assert_allclose(pout, expected, rtol=1e-5, atol=1e-8)
     else:
         assert isinstance(pout, tuple)
         assert len(pout) == len(what)
         for ii in range(len(what)):
-            assert np.allclose(pout[ii], expected[ii])
+            np.testing.assert_allclose(pout[ii], expected[ii], rtol=1e-5, atol=1e-8)
 
 
 def test_volume_averaged_interpolator_missing_key(uniform_cartesian_grid) -> None:
@@ -956,11 +951,7 @@ def test_volume_averaged_interpolator_known_solutions() -> None:
 
     pts = grid.volume_averaged_interpolator(pos, "B_z", persistent=True)
 
-    assert np.allclose(
-        pts.value,
-        np.array([np.nan, 0, 0.5, 1, 1.5, 2, 2.5, 3, np.nan]),
-        equal_nan=True,
-    )
+    np.testing.assert_allclose(pts.value, np.array([np.nan, 0, 0.5, 1, 1.5, 2, 2.5, 3, np.nan]), equal_nan=True, rtol=1e-5, atol=1e-8)
 
 
 def test_volume_averaged_interpolator_compare_NN_1D(uniform_cartesian_grid) -> None:
@@ -1124,4 +1115,4 @@ def test_fast_nearest_neighbor_interpolate() -> None:
 
     result = grids._fast_nearest_neighbor_interpolate(pos, ax)
 
-    assert np.allclose(expected, result)
+    np.testing.assert_allclose(expected, result, rtol=1e-5, atol=1e-8)

--- a/tests/plasma/test_grids.py
+++ b/tests/plasma/test_grids.py
@@ -258,9 +258,7 @@ def test_AbstractGrid_uniform_attributes(
 
     # If an expected value is given, verify the attribute matches
     if value is not None:
-        if isinstance(value, np.ndarray):
-            np.testing.assert_allclose(attr, value, rtol=0.1, atol=1e-8)
-        elif isinstance(value, float | int):
+        if isinstance(value, np.ndarray | float | int):
             np.testing.assert_allclose(attr, value, rtol=0.1, atol=1e-8)
         else:
             assert attr == value
@@ -298,9 +296,7 @@ def test_AbstractGrid_nonuniform_attributes(
 
     # If an expected value is given, verify the attribute matches
     if value is not None:
-        if isinstance(value, np.ndarray):
-            np.testing.assert_allclose(attr, value, rtol=0.1, atol=1e-8)
-        elif isinstance(value, float | int):
+        if isinstance(value, np.ndarray | float | int):
             np.testing.assert_allclose(attr, value, rtol=0.1, atol=1e-8)
         else:
             assert attr == value
@@ -555,7 +551,9 @@ def test_soften_edges(uniform_cartesian_grid, width) -> None:
     assert_quantity_allclose(grid["rho"][:, :, -1], 0 * u.kg / u.m**3)
 
     # Assert center value is nearly unchanged
-    np.testing.assert_allclose(grid["rho"][xi, yi, zi], center_value, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        grid["rho"][xi, yi, zi], center_value, rtol=1e-5, atol=1e-8
+    )
 
 
 create_args_uniform_cartesian = [
@@ -614,7 +612,13 @@ def test_uniform_cartesian_NN_interp(
     pout = uniform_cartesian_grid.nearest_neighbor_interpolator(pos, *quantities)
 
     # Should be correct to within dx/2, so 0.6 leaves some room
-    np.testing.assert_allclose(np.asarray(pout), np.asarray(expected), atol=(0.6 * uniform_cartesian_grid.dax0).value, equal_nan=True, rtol=1e-5)
+    np.testing.assert_allclose(
+        np.asarray(pout),
+        np.asarray(expected),
+        atol=(0.6 * uniform_cartesian_grid.dax0).value,
+        equal_nan=True,
+        rtol=1e-5,
+    )
 
 
 @pytest.mark.parametrize(
@@ -657,7 +661,12 @@ def test_uniform_cartesian_NN_interp_persistence(uniform_cartesian_grid) -> None
 
     # Transpose of pos is required because pout is ordered first by quantity
     # (axis in this case) while pos is [N,3]
-    np.testing.assert_allclose(np.asarray(pout), np.asarray(pos[:, [0, 1]].T), atol=(0.6 * uniform_cartesian_grid.dax0).value, rtol=1e-5)
+    np.testing.assert_allclose(
+        np.asarray(pout),
+        np.asarray(pos[:, [0, 1]].T),
+        atol=(0.6 * uniform_cartesian_grid.dax0).value,
+        rtol=1e-5,
+    )
 
     # Change quantities with persistent still True
     # Code should detect this and automatically run as
@@ -670,7 +679,12 @@ def test_uniform_cartesian_NN_interp_persistence(uniform_cartesian_grid) -> None
         persistent=True,
     )
 
-    np.testing.assert_allclose(np.asarray(pout), np.asarray(pos[:, [0, 2]].T), atol=(0.6 * uniform_cartesian_grid.dax0).value, rtol=1e-5)
+    np.testing.assert_allclose(
+        np.asarray(pout),
+        np.asarray(pos[:, [0, 2]].T),
+        atol=(0.6 * uniform_cartesian_grid.dax0).value,
+        rtol=1e-5,
+    )
 
 
 # **********************************************************************
@@ -780,7 +794,13 @@ def test_nonuniform_cartesian_NN_interp(
     # for this test
     dx_max = np.max(np.gradient(nonuniform_cartesian_grid.grid[:, 0]))
 
-    np.testing.assert_allclose(np.asarray(pout), np.asarray(expected), atol=np.asarray(dx_max), equal_nan=True, rtol=1e-5)
+    np.testing.assert_allclose(
+        np.asarray(pout),
+        np.asarray(expected),
+        atol=np.asarray(dx_max),
+        equal_nan=True,
+        rtol=1e-5,
+    )
 
 
 @pytest.mark.filterwarnings(
@@ -951,7 +971,13 @@ def test_volume_averaged_interpolator_known_solutions() -> None:
 
     pts = grid.volume_averaged_interpolator(pos, "B_z", persistent=True)
 
-    np.testing.assert_allclose(pts.value, np.array([np.nan, 0, 0.5, 1, 1.5, 2, 2.5, 3, np.nan]), equal_nan=True, rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        pts.value,
+        np.array([np.nan, 0, 0.5, 1, 1.5, 2, 2.5, 3, np.nan]),
+        equal_nan=True,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
 
 def test_volume_averaged_interpolator_compare_NN_1D(uniform_cartesian_grid) -> None:

--- a/tests/simulation/test_particle_tracker.py
+++ b/tests/simulation/test_particle_tracker.py
@@ -314,12 +314,7 @@ def test_particle_tracker_potential_difference(
     final_expected_energy = (E_strength * L * point_particle.charge).to(u.J)
     final_simulated_energy = (0.5 * point_particle.mass * speeds[-1] ** 2).to(u.J)
 
-    assert np.isclose(
-        final_expected_energy,
-        final_simulated_energy,
-        atol=0.5,
-        rtol=5e-2,
-    )
+    np.testing.assert_allclose(final_expected_energy, final_simulated_energy, atol=0.5, rtol=5e-2)
 
 
 def test_asynchronous_time_step(no_particles_on_grids_instantiated) -> None:
@@ -882,12 +877,7 @@ class TestParticleTrajectory:
         )
 
         # Discard the first five points due to large relative error.
-        assert np.isclose(
-            relativistic_theory_x[5:],
-            save_routine.results["x"][5:, 0, 0],
-            equal_nan=True,
-            rtol=0.05,
-        ).all()
+        np.testing.assert_allclose(relativistic_theory_x[5:], save_routine.results["x"][5:, 0, 0], equal_nan=True, rtol=0.05, atol=1e-8)
 
         # Ensure that a non-relativistic analytic solution does not appear to fit
         # the relativistic trajectory within the defined tolerance parameters.
@@ -1010,12 +1000,7 @@ class TestParticleTrajectory:
         )
 
         # Discard the first five points due to large relative error.
-        assert np.isclose(
-            classical_theory_x[5:],
-            save_routine.results["x"][5:, 0, 0],
-            equal_nan=True,
-            rtol=0.05,
-        ).all()
+        np.testing.assert_allclose(classical_theory_x[5:], save_routine.results["x"][5:, 0, 0], equal_nan=True, rtol=0.05, atol=1e-8)
 
     @classmethod
     @pytest.mark.parametrize(

--- a/tests/simulation/test_particle_tracker.py
+++ b/tests/simulation/test_particle_tracker.py
@@ -314,7 +314,9 @@ def test_particle_tracker_potential_difference(
     final_expected_energy = (E_strength * L * point_particle.charge).to(u.J)
     final_simulated_energy = (0.5 * point_particle.mass * speeds[-1] ** 2).to(u.J)
 
-    np.testing.assert_allclose(final_expected_energy, final_simulated_energy, atol=0.5, rtol=5e-2)
+    np.testing.assert_allclose(
+        final_expected_energy, final_simulated_energy, atol=0.5, rtol=5e-2
+    )
 
 
 def test_asynchronous_time_step(no_particles_on_grids_instantiated) -> None:
@@ -877,7 +879,13 @@ class TestParticleTrajectory:
         )
 
         # Discard the first five points due to large relative error.
-        np.testing.assert_allclose(relativistic_theory_x[5:], save_routine.results["x"][5:, 0, 0], equal_nan=True, rtol=0.05, atol=1e-8)
+        np.testing.assert_allclose(
+            relativistic_theory_x[5:],
+            save_routine.results["x"][5:, 0, 0],
+            equal_nan=True,
+            rtol=0.05,
+            atol=1e-8,
+        )
 
         # Ensure that a non-relativistic analytic solution does not appear to fit
         # the relativistic trajectory within the defined tolerance parameters.
@@ -1000,7 +1008,13 @@ class TestParticleTrajectory:
         )
 
         # Discard the first five points due to large relative error.
-        np.testing.assert_allclose(classical_theory_x[5:], save_routine.results["x"][5:, 0, 0], equal_nan=True, rtol=0.05, atol=1e-8)
+        np.testing.assert_allclose(
+            classical_theory_x[5:],
+            save_routine.results["x"][5:, 0, 0],
+            equal_nan=True,
+            rtol=0.05,
+            atol=1e-8,
+        )
 
     @classmethod
     @pytest.mark.parametrize(

--- a/tests/simulation/test_resolution_constraints.py
+++ b/tests/simulation/test_resolution_constraints.py
@@ -49,4 +49,4 @@ class TestCFL_limit_electromagnetic_yee:
             atol = 1e-8
 
         rc = CFL_limit_electromagnetic_yee(*args, **kwargs)
-        assert np.allclose(rc, expected, atol=atol)
+        np.testing.assert_allclose(rc, expected, atol=atol, rtol=1e-5)

--- a/tests/utils/data/test_downloader.py
+++ b/tests/utils/data/test_downloader.py
@@ -224,7 +224,9 @@ def test_get_file_NIST_PSTAR_datafile(downloader_validated) -> None:
     path = downloader_validated.get_file("NIST_PSTAR_aluminum.txt")
 
     arr = np.loadtxt(path, skiprows=7)
-    np.testing.assert_allclose(arr[0, :], np.array([1e-3, 1.043e2]), rtol=1e-5, atol=1e-8)
+    np.testing.assert_allclose(
+        arr[0, :], np.array([1e-3, 1.043e2]), rtol=1e-5, atol=1e-8
+    )
 
 
 @pytest.mark.skip(

--- a/tests/utils/data/test_downloader.py
+++ b/tests/utils/data/test_downloader.py
@@ -224,7 +224,7 @@ def test_get_file_NIST_PSTAR_datafile(downloader_validated) -> None:
     path = downloader_validated.get_file("NIST_PSTAR_aluminum.txt")
 
     arr = np.loadtxt(path, skiprows=7)
-    assert np.allclose(arr[0, :], np.array([1e-3, 1.043e2]))
+    np.testing.assert_allclose(arr[0, :], np.array([1e-3, 1.043e2]), rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
## Summary

Converts 357 bare `assert np.isclose(...)` and `assert np.allclose(...)` calls
across 41 test files to `np.testing.assert_allclose(...)`.

**Why this matters:** bare `assert np.isclose(a, b)` produces an uninformative
`AssertionError` on failure. `np.testing.assert_allclose` prints the actual vs
desired values, mismatching indices, and the tolerance used — dramatically
reducing debugging time.

## Key details

- **Default tolerances set explicitly** as `rtol=1e-5, atol=1e-8` to match
  `np.isclose` defaults exactly. `np.testing.assert_allclose` defaults to
  `atol=0`, which causes false failures for comparisons against near-zero values.

- **Shape fixes** in `test_nullpoint.py`, `test_mhd_wave_class.py`: unnecessary
  `.reshape(1, 3)` calls converted to `.flatten()`. `np.allclose` silently
  broadcasts mismatched shapes; `assert_allclose` enforces shape equality.

- **Quantity atol** in `test_grids.py`: `float(Quantity)` raises for
  dimensional quantities, so `atol` is stripped via `.value` and both arrays
  via `np.asarray()`.

- **Parametrized tolerance dicts** in `test_speeds.py`: `isclose_kw` dict
  expansion handled via `**{"rtol": 1e-5, "atol": 1e-8, **isclose_kw}` so
  parametrized values override the fallback defaults.

- **Unit-aware list comparison** in `test_mhd_wave_class.py`: Python lists of
  `Quantity` objects wrapped in `u.Quantity()` before comparison so
  `assert_allclose` can compare them correctly.

- **Intentional broadcasting preserved**: particle tracker gyroradius/energy
  conservation tests that compare `(N_timesteps, N_particles)` vs `(N_particles,)`
  are kept as `assert np.allclose(...)` since the broadcasting over all time
  steps is the intended physics check.

## Test results

- 4,343 tests pass (excluding pre-existing errors in `tests/diagnostics/` that
  exist on `main` before this PR).
- No new test failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)