### PR TITLE
Add GitHub workflow to perform SPEC 0 updates

### DIFF
--- a/.github/workflows/update-spec0.yml
+++ b/.github/workflows/update-spec0.yml
@@ -1,4 +1,4 @@
-name: Update minimum allowed versions of dependencies
+name: Perform SPEC 0 updates
 
 on:
   schedule:
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  update:
+  bump-minimum-versions:
     runs-on: ubuntu-latest
     steps:
       - uses: scientific-python/spec0-action@8b8b76f254aecce36e6f07de7dde174cb3cafa81 # v1.3

--- a/.github/workflows/update-spec0.yml
+++ b/.github/workflows/update-spec0.yml
@@ -2,8 +2,7 @@ name: Perform SPEC 0 updates
 
 on:
   schedule:
-    # Day 5 of each quarter. Allows two day buffer after the quarterly schedule release on day 1
-    - cron: "41 0 5 1,4,7,10 *"
+  - cron: 41 0 5 1,4,7,10 *
   workflow_dispatch:
 
 permissions:
@@ -18,6 +17,6 @@ jobs:
   bump-minimum-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: scientific-python/spec0-action@8b8b76f254aecce36e6f07de7dde174cb3cafa81 # v1.3
-        with:
-          update_all: 2 # also bump non-SPEC0 deps older than 2 years
+    - uses: scientific-python/spec0-action@8b8b76f254aecce36e6f07de7dde174cb3cafa81   # v1.3
+      with:
+        update_all: 2   # also bump non-SPEC0 deps older than 2 years

--- a/.github/workflows/update-spec0.yml
+++ b/.github/workflows/update-spec0.yml
@@ -1,0 +1,23 @@
+name: Update minimum allowed versions of dependencies
+
+on:
+  schedule:
+    # Day 5 of each quarter. Allows two day buffer after the quarterly schedule release on day 1
+    - cron: "41 0 5 1,4,7,10 *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: scientific-python/spec0-action@8b8b76f254aecce36e6f07de7dde174cb3cafa81 # v1.3
+        with:
+          update_all: 2 # also bump non-SPEC0 deps older than 2 years

--- a/changelog/3362.internal.rst
+++ b/changelog/3362.internal.rst
@@ -1,0 +1,1 @@
+Added a GitHub workflow to perform quarterly updates of the minimum allowed versions of dependencies.


### PR DESCRIPTION
## Description

This PR adds a workflow to run [scientific-python/spec0-action](https://github.com/scientific-python/spec0-action).  This workflow will create a pull request each quarter (or when manually triggered by workflow dispatch) that bumps the minimum allowed versions of dependencies as per the schedule in [SPEC 0](https://scientific-python.org/specs/spec-0000/).

## Motivation and background

SPEC 0 recommends that packages drop support for minor versions of dependencies that are more than 24 months old and for minor releases of Python that are more than 36 months old. This workflow will help us automate SPEC 0 updates and avoid having to do them manually.

## Limitations

It will probably be necessary to do a `pre-commit.ci autofix` on each PR to run `pyproject-fmt`.

It may be necessary to manually run `uv lock`.  
