### PR TITLE
Continuation of B-dot probe implementation from PR #3055 by Maimoona Irfan

### DIFF
--- a/src/plasmapy/analysis/magnetic_pickup_probe/__init__.py
+++ b/src/plasmapy/analysis/magnetic_pickup_probe/__init__.py
@@ -1,0 +1,10 @@
+"""
+Subpackage containing routines for analyzing magnetic pickup probe
+(Bdot probe) signals.
+"""
+
+__all__ = ["magnetic_field_calculation"]
+
+from plasmapy.analysis.magnetic_pickup_probe.magnetic_field_calculation import (
+    magnetic_field_calculation,
+)

--- a/src/plasmapy/analysis/magnetic_pickup_probe/magnetic_field_calculation.py
+++ b/src/plasmapy/analysis/magnetic_pickup_probe/magnetic_field_calculation.py
@@ -1,0 +1,103 @@
+"""Functionality for calculating magnetic field from magnetic pickup (B-dot) probe."""
+
+__all__ = ["magnetic_field_calculation"]
+
+import numpy as np
+from scipy.integrate import cumulative_trapezoid
+
+
+def magnetic_field_calculation(
+    bdot_voltage: np.ndarray,
+    time_array: np.ndarray,
+    loop_area: float,
+    num_loop: int = 1,
+    gain: float = 1.0,
+) -> np.ndarray:
+    r"""
+    Take the voltage output of a magnetic pickup probe (Bdot probe) and
+    time base and return the associated array of the magnetic field as
+    a function of time.
+
+    Parameters
+    ----------
+    bdot_voltage: `numpy.ndarray`
+        1-D array containing voltage fluctuations from a bdot probe
+        (should be in units of volts). The array values are proportional
+        to the time changing magnetic field via Faraday's law.
+
+    time_array: `numpy.ndarray`
+        1-D time series of the data collection (should be in seconds).
+
+    loop_area: `float`
+        The area through which the changing flux is measured (should be
+        in square meters).
+
+    num_loop: `int`
+        The number of loops of the Bdot probe, each with corresponding
+        ``loop_area``. (Default: 1)
+
+    gain: `float`
+        Any dimensionless gains that need to be applied. (Default: 1.0)
+
+    Returns
+    -------
+    magnetic_field_array: `numpy.ndarray`
+        The array containing the magnetic field (in tesla for SI
+        inputs) as a function of time.
+
+    Raises
+    ------
+    ValueError
+        If ``bdot_voltage`` and ``time_array`` do not have equal sizes.
+
+    Notes
+    -----
+    The integral form of Faraday's law states that the time change in
+    flux through an area generates a voltage around a loop,
+
+    .. math::
+
+        V = -N\frac{d\Phi}{dt}
+
+    where :math:`\Phi` is the magnetic flux
+
+    .. math::
+
+        \Phi = \int{BdA}
+
+    and :math:`N` is the number of loops.
+
+    A magnetic pickup probe works by providing a fixed area loop or
+    loops using a length of conducting wire through which magnetic
+    fields penetrate. As these fields change in time, a voltage is
+    generated that can be measured by some kind of data acquisition
+    device (such as an oscilloscope). We can also assume that the loop
+    is small enough that the magnetic field through the loop is
+    constant everywhere in the loop (and only changes in time). Given
+    this, we can write
+
+    .. math::
+
+        V = -NA\frac{dB}{dt}
+
+    where the voltage becomes proportional only to the change in
+    magnetic field and the area of the loop. Magnetic field as a
+    function of time can be recovered by time integrating
+    :math:`-V(t)/(NAg)`, where :math:`g` is any dimensionless gain
+    applied to the measured voltage.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> bdot_voltage = np.array([1.0, 1.0, 1.0])
+    >>> time_array = np.array([0.0, 0.5, 1.0])
+    >>> magnetic_field_calculation(bdot_voltage, time_array, loop_area=1.0)
+    array([ 0. , -0.5, -1. ])
+    """
+    if len(bdot_voltage) != len(time_array):
+        msg = "sizes of time_array and bdot_voltage are not equal."
+        raise ValueError(msg)
+
+    scaled_voltage = -np.asarray(bdot_voltage) / (loop_area * num_loop * gain)
+
+    return cumulative_trapezoid(scaled_voltage, time_array, initial=0)

--- a/src/plasmapy/diagnostics/magnetic_pickup_probe.py
+++ b/src/plasmapy/diagnostics/magnetic_pickup_probe.py
@@ -1,0 +1,96 @@
+"""Defines the basic magnetic pickup probe (Bdot probe) analysis."""
+
+__all__ = ["compute_bfield"]
+
+from warnings import warn
+from scipy.integrate import cumulative_trapezoid
+from typing import Tuple
+import numpy as np
+
+
+import astropy.units as u
+from plasmapy.utils.decorators import validate_quantities
+from typing import Tuple
+
+@validate_quantities
+def compute_bfield(bdot_voltage: u.Quantity[u.volt], time_array: u.Quantity[u.s], loop_area: u.Quantity[u.m**2], num_loop: int = 1, gain: float = 1.0) -> u.Quantity[u.T]:
+    r"""
+    Take the voltage output of a magnetic pickup probe (Bdot probe) and time base and 
+    return the associated array of the magnetic field as a function of time.
+
+    Parameters
+    ----------
+    bdot_voltage: `astropy.units.Quantity`
+        A data array containing voltage fluctuations from a bdot probe
+        in units convertible to volts. The array values are proportional
+        to time changing magnetic field via Faradays Law.
+
+    time_array: `astropy.units.Quantity`
+        The time series to the data collection in units of seconds.
+
+    loop_area: 'astropy.units.Quantity'
+        The area through which the changing flux is measured in units
+        convertible to square meters.
+
+    num_loop: int
+        The number of loops of the Bdot probe (assumed to be all the same area).
+        
+    gain: float
+        Any dimensionless gains that need to be applied.
+        
+    Returns
+    -------
+    magnetic_field_array: `astropy.units.Quantity`
+        The array containing the magnetic field in units convertible
+        to tesla as a function of time in seconds.
+        
+    Notes
+    -----
+    The integral form of Faraday's Law states that the time change in flux through an area generates a voltage around a loop,
+    .. math::
+       V = -N\frac{d\Phi}{dt}
+    where :math:`\Phi` is the magnetic flux
+    .. math::
+        \Phi = \int{BdA}
+    and :math:`N` is the number of loops.
+
+
+    A magnetic pickup probe works by providing a fixed area loop or loops using a length of conducting wire through 
+    which magnetic fields penetrate. As these fields change in time, a voltage is generated that can be measured
+    by some kind of data acquisition device (such as an oscilloscope). We can also assume that the loop is small 
+    enough that the magnetic field through the loop is constant everywhere in the loop (and only changes in time).
+    Given this, we can write
+    .. math::
+        V = -A\frac{dB}{dt}
+    where the voltage becomes proportional only to the change in magnetic field and the area of the loop. Magnetic
+    field as a function of time can be recovered by time integrating :math:`V(t)/NA`.
+    
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> time_array = np.linspace(0, 4*np.pi, 100) * u.s
+    >>> bdot_voltage = np.sin(time_array / u.s) * u.V  # create a voltage oscillation
+    >>> loop_area = 1 * u.m**2
+    >>> num_loop = 1
+    >>> gain = 1
+    >>> bfield = compute_bfield(
+    ...     bdot_voltage,
+    ...     time_array,
+    ...     loop_area,
+    ...     num_loop=num_loop,
+    ...     gain=gain,
+    ... )
+    >>> print(bfield)
+    """
+    if len(bdot_voltage) != len(time_array):
+        raise ValueError("sizes of time_array and bdot_voltage are not equal.")
+    
+    bdot_voltage = bdot_voltage.value
+    loop_area = loop_area.value
+    time_array = time_array.value
+    bdot_voltage /= (loop_area*num_loop*gain)
+    # units are removed by cumulative_trapezoid
+    magnetic_field_array = cumulative_trapezoid(bdot_voltage, time_array, initial=0)  # tesla
+
+    return magnetic_field_array * u.T

--- a/tests/diagnostics/test_magnetic_pickup_probe.py
+++ b/tests/diagnostics/test_magnetic_pickup_probe.py
@@ -1,0 +1,35 @@
+"""Unit test for the magnetic pickup probe (B-dot probe) diagnostics."""
+
+import numpy as np
+import astropy.units as u
+import pytest
+
+from plasmapy.diagnostics.magnetic_pickup_probe import compute_bfield
+
+
+def test_compute_bfield_integrates_voltage_to_field() -> None:
+    """
+    Test compute_bfield by inputting a sine wave voltage and checking
+    if the output magnetic field matches the integrated waveform.
+    """
+    # Create a time array in seconds
+    time = np.linspace(0, 2 * np.pi, 50) * u.s
+
+    # Create a sine voltage signal: V(t) = sin(t)
+    voltage = np.sin(time / u.s) * u.V
+
+    # Set probe parameters
+    loop_area = 2 * u.m**2
+    num_loop = 3
+    gain = 5
+
+    # Expected magnetic field is the integral of V(t)/(N*A*gain)
+    expected_field = -np.cos(time.value) + 1  # Integral of sin(t) is -cos(t), plus constant
+    expected_field *= (1 / (loop_area * num_loop * gain)).value  # Apply scaling
+    expected_field = expected_field * u.T  # Assign Tesla units
+
+    # Compute B field using function
+    computed_bfield = compute_bfield(voltage, time, loop_area, num_loop, gain)
+
+    # Use a tolerance since numerical integration introduces small errors
+    assert u.allclose(computed_bfield, expected_field, rtol=1e-3, atol=1e-5 * u.T)


### PR DESCRIPTION
## Description
Continues #3055 by @mirfan4906, whose work is imported unchanged as the first commit. 
This PR adds `plasmapy.diagnostics.magnetic_pickup_probe,` containing a `compute_bfield()` function that converts the voltage signal of a magnetic pickup (B-dot) probe into magnetic field strength by numerically integrating Faraday's law. I'm currently working with Prof. @dschaffner's group, where this originated, and hope to continue it the rest of the way. 

## Related Issues
Supersedes #3055 
See also #1652 