### PR TITLE
Drop sphinx-codeautolink for documentation build

### DIFF
--- a/changelog/3355.doc.rst
+++ b/changelog/3355.doc.rst
@@ -1,0 +1,1 @@
+Removed ``sphinx-codeautolink`` as an extension to the documentation build.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,6 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_changelog",
-    "sphinx_codeautolink",
     "sphinx_copybutton",
     "sphinx_gallery.load_style",
     "sphinx_issues",
@@ -241,12 +240,6 @@ bibtex_bibfiles = ["bibliography.bib"]
 bibtex_default_style = "plain"
 bibtex_reference_style = "author_year"
 bibtex_cite_id = "{key}"
-
-# sphinx-codeautolink
-
-codeautolink_concat_default = True
-codeautolink_warn_on_failed_resolve = False  # turn on for debugging
-codeautolink_warn_on_missing_inventory = False  # turn on for debugging
 
 # intersphinx
 

--- a/docs/contributing/coding_guide.rst
+++ b/docs/contributing/coding_guide.rst
@@ -979,8 +979,6 @@ Equations and Physical Formulae
   the physical constants. For example, the following line of code
   obscures information about the physics being represented:
 
-  .. autolink-skip:: section
-
   .. code-block:: python
 
      omega_ce = 1.76e7*(B/u.G)*u.rad/u.s  # doctest: +SKIP

--- a/docs/plasma/index.rst
+++ b/docs/plasma/index.rst
@@ -32,8 +32,6 @@ Creating Plasma Objects
 Plasma objects are constructed using the special factory class
 `~plasmapy.plasma.plasma_factory.Plasma`:
 
-.. autolink-skip::
-
 .. code-block:: python
 
     from plasmapy.plasma.plasma_factory import Plasma

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ docs = [
   "pygments>=2.20",
   "sphinx>=9.1",
   "sphinx-changelog>=1.6",
-  "sphinx-codeautolink>=0.18.1",
   "sphinx-copybutton>=0.5.2",
   "sphinx-gallery>=0.21",
   "sphinx-issues>=6",

--- a/src/plasmapy/analysis/time_series/conditional_averaging.py
+++ b/src/plasmapy/analysis/time_series/conditional_averaging.py
@@ -71,8 +71,6 @@ class ConditionalEvents:
 
     Examples
     --------
-    .. autolink-skip:: section
-
     >>> from plasmapy.analysis.time_series.conditional_averaging import (
     ...     ConditionalEvents,
     ... )

--- a/src/plasmapy/formulary/braginskii.py
+++ b/src/plasmapy/formulary/braginskii.py
@@ -288,8 +288,6 @@ class ClassicalTransport:
 
     Examples
     --------
-    .. autolink-skip:: section
-
     >>> import astropy.units as u
     >>> t = ClassicalTransport(1 * u.eV, 1e20 / u.m**3, 1 * u.eV, 1e20 / u.m**3, "p")
     >>> t.resistivity  # doctest: +SKIP

--- a/src/plasmapy/formulary/collisions/misc.py
+++ b/src/plasmapy/formulary/collisions/misc.py
@@ -198,8 +198,6 @@ def mobility(
 
     Examples
     --------
-    .. autolink-skip:: section
-
     >>> import astropy.units as u
     >>> n = 1e19 * u.m**-3
     >>> T = 1e6 * u.K
@@ -433,8 +431,6 @@ def Spitzer_resistivity(
 
     Examples
     --------
-    .. autolink-skip:: section
-
     >>> import astropy.units as u
     >>> n = 1e19 * u.m**-3
     >>> T = 1e6 * u.K

--- a/src/plasmapy/utils/decorators/lite_func.py
+++ b/src/plasmapy/utils/decorators/lite_func.py
@@ -40,8 +40,6 @@ def bind_lite_func(lite_func, attrs: dict[str, Callable] | None = None):  # noqa
 
     Examples
     --------
-    .. autolink-skip:: section
-
     .. code-block:: python
 
         def foo_lite(x):

--- a/uv.lock
+++ b/uv.lock
@@ -244,7 +244,7 @@ name = "cffi"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
@@ -1731,7 +1731,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1862,7 +1862,6 @@ dev = [
     { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-changelog" },
-    { name = "sphinx-codeautolink" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-gallery" },
     { name = "sphinx-issues" },
@@ -1892,7 +1891,6 @@ docs = [
     { name = "pygments" },
     { name = "sphinx" },
     { name = "sphinx-changelog" },
-    { name = "sphinx-codeautolink" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-gallery" },
     { name = "sphinx-issues" },
@@ -1946,7 +1944,6 @@ type-check = [
     { name = "pytest-xdist" },
     { name = "sphinx" },
     { name = "sphinx-changelog" },
-    { name = "sphinx-codeautolink" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-gallery" },
     { name = "sphinx-issues" },
@@ -2015,7 +2012,6 @@ dev = [
     { name = "ruff", specifier = ">=0.14.11" },
     { name = "sphinx", specifier = ">=9.1" },
     { name = "sphinx-changelog", specifier = ">=1.6" },
-    { name = "sphinx-codeautolink", specifier = ">=0.18.1" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-gallery", specifier = ">=0.21" },
     { name = "sphinx-issues", specifier = ">=6" },
@@ -2045,7 +2041,6 @@ docs = [
     { name = "pygments", specifier = ">=2.20" },
     { name = "sphinx", specifier = ">=9.1" },
     { name = "sphinx-changelog", specifier = ">=1.6" },
-    { name = "sphinx-codeautolink", specifier = ">=0.18.1" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-gallery", specifier = ">=0.21" },
     { name = "sphinx-issues", specifier = ">=6" },
@@ -2097,7 +2092,6 @@ type-check = [
     { name = "pytest-xdist", specifier = ">=3.8" },
     { name = "sphinx", specifier = ">=9.1" },
     { name = "sphinx-changelog", specifier = ">=1.6" },
-    { name = "sphinx-codeautolink", specifier = ">=0.18.1" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-gallery", specifier = ">=0.21" },
     { name = "sphinx-issues", specifier = ">=6" },
@@ -2861,19 +2855,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/25/609b92c07ad7cc415e828f6e0c7611414c37e0117c89df4e7f9fd25a7b3e/sphinx_changelog-1.6.0.tar.gz", hash = "sha256:5251941cf49496584aaeb596087e6d51458ce0e742740a384a84ff47753fb5f9", size = 13157, upload-time = "2024-08-28T09:12:53.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/8a/a11c95df73c1845e3aaff2ef0ea4be34af43221fdb20e597f0781a45f866/sphinx_changelog-1.6.0-py3-none-any.whl", hash = "sha256:68313c4d33eacfd62a1cd0d780f3f7c0ac6a8d3882eec3d928265ed9f28e7bec", size = 6809, upload-time = "2024-08-28T09:12:52.367Z" },
-]
-
-[[package]]
-name = "sphinx-codeautolink"
-version = "0.18.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "sphinx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/d3/51a6f2d822621d1e4eaf575ad5139e3120db5a0f535d518c1c0c1b9fb828/sphinx_codeautolink-0.18.1.tar.gz", hash = "sha256:820b55f630298297b4f8f18d8825529f25895d3734ac7ac06584f62845c4fd4b", size = 63342, upload-time = "2026-04-30T10:22:26.433Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/4a/f46a675afd0479558bcaa867060fdf5c1c4647446f77f0e8447cd36298d3/sphinx_codeautolink-0.18.1-py3-none-any.whl", hash = "sha256:59592ae4548ce49a169d1bcded5d91f9b1d3190b8125615845af9ec5cc13c808", size = 36936, upload-time = "2026-04-30T10:22:24.779Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR drop sphinx-codeautolink as an extension for the documentation build.

 - [ ] Create an issue here for adding back sphinx-codeautolink as an extension (along with maybe a pull request?)
 - [ ] Create an issue on the sphinx-codeautolink repository about the error.

## Motivation

Whilst working on #3345, I'm running into a confusing error with sphinx-codeautolink, which seems to happen only for `astropy>=8.0.0`.  Since this is taking too long to figure out, this PR removes sphinx-codeautolink as an extension.  I really like the extension, so I'm hoping that this is only temporary.