### PR TITLE
Fix thermal_pressure docstring and reorder Bohm_diffusion sections

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -792,3 +792,7 @@ authors:
 - given-names: Mike
   family-names: German
   alias: steps-re
+
+- given-names: Jadon
+  family-names: Lawson
+  alias: elitecloudmage

--- a/changelog/3354.doc.rst
+++ b/changelog/3354.doc.rst
@@ -1,0 +1,2 @@
+Fixes thermal pressure equation and docstring section
+ordering in `~plasmapy.formulary.misc`.

--- a/src/plasmapy/formulary/misc.py
+++ b/src/plasmapy/formulary/misc.py
@@ -75,10 +75,10 @@ def Bohm_diffusion(
     B : `~astropy.units.Quantity`
         The magnitude of the magnetic field in the plasma.
 
-    Warns
-    -----
-    : `~astropy.units.UnitsWarning`
-        If units are not provided, SI units are assumed.
+    Returns
+    -------
+    D_B : `~astropy.units.Quantity`
+        The Bohm diffusion coefficient in meters squared per second.
 
     Raises
     ------
@@ -88,6 +88,11 @@ def Bohm_diffusion(
 
     `~astropy.units.UnitConversionError`
         If ``T_e`` is not in appropriate units.
+
+    Warns
+    -----
+    : `~astropy.units.UnitsWarning`
+        If units are not provided, SI units are assumed.
 
     Examples
     --------
@@ -100,11 +105,6 @@ def Bohm_diffusion(
     >>> B = 10 * u.T
     >>> Bohm_diffusion(T_e, B)
     <Quantity 0.3125 m2 / s>
-
-    Returns
-    -------
-    D_B : `~astropy.units.Quantity`
-        The Bohm diffusion coefficient in meters squared per second.
     """
     return k_B * T_e / (16 * e * B)
 
@@ -273,12 +273,21 @@ def thermal_pressure(T: u.Quantity[u.K], n: u.Quantity[u.m**-3]) -> u.Quantity[u
         If the particle temperature is not in units of temperature or
         energy per particle.
 
+    Warns
+    -----
+    : `~astropy.units.UnitsWarning`
+        If units are not provided, SI units are assumed.
+
+    See Also
+    --------
+    ~plasmapy.formulary.dimensionless.beta : The ratio of thermal pressure to magnetic pressure.
+
     Notes
     -----
     The thermal pressure is given by:
 
     .. math::
-        T_{th} = n k_B T
+        p_{th} = n k_B T
 
     Examples
     --------


### PR DESCRIPTION
- Updated T_{th} → p_{th} so the symbol matches the pressure the function returns
- Reorder Bohm_diffusion docstring sections to match numpydoc
- Added 'Warns' and 'See Also' blocks to thermal_pressure


Hey! 👋 this is my first contribution to PlasmaPy, happy to adjust anything if the approach or formatting isn't quite to your guidelines.

Addresses #3258